### PR TITLE
fix(slack): surface user IDs in thread context so Claude can tag people

### DIFF
--- a/src/slack/thread-context.ts
+++ b/src/slack/thread-context.ts
@@ -67,7 +67,7 @@ export async function resolveSlackMentions(
   let resolved = text;
   for (const match of matches) {
     const name = await resolveUserName(app, match[1]);
-    resolved = resolved.replace(match[0], `@${name}`);
+    resolved = resolved.replace(match[0], `@${name} (<@${match[1]}>)`);
   }
   return resolved;
 }
@@ -174,6 +174,7 @@ export async function buildPromptPreamble(
     `Thread: ${threadTs}`,
     `You are responding in this thread. You already have the full thread history below.`,
     `Do NOT use Slack search or read tools to find this thread — you already have all the context you need.`,
+    `To tag a user, use their Slack mention format \`<@USERID>\` (shown in thread history as \`User(Name <@USERID>)\`). Plain \`@Name\` does not notify them.`,
     ``,
     `If you decide this message does NOT need a reply (e.g. it's noise, already handled, or you've finished silent work), your final response must be exactly the sentinel \`${NO_SLACK_MESSAGE}\` and nothing else — no surrounding text, no explanation, no quotes. Anything else will be posted to the channel verbatim.`,
     ``,
@@ -239,7 +240,9 @@ async function fetchThreadHistory(
     if (messages.length === 0) return null;
 
     const lines = messages.map((m) => {
-      const role = m.isBot ? "Junior (you)" : `User(${m.userName})`;
+      const role = m.isBot
+        ? "Junior (you)"
+        : `User(${m.userName}${m.user !== "unknown" ? ` <@${m.user}>` : ""})`;
       let line = `${role}: ${m.text}`;
       if (m.fileNames.length > 0) {
         const fileNotes = m.fileNames.map((f) => `[shared image: ${f}]`).join(" ");

--- a/src/slack/thread-context.ts
+++ b/src/slack/thread-context.ts
@@ -64,12 +64,20 @@ export async function resolveSlackMentions(
   const matches = [...text.matchAll(mentionPattern)];
   if (matches.length === 0) return text;
 
-  let resolved = text;
-  for (const match of matches) {
-    const name = await resolveUserName(app, match[1]);
-    resolved = resolved.replace(match[0], `@${name} (<@${match[1]}>)`);
-  }
-  return resolved;
+  // Pre-resolve unique IDs in parallel, then replace in one pass.
+  // Single-pass replace (regex + callback) avoids re-matching inside prior
+  // replacements when the same user is mentioned more than once.
+  const uniqueIds = [...new Set(matches.map((m) => m[1]))];
+  const nameMap = new Map(
+    await Promise.all(
+      uniqueIds.map(async (id) => [id, await resolveUserName(app, id)] as const),
+    ),
+  );
+
+  return text.replace(mentionPattern, (_, userId: string) => {
+    const name = nameMap.get(userId) ?? userId;
+    return `@${name} (<@${userId}>)`;
+  });
 }
 
 export interface WorkspaceContext {


### PR DESCRIPTION
## Summary

- `resolveSlackMentions` now produces `@Name (<@USERID>)` instead of just `@Name` — Claude sees the Slack mention format in thread history and copies it
- Thread history prefixes now include the user ID: `User(Dash <@U12345>):` instead of `User(Dash):`
- Added a one-line preamble note: "To tag a user, use their Slack mention format `<@USERID>`"

**Root cause:** Thread context stripped `<@USERID>` → `@Name` before sending to Claude, leaving the model with no source for user IDs. Claude wrote plain `@Name` in responses, which Slack does not convert to a real mention/notification.

## Test plan

- [ ] Send a message in a thread — reply should use `<@USERID>` format when mentioning participants (renders as a real Slack tag)
- [ ] Verify thread history still reads naturally (display names still present alongside IDs)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)