### PR TITLE
feat(commands): add !mute and !unmute thread commands

### DIFF
--- a/docs/features/thread-commands.md
+++ b/docs/features/thread-commands.md
@@ -20,6 +20,8 @@ Users need to control thread behavior beyond just sending messages. Reset a brok
 - `!repo <name>` — Switch target repo for this thread
 - `!branch <ref>` — Set worktree base ref (next worktree creation uses this)
 - `!quiet` / `!normal` / `!verbose` — Set verbosity
+- `!mute` — Stop seeing or replying to any messages until `!unmute`
+- `!unmute` — Resume normal operation
 - `!help` — List available commands
 
 ## Design Decision: `!` prefix, not Slack slash commands

--- a/src/claude/args.test.ts
+++ b/src/claude/args.test.ts
@@ -19,6 +19,7 @@ function makeSession(overrides: Partial<ThreadSession> = {}): ThreadSession {
     status: "idle",
     pendingMessages: [],
     verbosity: "normal",
+    muted: false,
     model: null,
     cwd: null,
     pid: null,

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -82,6 +82,9 @@ export class SessionManager {
     this.rememberSeenMessage(dedupeKey);
 
     const session = await this.getOrCreateSession(event);
+
+    if (session.muted) return;
+
     const agentSession = this.getOrCreateAgentSession(session, agentName);
 
     if (agentSession.status === "busy") {
@@ -120,6 +123,8 @@ export class SessionManager {
       const handled = await this.handleCommand(session, event);
       if (handled) return;
     }
+
+    if (session.muted) return;
 
     if (session.status === "busy") {
       session.pendingMessages.push({
@@ -221,6 +226,8 @@ export class SessionManager {
           "`!verbose` — Verbose output",
           "`!adhoc <text>` — Add ad-hoc item to calendar",
           "`!bugs <text>` — Add bug item to calendar",
+          "`!mute` — Stop responding until !unmute",
+          "`!unmute` — Resume responding",
           "`!help` — Show this help",
         ].join("\n");
         this.onCommandResponse?.(event, helpText);
@@ -325,6 +332,20 @@ export class SessionManager {
           `4. Reply with a one-line confirmation.`,
         ].join("\n");
         return false;
+      }
+
+      case "mute": {
+        session.muted = true;
+        await this.store.set(session.threadId, session);
+        this.onCommandResponse?.(event, "Muted. I'll stop responding until you `!unmute`.");
+        return true;
+      }
+
+      case "unmute": {
+        session.muted = false;
+        await this.store.set(session.threadId, session);
+        this.onCommandResponse?.(event, "Unmuted.");
+        return true;
       }
 
       default:

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -199,6 +199,7 @@ export class SessionManager {
           : "never";
         const lines = [
           `*Status:* ${session.status}`,
+          `*Muted:* ${session.muted ? "yes" : "no"}`,
           `*Agent:* ${session.agentType ?? "default"}`,
           `*Repo:* ${session.targetRepo ?? "none"}`,
           `*Worktree:* ${session.worktreePath ?? "none"}`,
@@ -629,7 +630,17 @@ export class SessionManager {
       ? fresh.pendingMessages
       : (agentSession?.pendingMessages ?? []);
 
-    if (pendingMessages.length > 0) {
+    if (pendingMessages.length > 0 && fresh.muted) {
+      // Thread was muted mid-turn — discard buffered messages, don't drain.
+      if (isTopLevel) {
+        fresh.pendingMessages = [];
+        fresh.status = "idle";
+      } else if (agentSession) {
+        agentSession.pendingMessages = [];
+        agentSession.status = "idle";
+      }
+      await this.store.set(fresh.threadId, fresh);
+    } else if (pendingMessages.length > 0) {
       const combined = pendingMessages
         .map((m) => `[${m.user}]: ${m.text}`)
         .join("\n");

--- a/src/session/store/sqlite.ts
+++ b/src/session/store/sqlite.ts
@@ -191,5 +191,6 @@ function normalizeSession(session: ThreadSession): ThreadSession {
   session.agentSessions ??= {};
   // Migration: existing sessions before worktreePaths was added default to {}
   session.worktreePaths ??= {};
+  session.muted ??= false;
   return session;
 }

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -43,6 +43,7 @@ export interface ThreadSession {
   status: SessionStatus;
   pendingMessages: PendingMessage[];
   verbosity: SessionVerbosity;
+  muted: boolean;
   model: string | null;
   cwd: string | null;
   pid: number | null;
@@ -71,6 +72,7 @@ export function createSession(
     status: "idle",
     pendingMessages: [],
     verbosity: defaultVerbosity,
+    muted: false,
     model: null,
     cwd: null,
     pid: null,

--- a/src/slack/commands.ts
+++ b/src/slack/commands.ts
@@ -19,6 +19,8 @@ const KNOWN_COMMANDS = new Set([
   "help",
   "adhoc",
   "bugs",
+  "mute",
+  "unmute",
 ]);
 
 export interface ParsedCommand {


### PR DESCRIPTION
## Summary

- Adds `!mute` to silence a bot on a thread without resetting the session — all incoming messages are dropped silently until unmuted
- Adds `!unmute` to resume normal operation
- Mute check runs **after** command parsing so `!unmute` works even while muted
- `muted` field persists in SQLite via JSON blob; `??= false` in `normalizeSession` handles existing sessions

## Test plan

- [ ] `!mute` in active thread → bot acknowledges, subsequent messages get no response
- [ ] `!unmute` while muted → bot acknowledges and resumes responding
- [ ] `!status` while muted → still responds (commands bypass mute gate)
- [ ] Bot restart with muted session → mute persists (SQLite-backed)
- [ ] `!help` shows `!mute` and `!unmute` entries

🤖 Generated with [Claude Code](https://claude.ai/claude-code)