### PR TITLE
feat(dev-server): junior owns dev-server lifecycle (Scope-2a)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -6,6 +6,22 @@ export interface RepoConfig {
   defaultBase: string;
   /** Optional setup script for worktree creation. Run as `<repo.path>/<command> <worktreePath> <branch>`. */
   worktreeSetupCommand?: string;
+  /**
+   * Command to start the dev server (e.g. "pnpm dev", "npm run dev").
+   * Split on whitespace and passed directly to Bun.spawn — no shell.
+   * Leave unset for repos that don't run a dev server.
+   */
+  devCommand?: string;
+  /**
+   * Port the dev server listens on (e.g. 3000, 8000).
+   * Used for readiness probing and external-listener conflict detection.
+   */
+  devPort?: number;
+  /**
+   * URL junior curls to confirm the dev server is ready (expects HTTP 200).
+   * Defaults to http://localhost:<devPort> when unset.
+   */
+  readyUrl?: string;
 }
 
 export type SessionStoreKind = "memory" | "sqlite";

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { cleanupStaleSessions } from "./lifecycle/cleanup.ts";
 import { AgentRouter } from "./agents/router.ts";
 import { SupportRouter } from "./support/router.ts";
 import { WorktreeManager } from "./worktree/manager.ts";
+import { DevServerManager } from "./lifecycle/dev-server.ts";
 import { startMcpServer } from "./mcp/slack-server.ts";
 import { log } from "./logger.ts";
 
@@ -23,6 +24,7 @@ log.info("boot", `Session store: ${config.session.store}`);
 const sessionManager = new SessionManager(store, config);
 const agentRouter = new AgentRouter(config.repos, ".claude/agents");
 const worktreeManager = new WorktreeManager(config.repos);
+const devServerManager = new DevServerManager(config.repos, worktreeManager);
 startMcpServer(config.slack.botToken, store, worktreeManager);
 sessionManager.agentRouter = agentRouter;
 sessionManager.worktreeManager = worktreeManager;
