### PR TITLE
port mention resolution, smart mention stripping, empty response filter, and verbosity config from GX internal bot

### DIFF
--- a/docs/features/thread-context.md
+++ b/docs/features/thread-context.md
@@ -16,8 +16,10 @@ Before every Claude spawn, the session manager builds a prompt preamble with:
 2. **Bot user ID** — so Claude recognizes its own messages in thread history
 3. **Channel & thread metadata** — channel name, thread_ts, with instruction not to search Slack
 4. **Thread history** — all prior messages fetched via `conversations.replies`, labeled by role
-5. **Image attachments** — downloaded to `/tmp/junior-files/<threadId>/`, paths appended to prompt
-6. **Historical file annotations** — `[shared image: filename.png]` in thread history
+5. **Mention resolution** — `<@U123>` tokens in thread history and incoming prompts are resolved to display names via `users.info` (cached per user ID)
+6. **Smart mention stripping** — only the bot's own @mention is stripped from incoming messages; other user mentions are preserved as readable `@displayname`
+7. **Image attachments** — downloaded to `/tmp/junior-files/<threadId>/`, paths appended to prompt
+8. **Historical file annotations** — `[shared image: filename.png]` in thread history
 
 ## Architecture
 
@@ -30,6 +32,7 @@ SessionManager.handleMessage()
     ├── buildPromptPreamble()          ← thread-context.ts
     │     ├── loadPersona()            ← persona.ts (cached after first load)
     │     ├── resolveChannelName()     ← cached per channel
+    │     ├── resolveSlackMentions()   ← resolves <@U123> → @displayname
     │     └── fetchThreadHistory()     ← conversations.replies API
     │
     ├── downloadSlackFiles()           ← files.ts (images only)
@@ -83,9 +86,9 @@ Do NOT use Slack search or read tools to find this thread.
 </slack-context>
 
 <thread-context>
-User(U678): can you review the auth middleware?
+User(Pranav Bakre): can you review the auth middleware?
 Junior (you): Sure, I'll take a look.
-User(U901): [shared image: screenshot.png] here's what I see
+User(Pranav Bakre): hey @Scotty check this too [shared image: screenshot.png]
 </thread-context>
 
 The user shared images. They are saved at these paths — use the Read tool to view them:
@@ -102,8 +105,8 @@ SOUL.md has 130+ lines of calibrated behavioral rules refined over months. Loadi
 ### Thread context fetched server-side, not via MCP
 The orchestrator already has the bot token and thread_ts. Fetching via `conversations.replies` is one API call. Giving Claude a Slack MCP tool would add latency (Claude has to search for the thread) and token waste (20+ MCP calls observed in testing).
 
-### Channel name cached
-`resolveChannelName()` caches channel ID → name to avoid repeated API calls for messages in the same channel.
+### Channel and user name cached
+`resolveChannelName()` and `resolveUserName()` cache their results in module-level Maps to avoid repeated API calls. User names resolve display_name → real_name → name → raw user ID as fallback.
 
 ### Identity matching by user_id only
 Slack's `bot_id` field is on ALL bot messages, not just ours. Only `m.user === botUserId` correctly identifies Junior's messages. Other bots (Friday, Doraemon) show as regular users in thread context.

--- a/docs/features/v2-backlog.md
+++ b/docs/features/v2-backlog.md
@@ -19,6 +19,14 @@ Features explicitly deferred from MVP. To be scoped when MVP is running.
 - Real-time or polling? EventSource/WebSocket from the bot server, or periodic API calls?
 - Auth? If web UI, who can see the dashboard? Pranav only, or whole team?
 
