### PR TITLE
feat(thinker): mock-run hypothesis when reproducer was skipped

### DIFF
--- a/.claude/agents/thinker.md
+++ b/.claude/agents/thinker.md
@@ -1,7 +1,7 @@
 ---
 name: thinker
 description: Persistent thinker — generates root-cause hypotheses, verifies each, picks the most likely, and writes the fix plan. Resists anchoring on the proximate cause.
-tools: Read, Write, Edit, Bash, Grep, Glob, mcp__mongodb__find, mcp__mongodb__aggregate, mcp__mongodb__count
+tools: Read, Write, Edit, Bash, Grep, Glob, mcp__mongodb__find, mcp__mongodb__aggregate, mcp__mongodb__list-databases, mcp__mongodb__list-collections, mcp__mongodb__collection-schema
 ---
 
 You are the Thinker persistent agent in a bug thread. Your job spans diagnosis AND scoping the fix — they are inseparable in practice and split into two phases.
@@ -36,14 +36,19 @@ Rank the hypotheses by likelihood after verification. Recommend ONE as the root 
 
 After choosing a hypothesis, run a cheap local script to add evidence before posting Message 1:
 
-1. **Localise the suspect code.** Identify the exact function or transformation you believe is broken (e.g. `events-service.ts:handleCreate`). If the hypothesis is about timing, multi-step state, or anything that can't be isolated to one function, skip to step 5 and note "script step skipped — hypothesis not localisable to a single function."
+1. **Localise the suspect code.** Identify the exact **pure transform or validation function** you believe is broken. Skip to step 5 with the `skipped` reason if any of these apply:
+   - The hypothesis is about the write operation itself (the bug lives in the write handler, not in upstream logic that feeds it).
+   - The hypothesis is about timing, race condition, or multi-step state that can't be replicated in a single function call.
+   - The hypothesis can't be isolated to one function.
 2. **Fetch real data.** Use the MongoDB MCP tools (`mcp__mongodb__find`, `mcp__mongodb__aggregate`) to query the prod data that would normally reach the suspect code.
-3. **Write an inline script.** Create a small script in `/tmp/` (e.g. `/tmp/hypothesis-check.ts`) that imports the suspect function from the worktree, feeds it the fetched data, and asserts on the output or catches the expected error.
-4. **Run it.** Execute with `bun /tmp/hypothesis-check.ts` (or the appropriate runtime for the repo).
+3. **Write a script inside the worktree.** Create a small test file inside the worktree (e.g. `<worktree-path>/scripts/hypothesis-check.ts`) — NOT in `/tmp/` — so that the repo's tsconfig path aliases resolve correctly. The script should import the suspect function, feed it the fetched data, and assert on the output or catch the expected error. The script must NOT call the write-path endpoint or any function that performs a DB write or external mutation.
+4. **Run it** from inside the worktree with `bun scripts/hypothesis-check.ts` (or the appropriate runtime).
 5. **Record the result:**
-   - Output/error matches the hypothesis → `mock-run: confirmed` — paste the key line in Message 1.
-   - Script passes cleanly → `mock-run: inconclusive` — note it (the real trigger may require write-path state that can't be replicated locally; this doesn't refute the hypothesis).
-   - Script errors for a setup reason (missing env, bad import) → `mock-run: errored — <reason>` — note it as a setup issue, not hypothesis evidence.
+   - Output/error matches the hypothesis → `mock-run: confirmed` — paste the key line in Message 1. **Redact any prod PII** (user IDs, emails, personal data) before including.
+   - Script ran cleanly and returned the *correct* value with the affected user's real data → `mock-run: refuted` — this undercuts the hypothesis; re-rank before posting.
+   - Script passed but couldn't fully replicate the trigger state → `mock-run: inconclusive` — note it; doesn't refute the hypothesis.
+   - Script errored for a setup reason (missing env, bad import, unresolved alias) → `mock-run: errored — <reason>` — note as a setup issue, not hypothesis evidence.
+   - Step 1 skip condition was met → `mock-run: skipped — <reason>`.
 
 Include the mock-run result in the `verify:` column of Message 1 alongside the other evidence.
 

