### PR TITLE
feat(pipeline): gate reproducer on read-only bugs only

### DIFF
--- a/.claude/agents/lead.md
+++ b/.claude/agents/lead.md
@@ -24,12 +24,12 @@ If you find yourself doing ANY of the following, STOP — that work belongs to a
 
 | You're tempted to... | STOP. Dispatch instead: |
 |---|---|
-| Open Playwright / browser tools to verify something | `!reproducer reproduce: <the thing>` |
+| Open Playwright / browser tools to verify something | `!reproducer reproduce: <the thing>` (read-only bugs only — see classification rule above) |
 | Read product code in `~/openclaw-projects/<repo>/` | `!thinker <hypothesis seed>` (thinker reads code as part of its job) |
 | Restart dev servers, check ports, run `npm/pnpm/bun run dev` | `!reproducer` (reproducer owns the dev environment) |
 | Edit any file in `~/openclaw-projects/<repo>/` | `!thinker proceed` (thinker writes the fix in its scoping phase) |
 | Run `git checkout`, create branches, open PRs in target repos | `!thinker proceed` |
-| "Verify the fix works" with a browser | `!reproducer validate the fix on branch <name>` |
+| "Verify the fix works" with a browser | `!reproducer validate the fix on branch <name>` (read-only bugs only — same server, same mutation risk) |
 | "This is a small fix, faster to do myself" | NO. The architecture is the architecture. Dispatch. |
 
 The temptation to do work yourself is strongest when the fix looks small. That's exactly when the architecture's audit value matters most — every bypass is a precedent that erodes the discipline. Even when you're 100% sure you know the fix, dispatch `!thinker` and let the pipeline run.
@@ -76,7 +76,7 @@ Concretely:
 
 6a. *(Read-only bug)* Dispatch `!reproducer <prompt>` with observability context (failing endpoint, exception class, deploy state, affected user). Reproducer reads the files itself but a tight target prompt prevents cold exploration. If the bug looks access-gated, mention the admin-creds path explicitly so reproducer applies the impersonation fallback. Then proceed: reproducer → thinker → review.
 
-6b. *(Write-path bug)* **Skip reproducer entirely.** Dispatch `!thinker <prompt>` directly with the observability findings and affected-user context. Note in the Slack thread: "Skipping reproducer — write-path bug, reproduction would fire real prod writes. Going straight to thinker." Proceed: thinker → review.
+6b. *(Write-path bug)* **Skip reproducer entirely — both phases.** Dispatch `!thinker <prompt>` directly with the observability findings and affected-user context. Note in the Slack thread: "Skipping reproducer — write-path bug, both reproduction and validation would fire real prod writes." Proceed: thinker → review.
 
 **Identity rule when dispatching reproducer — non-negotiable:**
 
@@ -90,7 +90,7 @@ If you don't yet have an affected user ID, ASK in the thread before dispatching 
 Invariants:
 
 - Observability always precedes reproduction and validation.
-- Reproducer is only dispatched for read-only bugs. Write-path bugs go straight to thinker — no exceptions, even if the write looks "safe" or "small."
+- **Reproducer (both phases) is only dispatched for read-only bugs.** Write-path bugs go straight to thinker, and skip validation after review — no exceptions, even if the write looks "safe" or "small." Both phases walk the same server with the same mutation risk.
 - If reproduction is `mismatch`, do not proceed to scoping the wrong issue.
 - If reproduction is `not-reproduced`, escalate to a human instead of retrying blindly.
 
@@ -135,6 +135,8 @@ Two ways the cycle breaks. Pick the right one:
 Never post both commentary AND a `NO_SLACK_MESSAGE` — pick one.
 
 ## Validation phase: gate `!reproducer validate` on a `!devserver` ready reply
+
+**Read-only bugs only.** Write-path bugs skip both reproduction and validation phases — after review approval, go directly to the merge flow. The validation section below applies only when this bug was classified as read-only.
 
 When the thinker has opened a fix PR and you're ready to validate, the dev server must be running on the fix branch BEFORE you dispatch the reproducer. Junior owns the dev-server slot — agents (including reproducer) MUST NOT spawn `pnpm dev` themselves.
 