@@ -114,7 +116,7 @@ sessionManager.onError = (session, error) => {
 
 registerHomeTab(app, store, config.session.homeWindowMs);
 
-setupGracefulShutdown(sessionManager, store);
+setupGracefulShutdown(sessionManager, store, devServerManager);
 
 // Periodic health checks
 setInterval(() => {
@@ -134,6 +136,10 @@ setInterval(() => {
 }, config.session.cleanupIntervalMs);
 
 (async () => {
+  // Bootstrap dev-server worktrees and check for external port conflicts before
+  // accepting any Slack events.
+  await devServerManager.bootstrap();
+
   await app.start();
 
   // Resolve bot identity before registering event handlers

--- a/src/index.ts
+++ b/src/index.ts
@@ -137,8 +137,17 @@ setInterval(() => {
 
 (async () => {
   // Bootstrap dev-server worktrees and check for external port conflicts before
-  // accepting any Slack events.
-  await devServerManager.bootstrap();
+  // accepting any Slack events. Failure here is non-fatal — log loudly and
+  // continue so other features keep working even if a single repo's worktree
+  // setup is broken (missing remote, dirty state, etc.).
+  try {
+    await devServerManager.bootstrap();
+  } catch (err) {
+    log.error(
+      "boot",
+      `dev-server bootstrap failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
 
   await app.start();
 

--- a/src/lifecycle/dev-server.test.ts
+++ b/src/lifecycle/dev-server.test.ts
@@ -25,7 +25,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { RepoConfig } from "../config.ts";
 import { WorktreeManager } from "../worktree/manager.ts";
-import { DevServerManager } from "./dev-server.ts";
+import { DevServerManager, resolveReadyUrl } from "./dev-server.ts";
 
 // ---------------------------------------------------------------------------
 // Helpers shared across suites
@@ -340,13 +340,27 @@ describe("DevServerManager (unit — logic paths)", () => {
     }
   });
 
-  it("resolves readyUrl from devPort when readyUrl is omitted", () => {
-    // Tested indirectly: DevServerInfo.readyUrl should equal http://localhost:<devPort>.
-    // We verify via the bootstrap path (no real spawn needed here since we
-    // only care about the URL derivation logic, exercised in integration tests).
-    // This is intentionally a placeholder that documents the expected behaviour —
-    // the integration test "ensure() spawns..." asserts readyUrl directly.
-    expect(`http://localhost:41234`).toBe(`http://localhost:${41_234}`);
+  it("resolveReadyUrl falls back to localhost:<devPort> when readyUrl is unset", () => {
+    expect(
+      resolveReadyUrl({
+        name: "x",
+        path: "/x",
+        defaultBase: "origin/main",
+        devPort: 41234,
+      }),
+    ).toBe("http://localhost:41234");
+  });
+
+  it("resolveReadyUrl prefers explicit readyUrl over devPort", () => {
+    expect(
+      resolveReadyUrl({
+        name: "x",
+        path: "/x",
+        defaultBase: "origin/main",
+        devPort: 41234,
+        readyUrl: "https://prod-like.local:8443/health",
+      }),
+    ).toBe("https://prod-like.local:8443/health");
   });
 
   it("status() returns all states when called without repoName", () => {
@@ -403,19 +417,8 @@ describe("DevServerManager (unit — logic paths)", () => {
 // ---------------------------------------------------------------------------
 
 describe("DevServerManager idle TTL (unit — timer injection)", () => {
-  it("idle sweeper kills a server whose lastUsedAt is past the TTL", async () => {
-    // We can't easily override the 20-minute TTL constant, so instead we
-    // directly manipulate the private state map to plant a stale entry with a
-    // known PID and verify the sweeper kills it.
-    //
-    // To make this deterministic without waiting real time, we access the
-    // manager's internal `state` map through its `status()` accessor and set
-    // `lastUsedAt` to a time far in the past, then trigger a manual sweep call
-    // by invoking the public `kill()` path the sweeper would use.
-    //
-    // This tests: the sweeper correctly identifies stale entries and calls kill().
-
-    // Spin up a real process to get a real PID to track.
+  it("sweepNow() detects and kills servers whose lastUsedAt is past the TTL", async () => {
+    // Real process to give us a PID to track.
     const sleepProc = Bun.spawn(["sleep", "30"], {
       stdout: "pipe",
       stderr: "pipe",
@@ -423,29 +426,29 @@ describe("DevServerManager idle TTL (unit — timer injection)", () => {
     const fakePid = sleepProc.pid;
     expect(isPidAlive(fakePid)).toBe(true);
 
-    const manager = new DevServerManager([], new WorktreeManager([]));
+    // 1 second TTL so we don't have to fake clock arithmetic.
+    const manager = new DevServerManager([], new WorktreeManager([]), {
+      idleTtlMs: 1_000,
+      sweepIntervalMs: 60_000,
+    });
     try {
-      // Inject a stale state entry directly via internal map exposure.
-      // We use a type cast since state is private — acceptable in test code.
+      // Plant a state entry with lastUsedAt 5 seconds in the past.
       (manager as unknown as { state: Map<string, unknown> }).state.set(
         "stale-repo",
         {
           pid: fakePid,
           branch: "main",
-          startedAt: Date.now() - 25 * 60 * 1_000,
-          lastUsedAt: Date.now() - 25 * 60 * 1_000, // 25 minutes ago → past 20-min TTL
+          startedAt: Date.now() - 5_000,
+          lastUsedAt: Date.now() - 5_000,
         },
       );
 
-      // Manually trigger what the sweeper would do: call kill() for the stale repo.
-      // In production the setInterval does this; here we call directly.
-      await manager.kill("stale-repo");
+      const killed = await manager.sweepNow();
+      expect(killed).toEqual(["stale-repo"]);
 
-      // The fake PID should now be dead.
       await waitFor(() => !isPidAlive(fakePid), 8_000);
       expect(isPidAlive(fakePid)).toBe(false);
     } finally {
-      // Clean up in case the test failed before killing.
       try {
         process.kill(fakePid, "SIGKILL");
       } catch {
@@ -454,4 +457,37 @@ describe("DevServerManager idle TTL (unit — timer injection)", () => {
       manager.dispose();
     }
   }, 15_000);
+
+  it("sweepNow() leaves fresh entries alone", async () => {
+    const sleepProc = Bun.spawn(["sleep", "30"], { stdout: "pipe", stderr: "pipe" });
+    const fakePid = sleepProc.pid;
+
+    // 60-second TTL — anything just-set is well within the window.
+    const manager = new DevServerManager([], new WorktreeManager([]), {
+      idleTtlMs: 60_000,
+      sweepIntervalMs: 60_000,
+    });
+    try {
+      (manager as unknown as { state: Map<string, unknown> }).state.set(
+        "fresh-repo",
+        {
+          pid: fakePid,
+          branch: "main",
+          startedAt: Date.now(),
+          lastUsedAt: Date.now(),
+        },
+      );
+
+      const killed = await manager.sweepNow();
+      expect(killed).toEqual([]);
+      expect(isPidAlive(fakePid)).toBe(true);
+    } finally {
+      try {
+        process.kill(fakePid, "SIGKILL");
+      } catch {
+        // already dead
+      }
+      manager.dispose();
+    }
+  }, 10_000);
 });

--- a/src/lifecycle/dev-server.test.ts
+++ b/src/lifecycle/dev-server.test.ts
@@ -1,0 +1,457 @@
+/**
+ * Tests for DevServerManager (Scope-2a).
+ *
+ * Unit tests: mock-inject spawn/fetch behaviour to verify logic paths without
+ *   spinning up real processes or git repos.
+ * Integration tests: real-fs, real-git, real spawn — a tiny shell-script dev
+ *   server that listens on a high-numbered port and exits cleanly on SIGINT.
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+} from "bun:test";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  chmodSync,
+  existsSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { RepoConfig } from "../config.ts";
+import { WorktreeManager } from "../worktree/manager.ts";
+import { DevServerManager } from "./dev-server.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers shared across suites
+// ---------------------------------------------------------------------------
+
+async function spawnRun(args: string[], cwd: string): Promise<void> {
+  const proc = Bun.spawn(args, {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const code = await proc.exited;
+  if (code !== 0) {
+    const err = await new Response(proc.stderr).text();
+    throw new Error(`${args.join(" ")} failed: ${err}`);
+  }
+}
+
+/** Wait up to `timeoutMs` for `predicate()` to return true. */
+async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs = 5_000,
+  intervalMs = 100,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await predicate()) return;
+    await Bun.sleep(intervalMs);
+  }
+  throw new Error("waitFor timed out");
+}
+
+/** Returns true if the given PID is still alive. */
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Integration test suite — real git repo + real shell "dev server"
+// ---------------------------------------------------------------------------
+
+describe("DevServerManager (integration)", () => {
+  let repoRoot: string;
+  let serverPort: number;
+  let repos: RepoConfig[];
+  let worktreeManager: WorktreeManager;
+
+  // Ports in the 40000–49999 range are unlikely to be in use.
+  // We pick a fixed one; if it's held the test will time out at bootstrap.
+  serverPort = 41_234;
+
+  beforeAll(async () => {
+    repoRoot = mkdtempSync(join(tmpdir(), "junior-ds-test-"));
+
+    // Init a minimal git repo with one commit on `main`.
+    await spawnRun(["git", "init", "-q", "-b", "main"], repoRoot);
+    await spawnRun(
+      ["git", "config", "user.email", "test@example.com"],
+      repoRoot,
+    );
+    await spawnRun(["git", "config", "user.name", "test"], repoRoot);
+    writeFileSync(join(repoRoot, "README.md"), "hello\n");
+    await spawnRun(["git", "add", "."], repoRoot);
+    await spawnRun(["git", "commit", "-q", "-m", "init"], repoRoot);
+
+    // A `fix` branch for branch-change tests.
+    await spawnRun(["git", "checkout", "-q", "-b", "fix/test"], repoRoot);
+    writeFileSync(join(repoRoot, "FIX.md"), "fix\n");
+    await spawnRun(["git", "add", "."], repoRoot);
+    await spawnRun(["git", "commit", "-q", "-m", "fix"], repoRoot);
+    await spawnRun(["git", "checkout", "-q", "main"], repoRoot);
+
+    // Point origin at ourselves so git fetch works inside worktrees.
+    await spawnRun(["git", "remote", "add", "origin", repoRoot], repoRoot);
+    await spawnRun(["git", "fetch", "-q", "origin"], repoRoot);
+
+    // Write a fake "dev server" using Node.js (always available alongside Bun).
+    // It listens on a high port, responds HTTP 200 to every request, and exits
+    // cleanly on SIGINT. No nc/socat needed — pure Node http module.
+    //
+    // IMPORTANT: the script must be committed to git so the worktree checkout
+    // includes it. After writing, commit and re-fetch so the dev-server worktree
+    // (created from origin/main) gets the script.
+    const serverScript = join(repoRoot, "fake-server.js");
+    writeFileSync(
+      serverScript,
+      `#!/usr/bin/env node
+const http = require('http');
+const port = parseInt(process.argv[2] || '${serverPort}', 10);
+const server = http.createServer((req, res) => {
+  res.writeHead(200);
+  res.end('ok');
+});
+server.listen(port, '127.0.0.1');
+process.on('SIGINT', () => { server.close(); process.exit(0); });
+process.on('SIGTERM', () => { server.close(); process.exit(0); });
+`,
+    );
+    chmodSync(serverScript, 0o755);
+    // Commit the script into git so the worktree picks it up.
+    await spawnRun(["git", "add", "fake-server.js"], repoRoot);
+    await spawnRun(["git", "commit", "-q", "-m", "add fake dev server"], repoRoot);
+    await spawnRun(["git", "fetch", "-q", "origin"], repoRoot);
+
+    repos = [
+      {
+        name: "test-repo",
+        path: repoRoot,
+        defaultBase: "origin/main",
+        devCommand: `node fake-server.js ${serverPort}`,
+        devPort: serverPort,
+      },
+    ];
+    worktreeManager = new WorktreeManager(repos);
+  });
+
+  afterAll(() => {
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it("bootstrap creates the dev-server worktree if it does not exist", async () => {
+    const manager = new DevServerManager(repos, worktreeManager);
+    try {
+      await manager.bootstrap();
+
+      const wtPath = worktreeManager.getWorktreePath("test-repo", "dev-server");
+      expect(existsSync(wtPath)).toBe(true);
+      expect(existsSync(join(wtPath, "README.md"))).toBe(true);
+    } finally {
+      manager.dispose();
+    }
+  });
+
+  it("bootstrap is idempotent — does not fail if worktree already exists", async () => {
+    const manager = new DevServerManager(repos, worktreeManager);
+    try {
+      // Second call after the first bootstrap already created the worktree.
+      await manager.bootstrap();
+      await manager.bootstrap();
+
+      const wtPath = worktreeManager.getWorktreePath("test-repo", "dev-server");
+      expect(existsSync(wtPath)).toBe(true);
+    } finally {
+      manager.dispose();
+    }
+  });
+
+  it("status() returns undefined when no server is tracked for a repo", () => {
+    const manager = new DevServerManager(repos, worktreeManager);
+    try {
+      expect(manager.status("test-repo")).toBeUndefined();
+    } finally {
+      manager.dispose();
+    }
+  });
+
+  it("kill() is idempotent when nothing is tracked", async () => {
+    const manager = new DevServerManager(repos, worktreeManager);
+    try {
+      await expect(manager.kill("test-repo")).resolves.toBeUndefined();
+    } finally {
+      manager.dispose();
+    }
+  });
+
+  it("ensure() spawns the dev server and returns pid/port/readyUrl", async () => {
+    const manager = new DevServerManager(repos, worktreeManager);
+    try {
+      const info = await manager.ensure("test-repo", "main");
+      expect(info.pid).toBeGreaterThan(0);
+      expect(info.port).toBe(serverPort);
+      expect(info.readyUrl).toBe(`http://localhost:${serverPort}`);
+      expect(isPidAlive(info.pid)).toBe(true);
+
+      const state = manager.status("test-repo") as
+        | import("./dev-server.ts").DevServerState
+        | undefined;
+      expect(state?.branch).toBe("main");
+      expect(state?.pid).toBe(info.pid);
+    } finally {
+      await manager.killAll();
+      manager.dispose();
+    }
+  }, 30_000);
+
+  it("ensure() reuses a warm server when branch matches", async () => {
+    const manager = new DevServerManager(repos, worktreeManager);
+    try {
+      const first = await manager.ensure("test-repo", "main");
+      const second = await manager.ensure("test-repo", "main");
+
+      // Same PID — no restart happened.
+      expect(second.pid).toBe(first.pid);
+    } finally {
+      await manager.killAll();
+      manager.dispose();
+    }
+  }, 30_000);
+
+  it("ensure() restarts the server when branch changes", async () => {
+    const manager = new DevServerManager(repos, worktreeManager);
+    try {
+      const first = await manager.ensure("test-repo", "main");
+      const firstPid = first.pid;
+
+      const second = await manager.ensure("test-repo", "fix/test");
+
+      // Different PID — server was restarted.
+      expect(second.pid).not.toBe(firstPid);
+      // First PID should be dead.
+      expect(isPidAlive(firstPid)).toBe(false);
+
+      const state = manager.status("test-repo") as
+        | import("./dev-server.ts").DevServerState
+        | undefined;
+      expect(state?.branch).toBe("fix/test");
+    } finally {
+      await manager.killAll();
+      manager.dispose();
+    }
+  }, 60_000);
+
+  it("kill() sends SIGINT and the process exits", async () => {
+    const manager = new DevServerManager(repos, worktreeManager);
+    try {
+      const info = await manager.ensure("test-repo", "main");
+      const pid = info.pid;
+      expect(isPidAlive(pid)).toBe(true);
+
+      await manager.kill("test-repo");
+
+      // Process should be dead.
+      await waitFor(() => !isPidAlive(pid), 8_000);
+      expect(isPidAlive(pid)).toBe(false);
+
+      // State should be cleared.
+      expect(manager.status("test-repo")).toBeUndefined();
+    } finally {
+      await manager.killAll();
+      manager.dispose();
+    }
+  }, 30_000);
+
+  it("killAll() kills every tracked server", async () => {
+    const manager = new DevServerManager(repos, worktreeManager);
+    try {
+      const info = await manager.ensure("test-repo", "main");
+      const pid = info.pid;
+      expect(isPidAlive(pid)).toBe(true);
+
+      await manager.killAll();
+      await waitFor(() => !isPidAlive(pid), 8_000);
+      expect(isPidAlive(pid)).toBe(false);
+    } finally {
+      manager.dispose();
+    }
+  }, 30_000);
+});
+
+// ---------------------------------------------------------------------------
+// Unit tests — verify logic paths without real processes or git repos
+// ---------------------------------------------------------------------------
+
+describe("DevServerManager (unit — logic paths)", () => {
+  it("throws when repo is unknown to ensure()", async () => {
+    const manager = new DevServerManager([], new WorktreeManager([]));
+    try {
+      await expect(manager.ensure("no-such-repo", "main")).rejects.toThrow(
+        /Unknown repo/,
+      );
+    } finally {
+      manager.dispose();
+    }
+  });
+
+  it("throws when devCommand is not configured", async () => {
+    const repos: RepoConfig[] = [
+      { name: "bare-repo", path: "/tmp/bare", defaultBase: "main" },
+    ];
+    const manager = new DevServerManager(repos, new WorktreeManager(repos));
+    try {
+      await expect(manager.ensure("bare-repo", "main")).rejects.toThrow(
+        /No devCommand/,
+      );
+    } finally {
+      manager.dispose();
+    }
+  });
+
+  it("throws when devCommand is set but neither devPort nor readyUrl is configured", async () => {
+    const repos: RepoConfig[] = [
+      {
+        name: "misconfigured",
+        path: "/tmp/misc",
+        defaultBase: "main",
+        devCommand: "pnpm dev",
+        // no devPort, no readyUrl
+      },
+    ];
+    const manager = new DevServerManager(repos, new WorktreeManager(repos));
+    try {
+      await expect(manager.ensure("misconfigured", "main")).rejects.toThrow(
+        /neither devPort nor readyUrl/,
+      );
+    } finally {
+      manager.dispose();
+    }
+  });
+
+  it("resolves readyUrl from devPort when readyUrl is omitted", () => {
+    // Tested indirectly: DevServerInfo.readyUrl should equal http://localhost:<devPort>.
+    // We verify via the bootstrap path (no real spawn needed here since we
+    // only care about the URL derivation logic, exercised in integration tests).
+    // This is intentionally a placeholder that documents the expected behaviour —
+    // the integration test "ensure() spawns..." asserts readyUrl directly.
+    expect(`http://localhost:41234`).toBe(`http://localhost:${41_234}`);
+  });
+
+  it("status() returns all states when called without repoName", () => {
+    const manager = new DevServerManager([], new WorktreeManager([]));
+    try {
+      const all = manager.status();
+      expect(all).toBeInstanceOf(Map);
+      expect((all as Map<string, unknown>).size).toBe(0);
+    } finally {
+      manager.dispose();
+    }
+  });
+
+  it("bootstrap() skips repos without devCommand", async () => {
+    const repos: RepoConfig[] = [
+      { name: "no-dev", path: "/tmp/no-dev", defaultBase: "main" },
+    ];
+    // Should complete without error even though the path doesn't exist,
+    // because repos without devCommand are skipped entirely.
+    const manager = new DevServerManager(repos, new WorktreeManager(repos));
+    try {
+      await expect(manager.bootstrap()).resolves.toBeUndefined();
+    } finally {
+      manager.dispose();
+    }
+  });
+
+  it("kill() is idempotent — second call after first is a no-op", async () => {
+    const repos: RepoConfig[] = [
+      { name: "idle-repo", path: "/tmp/idle", defaultBase: "main" },
+    ];
+    const manager = new DevServerManager(repos, new WorktreeManager(repos));
+    try {
+      // Kill with nothing tracked — should not throw.
+      await manager.kill("idle-repo");
+      await manager.kill("idle-repo");
+    } finally {
+      manager.dispose();
+    }
+  });
+
+  it("killAll() with no tracked servers completes without error", async () => {
+    const manager = new DevServerManager([], new WorktreeManager([]));
+    try {
+      await expect(manager.killAll()).resolves.toBeUndefined();
+    } finally {
+      manager.dispose();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Unit test: idle TTL sweeper kills idle servers
+// ---------------------------------------------------------------------------
+
+describe("DevServerManager idle TTL (unit — timer injection)", () => {
+  it("idle sweeper kills a server whose lastUsedAt is past the TTL", async () => {
+    // We can't easily override the 20-minute TTL constant, so instead we
+    // directly manipulate the private state map to plant a stale entry with a
+    // known PID and verify the sweeper kills it.
+    //
+    // To make this deterministic without waiting real time, we access the
+    // manager's internal `state` map through its `status()` accessor and set
+    // `lastUsedAt` to a time far in the past, then trigger a manual sweep call
+    // by invoking the public `kill()` path the sweeper would use.
+    //
+    // This tests: the sweeper correctly identifies stale entries and calls kill().
+
+    // Spin up a real process to get a real PID to track.
+    const sleepProc = Bun.spawn(["sleep", "30"], {
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const fakePid = sleepProc.pid;
+    expect(isPidAlive(fakePid)).toBe(true);
+
+    const manager = new DevServerManager([], new WorktreeManager([]));
+    try {
+      // Inject a stale state entry directly via internal map exposure.
+      // We use a type cast since state is private — acceptable in test code.
+      (manager as unknown as { state: Map<string, unknown> }).state.set(
+        "stale-repo",
+        {
+          pid: fakePid,
+          branch: "main",
+          startedAt: Date.now() - 25 * 60 * 1_000,
+          lastUsedAt: Date.now() - 25 * 60 * 1_000, // 25 minutes ago → past 20-min TTL
+        },
+      );
+
+      // Manually trigger what the sweeper would do: call kill() for the stale repo.
+      // In production the setInterval does this; here we call directly.
+      await manager.kill("stale-repo");
+
+      // The fake PID should now be dead.
+      await waitFor(() => !isPidAlive(fakePid), 8_000);
+      expect(isPidAlive(fakePid)).toBe(false);
+    } finally {
+      // Clean up in case the test failed before killing.
+      try {
+        process.kill(fakePid, "SIGKILL");
+      } catch {
+        // already dead
+      }
+      manager.dispose();
+    }
+  }, 15_000);
+});

--- a/src/lifecycle/dev-server.ts
+++ b/src/lifecycle/dev-server.ts
@@ -45,18 +45,51 @@ const IDLE_SWEEP_INTERVAL_MS = 60_000;
 /** Grace period for SIGINT before escalating to SIGKILL (ms). */
 const SIGINT_GRACE_MS = 5_000;
 
+export interface DevServerManagerOptions {
+  /** Override the 20-min idle TTL. Tests use this to drive the sweeper. */
+  idleTtlMs?: number;
+  /** Override the 60s sweep interval. Tests use this to drive the sweeper. */
+  sweepIntervalMs?: number;
+}
+
 export class DevServerManager {
   private repos: RepoConfig[];
   private worktreeManager: WorktreeManager;
   private state = new Map<string, DevServerState>();
   private sweepTimer: ReturnType<typeof setInterval> | null = null;
+  private idleTtlMs: number;
+  private sweepIntervalMs: number;
 
-  constructor(repos: RepoConfig[], worktreeManager?: WorktreeManager) {
+  constructor(
+    repos: RepoConfig[],
+    worktreeManager?: WorktreeManager,
+    opts: DevServerManagerOptions = {},
+  ) {
     this.repos = repos;
     // Allow callers to inject a WorktreeManager (tests do this). When running
     // in production the manager is always passed from index.ts.
     this.worktreeManager = worktreeManager ?? new WorktreeManager(repos);
+    this.idleTtlMs = opts.idleTtlMs ?? IDLE_TTL_MS;
+    this.sweepIntervalMs = opts.sweepIntervalMs ?? IDLE_SWEEP_INTERVAL_MS;
     this.startIdleTtlSweeper();
+  }
+
+  /**
+   * Run the idle-TTL sweep synchronously, once. Test hook so the
+   * detection logic in the sweeper body is exercisable without driving
+   * a 1-minute interval timer. Returns the names of repos whose dev
+   * servers were killed by this sweep.
+   */
+  async sweepNow(): Promise<string[]> {
+    const now = Date.now();
+    const killed: string[] = [];
+    for (const [repoName, s] of this.state) {
+      if (s.pid != null && now - s.lastUsedAt > this.idleTtlMs) {
+        killed.push(repoName);
+        await this.kill(repoName);
+      }
+    }
+    return killed;
   }
 
   /**
@@ -66,6 +99,18 @@ export class DevServerManager {
    *   process (if any) and start a fresh one.
    * - If the server is already running on the correct branch (and the PID is
    *   alive), bump `lastUsedAt` and return immediately.
+   *
+   * **RE-ENTRANCY PRECONDITION** — callers must serialize `ensure()` per repo.
+   * Two concurrent `ensure(repo, branch)` calls both miss the reuse branch,
+   * both run `git reset --hard`, and both call `Bun.spawn`. The second
+   * `state.set` orphans the first PID — it stays bound to the port forever
+   * with no in-memory handle to kill. Today the only caller is the (yet to
+   * land) Scope-2b lockfile path, which already serializes via
+   * `proper-lockfile`. If you add a second caller before the lock is wired,
+   * you MUST add per-repo serialization at the call site, OR build it into
+   * this method (an in-memory `Map<repoName, Promise<DevServerInfo>>` of
+   * in-flight calls would be the minimal fix). Do not assume callers are
+   * single-threaded just because nothing visibly races today.
    */
   async ensure(repoName: string, branch: string): Promise<DevServerInfo> {
     const repo = this.getRepoOrThrow(repoName);
@@ -252,14 +297,14 @@ export class DevServerManager {
     this.sweepTimer = setInterval(() => {
       const now = Date.now();
       for (const [repoName, s] of this.state) {
-        if (s.pid != null && now - s.lastUsedAt > IDLE_TTL_MS) {
+        if (s.pid != null && now - s.lastUsedAt > this.idleTtlMs) {
           log.info("dev-server", `idle TTL expired for repo=${repoName}; killing`);
           this.kill(repoName).catch((err) => {
             log.error("dev-server", `idle kill failed for repo=${repoName}: ${err}`);
           });
         }
       }
-    }, IDLE_SWEEP_INTERVAL_MS);
+    }, this.sweepIntervalMs);
 
     // Don't block process exit on the sweeper.
     if (this.sweepTimer.unref) {
@@ -330,7 +375,7 @@ export class DevServerManager {
 // Module-level helpers (no class dependency)
 // ---------------------------------------------------------------------------
 
-function resolveReadyUrl(repo: RepoConfig): string {
+export function resolveReadyUrl(repo: RepoConfig): string {
   if (repo.readyUrl) return repo.readyUrl;
   return `http://localhost:${repo.devPort}`;
 }

--- a/src/lifecycle/dev-server.ts
+++ b/src/lifecycle/dev-server.ts
@@ -1,0 +1,394 @@
+/**
+ * DevServerManager — Scope-2a
+ *
+ * Junior owns the lifecycle of dev servers that are used for bug-pipeline
+ * validation. Each repo with `devCommand` configured gets a single shared
+ * dev-server process running from a dedicated worktree at
+ * `<repo>/.claude/worktrees/slack-dev-server`.
+ *
+ * Scope-2b will layer the per-repo lock/queue on top; this module only handles
+ * spawn / probe / kill / idle-TTL.
+ */
+
+import { log } from "../logger.ts";
+import type { RepoConfig } from "../config.ts";
+import { WorktreeManager } from "../worktree/manager.ts";
+
+export interface DevServerState {
+  pid: number | null;
+  branch: string | null;
+  startedAt: number;
+  lastUsedAt: number;
+}
+
+export interface DevServerInfo {
+  pid: number;
+  port: number;
+  readyUrl: string;
+}
+
+/** Fixed thread-ID used for the per-repo dev-server worktree. */
+const DEV_SERVER_THREAD_ID = "dev-server";
+
+/** How long to poll readyUrl before giving up (ms). */
+const READY_TIMEOUT_MS = 90_000;
+
+/** How long between readiness poll attempts (ms). */
+const READY_POLL_INTERVAL_MS = 1_000;
+
+/** Idle TTL — kill dev server after this many ms with no `ensure()` call. */
+const IDLE_TTL_MS = 20 * 60 * 1_000;
+
+/** How often to check for idle servers (ms). */
+const IDLE_SWEEP_INTERVAL_MS = 60_000;
+
+/** Grace period for SIGINT before escalating to SIGKILL (ms). */
+const SIGINT_GRACE_MS = 5_000;
+
+export class DevServerManager {
+  private repos: RepoConfig[];
+  private worktreeManager: WorktreeManager;
+  private state = new Map<string, DevServerState>();
+  private sweepTimer: ReturnType<typeof setInterval> | null = null;
+
+  constructor(repos: RepoConfig[], worktreeManager?: WorktreeManager) {
+    this.repos = repos;
+    // Allow callers to inject a WorktreeManager (tests do this). When running
+    // in production the manager is always passed from index.ts.
+    this.worktreeManager = worktreeManager ?? new WorktreeManager(repos);
+    this.startIdleTtlSweeper();
+  }
+
+  /**
+   * Ensure the dev server for `repoName` is running on `branch`.
+   *
+   * - If no server is tracked, or the tracked branch differs, kill the current
+   *   process (if any) and start a fresh one.
+   * - If the server is already running on the correct branch (and the PID is
+   *   alive), bump `lastUsedAt` and return immediately.
+   */
+  async ensure(repoName: string, branch: string): Promise<DevServerInfo> {
+    const repo = this.getRepoOrThrow(repoName);
+    this.assertDevConfigured(repo);
+
+    const current = this.state.get(repoName);
+
+    if (current?.pid != null && current.branch === branch) {
+      if (isPidAlive(current.pid)) {
+        log.info("dev-server", `reuse repo=${repoName} branch=${branch} pid=${current.pid}`);
+        current.lastUsedAt = Date.now();
+        return this.makeInfo(repo, current.pid);
+      }
+      // PID is dead — fall through to restart
+      log.warn("dev-server", `tracked pid=${current.pid} for repo=${repoName} is dead; restarting`);
+    }
+
+    // Kill whatever is running (if anything) before switching branches.
+    await this.kill(repoName);
+
+    const worktreePath = this.worktreeManager.getWorktreePath(repoName, DEV_SERVER_THREAD_ID);
+
+    // Switch the dev-server worktree to the requested branch.
+    // We use `fetch + reset --hard origin/<branch>` rather than `git checkout`
+    // because `git checkout <branch>` fails when that branch is already checked
+    // out in another worktree (e.g. the bare repo on `main`). `reset --hard`
+    // moves the worktree's HEAD to the remote ref without touching branches in
+    // other worktrees. FETCH_HEAD is also tried as a fallback for local-only
+    // branches that have no upstream.
+    log.info("dev-server", `checkout repo=${repoName} branch=${branch} at ${worktreePath}`);
+    await runGit(["fetch", "origin"], worktreePath);
+    // Try to reset to the remote tracking branch. Fall back to local ref.
+    try {
+      await runGit(["reset", "--hard", `origin/${branch}`], worktreePath);
+    } catch {
+      // No upstream — try local ref (e.g. for branches only pushed as local).
+      await runGit(["reset", "--hard", branch], worktreePath);
+    }
+
+    // Spawn the dev server.
+    const cmdParts = (repo.devCommand as string).trim().split(/\s+/);
+    log.info("dev-server", `spawn repo=${repoName} cmd=${cmdParts.join(" ")} cwd=${worktreePath}`);
+    const proc = Bun.spawn(cmdParts, {
+      cwd: worktreePath,
+      stdout: "pipe",
+      stderr: "pipe",
+      // Don't inherit stdin — we don't want the process to block on stdin.
+    });
+
+    const pid = proc.pid;
+    const now = Date.now();
+    this.state.set(repoName, { pid, branch, startedAt: now, lastUsedAt: now });
+
+    // Poll readyUrl until HTTP 200 or timeout.
+    const readyUrl = resolveReadyUrl(repo);
+    await this.waitForReady(repoName, readyUrl, pid, proc);
+
+    log.info("dev-server", `ready repo=${repoName} branch=${branch} pid=${pid} url=${readyUrl}`);
+    return this.makeInfo(repo, pid);
+  }
+
+  /**
+   * Kill the dev server for `repoName`. Idempotent — no-op if nothing is
+   * tracked or the process is already dead.
+   */
+  async kill(repoName: string): Promise<void> {
+    const current = this.state.get(repoName);
+    if (!current?.pid) {
+      this.state.delete(repoName);
+      return;
+    }
+    const pid = current.pid;
+    // Clear state immediately so concurrent calls are idempotent.
+    this.state.delete(repoName);
+
+    if (!isPidAlive(pid)) {
+      log.info("dev-server", `kill repo=${repoName} pid=${pid} already dead`);
+      return;
+    }
+
+    log.info("dev-server", `kill repo=${repoName} pid=${pid} SIGINT`);
+    try {
+      process.kill(pid, "SIGINT");
+    } catch {
+      // Process may have just exited — that's fine.
+      return;
+    }
+
+    // Wait up to SIGINT_GRACE_MS for the process to exit gracefully.
+    const deadline = Date.now() + SIGINT_GRACE_MS;
+    while (Date.now() < deadline) {
+      await sleep(200);
+      if (!isPidAlive(pid)) {
+        log.info("dev-server", `kill repo=${repoName} pid=${pid} exited after SIGINT`);
+        return;
+      }
+    }
+
+    // Escalate to SIGKILL.
+    log.warn("dev-server", `kill repo=${repoName} pid=${pid} escalating to SIGKILL`);
+    try {
+      process.kill(pid, "SIGKILL");
+    } catch {
+      // Already dead.
+    }
+  }
+
+  /** Kill all tracked dev servers in parallel. Called during shutdown. */
+  async killAll(): Promise<void> {
+    const names = [...this.state.keys()];
+    await Promise.all(names.map((name) => this.kill(name)));
+  }
+
+  /** Return current state for diagnostics. Pass repoName to scope. */
+  status(repoName?: string): Map<string, DevServerState> | DevServerState | undefined {
+    if (repoName !== undefined) {
+      return this.state.get(repoName);
+    }
+    return new Map(this.state);
+  }
+
+  /**
+   * Bootstrap step: run once at junior startup.
+   *
+   * For each repo with `devCommand` configured:
+   *   1. Ensure the dev-server worktree exists (create via WorktreeManager if not).
+   *   2. Check if the configured port already has a listener that junior didn't
+   *      spawn. If so, refuse to spawn and log loudly.
+   */
+  async bootstrap(): Promise<void> {
+    for (const repo of this.repos) {
+      if (!repo.devCommand) continue;
+
+      // Step 1: ensure the dev-server worktree exists.
+      const exists = await this.worktreeManager.worktreeExists(repo.name, DEV_SERVER_THREAD_ID);
+      if (!exists) {
+        log.info("dev-server", `bootstrap: creating dev-server worktree for repo=${repo.name}`);
+        try {
+          await this.worktreeManager.createWorktree(
+            repo.name,
+            DEV_SERVER_THREAD_ID,
+            repo.defaultBase,
+            `dev-server-slot/${repo.name}`,
+          );
+          log.info("dev-server", `bootstrap: worktree created for repo=${repo.name}`);
+        } catch (err) {
+          log.error(
+            "dev-server",
+            `bootstrap: failed to create worktree for repo=${repo.name}: ${err instanceof Error ? err.message : String(err)}`,
+          );
+          // Non-fatal: dev-server usage will fail gracefully at ensure() time.
+        }
+      }
+
+      // Step 2: scan the configured port for external listeners.
+      if (repo.devPort != null) {
+        const held = await isPortHeld(repo.devPort);
+        if (held) {
+          log.error(
+            "dev-server",
+            `[dev-server] port ${repo.devPort} for ${repo.name} is held by something junior didn't spawn; skipping bootstrap.`,
+          );
+          // We intentionally do NOT kill it — it might be the human developer's
+          // own server. Scope-2b's lock acquire path will handle the conflict at
+          // validation time.
+        }
+      }
+    }
+  }
+
+  /** Tear down the sweeper timer. Call this when the process exits (for tests). */
+  dispose(): void {
+    if (this.sweepTimer != null) {
+      clearInterval(this.sweepTimer);
+      this.sweepTimer = null;
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------------------
+
+  private startIdleTtlSweeper(): void {
+    this.sweepTimer = setInterval(() => {
+      const now = Date.now();
+      for (const [repoName, s] of this.state) {
+        if (s.pid != null && now - s.lastUsedAt > IDLE_TTL_MS) {
+          log.info("dev-server", `idle TTL expired for repo=${repoName}; killing`);
+          this.kill(repoName).catch((err) => {
+            log.error("dev-server", `idle kill failed for repo=${repoName}: ${err}`);
+          });
+        }
+      }
+    }, IDLE_SWEEP_INTERVAL_MS);
+
+    // Don't block process exit on the sweeper.
+    if (this.sweepTimer.unref) {
+      this.sweepTimer.unref();
+    }
+  }
+
+  private async waitForReady(
+    repoName: string,
+    readyUrl: string,
+    expectedPid: number,
+    _proc: ReturnType<typeof Bun.spawn>,
+  ): Promise<void> {
+    const deadline = Date.now() + READY_TIMEOUT_MS;
+    let lastErr = "";
+
+    while (Date.now() < deadline) {
+      // Bail if the PID died before becoming ready.
+      if (!isPidAlive(expectedPid)) {
+        throw new Error(
+          `dev server for ${repoName} exited before becoming ready (url=${readyUrl})`,
+        );
+      }
+
+      try {
+        const res = await fetch(readyUrl, { signal: AbortSignal.timeout(2_000) });
+        if (res.ok) return;
+        lastErr = `HTTP ${res.status}`;
+      } catch (err) {
+        lastErr = err instanceof Error ? err.message : String(err);
+      }
+
+      await sleep(READY_POLL_INTERVAL_MS);
+    }
+
+    // Timed out — kill the orphan and throw.
+    await this.kill(repoName);
+    throw new Error(
+      `dev server for ${repoName} did not become ready within ${READY_TIMEOUT_MS / 1000}s (url=${readyUrl}, last error: ${lastErr})`,
+    );
+  }
+
+  private getRepoOrThrow(repoName: string): RepoConfig {
+    const repo = this.repos.find((r) => r.name === repoName);
+    if (!repo) throw new Error(`Unknown repo: ${repoName}`);
+    return repo;
+  }
+
+  private assertDevConfigured(repo: RepoConfig): void {
+    if (!repo.devCommand) {
+      throw new Error(`No devCommand configured for repo ${repo.name}`);
+    }
+    if (!repo.devPort && !repo.readyUrl) {
+      throw new Error(
+        `Repo ${repo.name} has devCommand but neither devPort nor readyUrl is set; cannot probe readiness`,
+      );
+    }
+  }
+
+  private makeInfo(repo: RepoConfig, pid: number): DevServerInfo {
+    const port = repo.devPort ?? 0;
+    const readyUrl = resolveReadyUrl(repo);
+    return { pid, port, readyUrl };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Module-level helpers (no class dependency)
+// ---------------------------------------------------------------------------
+
+function resolveReadyUrl(repo: RepoConfig): string {
+  if (repo.readyUrl) return repo.readyUrl;
+  return `http://localhost:${repo.devPort}`;
+}
+
+/** Send signal 0 to check if a PID is alive. Returns false if ESRCH. */
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/** Promise-based sleep. */
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Check if a TCP port is already bound by attempting a non-blocking connect
+ * via Node's `net` module.
+ *
+ * Works on both macOS and Linux without depending on external tools.
+ */
+async function isPortHeld(port: number): Promise<boolean> {
+  const net = await import("node:net");
+  return new Promise((resolve) => {
+    const socket = new net.Socket();
+    let settled = false;
+
+    const done = (held: boolean) => {
+      if (!settled) {
+        settled = true;
+        socket.destroy();
+        resolve(held);
+      }
+    };
+
+    socket.setTimeout(3_000);
+    socket.once("connect", () => done(true));
+    socket.once("error", () => done(false));
+    socket.once("timeout", () => done(false));
+    socket.connect(port, "127.0.0.1");
+  });
+}
+
+/** Run a git command in `cwd`. Throws on non-zero exit. */
+async function runGit(args: string[], cwd: string): Promise<string> {
+  const proc = Bun.spawn(["git", ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const exitCode = await proc.exited;
+  if (exitCode !== 0) {
+    const stderr = await new Response(proc.stderr).text();
+    throw new Error(`git ${args[0]} failed: ${stderr.trim()}`);
+  }
+  return await new Response(proc.stdout).text();
+}

--- a/src/lifecycle/shutdown.ts
+++ b/src/lifecycle/shutdown.ts
@@ -1,9 +1,11 @@
 import type { SessionManager } from "../session/manager.ts";
 import type { SessionStore } from "../session/store/interface.ts";
+import type { DevServerManager } from "./dev-server.ts";
 
 export function setupGracefulShutdown(
   manager: SessionManager,
   store: SessionStore,
+  devServerManager?: DevServerManager,
 ): void {
   const shutdown = async () => {
     console.log("Shutting down...");
@@ -21,6 +23,11 @@ export function setupGracefulShutdown(
         if (session.status === "busy") {
           kills.push(manager.resetSession(threadId));
         }
+      }
+
+      // Kill all managed dev servers in parallel with session teardown.
+      if (devServerManager) {
+        kills.push(devServerManager.killAll());
       }
 
       await Promise.all(kills);


### PR DESCRIPTION
## Summary

Scope-2a of the bug-pipeline worktree feature. Today reproducer phase-2 spawns \`pnpm dev\` itself and the child process leaks when the agent's turn ends; this PR moves dev-server lifecycle ownership from the agent to junior. Independently fixes the leaked-process bug, and is the prerequisite for Scope-2b's queue.

- New \`RepoConfig\` fields: \`devCommand?\`, \`devPort?\`, \`readyUrl?\`. Repos that don't run dev servers leave them unset.
- New \`DevServerManager\` (\`src/lifecycle/dev-server.ts\`): tracks \`{pid, branch, startedAt, lastUsedAt}\` per repo. Methods: \`bootstrap()\`, \`ensure(repo, branch)\`, \`kill(repo)\`, \`killAll()\`, \`status()\`. Idle TTL of 20 min sweeper started in constructor.
- \`bootstrap()\`: ensures the dev-server worktree at \`<repo>/.claude/worktrees/slack-dev-server\` exists for each repo with a \`devCommand\`; advisory port-conflict check via TCP probe; logs loudly without aborting if something else holds the port (Scope-2b's lock acquire path will surface it definitively).
- \`ensure()\` uses \`git fetch && git reset --hard origin/<branch>\` rather than \`checkout\` because checkout rejects when the target branch is checked out elsewhere (the bare repo). Falls back to local-only branches when no upstream.
- \`devCommand\` splits on whitespace via \`Bun.spawn\` (no shell) — handles \`"pnpm dev"\`, \`"npm run dev"\`, \`"bun run dev"\`. Shell-quoted commands not supported (deferred, JSDoc'd).
- Wired into junior boot: instantiated after \`WorktreeManager\` in \`src/index.ts\`, \`bootstrap()\` runs before \`app.start()\`, \`killAll()\` runs in graceful shutdown.

**Out of scope (deferred to Scope-2b):** \`proper-lockfile\` queue, \`!devserver\` directive, \`.lock\`/\`.queue\` files, prompt edits to reproducer/lead pointing at the directive. \`DevServerManager.ensure()\` is the wrap point for the lock acquire; Scope-2b will wrap it, not replace it.

Design doc: \`docs/features/bug-pipeline-worktrees.md\`.

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bun test\` — 202 pass / 0 fail (184 pre-existing + 18 new in \`dev-server.test.ts\`)
- [x] Scope-1's \`!repo\` flow untouched (no regression — single \`worktreePath\` path doesn't go through \`DevServerManager\`)
- [ ] Manual: junior boot logs the bootstrap step for each \`devCommand\` repo; conflicting listener triggers the loud warning
- [ ] Manual: graceful shutdown kills tracked dev-server PIDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)