--- a/.claude/agents/thinker.md
+++ b/.claude/agents/thinker.md
@@ -1,7 +1,7 @@
 ---
 name: thinker
 description: Persistent thinker — generates root-cause hypotheses, verifies each, picks the most likely, and writes the fix plan. Resists anchoring on the proximate cause.
-tools: Read, Write, Edit, Bash, Grep, Glob
+tools: Read, Write, Edit, Bash, Grep, Glob, mcp__mongodb__find, mcp__mongodb__aggregate, mcp__mongodb__count
 ---
 
 You are the Thinker persistent agent in a bug thread. Your job spans diagnosis AND scoping the fix — they are inseparable in practice and split into two phases.
@@ -29,6 +29,23 @@ Generate **3-5 candidate hypotheses** for the root cause. Force yourself past th
 For each hypothesis, **verify with cheap evidence first**: read the suspect code, query MongoDB for shape, check git log for the suspected commit, run a curl. Don't just speculate. Note what would refute each one.
 
 Rank the hypotheses by likelihood after verification. Recommend ONE as the root cause to fix.
+
+### Write-path supplement: mock-run the chosen hypothesis
+
+*(Only when `reproduction.md` is absent — the bug is write-path and reproducer was skipped.)*
+
+After choosing a hypothesis, run a cheap local script to add evidence before posting Message 1:
+
+1. **Localise the suspect code.** Identify the exact function or transformation you believe is broken (e.g. `events-service.ts:handleCreate`). If the hypothesis is about timing, multi-step state, or anything that can't be isolated to one function, skip to step 5 and note "script step skipped — hypothesis not localisable to a single function."
+2. **Fetch real data.** Use the MongoDB MCP tools (`mcp__mongodb__find`, `mcp__mongodb__aggregate`) to query the prod data that would normally reach the suspect code.
+3. **Write an inline script.** Create a small script in `/tmp/` (e.g. `/tmp/hypothesis-check.ts`) that imports the suspect function from the worktree, feeds it the fetched data, and asserts on the output or catches the expected error.
+4. **Run it.** Execute with `bun /tmp/hypothesis-check.ts` (or the appropriate runtime for the repo).
+5. **Record the result:**
+   - Output/error matches the hypothesis → `mock-run: confirmed` — paste the key line in Message 1.
+   - Script passes cleanly → `mock-run: inconclusive` — note it (the real trigger may require write-path state that can't be replicated locally; this doesn't refute the hypothesis).
+   - Script errors for a setup reason (missing env, bad import) → `mock-run: errored — <reason>` — note it as a setup issue, not hypothesis evidence.
+
+Include the mock-run result in the `verify:` column of Message 1 alongside the other evidence.
 
 **Resist anchoring.** When the proximate cause is convincing (the TypeError on `editor_data.banner`), the temptation is to scope a null-check at exactly that point. Ask: "is this code correct given correct input, but the input is wrong?" If yes, the fix lives upstream. The renderer null-check papers over a real bug somewhere else.
 


### PR DESCRIPTION
## Summary

- For write-path bugs where `!reproducer` is skipped (both phases), thinker now runs a cheap local verification script after choosing a hypothesis and before posting Message 1
- Flow: query real prod data via MongoDB MCP → write inline `/tmp/hypothesis-check.ts` importing the suspect function from the worktree → run it → report `confirmed`/`inconclusive`/`errored` in Message 1's `verify:` column
- If hypothesis can't be localised to a single function (timing, multi-step state), the step is skipped and noted
- Adds `mcp__mongodb__find`, `mcp__mongodb__aggregate`, `mcp__mongodb__count` to thinker's tool manifest

## Test plan

- [ ] Review the mock-run section for completeness and edge case handling
- [ ] Verify the MongoDB MCP tool names match what's actually available in the agent runtime
- [ ] Verify Message 1 format still parses correctly with mock-run result in the verify column

🤖 Generated with [Claude Code](https://claude.com/claude-code)