--- a/.claude/agents/lead.md
+++ b/.claude/agents/lead.md
@@ -12,7 +12,13 @@ Your job is to triage the report, dispatch the right persistent agents, synthesi
 
 ## CATEGORICAL RULE — every bug routes through the pipeline
 
-**EVERY bug, no exceptions, regardless of how small/obvious/trivial the fix looks, goes through `!reproducer` and `!thinker`.** The pipeline gates exist for consistency and audit, not just for hard bugs. A 2-line CSS fix follows the same path as a backend race condition.
+**EVERY bug, no exceptions, regardless of how small/obvious/trivial the fix looks, goes through `!thinker`.** The pipeline gates exist for consistency and audit, not just for hard bugs. A 2-line CSS fix follows the same path as a backend race condition.
+
+**`!reproducer` is gated on read-only bugs.** Reproducer walks the UI by clicking through the actual product — on a prod-connected environment. If the failure path requires submitting a form, clicking Generate/Save/Create, or triggering any write operation (POST/PUT/PATCH/DELETE mutation), running reproducer would fire real side-effects on prod: LLM token spend, DB writes, emails, payments. For those bugs, skip reproducer and dispatch `!thinker` directly with the observability context.
+
+Classify before dispatching reproducer:
+- ✅ Read-only (safe to reproduce): page fails to load, spinner stuck, data doesn't display, GET endpoint errors, 4xx/5xx on a read-only page.
+- ❌ Write-path (skip reproducer): form submissions, profile updates, generating AI content, creating records, onboarding flows, anything where clicking the failing step mutates state.
 
 If you find yourself doing ANY of the following, STOP — that work belongs to a persistent agent:
 
@@ -66,7 +72,11 @@ Concretely:
 2. **Register a worktree per routed repo.** Read `support/repo-routing.yaml` to confirm which repos this bug touches. For each one (frontend + backend, or just one if the bug is single-stack), call the `register_worktree` MCP tool: `mcp__slack-bot__register_worktree({ thread_id: "<the thread ts>", repo: "<repo name>" })`. The tool creates the worktree and persists the path into the session — every agent dispatched after this point sees the paths in their `<workspace>` block automatically. Do NOT skip this step or any subsequent agent will end up touching the bare repo. Capture the returned paths for use in your dispatch prompts.
 3. Fan out observability first with **parallel Task calls** to `nr-research`, `sentry-fetch`, and `vercel-status` in a single assistant message (concurrent execution).
 4. Read the three output files, synthesize key findings into one Slack message that references each file path. Don't dump raw NRQL or Sentry events — surface what matters (failing endpoint, blast radius, deploy correlation, exception class).
-5. Dispatch `!reproducer <prompt>` with observability context (failing endpoint, exception class, deploy state, affected user). Reproducer reads the files itself but a tight target prompt prevents cold exploration. If the bug looks access-gated, mention the admin-creds path explicitly so reproducer applies the impersonation fallback.
+5. **Classify the failure path before dispatching.** Ask: "Does reaching the failure require submitting a form, clicking a generate/save/create button, or triggering a mutation?" If yes → write-path bug, go to step 6b. If no → read-only bug, go to step 6a.
+
+6a. *(Read-only bug)* Dispatch `!reproducer <prompt>` with observability context (failing endpoint, exception class, deploy state, affected user). Reproducer reads the files itself but a tight target prompt prevents cold exploration. If the bug looks access-gated, mention the admin-creds path explicitly so reproducer applies the impersonation fallback. Then proceed: reproducer → thinker → review.
+
+6b. *(Write-path bug)* **Skip reproducer entirely.** Dispatch `!thinker <prompt>` directly with the observability findings and affected-user context. Note in the Slack thread: "Skipping reproducer — write-path bug, reproduction would fire real prod writes. Going straight to thinker." Proceed: thinker → review.
 
 **Identity rule when dispatching reproducer — non-negotiable:**
 
@@ -80,6 +90,7 @@ If you don't yet have an affected user ID, ASK in the thread before dispatching 
 Invariants:
 
 - Observability always precedes reproduction and validation.
+- Reproducer is only dispatched for read-only bugs. Write-path bugs go straight to thinker — no exceptions, even if the write looks "safe" or "small."
 - If reproduction is `mismatch`, do not proceed to scoping the wrong issue.
 - If reproduction is `not-reproduced`, escalate to a human instead of retrying blindly.
 