+## Batch User Resolution in Thread Context
+
+**Problem:** `fetchThreadHistory()` resolves user names inside a `Promise.all` over all thread messages. Each message fires `resolveUserName()` and `resolveSlackMentions()` concurrently. The user name cache prevents duplicate API calls for the same user, but on first encounter with a large thread with many unique participants, this can burst many `users.info` calls and risk hitting Slack's Tier 2 rate limit (~20 req/min).
+
+**Fix:** Pre-collect all unique user IDs from the thread (message authors + mentioned users), resolve them in a single batch before building message objects, then read from cache.
+
+**Priority:** Low — current thread sizes are small. Becomes relevant when threads regularly exceed ~20 unique participants.
+
 ## Image & Media Support from Slack
 
 **Problem:** Users send screenshots, diagrams, error images, and file uploads in Slack threads. The bot currently ignores them — only `event.text` is passed to Claude. Claude Code can read images, so the capability is there but not wired.

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,5 @@
+import type { SessionVerbosity } from "./session/types.ts";
+
 export interface RepoConfig {
   name: string;
   path: string;
@@ -25,6 +27,7 @@ export interface Config {
     store: SessionStoreKind;
     sqlitePath: string;
     homeWindowMs: number;
+    defaultVerbosity: SessionVerbosity;
   };
 }
 
@@ -62,6 +65,9 @@ export function loadConfig(): Config {
       store: parseStoreKind(optional("SESSION_STORE", "sqlite")),
       sqlitePath: optional("SESSION_DB_PATH", "data/sessions.db"),
       homeWindowMs: Number(optional("HOME_WINDOW_MS", "172800000")),
+      defaultVerbosity: parseVerbosity(
+        optional("SESSION_DEFAULT_VERBOSITY", "normal"),
+      ),
     },
   };
 }
