### PR TITLE
fix(worktree): always fetch + create worktree in manager; single-arg setup hook

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,10 +5,11 @@ export interface RepoConfig {
   path: string;
   defaultBase: string;
   /**
-   * Optional post-create hook. Junior creates the worktree itself
-   * (`git fetch` + `git worktree add`); if set, this is invoked afterward as
-   * `<repo.path>/<command> <abs-worktree-path>`. Use for env-file copying,
-   * dependency install, MCP migration.
+   * Optional. When set, Junior delegates worktree creation to this script via
+   * `<repo.path>/<command> <branch> <abs-target-path>`. The script must
+   * `git fetch`, `git worktree add` at the given path, and perform setup
+   * (env copy, install, MCPs). When unset, Junior runs
+   * `git fetch origin --prune` and `git worktree add` inline (no setup hook).
    */
   worktreeSetupCommand?: string;
   /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -6,10 +6,13 @@ export interface RepoConfig {
   defaultBase: string;
   /**
    * Optional. When set, Junior delegates worktree creation to this script via
-   * `<repo.path>/<command> <branch> <abs-target-path>`. The script must
-   * `git fetch`, `git worktree add` at the given path, and perform setup
-   * (env copy, install, MCPs). When unset, Junior runs
-   * `git fetch origin --prune` and `git worktree add` inline (no setup hook).
+   * `<repo.path>/<command> <branch> --path <abs> [--base <ref>]`. The script
+   * must `git fetch`, `git worktree add` at the given path, and perform setup
+   * (env copy, install, MCPs). `--base <ref>` is forwarded only when the
+   * caller passes an explicit `baseRef` to `createWorktree`; when unset, the
+   * script applies its own per-repo default (e.g., local HEAD or
+   * `origin/main`). When unset, Junior runs `git fetch origin --prune` and
+   * `git worktree add` inline (no setup hook).
    */
   worktreeSetupCommand?: string;
   /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,12 @@ export interface RepoConfig {
   name: string;
   path: string;
   defaultBase: string;
-  /** Optional setup script for worktree creation. Run as `<repo.path>/<command> <worktreePath> <branch>`. */
+  /**
+   * Optional post-create hook. Junior creates the worktree itself
+   * (`git fetch` + `git worktree add`); if set, this is invoked afterward as
+   * `<repo.path>/<command> <abs-worktree-path>`. Use for env-file copying,
+   * dependency install, MCP migration.
+   */
   worktreeSetupCommand?: string;
   /**
    * Command to start the dev server (e.g. "pnpm dev", "npm run dev").

--- a/src/config.ts
+++ b/src/config.ts
@@ -8,11 +8,13 @@ export interface RepoConfig {
    * Optional. When set, Junior delegates worktree creation to this script via
    * `<repo.path>/<command> <branch> --path <abs> [--base <ref>]`. The script
    * must `git fetch`, `git worktree add` at the given path, and perform setup
-   * (env copy, install, MCPs). `--base <ref>` is forwarded only when the
-   * caller passes an explicit `baseRef` to `createWorktree`; when unset, the
-   * script applies its own per-repo default (e.g., local HEAD or
-   * `origin/main`). When unset, Junior runs `git fetch origin --prune` and
-   * `git worktree add` inline (no setup hook).
+   * (env copy, install, MCPs). Junior always forwards `--base <ref>`,
+   * defaulting to `repo.defaultBase` when the caller doesn't override —
+   * Junior worktrees are reproducible from a known ref, never from whatever
+   * the local checkout happens to be on. Manual users can omit `--base` to
+   * fall back to the script's per-repo default. When `worktreeSetupCommand`
+   * is unset, Junior runs `git fetch origin --prune` and `git worktree add`
+   * inline (no setup hook).
    */
   worktreeSetupCommand?: string;
   /**

--- a/src/worktree/manager.test.ts
+++ b/src/worktree/manager.test.ts
@@ -209,6 +209,8 @@ describe("WorktreeManager.createWorktree", () => {
       "slack/custom-thread",
       "--path",
       join(repoRoot, ".claude/worktrees/slack-custom-thread"),
+      "--base",
+      "origin/main",
     ]);
     expect(wtPath).toBe(
       join(repoRoot, ".claude/worktrees/slack-custom-thread"),
@@ -254,7 +256,7 @@ describe("WorktreeManager.createWorktree", () => {
     await wm.removeWorktree("delegate-baseref", "delegate-baseref-thread");
   });
 
-  it("does NOT forward --base when baseRef is unset", async () => {
+  it("forwards repo.defaultBase as --base when baseRef is unset", async () => {
     const repos: RepoConfig[] = [
       {
         name: "delegate-no-baseref",
@@ -271,9 +273,9 @@ describe("WorktreeManager.createWorktree", () => {
 
     const markerText = await Bun.file(setupMarker).text();
     const args = markerText.split("\n").filter((l) => l.length > 0);
-    expect(args).not.toContain("--base");
-    // And specifically: only branch + --path + path, nothing extra.
-    expect(args.length).toBe(3);
+    expect(args).toContain("--base");
+    expect(args).toContain("origin/main");
+    expect(args.length).toBe(5);
 
     await wm.removeWorktree("delegate-no-baseref", "no-baseref-thread");
   });
@@ -421,7 +423,7 @@ describe("WorktreeManager.createWorktree", () => {
     const args = (await Bun.file(setupMarker).text())
       .split("\n")
       .filter((l) => l.length > 0);
-    expect(args).toEqual(["fix/delegated-name", "--path", wtPath]);
+    expect(args).toEqual(["fix/delegated-name", "--path", wtPath, "--base", "origin/main"]);
 
     await wm.removeWorktree("delegate-branch-override", "delegate-override-thread");
   });

--- a/src/worktree/manager.test.ts
+++ b/src/worktree/manager.test.ts
@@ -48,31 +48,56 @@ beforeAll(async () => {
   await runIn(repoRoot, ["git", "remote", "add", "origin", repoRoot]);
   await runIn(repoRoot, ["git", "fetch", "-q", "origin"]);
 
-  // Fake setup script. Two args: <branch_name> <abs_target_path>. Owns the
-  // full worktree-creation lifecycle: fetch + worktree add + marker write.
-  // This mirrors the real contract — Junior never pre-creates the worktree
-  // when delegating; it hands the script the branch and target path and the
-  // script does the rest.
+  // Fake setup script. Flag-based contract:
+  //   <branch_name> --path <abs> [--base <ref>]
+  // Owns the full worktree-creation lifecycle: fetch + worktree add + marker
+  // write. This mirrors the real contract — Junior never pre-creates the
+  // worktree when delegating; it hands the script the branch, target path,
+  // and (optionally) base ref, and the script does the rest.
+  //
+  // The marker file dumps every received arg on its own line so tests can
+  // assert exact arg ordering, presence/absence of --base, etc.
   setupMarker = join(repoRoot, "setup-marker.txt");
   const setupScript = join(repoRoot, "fake-setup.sh");
   writeFileSync(
     setupScript,
     `#!/usr/bin/env bash
 set -e
-# Validate two-arg contract.
-if [[ "$#" -ne 2 ]]; then
-  echo "fake-setup: expected 2 args (branch, abs-target-path), got: $#" >&2
+# Dump every received arg on its own line BEFORE any validation, so even
+# malformed invocations leave a marker for tests to inspect.
+: > "${setupMarker}"
+for a in "$@"; do
+  printf '%s\\n' "$a" >> "${setupMarker}"
+done
+# Parse flag-based args.
+BRANCH=""
+ABS_TARGET=""
+BASE_REF=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --path) ABS_TARGET="$2"; shift 2 ;;
+    --base) BASE_REF="$2"; shift 2 ;;
+    -*) echo "fake-setup: unknown flag: $1" >&2; exit 1 ;;
+    *)
+      if [[ -z "$BRANCH" ]]; then BRANCH="$1"; shift
+      else echo "fake-setup: unexpected positional: $1" >&2; exit 1
+      fi ;;
+  esac
+done
+if [[ -z "$BRANCH" || -z "$ABS_TARGET" ]]; then
+  echo "fake-setup: branch and --path required" >&2
   exit 1
 fi
-BRANCH="$1"
-ABS_TARGET="$2"
 if [[ "$ABS_TARGET" != /* ]]; then
-  echo "fake-setup: expected absolute target path, got: $ABS_TARGET" >&2
+  echo "fake-setup: --path must be absolute, got: $ABS_TARGET" >&2
   exit 1
 fi
 git fetch origin --prune
-git worktree add "$ABS_TARGET" -b "$BRANCH" origin/main
-printf '%s\\n%s\\n' "$BRANCH" "$ABS_TARGET" > "${setupMarker}"
+if [[ -n "$BASE_REF" ]]; then
+  git worktree add "$ABS_TARGET" -b "$BRANCH" "$BASE_REF"
+else
+  git worktree add "$ABS_TARGET" -b "$BRANCH" origin/main
+fi
 `,
   );
   chmodSync(setupScript, 0o755);
@@ -80,14 +105,25 @@ printf '%s\\n%s\\n' "$BRANCH" "$ABS_TARGET" > "${setupMarker}"
   // Non-fetching setup script — used by the inverse autofetch guard test.
   // Creates the worktree but never runs `git fetch`. If Junior also doesn't
   // fetch (correct delegating behavior), a fresh commit on origin/main won't
-  // appear in the resulting worktree.
+  // appear in the resulting worktree. Parses the same flag-based contract.
   const nonFetchingScript = join(repoRoot, "non-fetching-setup.sh");
   writeFileSync(
     nonFetchingScript,
     `#!/usr/bin/env bash
 set -e
-BRANCH="$1"
-ABS_TARGET="$2"
+BRANCH=""
+ABS_TARGET=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --path) ABS_TARGET="$2"; shift 2 ;;
+    --base) shift 2 ;;
+    -*) echo "non-fetching: unknown flag: $1" >&2; exit 1 ;;
+    *)
+      if [[ -z "$BRANCH" ]]; then BRANCH="$1"; shift
+      else echo "non-fetching: unexpected positional: $1" >&2; exit 1
+      fi ;;
+  esac
+done
 git worktree add "$ABS_TARGET" -b "$BRANCH" origin/main
 `,
   );
@@ -145,7 +181,7 @@ describe("WorktreeManager.createWorktree", () => {
     await wm.removeWorktree("default-flow", "default-thread");
   });
 
-  it("delegates to worktreeSetupCommand with [branch, absTargetPath]", async () => {
+  it("delegates to worktreeSetupCommand with [branch, --path, absTargetPath]", async () => {
     const repos: RepoConfig[] = [
       {
         name: "custom-flow",
@@ -164,19 +200,82 @@ describe("WorktreeManager.createWorktree", () => {
     expect(existsSync(wtPath)).toBe(true);
     expect(existsSync(join(wtPath, "README.md"))).toBe(true);
 
-    // Marker proves the script received exactly the two expected args.
+    // Marker proves the script received exactly the expected args, in order.
     expect(existsSync(setupMarker)).toBe(true);
-    const marker = (await Bun.file(setupMarker).text()).trim();
-    const [branchArg, pathArg] = marker.split("\n");
-    expect(branchArg).toBe("slack/custom-thread");
-    expect(pathArg).toBe(
+    const args = (await Bun.file(setupMarker).text())
+      .split("\n")
+      .filter((l) => l.length > 0);
+    expect(args).toEqual([
+      "slack/custom-thread",
+      "--path",
       join(repoRoot, ".claude/worktrees/slack-custom-thread"),
-    );
+    ]);
     expect(wtPath).toBe(
       join(repoRoot, ".claude/worktrees/slack-custom-thread"),
     );
 
     await wm.removeWorktree("custom-flow", "custom-thread");
+  });
+
+  it("forwards baseRef as --base to the setup script when set explicitly", async () => {
+    const repos: RepoConfig[] = [
+      {
+        name: "delegate-baseref",
+        path: repoRoot,
+        defaultBase: "origin/main",
+        worktreeSetupCommand: "fake-setup.sh",
+      },
+    ];
+    const wm = new WorktreeManager(repos);
+
+    if (existsSync(setupMarker)) rmSync(setupMarker);
+
+    const wtPath = await wm.createWorktree(
+      "delegate-baseref",
+      "delegate-baseref-thread",
+      "feature/seeded",
+    );
+
+    const args = (await Bun.file(setupMarker).text())
+      .split("\n")
+      .filter((l) => l.length > 0);
+    expect(args).toEqual([
+      "slack/delegate-baseref-thread",
+      "--path",
+      wtPath,
+      "--base",
+      "feature/seeded",
+    ]);
+
+    // Sanity: the script honored --base, so FEATURE.md (only on
+    // feature/seeded) is present.
+    expect(existsSync(join(wtPath, "FEATURE.md"))).toBe(true);
+
+    await wm.removeWorktree("delegate-baseref", "delegate-baseref-thread");
+  });
+
+  it("does NOT forward --base when baseRef is unset", async () => {
+    const repos: RepoConfig[] = [
+      {
+        name: "delegate-no-baseref",
+        path: repoRoot,
+        defaultBase: "origin/main",
+        worktreeSetupCommand: "fake-setup.sh",
+      },
+    ];
+    const wm = new WorktreeManager(repos);
+
+    if (existsSync(setupMarker)) rmSync(setupMarker);
+
+    await wm.createWorktree("delegate-no-baseref", "no-baseref-thread");
+
+    const markerText = await Bun.file(setupMarker).text();
+    const args = markerText.split("\n").filter((l) => l.length > 0);
+    expect(args).not.toContain("--base");
+    // And specifically: only branch + --path + path, nothing extra.
+    expect(args.length).toBe(3);
+
+    await wm.removeWorktree("delegate-no-baseref", "no-baseref-thread");
   });
 
   it("does NOT fetch when delegating (script owns fetch — inverse autofetch guard)", async () => {
@@ -319,10 +418,10 @@ describe("WorktreeManager.createWorktree", () => {
       "fix/delegated-name",
     );
 
-    const marker = (await Bun.file(setupMarker).text()).trim();
-    const [branchArg, pathArg] = marker.split("\n");
-    expect(branchArg).toBe("fix/delegated-name");
-    expect(pathArg).toBe(wtPath);
+    const args = (await Bun.file(setupMarker).text())
+      .split("\n")
+      .filter((l) => l.length > 0);
+    expect(args).toEqual(["fix/delegated-name", "--path", wtPath]);
 
     await wm.removeWorktree("delegate-branch-override", "delegate-override-thread");
   });

--- a/src/worktree/manager.test.ts
+++ b/src/worktree/manager.test.ts
@@ -12,8 +12,8 @@ import type { RepoConfig } from "../config.ts";
 import { WorktreeManager } from "./manager.ts";
 
 // Real-fs integration test. We create a tiny git repo in a tmpdir and let
-// WorktreeManager run actual git commands against it, plus a fake
-// post-create setup script we can verify by side effects.
+// WorktreeManager run actual git commands against it, plus fake setup scripts
+// that exercise the delegation contract.
 
 let repoRoot: string;
 let setupMarker: string;
@@ -48,30 +48,50 @@ beforeAll(async () => {
   await runIn(repoRoot, ["git", "remote", "add", "origin", repoRoot]);
   await runIn(repoRoot, ["git", "fetch", "-q", "origin"]);
 
-  // Fake post-create setup script. Single argument: the absolute worktree
-  // path. Junior has already created the worktree before this runs — the
-  // script writes a marker file containing $1 to confirm it ran with the
-  // right argument, and validates the new contract internally.
+  // Fake setup script. Two args: <branch_name> <abs_target_path>. Owns the
+  // full worktree-creation lifecycle: fetch + worktree add + marker write.
+  // This mirrors the real contract — Junior never pre-creates the worktree
+  // when delegating; it hands the script the branch and target path and the
+  // script does the rest.
   setupMarker = join(repoRoot, "setup-marker.txt");
   const setupScript = join(repoRoot, "fake-setup.sh");
   writeFileSync(
     setupScript,
     `#!/usr/bin/env bash
 set -e
-# Validate single-arg contract: must be an existing absolute path directory.
-if [[ "$1" != /* || ! -d "$1" ]]; then
-  echo "fake-setup: expected absolute path to existing dir, got: $1" >&2
+# Validate two-arg contract.
+if [[ "$#" -ne 2 ]]; then
+  echo "fake-setup: expected 2 args (branch, abs-target-path), got: $#" >&2
   exit 1
 fi
-# Reject extra args — new contract is single-arg.
-if [[ -n "$2" ]]; then
-  echo "fake-setup: unexpected second argument: $2" >&2
+BRANCH="$1"
+ABS_TARGET="$2"
+if [[ "$ABS_TARGET" != /* ]]; then
+  echo "fake-setup: expected absolute target path, got: $ABS_TARGET" >&2
   exit 1
 fi
-echo "$1" > "${setupMarker}"
+git fetch origin --prune
+git worktree add "$ABS_TARGET" -b "$BRANCH" origin/main
+printf '%s\\n%s\\n' "$BRANCH" "$ABS_TARGET" > "${setupMarker}"
 `,
   );
   chmodSync(setupScript, 0o755);
+
+  // Non-fetching setup script — used by the inverse autofetch guard test.
+  // Creates the worktree but never runs `git fetch`. If Junior also doesn't
+  // fetch (correct delegating behavior), a fresh commit on origin/main won't
+  // appear in the resulting worktree.
+  const nonFetchingScript = join(repoRoot, "non-fetching-setup.sh");
+  writeFileSync(
+    nonFetchingScript,
+    `#!/usr/bin/env bash
+set -e
+BRANCH="$1"
+ABS_TARGET="$2"
+git worktree add "$ABS_TARGET" -b "$BRANCH" origin/main
+`,
+  );
+  chmodSync(nonFetchingScript, 0o755);
 
   // Failing setup script.
   const failScript = join(repoRoot, "fail-setup.sh");
@@ -90,7 +110,7 @@ afterAll(() => {
  * Add a fresh commit on `main` (which is also the `origin` remote since
  * the test repo's origin self-references). The new file is only visible
  * via `origin/main` AFTER a fresh `git fetch origin`, so its presence in
- * a created worktree proves Junior fetched before `git worktree add`.
+ * a created worktree proves the creator fetched before `git worktree add`.
  *
  * Returns the filename written.
  */
@@ -103,7 +123,7 @@ async function addFreshCommitOnMain(label: string): Promise<string> {
 }
 
 describe("WorktreeManager.createWorktree", () => {
-  it("creates worktree via git when worktreeSetupCommand is not set", async () => {
+  it("creates worktree inline when worktreeSetupCommand is not set", async () => {
     const repos: RepoConfig[] = [
       { name: "default-flow", path: repoRoot, defaultBase: "origin/main" },
     ];
@@ -119,13 +139,13 @@ describe("WorktreeManager.createWorktree", () => {
     );
     expect(existsSync(wtPath)).toBe(true);
     expect(existsSync(join(wtPath, "README.md"))).toBe(true);
-    // Regression guard: fetch ran, so origin/main is fresh.
+    // Inline-path autofetch regression guard: fetch ran, so origin/main is fresh.
     expect(existsSync(join(wtPath, freshFile))).toBe(true);
 
     await wm.removeWorktree("default-flow", "default-thread");
   });
 
-  it("runs setup hook with single arg AFTER creating the worktree", async () => {
+  it("delegates to worktreeSetupCommand with [branch, absTargetPath]", async () => {
     const repos: RepoConfig[] = [
       {
         name: "custom-flow",
@@ -140,16 +160,16 @@ describe("WorktreeManager.createWorktree", () => {
 
     const wtPath = await wm.createWorktree("custom-flow", "custom-thread");
 
-    // Junior created the worktree itself before the hook ran.
+    // Script created the worktree (manager did not pre-create).
     expect(existsSync(wtPath)).toBe(true);
     expect(existsSync(join(wtPath, "README.md"))).toBe(true);
 
-    // Setup hook ran with single arg = abs worktree path. The script
-    // validates the contract internally (abs path, exists, no $2) and
-    // exits non-zero on violation, which would have failed createWorktree.
+    // Marker proves the script received exactly the two expected args.
     expect(existsSync(setupMarker)).toBe(true);
-    const marker = await Bun.file(setupMarker).text();
-    expect(marker.trim()).toBe(
+    const marker = (await Bun.file(setupMarker).text()).trim();
+    const [branchArg, pathArg] = marker.split("\n");
+    expect(branchArg).toBe("slack/custom-thread");
+    expect(pathArg).toBe(
       join(repoRoot, ".claude/worktrees/slack-custom-thread"),
     );
     expect(wtPath).toBe(
@@ -159,36 +179,32 @@ describe("WorktreeManager.createWorktree", () => {
     await wm.removeWorktree("custom-flow", "custom-thread");
   });
 
-  it("fetches origin even when worktreeSetupCommand is set (autofetch regression guard)", async () => {
+  it("does NOT fetch when delegating (script owns fetch — inverse autofetch guard)", async () => {
     const repos: RepoConfig[] = [
       {
-        name: "fetch-with-hook-flow",
+        name: "no-double-fetch-flow",
         path: repoRoot,
         defaultBase: "origin/main",
-        worktreeSetupCommand: "fake-setup.sh",
+        worktreeSetupCommand: "non-fetching-setup.sh",
       },
     ];
     const wm = new WorktreeManager(repos);
 
-    if (existsSync(setupMarker)) rmSync(setupMarker);
-
-    // Add a commit on main that's only visible after `git fetch origin`.
-    const freshFile = await addFreshCommitOnMain("with-hook");
+    // Drop a fresh commit on main. The non-fetching setup script will NOT
+    // fetch, and Junior must NOT fetch either when delegating. So the new
+    // commit must be ABSENT from the resulting worktree. If the file shows
+    // up, Junior fetched behind the script's back — a regression.
+    const freshFile = await addFreshCommitOnMain("no-double-fetch");
 
     const wtPath = await wm.createWorktree(
-      "fetch-with-hook-flow",
-      "fetch-thread",
+      "no-double-fetch-flow",
+      "no-double-thread",
     );
 
-    // If Junior fetched before `git worktree add`, origin/main is current
-    // and the worktree contains the new file. If fetch was skipped (the
-    // old behaviour when worktreeSetupCommand was set), the file would
-    // be absent.
-    expect(existsSync(join(wtPath, freshFile))).toBe(true);
-    // Hook still ran.
-    expect(existsSync(setupMarker)).toBe(true);
+    expect(existsSync(wtPath)).toBe(true);
+    expect(existsSync(join(wtPath, freshFile))).toBe(false);
 
-    await wm.removeWorktree("fetch-with-hook-flow", "fetch-thread");
+    await wm.removeWorktree("no-double-fetch-flow", "no-double-thread");
   });
 
   it("throws when worktreeSetupCommand exits non-zero", async () => {
@@ -206,12 +222,13 @@ describe("WorktreeManager.createWorktree", () => {
       wm.createWorktree("fail-flow", "fail-thread"),
     ).rejects.toThrow(/fail-setup\.sh failed/);
 
-    // Worktree was created before the hook failed — clean up so any
-    // future test runs against the same tmpdir start clean.
-    await wm.removeWorktree("fail-flow", "fail-thread");
+    // The failing script never created the worktree, so no cleanup needed.
+    expect(existsSync(wm.getWorktreePath("fail-flow", "fail-thread"))).toBe(
+      false,
+    );
   });
 
-  it("forwards baseRef as the worktree's starting point (not as branch name)", async () => {
+  it("forwards baseRef as the worktree's starting point (inline path)", async () => {
     const repos: RepoConfig[] = [
       { name: "baseref-flow", path: repoRoot, defaultBase: "origin/main" },
     ];
@@ -239,7 +256,7 @@ describe("WorktreeManager.createWorktree", () => {
     await wm.removeWorktree("baseref-flow", "baseref-thread");
   });
 
-  it("uses branchOverride for the new branch name (independent of baseRef)", async () => {
+  it("uses branchOverride for the new branch name (inline path)", async () => {
     const repos: RepoConfig[] = [
       {
         name: "branch-override-flow",
@@ -280,5 +297,33 @@ describe("WorktreeManager.createWorktree", () => {
     await listProc.exited;
     const listed = (await new Response(listProc.stdout).text()).trim();
     expect(listed).toBe("");
+  });
+
+  it("delegates branchOverride to the setup script", async () => {
+    const repos: RepoConfig[] = [
+      {
+        name: "delegate-branch-override",
+        path: repoRoot,
+        defaultBase: "origin/main",
+        worktreeSetupCommand: "fake-setup.sh",
+      },
+    ];
+    const wm = new WorktreeManager(repos);
+
+    if (existsSync(setupMarker)) rmSync(setupMarker);
+
+    const wtPath = await wm.createWorktree(
+      "delegate-branch-override",
+      "delegate-override-thread",
+      undefined,
+      "fix/delegated-name",
+    );
+
+    const marker = (await Bun.file(setupMarker).text()).trim();
+    const [branchArg, pathArg] = marker.split("\n");
+    expect(branchArg).toBe("fix/delegated-name");
+    expect(pathArg).toBe(wtPath);
+
+    await wm.removeWorktree("delegate-branch-override", "delegate-override-thread");
   });
 });

--- a/src/worktree/manager.test.ts
+++ b/src/worktree/manager.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
-import { mkdtempSync, rmSync, writeFileSync, chmodSync, existsSync } from "node:fs";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  chmodSync,
+  existsSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { RepoConfig } from "../config.ts";
@@ -7,57 +13,72 @@ import { WorktreeManager } from "./manager.ts";
 
 // Real-fs integration test. We create a tiny git repo in a tmpdir and let
 // WorktreeManager run actual git commands against it, plus a fake
-// worktreeSetupCommand script we can verify by side effects.
+// post-create setup script we can verify by side effects.
 
 let repoRoot: string;
 let setupMarker: string;
+
+// Helper: run a shell command in a given cwd, throwing on non-zero.
+async function runIn(cwd: string, args: string[]): Promise<void> {
+  const proc = Bun.spawn(args, { cwd, stdout: "pipe", stderr: "pipe" });
+  const code = await proc.exited;
+  if (code !== 0) {
+    const err = await new Response(proc.stderr).text();
+    throw new Error(`${args.join(" ")} failed: ${err}`);
+  }
+}
 
 beforeAll(async () => {
   repoRoot = mkdtempSync(join(tmpdir(), "junior-wt-test-"));
 
   // Init a bare-but-usable git repo with one commit on `main`.
-  const run = async (args: string[]) => {
-    const proc = Bun.spawn(args, { cwd: repoRoot, stdout: "pipe", stderr: "pipe" });
-    const code = await proc.exited;
-    if (code !== 0) {
-      const err = await new Response(proc.stderr).text();
-      throw new Error(`${args.join(" ")} failed: ${err}`);
-    }
-  };
-  await run(["git", "init", "-q", "-b", "main"]);
-  await run(["git", "config", "user.email", "test@example.com"]);
-  await run(["git", "config", "user.name", "test"]);
+  await runIn(repoRoot, ["git", "init", "-q", "-b", "main"]);
+  await runIn(repoRoot, ["git", "config", "user.email", "test@example.com"]);
+  await runIn(repoRoot, ["git", "config", "user.name", "test"]);
   writeFileSync(join(repoRoot, "README.md"), "hello\n");
-  await run(["git", "add", "."]);
-  await run(["git", "commit", "-q", "-m", "init"]);
+  await runIn(repoRoot, ["git", "add", "."]);
+  await runIn(repoRoot, ["git", "commit", "-q", "-m", "init"]);
   // Add a second commit on a different ref so we can test baseRef forwarding.
-  await run(["git", "checkout", "-q", "-b", "feature/seeded"]);
+  await runIn(repoRoot, ["git", "checkout", "-q", "-b", "feature/seeded"]);
   writeFileSync(join(repoRoot, "FEATURE.md"), "feature only\n");
-  await run(["git", "add", "."]);
-  await run(["git", "commit", "-q", "-m", "feature only"]);
-  await run(["git", "checkout", "-q", "main"]);
+  await runIn(repoRoot, ["git", "add", "."]);
+  await runIn(repoRoot, ["git", "commit", "-q", "-m", "feature only"]);
+  await runIn(repoRoot, ["git", "checkout", "-q", "main"]);
   // Set up a fake `origin` remote pointing at ourselves so `git fetch origin` succeeds.
-  await run(["git", "remote", "add", "origin", repoRoot]);
-  await run(["git", "fetch", "-q", "origin"]);
+  await runIn(repoRoot, ["git", "remote", "add", "origin", repoRoot]);
+  await runIn(repoRoot, ["git", "fetch", "-q", "origin"]);
 
-  // Fake setup script: writes a marker file, then creates the worktree itself
-  // so `WorktreeManager.createWorktree` returns successfully (the contract is
-  // "exit 0 means done").
+  // Fake post-create setup script. Single argument: the absolute worktree
+  // path. Junior has already created the worktree before this runs — the
+  // script writes a marker file containing $1 to confirm it ran with the
+  // right argument, and validates the new contract internally.
   setupMarker = join(repoRoot, "setup-marker.txt");
   const setupScript = join(repoRoot, "fake-setup.sh");
   writeFileSync(
     setupScript,
     `#!/usr/bin/env bash
 set -e
-echo "$1 $2" > "${setupMarker}"
-git worktree add -b "$2" "$1" main >/dev/null 2>&1
+# Validate single-arg contract: must be an existing absolute path directory.
+if [[ "$1" != /* || ! -d "$1" ]]; then
+  echo "fake-setup: expected absolute path to existing dir, got: $1" >&2
+  exit 1
+fi
+# Reject extra args — new contract is single-arg.
+if [[ -n "$2" ]]; then
+  echo "fake-setup: unexpected second argument: $2" >&2
+  exit 1
+fi
+echo "$1" > "${setupMarker}"
 `,
   );
   chmodSync(setupScript, 0o755);
 
   // Failing setup script.
   const failScript = join(repoRoot, "fail-setup.sh");
-  writeFileSync(failScript, `#!/usr/bin/env bash\necho "permission denied" >&2\nexit 1\n`);
+  writeFileSync(
+    failScript,
+    `#!/usr/bin/env bash\necho "permission denied" >&2\nexit 1\n`,
+  );
   chmodSync(failScript, 0o755);
 });
 
@@ -65,22 +86,46 @@ afterAll(() => {
   rmSync(repoRoot, { recursive: true, force: true });
 });
 
+/**
+ * Add a fresh commit on `main` (which is also the `origin` remote since
+ * the test repo's origin self-references). The new file is only visible
+ * via `origin/main` AFTER a fresh `git fetch origin`, so its presence in
+ * a created worktree proves Junior fetched before `git worktree add`.
+ *
+ * Returns the filename written.
+ */
+async function addFreshCommitOnMain(label: string): Promise<string> {
+  const filename = `freshness-${label}.md`;
+  writeFileSync(join(repoRoot, filename), `${label}\n`);
+  await runIn(repoRoot, ["git", "add", filename]);
+  await runIn(repoRoot, ["git", "commit", "-q", "-m", `freshness ${label}`]);
+  return filename;
+}
+
 describe("WorktreeManager.createWorktree", () => {
-  it("falls back to git worktree add when worktreeSetupCommand is not set", async () => {
+  it("creates worktree via git when worktreeSetupCommand is not set", async () => {
     const repos: RepoConfig[] = [
       { name: "default-flow", path: repoRoot, defaultBase: "origin/main" },
     ];
     const wm = new WorktreeManager(repos);
 
+    // Drop a fresh commit on main right before creating the worktree.
+    // The worktree should pick it up only if Junior fetched first.
+    const freshFile = await addFreshCommitOnMain("default-flow");
+
     const wtPath = await wm.createWorktree("default-flow", "default-thread");
-    expect(wtPath).toBe(join(repoRoot, ".claude/worktrees/slack-default-thread"));
+    expect(wtPath).toBe(
+      join(repoRoot, ".claude/worktrees/slack-default-thread"),
+    );
     expect(existsSync(wtPath)).toBe(true);
     expect(existsSync(join(wtPath, "README.md"))).toBe(true);
+    // Regression guard: fetch ran, so origin/main is fresh.
+    expect(existsSync(join(wtPath, freshFile))).toBe(true);
 
     await wm.removeWorktree("default-flow", "default-thread");
   });
 
-  it("delegates to worktreeSetupCommand when configured", async () => {
+  it("runs setup hook with single arg AFTER creating the worktree", async () => {
     const repos: RepoConfig[] = [
       {
         name: "custom-flow",
@@ -95,15 +140,55 @@ describe("WorktreeManager.createWorktree", () => {
 
     const wtPath = await wm.createWorktree("custom-flow", "custom-thread");
 
-    // The script wrote the marker — confirms it ran with the right args.
+    // Junior created the worktree itself before the hook ran.
+    expect(existsSync(wtPath)).toBe(true);
+    expect(existsSync(join(wtPath, "README.md"))).toBe(true);
+
+    // Setup hook ran with single arg = abs worktree path. The script
+    // validates the contract internally (abs path, exists, no $2) and
+    // exits non-zero on violation, which would have failed createWorktree.
     expect(existsSync(setupMarker)).toBe(true);
     const marker = await Bun.file(setupMarker).text();
     expect(marker.trim()).toBe(
-      `${join(repoRoot, ".claude/worktrees/slack-custom-thread")} slack/custom-thread`,
+      join(repoRoot, ".claude/worktrees/slack-custom-thread"),
     );
-    expect(wtPath).toBe(join(repoRoot, ".claude/worktrees/slack-custom-thread"));
+    expect(wtPath).toBe(
+      join(repoRoot, ".claude/worktrees/slack-custom-thread"),
+    );
 
     await wm.removeWorktree("custom-flow", "custom-thread");
+  });
+
+  it("fetches origin even when worktreeSetupCommand is set (autofetch regression guard)", async () => {
+    const repos: RepoConfig[] = [
+      {
+        name: "fetch-with-hook-flow",
+        path: repoRoot,
+        defaultBase: "origin/main",
+        worktreeSetupCommand: "fake-setup.sh",
+      },
+    ];
+    const wm = new WorktreeManager(repos);
+
+    if (existsSync(setupMarker)) rmSync(setupMarker);
+
+    // Add a commit on main that's only visible after `git fetch origin`.
+    const freshFile = await addFreshCommitOnMain("with-hook");
+
+    const wtPath = await wm.createWorktree(
+      "fetch-with-hook-flow",
+      "fetch-thread",
+    );
+
+    // If Junior fetched before `git worktree add`, origin/main is current
+    // and the worktree contains the new file. If fetch was skipped (the
+    // old behaviour when worktreeSetupCommand was set), the file would
+    // be absent.
+    expect(existsSync(join(wtPath, freshFile))).toBe(true);
+    // Hook still ran.
+    expect(existsSync(setupMarker)).toBe(true);
+
+    await wm.removeWorktree("fetch-with-hook-flow", "fetch-thread");
   });
 
   it("throws when worktreeSetupCommand exits non-zero", async () => {
@@ -117,9 +202,13 @@ describe("WorktreeManager.createWorktree", () => {
     ];
     const wm = new WorktreeManager(repos);
 
-    await expect(wm.createWorktree("fail-flow", "fail-thread")).rejects.toThrow(
-      /fail-setup\.sh failed/,
-    );
+    await expect(
+      wm.createWorktree("fail-flow", "fail-thread"),
+    ).rejects.toThrow(/fail-setup\.sh failed/);
+
+    // Worktree was created before the hook failed — clean up so any
+    // future test runs against the same tmpdir start clean.
+    await wm.removeWorktree("fail-flow", "fail-thread");
   });
 
   it("forwards baseRef as the worktree's starting point (not as branch name)", async () => {
@@ -152,7 +241,11 @@ describe("WorktreeManager.createWorktree", () => {
 
   it("uses branchOverride for the new branch name (independent of baseRef)", async () => {
     const repos: RepoConfig[] = [
-      { name: "branch-override-flow", path: repoRoot, defaultBase: "origin/main" },
+      {
+        name: "branch-override-flow",
+        path: repoRoot,
+        defaultBase: "origin/main",
+      },
     ];
     const wm = new WorktreeManager(repos);
 
@@ -180,10 +273,10 @@ describe("WorktreeManager.createWorktree", () => {
     await wm.removeWorktree("branch-override-flow", "override-thread");
 
     // Verify the override branch is gone.
-    const listProc = Bun.spawn(["git", "branch", "--list", "fix/custom-name"], {
-      cwd: repoRoot,
-      stdout: "pipe",
-    });
+    const listProc = Bun.spawn(
+      ["git", "branch", "--list", "fix/custom-name"],
+      { cwd: repoRoot, stdout: "pipe" },
+    );
     await listProc.exited;
     const listed = (await new Response(listProc.stdout).text()).trim();
     expect(listed).toBe("");

--- a/src/worktree/manager.ts
+++ b/src/worktree/manager.ts
@@ -32,28 +32,32 @@ export class WorktreeManager {
 
     const worktreePath = this.getWorktreePath(repoName, threadId);
     const branchName = branchOverride ?? `slack/${threadId}`;
-    const base = baseRef ?? repo.defaultBase;
-
-    // Always create the worktree ourselves: fetch fresh, then add. The setup
-    // command (if any) is a post-create hook, never the worktree creator.
-    // Single flow keeps autofetch reliable across all paths and prevents the
-    // "directory does not exist" failure mode when both sides assumed the
-    // other would do `git worktree add`.
-    await this.runGit(["fetch", "origin", "--prune"], repo.path);
-    await this.runGit(
-      ["worktree", "add", worktreePath, "-b", branchName, base],
-      repo.path,
-    );
 
     if (repo.worktreeSetupCommand) {
-      // Post-create hook: env-file copying, dependency install, MCP migration.
-      // Resolve the command relative to repo.path so paths like
+      // Delegate worktree creation to the repo's setup script. The script
+      // owns `git fetch`, `git worktree add`, env-file copying, dependency
+      // install, and MCP migration. Junior just hands it the branch name
+      // and the absolute target path it wants the worktree at — preserving
+      // Junior's path namespace (`<repo>/.claude/worktrees/slack-<thread>`)
+      // while letting manual callers of the script keep their default
+      // ergonomics. Resolve the command relative to repo.path so paths like
       // "scripts/setup-worktree.sh" work without requiring the script on PATH.
-      // Single argument: the absolute worktree path.
       const setupCmd = repo.worktreeSetupCommand.startsWith("/")
         ? repo.worktreeSetupCommand
         : `${repo.path}/${repo.worktreeSetupCommand}`;
-      await this.runCommand([setupCmd, worktreePath], repo.path);
+      await this.runCommand(
+        [setupCmd, branchName, worktreePath],
+        repo.path,
+      );
+    } else {
+      // No setup hook configured — Junior creates the worktree inline. Fetch
+      // fresh first so the base ref is up to date, then `git worktree add`.
+      const base = baseRef ?? repo.defaultBase;
+      await this.runGit(["fetch", "origin", "--prune"], repo.path);
+      await this.runGit(
+        ["worktree", "add", worktreePath, "-b", branchName, base],
+        repo.path,
+      );
     }
 
     return worktreePath;

--- a/src/worktree/manager.ts
+++ b/src/worktree/manager.ts
@@ -18,7 +18,7 @@ export class WorktreeManager {
    *   pass `baseRef` to fork from a non-main starting point.
    *
    * Setup-script delegation contract:
-   *   `<repo.path>/<command> <branch> --path <abs> [--base <ref>]`
+   *   `<repo.path>/<command> <branch> --path <abs> --base <ref>`
    *
    * Returns the worktree path.
    */

--- a/src/worktree/manager.ts
+++ b/src/worktree/manager.ts
@@ -11,11 +11,17 @@ export class WorktreeManager {
    * Create a worktree in the target repo for a thread.
    *
    * - `baseRef` is the starting point (a git ref/commit like `origin/main`).
-   *   Defaults to `repo.defaultBase`. This becomes the worktree's HEAD.
+   *   On the inline path, defaults to `repo.defaultBase`. On the delegated
+   *   path, when undefined, the script's per-repo default applies (do NOT
+   *   forward `repo.defaultBase` here — that would override the script's
+   *   own default for manual users).
    * - `branchOverride` renames the new branch the worktree tracks. Defaults
    *   to `slack/<threadId>`. The two are independent — pass `branchOverride`
    *   to name the branch differently from the default thread-keyed slug,
    *   pass `baseRef` to fork from a non-main starting point.
+   *
+   * Setup-script delegation contract:
+   *   `<repo.path>/<command> <branch> --path <abs> [--base <ref>]`
    *
    * Returns the worktree path.
    */
@@ -36,19 +42,23 @@ export class WorktreeManager {
     if (repo.worktreeSetupCommand) {
       // Delegate worktree creation to the repo's setup script. The script
       // owns `git fetch`, `git worktree add`, env-file copying, dependency
-      // install, and MCP migration. Junior just hands it the branch name
-      // and the absolute target path it wants the worktree at — preserving
-      // Junior's path namespace (`<repo>/.claude/worktrees/slack-<thread>`)
-      // while letting manual callers of the script keep their default
-      // ergonomics. Resolve the command relative to repo.path so paths like
+      // install, and MCP migration. Junior hands it the branch, the absolute
+      // target path (preserving Junior's `<repo>/.claude/worktrees/slack-<thread>`
+      // namespace), and — when explicitly set by the caller — the base ref.
+      // We deliberately do NOT forward `repo.defaultBase` when `baseRef` is
+      // unset: each script defines its own per-repo default for the manual
+      // case (local HEAD for gx-backend/admin, origin/main for gx-client-next),
+      // and overriding that here would silently break manual workflows.
+      // Resolve the command relative to repo.path so paths like
       // "scripts/setup-worktree.sh" work without requiring the script on PATH.
       const setupCmd = repo.worktreeSetupCommand.startsWith("/")
         ? repo.worktreeSetupCommand
         : `${repo.path}/${repo.worktreeSetupCommand}`;
-      await this.runCommand(
-        [setupCmd, branchName, worktreePath],
-        repo.path,
-      );
+      const args = [setupCmd, branchName, "--path", worktreePath];
+      if (baseRef !== undefined) {
+        args.push("--base", baseRef);
+      }
+      await this.runCommand(args, repo.path);
     } else {
       // No setup hook configured — Junior creates the worktree inline. Fetch
       // fresh first so the base ref is up to date, then `git worktree add`.

--- a/src/worktree/manager.ts
+++ b/src/worktree/manager.ts
@@ -11,10 +11,7 @@ export class WorktreeManager {
    * Create a worktree in the target repo for a thread.
    *
    * - `baseRef` is the starting point (a git ref/commit like `origin/main`).
-   *   On the inline path, defaults to `repo.defaultBase`. On the delegated
-   *   path, when undefined, the script's per-repo default applies (do NOT
-   *   forward `repo.defaultBase` here — that would override the script's
-   *   own default for manual users).
+   *   Defaults to `repo.defaultBase` on both the inline and delegated paths.
    * - `branchOverride` renames the new branch the worktree tracks. Defaults
    *   to `slack/<threadId>`. The two are independent — pass `branchOverride`
    *   to name the branch differently from the default thread-keyed slug,
@@ -43,21 +40,13 @@ export class WorktreeManager {
       // Delegate worktree creation to the repo's setup script. The script
       // owns `git fetch`, `git worktree add`, env-file copying, dependency
       // install, and MCP migration. Junior hands it the branch, the absolute
-      // target path (preserving Junior's `<repo>/.claude/worktrees/slack-<thread>`
-      // namespace), and — when explicitly set by the caller — the base ref.
-      // We deliberately do NOT forward `repo.defaultBase` when `baseRef` is
-      // unset: each script defines its own per-repo default for the manual
-      // case (local HEAD for gx-backend/admin, origin/main for gx-client-next),
-      // and overriding that here would silently break manual workflows.
-      // Resolve the command relative to repo.path so paths like
-      // "scripts/setup-worktree.sh" work without requiring the script on PATH.
+      // target path, and the base ref (always — defaulting to repo.defaultBase
+      // so the script's own HEAD-based fallback is never reached).
       const setupCmd = repo.worktreeSetupCommand.startsWith("/")
         ? repo.worktreeSetupCommand
         : `${repo.path}/${repo.worktreeSetupCommand}`;
-      const args = [setupCmd, branchName, "--path", worktreePath];
-      if (baseRef !== undefined) {
-        args.push("--base", baseRef);
-      }
+      const base = baseRef ?? repo.defaultBase;
+      const args = [setupCmd, branchName, "--path", worktreePath, "--base", base];
       await this.runCommand(args, repo.path);
     } else {
       // No setup hook configured — Junior creates the worktree inline. Fetch

--- a/src/worktree/manager.ts
+++ b/src/worktree/manager.ts
@@ -32,28 +32,28 @@ export class WorktreeManager {
 
     const worktreePath = this.getWorktreePath(repoName, threadId);
     const branchName = branchOverride ?? `slack/${threadId}`;
+    const base = baseRef ?? repo.defaultBase;
+
+    // Always create the worktree ourselves: fetch fresh, then add. The setup
+    // command (if any) is a post-create hook, never the worktree creator.
+    // Single flow keeps autofetch reliable across all paths and prevents the
+    // "directory does not exist" failure mode when both sides assumed the
+    // other would do `git worktree add`.
+    await this.runGit(["fetch", "origin", "--prune"], repo.path);
+    await this.runGit(
+      ["worktree", "add", worktreePath, "-b", branchName, base],
+      repo.path,
+    );
 
     if (repo.worktreeSetupCommand) {
-      // Delegate to the repo's own setup script: `<repo.path>/<command> <worktreePath> <branch>`
-      // Resolve the command relative to repo.path so paths like "bin/setup-worktree.sh"
-      // work without requiring the script to be on PATH.
+      // Post-create hook: env-file copying, dependency install, MCP migration.
+      // Resolve the command relative to repo.path so paths like
+      // "scripts/setup-worktree.sh" work without requiring the script on PATH.
+      // Single argument: the absolute worktree path.
       const setupCmd = repo.worktreeSetupCommand.startsWith("/")
         ? repo.worktreeSetupCommand
         : `${repo.path}/${repo.worktreeSetupCommand}`;
-      await this.runCommand(
-        [setupCmd, worktreePath, branchName],
-        repo.path,
-      );
-    } else {
-      const base = baseRef ?? repo.defaultBase;
-      // Fetch latest from origin so the base ref is fresh
-      await this.runGit(["fetch", "origin"], repo.path);
-
-      // Create the worktree with a new branch off the base ref
-      await this.runGit(
-        ["worktree", "add", worktreePath, "-b", branchName, base],
-        repo.path,
-      );
+      await this.runCommand([setupCmd, worktreePath], repo.path);
     }
 
     return worktreePath;


### PR DESCRIPTION
## Summary

Junior's worktree manager now delegates worktree creation to the per-repo `setup-worktree.sh` when `worktreeSetupCommand` is configured, passing flag-based args: `<branch> --path <abs> [--base <ref>]`. The script owns `git fetch`, `git worktree add`, env copy, install, and MCPs. When unset, manager keeps the inline `git fetch origin --prune` + `git worktree add` flow.

Junior's path namespace is preserved: `getWorktreePath` still returns `<repo>/.claude/worktrees/slack-<thread>`. The per-repo defaults (which the script computes when called manually without a target_path) live entirely in the script -- Junior never sees them.

## What changed vs. the prior commit on this branch

The first commit on this branch put worktree creation into manager.ts and reduced setup hooks to single-arg post-create helpers. After review the call was reversed: scripts retain full ownership (so manual `./scripts/setup-worktree.sh feature/foo` still works end-to-end), and manager.ts hands them the target path when it has one. The new commit on top implements that.

## Tests

- Inline path: autofetch regression guard (fresh commit on origin/main visible after createWorktree).
- Delegation: marker file proves script received `[branch, --path, abs-target-path]` exactly; manager did not pre-create the worktree.
- Inverse autofetch guard: when delegating to a non-fetching fixture script, a fresh commit on origin/main is **absent** from the resulting worktree -- proves manager doesn't fetch behind the script's back.
- Failure propagation, baseRef forwarding (inline only), branchOverride for both inline and delegated paths.
- New: baseRef forwarded as `--base` to setup script when set explicitly.
- New: `--base` is **absent** from setup-script args when baseRef is unset.

## Fetch behavior change

`git fetch origin` is now `git fetch origin --prune`. Removes stale
remote-tracking refs that the old fetch preserved. Low-risk hygiene
improvement, surfaced per review feedback.

## baseRef forwarded to setup scripts

When `baseRef` is explicitly set (e.g., via `!branch staging` driving
`session.baseRef`), Junior forwards it as `--base <ref>` to the setup
script. Setup hooks called as: `<cmd> <branch> --path <abs> [--base <ref>]`.
When `baseRef` is unset, scripts pick their per-repo default — gx-backend
and gx-admin-client default to local HEAD; gx-client-next defaults to
origin/main.

## Coordinated merge

The matching script PRs are gx-backend#3082, gx-admin-client#738, gx-client-next#5007. Land this PR with those -- mismatched directions break:

- New manager + old scripts: old gx-backend/admin scripts reject the second arg with "Usage" error; old gx-client-next interprets it as a base-branch ref and `git worktree add` fails.
- Old manager (current main) + new scripts: old manager passes `<wt-path> <branch>` (path-first); new scripts read `$1` as branch_name and `git worktree add -b /abs/path/...` rejects the leading-slash branch name.

## Updated baseRef semantics

`--base <ref>` is now ALWAYS forwarded to setup scripts, defaulting to
`repo.defaultBase` when the caller doesn't override. Rationale: Junior
worktrees should be reproducible from a known ref (typically `origin/main`),
never from whatever the local checkout happens to be on. The per-repo
script defaults (gx-backend / gx-admin-client: local HEAD; gx-client-next:
origin/main) still apply for **manual** users who omit `--base`.