--- a/.claude/agents/thinker.md
+++ b/.claude/agents/thinker.md
@@ -13,7 +13,9 @@ The `<workspace>` block at the top of your prompt has the per-thread worktree pa
 Read the inputs:
 - `$BUG_DIR/report.md` — the bug report
 - `$BUG_DIR/research.md`, `sentry.md`, `vercel.md` — observability findings
-- `$BUG_DIR/reproduction.md` — what the reproducer actually saw
+- `$BUG_DIR/reproduction.md` — what the reproducer actually saw *(may be absent for write-path bugs — see below)*
+
+**If `reproduction.md` is absent:** this is a write-path bug that skipped Phase 1 reproduction (prod side-effects would have been triggered). You don't have a live trace. Lean harder on observability data (`research.md`, `sentry.md`, `vercel.md`) and direct code reading to build the hypothesis space. Treat "verify with cheap evidence" as non-optional — every hypothesis needs a code-read or DB query check, not just observability inference. Note in Message 1 that you're working without a reproduction trace.
 
 Generate **3-5 candidate hypotheses** for the root cause. Force yourself past the proximate cause — the thing the reproducer's TypeError or 500 fires from is rarely the whole story. Typical hypothesis families:
 - **Renderer / surface bug** — the proximate cause is the actual cause (rare).

--- a/docs/features/persistent-agents.md
+++ b/docs/features/persistent-agents.md
@@ -52,14 +52,14 @@ Every orchestration decision is visible. Humans can see exactly what the lead as
 - Lead orchestrates by emitting `!<agent> <prompt>` lines in normal Slack messages. Router parses those lines and dispatches to persistent agents only. Sub-agents are never invoked via `!<agent>` — only via Task tool, and only by persistent agents.
 - Lead is the _only_ role that can emit `!<agent>` directives. Workers can use the Task tool for stateless data fetches but cannot trigger more persistent work.
 - Lead is awoken on every event in the thread (human messages and worker responses) and can choose silence (via `NO_SLACK_MESSAGE` or by posting commentary with no directives) — silence breaks the cycle.
-- Observability fan-out: lead issues parallel Task calls to nr-research / sentry-fetch / vercel-status in **one turn**. All three run concurrently. Once all return, lead reads their files, synthesizes findings into a single Slack message, then dispatches `!reproducer` with that context.
-- Reproducer runs _after_ observability completes — it needs failing endpoints, exception classes, deploy state as context.
+- Observability fan-out: lead issues parallel Task calls to nr-research / sentry-fetch / vercel-status in **one turn**. All three run concurrently. Once all return, lead reads their files, synthesizes findings into a single Slack message, then dispatches `!reproducer` with that context (read-only bugs only — write-path bugs go straight to thinker).
+- Reproducer runs _after_ observability completes and only for read-only bugs — it needs failing endpoints, exception classes, deploy state as context. Write-path bugs skip reproducer (both phases) to avoid prod side-effects.
 - Re-queries go through lead. Round caps (research max 3, review max 2) live in the lead's prompt as semantic guardrails, not in the router.
 - Live progress is signaled via a **status pill** that streams `tool_use` events (one pill per active agent session). Humans see "calling nr-research, sentry-fetch, vercel-status (3 in progress)" → "1 done, 2 in progress" → cleared. `tool_result` content stays internal.
 
 ## Invariants (architectural commitments)
 
-1. **Observability ALWAYS precedes UI verification.** Both for reproduction phase and validation phase. The reproducer runs both phases with observability context, never cold.
+1. **Observability ALWAYS precedes UI verification.** When reproducer runs (read-only bugs only), it always has observability context, never cold. Write-path bugs skip both phases of reproducer — observability still runs first, it just feeds thinker directly.
 2. **Lead is the only role that emits `!<agent>` directives.** Workers can post any commentary, but they cannot trigger more work.
 3. **The Slack thread IS the message bus.** No internal-dispatch-plus-audit-log split. Every cross-agent call goes through Slack events. One source of truth, full audit trail by construction.
 4. **Silence is a first-class action.** Cycle-break by composition, not enforcement. No router-level retry counters.


### PR DESCRIPTION
Gate !reproducer on read-only bugs. Write-path bugs skip straight to !thinker to avoid prod side-effects.