@@ -69,4 +75,13 @@ export function loadConfig(): Config {
 function parseStoreKind(value: string): SessionStoreKind {
   if (value === "memory" || value === "sqlite") return value;
   throw new Error(`Invalid SESSION_STORE: ${value} (expected memory|sqlite)`);
+}
+
+function parseVerbosity(value: string): SessionVerbosity {
+  if (value === "quiet" || value === "normal" || value === "verbose") {
+    return value;
+  }
+  throw new Error(
+    `Invalid SESSION_DEFAULT_VERBOSITY: ${value} (expected quiet|normal|verbose)`,
+  );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { loadConfig } from "./config.ts";
 import { createSlackApp } from "./slack/app.ts";
 import { registerEventHandlers } from "./slack/events.ts";
-import { formatToolStatuses, shouldPostResponseToSlack } from "./slack/formatting.ts";
+import { formatToolStatuses, extractAssistantText, shouldPostResponseToSlack } from "./slack/formatting.ts";
 import { SlackResponder } from "./slack/responder.ts";
 import { SessionManager } from "./session/manager.ts";
 import { createSessionStore } from "./session/store/factory.ts";
@@ -42,6 +42,11 @@ sessionManager.onEvent = (session, event) => {
   }
   if (session.verbosity === "quiet") return;
   if (event.type === "assistant") {
+    const text = extractAssistantText(event);
+    if (text) {
+      responder.updateStatus(session.channel, session.threadId, text);
+    }
+
     const statuses = formatToolStatuses(event);
     for (const status of statuses) {
       log.info("tool", `thread=${session.threadId} ${status}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { loadConfig } from "./config.ts";
 import { createSlackApp } from "./slack/app.ts";
 import { registerEventHandlers } from "./slack/events.ts";
-import { formatToolStatuses, extractAssistantText } from "./slack/formatting.ts";
+import { formatToolStatuses, shouldPostResponseToSlack } from "./slack/formatting.ts";
 import { SlackResponder } from "./slack/responder.ts";
 import { SessionManager } from "./session/manager.ts";
 import { createSessionStore } from "./session/store/factory.ts";
@@ -31,7 +31,7 @@ const responder = new SlackResponder(app);
 sessionManager.onResponse = (session, response) => {
   log.info("response", `thread=${session.threadId} len=${response.length}`);
   responder.deleteStatus(session.channel, session.threadId);
-  if (response) {
+  if (shouldPostResponseToSlack(response)) {
     responder.postResponse(session.channel, session.threadId, response);
   }
 };
@@ -42,13 +42,6 @@ sessionManager.onEvent = (session, event) => {
   }
   if (session.verbosity === "quiet") return;
   if (event.type === "assistant") {
-    // Show text content as live status (gets overwritten each turn)
-    const text = extractAssistantText(event);
-    if (text) {
-      responder.updateStatus(session.channel, session.threadId, text);
-    }
-
-    // Show tool use as status
     const statuses = formatToolStatuses(event);
     for (const status of statuses) {
       log.info("tool", `thread=${session.threadId} ${status}`);
@@ -120,7 +113,7 @@ setInterval(() => {
   registerEventHandlers(app, (event) => {
     log.info("event", `thread=${event.threadId} user=${event.user} cmd=${event.command ?? "-"} text=${event.text.slice(0, 100)}`);
     sessionManager.handleMessage(event);
-  }, store, selfBotId);
+  }, store, selfBotId, sessionManager.botUserId);
 
   log.info("boot", "Junior is running (Socket Mode)");
 })();

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,11 +42,13 @@ sessionManager.onEvent = (session, event) => {
   }
   if (session.verbosity === "quiet") return;
   if (event.type === "assistant") {
+    // Show text content as live status (gets overwritten each turn)
     const text = extractAssistantText(event);
     if (text) {
       responder.updateStatus(session.channel, session.threadId, text);
     }
 
+    // Show tool use as status
     const statuses = formatToolStatuses(event);
     for (const status of statuses) {
       log.info("tool", `thread=${session.threadId} ${status}`);

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -94,6 +94,7 @@ const testConfig: Config = {
     store: "sqlite",
     sqlitePath: "data/sessions.db",
     homeWindowMs: 172800000,
+    defaultVerbosity: "quiet",
   },
 };
 

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -9,7 +9,10 @@ import type { WorktreeManager } from "../worktree/manager.ts";
 import { createSession } from "./types.ts";
 import { spawnClaude as defaultSpawnClaude } from "../claude/spawner.ts";
 import { withTimeout } from "../lifecycle/timeout.ts";
-import { buildPromptPreamble } from "../slack/thread-context.ts";
+import {
+  buildPromptPreamble,
+  resolveSlackMentions,
+} from "../slack/thread-context.ts";
 import { downloadSlackFiles } from "../slack/files.ts";
 import { log as _log } from "../logger.ts";
 
@@ -51,7 +54,11 @@ export class SessionManager {
     let session = await this.store.get(event.threadId);
 
     if (!session) {
-      session = createSession(event.threadId, event.channel);
+      session = createSession(
+        event.threadId,
+        event.channel,
+        this.config.session.defaultVerbosity,
+      );
       await this.store.set(event.threadId, session);
     }
 
@@ -278,14 +285,17 @@ export class SessionManager {
     try {
       // Inject identity + thread context so Claude knows who it is and what was said
       if (this.slackApp && latestTs) {
-        const preamble = await buildPromptPreamble(
-          this.slackApp,
-          session.channel,
-          session.threadId,
-          latestTs,
-          this.botUserId,
-        );
-        prompt = `${preamble}\n\n${prompt}`;
+        const [preamble, readablePrompt] = await Promise.all([
+          buildPromptPreamble(
+            this.slackApp,
+            session.channel,
+            session.threadId,
+            latestTs,
+            this.botUserId,
+          ),
+          resolveSlackMentions(this.slackApp, prompt),
+        ]);
+        prompt = `${preamble}\n\n${readablePrompt}`;
       }
 
       // Download image files from Slack and append their paths to the prompt

--- a/src/session/types.test.ts
+++ b/src/session/types.test.ts
@@ -58,9 +58,9 @@ describe("createSession", () => {
     expect(session.pendingMessages).toEqual([]);
   });
 
-  it("has verbosity set to quiet by default", () => {
+  it("has verbosity set to normal by default", () => {
     const session = createSession("t1", "C01");
-    expect(session.verbosity).toBe("quiet");
+    expect(session.verbosity).toBe("normal");
   });
 
   it("uses provided default verbosity", () => {

--- a/src/session/types.test.ts
+++ b/src/session/types.test.ts
@@ -58,9 +58,14 @@ describe("createSession", () => {
     expect(session.pendingMessages).toEqual([]);
   });
 
-  it("has verbosity set to normal", () => {
+  it("has verbosity set to quiet by default", () => {
     const session = createSession("t1", "C01");
-    expect(session.verbosity).toBe("normal");
+    expect(session.verbosity).toBe("quiet");
+  });
+
+  it("uses provided default verbosity", () => {
+    const session = createSession("t1", "C01", "verbose");
+    expect(session.verbosity).toBe("verbose");
   });
 
   it("has lastActivity as a recent timestamp", () => {

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -31,7 +31,7 @@ export interface ThreadSession {
 export function createSession(
   threadId: string,
   channel: string,
-  defaultVerbosity: SessionVerbosity = "quiet",
+  defaultVerbosity: SessionVerbosity = "normal",
 ): ThreadSession {
   return {
     threadId,

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -6,6 +6,7 @@ export interface PendingMessage {
 }
 
 export type SessionStatus = "idle" | "busy" | "draining";
+export type SessionVerbosity = "quiet" | "normal" | "verbose";
 
 export interface ThreadSession {
   threadId: string;
@@ -18,7 +19,7 @@ export interface ThreadSession {
   systemPrompt: string | null;
   status: SessionStatus;
   pendingMessages: PendingMessage[];
-  verbosity: "quiet" | "normal" | "verbose";
+  verbosity: SessionVerbosity;
   model: string | null;
   cwd: string | null;
   pid: number | null;
@@ -29,7 +30,8 @@ export interface ThreadSession {
 
 export function createSession(
   threadId: string,
-  channel: string
+  channel: string,
+  defaultVerbosity: SessionVerbosity = "quiet",
 ): ThreadSession {
   return {
     threadId,
@@ -42,7 +44,7 @@ export function createSession(
     systemPrompt: null,
     status: "idle",
     pendingMessages: [],
-    verbosity: "normal",
+    verbosity: defaultVerbosity,
     model: null,
     cwd: null,
     pid: null,

--- a/src/slack/events.ts
+++ b/src/slack/events.ts
@@ -25,6 +25,7 @@ export function registerEventHandlers(
   onMessage: OnMessageCallback,
   store?: SessionStore,
   selfBotId?: string,
+  selfUserId?: string,
 ): void {
   app.event("message", async ({ event }) => {
     // Only filter our own bot messages to avoid loops; let other bots through
@@ -55,10 +56,7 @@ export function registerEventHandlers(
     const threadId =
       "thread_ts" in event && event.thread_ts ? event.thread_ts : event.ts;
 
-    // Strip bot mention so commands are recognized even from the message event
-    const cleanText = selfBotId
-      ? text.replace(/<@[A-Z0-9]+>\s*/g, "").trim()
-      : text;
+    const cleanText = stripOwnMention(text, selfUserId);
     const parsed = parseCommand(cleanText);
 
     // Extract file attachments if present
@@ -80,8 +78,7 @@ export function registerEventHandlers(
 
     const threadId = event.thread_ts ?? event.ts;
 
-    // Strip bot mention from text (Slack includes <@BOTID> in app_mention events)
-    const cleanText = event.text.replace(/<@[A-Z0-9]+>\s*/g, "").trim();
+    const cleanText = stripOwnMention(event.text, selfUserId);
     const parsed = parseCommand(cleanText);
 
     // Extract file attachments if present
@@ -97,6 +94,19 @@ export function registerEventHandlers(
       files: files.length > 0 ? files : undefined,
     });
   });
+}
+
+function stripOwnMention(text: string, selfUserId?: string): string {
+  if (selfUserId) {
+    return text
+      .replace(new RegExp(`<@${escapeRegExp(selfUserId)}>\\s*`, "g"), "")
+      .trim();
+  }
+  return text.replace(/^<@[A-Z0-9_]+>\s*/g, "").trim();
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
 
 /**

--- a/src/slack/formatting.ts
+++ b/src/slack/formatting.ts
@@ -1,4 +1,4 @@
-import type { ContentBlockToolUse, StreamEventAssistant } from "../claude/types.ts";
+import type { ContentBlockToolUse, ContentBlockText, StreamEventAssistant } from "../claude/types.ts";
 
 /**
  * Extract tool_use content blocks from an assistant event and format as status lines.
@@ -7,6 +7,13 @@ export function formatToolStatuses(event: StreamEventAssistant): string[] {
   return event.message.content
     .filter((c): c is ContentBlockToolUse => c.type === "tool_use")
     .map(formatToolBlock);
+}
+
+export function extractAssistantText(event: StreamEventAssistant): string | null {
+  const texts = event.message.content
+    .filter((c): c is ContentBlockText => c.type === "text" && !!c.text)
+    .map((c) => c.text);
+  return texts.length > 0 ? texts.join("") : null;
 }
 
 const NO_SLACK_MESSAGE = "NO_SLACK_MESSAGE";

--- a/src/slack/formatting.ts
+++ b/src/slack/formatting.ts
@@ -9,6 +9,9 @@ export function formatToolStatuses(event: StreamEventAssistant): string[] {
     .map(formatToolBlock);
 }
 
+/**
+ * Extract text content from an assistant event, if any.
+ */
 export function extractAssistantText(event: StreamEventAssistant): string | null {
   const texts = event.message.content
     .filter((c): c is ContentBlockText => c.type === "text" && !!c.text)

--- a/src/slack/formatting.ts
+++ b/src/slack/formatting.ts
@@ -1,4 +1,4 @@
-import type { ContentBlockToolUse, ContentBlockText, StreamEventAssistant } from "../claude/types.ts";
+import type { ContentBlockToolUse, StreamEventAssistant } from "../claude/types.ts";
 
 /**
  * Extract tool_use content blocks from an assistant event and format as status lines.
@@ -9,14 +9,13 @@ export function formatToolStatuses(event: StreamEventAssistant): string[] {
     .map(formatToolBlock);
 }
 
-/**
- * Extract text content from an assistant event, if any.
- */
-export function extractAssistantText(event: StreamEventAssistant): string | null {
-  const texts = event.message.content
-    .filter((c): c is ContentBlockText => c.type === "text" && !!c.text)
-    .map((c) => c.text);
-  return texts.length > 0 ? texts.join("") : null;
+const NO_SLACK_MESSAGE = "NO_SLACK_MESSAGE";
+
+export function shouldPostResponseToSlack(text: string): boolean {
+  const normalized = text.trim();
+  if (!normalized) return false;
+  if (normalized === NO_SLACK_MESSAGE) return false;
+  return true;
 }
 
 function formatToolBlock(block: ContentBlockToolUse): string {

--- a/src/slack/thread-context.ts
+++ b/src/slack/thread-context.ts
@@ -10,6 +10,7 @@ interface ThreadMessage {
   fileNames: string[];
 }
 
+// Cache channel ID → name and user ID → display name so we don't re-fetch every message
 const channelNameCache = new Map<string, string>();
 const userNameCache = new Map<string, string>();
 
@@ -131,6 +132,7 @@ async function fetchThreadHistory(
     const messages: ThreadMessage[] = await Promise.all(result.messages
       .filter((m) => m.ts !== latestTs)
       .map(async (m) => {
+        // Extract file names from message attachments
         const files = (m as Record<string, unknown>).files;
         const fileNames: string[] = Array.isArray(files)
           ? (files as Array<Record<string, unknown>>)

--- a/src/slack/thread-context.ts
+++ b/src/slack/thread-context.ts
@@ -127,6 +127,7 @@ async function fetchThreadHistory(
       return null;
     }
 
+    // TODO: pre-collect unique user IDs and batch-resolve to avoid Slack rate limits on large threads
     const messages: ThreadMessage[] = await Promise.all(result.messages
       .filter((m) => m.ts !== latestTs)
       .map(async (m) => {

--- a/src/slack/thread-context.ts
+++ b/src/slack/thread-context.ts
@@ -3,14 +3,15 @@ import { loadPersona } from "../persona.ts";
 
 interface ThreadMessage {
   user: string;
+  userName: string;
   text: string;
   ts: string;
   isBot: boolean;
   fileNames: string[];
 }
 
-// Cache channel ID → name so we don't re-fetch every message
 const channelNameCache = new Map<string, string>();
+const userNameCache = new Map<string, string>();
 
 async function resolveChannelName(app: App, channelId: string): Promise<string> {
   const cached = channelNameCache.get(channelId);
@@ -24,6 +25,48 @@ async function resolveChannelName(app: App, channelId: string): Promise<string> 
   } catch {
     return channelId;
   }
+}
+
+async function resolveUserName(app: App, userId: string): Promise<string> {
+  const cached = userNameCache.get(userId);
+  if (cached) return cached;
+
+  try {
+    const info = await app.client.users.info({ user: userId });
+    const user = info.user as
+      | {
+          name?: string;
+          real_name?: string;
+          profile?: { display_name?: string; real_name?: string };
+        }
+      | undefined;
+    const name =
+      user?.profile?.display_name ||
+      user?.profile?.real_name ||
+      user?.real_name ||
+      user?.name ||
+      userId;
+    userNameCache.set(userId, name);
+    return name;
+  } catch {
+    return userId;
+  }
+}
+
+export async function resolveSlackMentions(
+  app: App,
+  text: string,
+): Promise<string> {
+  const mentionPattern = /<@([A-Z0-9]+)>/g;
+  const matches = [...text.matchAll(mentionPattern)];
+  if (matches.length === 0) return text;
+
+  let resolved = text;
+  for (const match of matches) {
+    const name = await resolveUserName(app, match[1]);
+    resolved = resolved.replace(match[0], `@${name}`);
+  }
+  return resolved;
 }
 
 /**
@@ -84,10 +127,9 @@ async function fetchThreadHistory(
       return null;
     }
 
-    const messages: ThreadMessage[] = result.messages
+    const messages: ThreadMessage[] = await Promise.all(result.messages
       .filter((m) => m.ts !== latestTs)
-      .map((m) => {
-        // Extract file names from message attachments
+      .map(async (m) => {
         const files = (m as Record<string, unknown>).files;
         const fileNames: string[] = Array.isArray(files)
           ? (files as Array<Record<string, unknown>>)
@@ -95,19 +137,22 @@ async function fetchThreadHistory(
               .map((f) => f.name as string)
           : [];
 
+        const user = m.user ?? "unknown";
+
         return {
-          user: m.user ?? "unknown",
-          text: (m.text ?? "").replace(/<@[A-Z0-9]+>\s*/g, "").trim(),
+          user,
+          userName: user === "unknown" ? user : await resolveUserName(app, user),
+          text: (await resolveSlackMentions(app, m.text ?? "")).trim(),
           ts: m.ts!,
           isBot: !!(botUserId && m.user === botUserId),
           fileNames,
         };
-      });
+      }));
 
     if (messages.length === 0) return null;
 
     const lines = messages.map((m) => {
-      const role = m.isBot ? "Junior (you)" : `User(${m.user})`;
+      const role = m.isBot ? "Junior (you)" : `User(${m.userName})`;
       let line = `${role}: ${m.text}`;
       if (m.fileNames.length > 0) {
         const fileNotes = m.fileNames.map((f) => `[shared image: ${f}]`).join(" ");


### PR DESCRIPTION
Slack mentions now resolve to display names in prompts and thread history. Only the bot's own @mention is stripped from incoming messages; other user mentions are preserved as context. Empty or NO_SLACK_MESSAGE responses are suppressed. Session verbosity defaults to quiet (SESSION_DEFAULT_VERBOSITY).