### PR TITLE
feat: HTTP dashboard for session + dev-server status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,74 @@
 # junior
 
-Slack bot that acts as the control plane for Claude Code sessions. See [CLAUDE.md](./CLAUDE.md) for architecture, [docs/](./docs) for feature notes.
+A Slack bot that acts as the control plane for [Claude Code](https://claude.com/claude-code) sessions. Each Slack thread maps to its own short-lived `claude -p` subprocess. Across turns, conversation continuity comes from `--resume <sessionId>` rather than a long-lived process.
 
-## Run
+Successor to the OpenClaw-based agent system at [PranavBakre/openclaw-agents](https://github.com/PranavBakre/openclaw-agents) — same role (orchestrator + sub-agent dispatcher), rebuilt on top of Claude Code's CLI.
 
-```sh
-bun install
-bun run dev
-```
+**Stack:** Bun, TypeScript, [@slack/bolt](https://github.com/slackapi/bolt-js) (Socket Mode), Claude Code CLI authenticated via Max subscription, SQLite for session persistence.
 
-## Dashboard
+For deep architecture and the canonical "critical rules" list, see [CLAUDE.md](./CLAUDE.md). This README is the on-ramp.
 
-A localhost-only HTTP dashboard for inspecting live state — threads, per-agent
-sessions, dev-server queue depth, recent logs.
+---
+
+## What it does
+
+A Slack message in a configured channel triggers one of three things:
+
+1. **A persistent-agent dispatch** — `!review`, `!reproducer`, `!thinker`, `!echo`, or (implicit, in support channels) `!lead`. Each persistent agent gets its own `sessionId`, its own Slack username + emoji, and runs as a logically separate Claude conversation in the same thread.
+2. **A built-in directive** — e.g. `!devserver <branch>`, `!build`, `!status`, `!mute`. Directives are handled by junior itself or routed to a one-shot agent; they don't spawn a persistent agent.
+3. **A plain message** — buffered to the active session in that thread (or starts a new one). If a turn is in progress, the message is queued and drained as a combined prompt after the current turn exits — junior never interrupts a running process.
+
+### Multi-agent threads
+
+A single Slack thread can host multiple agents at once. The dispatcher is in [`src/support/router.ts`](src/support/router.ts); the agent identities are in [`src/support/agents.ts`](src/support/agents.ts):
+
+| Agent | Username | Emoji | Use |
+| --- | --- | --- | --- |
+| `lead` | Junior | :face_with_cowboy_hat: | Default in support channels — orchestrator / rubber duck |
+| `reproducer` | Reproducer | :mag: | Reproduce a reported bug deterministically |
+| `thinker` | Thinker | :wrench: | Form and mock-test a hypothesis |
+| `review` | Reviewer | :eyes: | Code review |
+| `echo` | Echo | :speech_balloon: | Reads/writes back — used as a coordination test bed |
+
+Each agent stores its own row in the `agent_sessions` SQLite table so threading can fan out without losing per-agent `--resume` continuity.
+
+### Slack MCP server
+
+While Claude is running, it can post to and read from Slack autonomously through an in-process HTTP MCP server ([`src/mcp/slack-server.ts`](src/mcp/slack-server.ts)). Tools exposed:
+
+- `slack_send_message`, `slack_read_channel`, `slack_read_thread`
+- `slack_search`, `slack_search_users`
+- `slack_upload_file`
+- `register_worktree` — let an agent claim a worktree path mid-turn
+
+This is what enables agents to talk back to other agents (or to the human) within a single turn instead of waiting for the turn to end.
+
+### Dev-server queue
+
+For repos with `devCommand` configured, junior owns the lifecycle of a single shared dev server per repo. Concurrent acquires across threads serialize on a `proper-lockfile` per-repo lock, with a 10-minute slot timeout and a 20-minute idle TTL (kills the server if no one re-acquires).
+
+- `!devserver <branch>` — acquire the slot for all dev-configured repos in the thread
+- `!devserver <branch> <repo>` — acquire for one repo
+- `!devserver status` — show holder + waiters per repo
+- `!devserver kill <repo>` — drop the slot
+
+Implementation: [`src/lifecycle/dev-server.ts`](src/lifecycle/dev-server.ts), [`src/lifecycle/dev-server-queue.ts`](src/lifecycle/dev-server-queue.ts).
+
+### Worktrees per (repo, thread)
+
+Each thread that touches a target repo gets its own git worktree under `<repo>/.claude/worktrees/slack-<threadId>`. A thread can have worktrees in multiple repos at once (full-stack bug → backend + frontend). See [`src/worktree/manager.ts`](src/worktree/manager.ts) and the `worktreePaths` field on `ThreadSession`.
+
+### SQLite persistence
+
+Sessions and per-agent sessions persist in `data/sessions.db` (`bun:sqlite`, single-writer). The schema is created on boot — no migration tooling needed yet. `SESSION_STORE=memory` switches to the in-memory store for tests.
+
+### Slack home tab
+
+Per-user view of recent threads, mute state, and last activity. Window is `HOME_WINDOW_MS` (default 48h). Code: [`src/slack/home.ts`](src/slack/home.ts).
+
+### HTTP dashboard
+
+Localhost-only HTTP dashboard for live introspection — threads, per-agent sessions, dev-server queue depth, recent logs.
 
 **Off by default.** Enable by setting `HTTP_DASHBOARD_PORT`:
 
@@ -21,20 +77,7 @@ HTTP_DASHBOARD_PORT=8787 bun run dev
 # open http://127.0.0.1:8787
 ```
 
-The server binds to `127.0.0.1` only — there is no auth. Do not put it
-behind a reverse proxy without adding one.
-
-### What it shows
-
-- **Threads** — every `ThreadSession` with its status, target repo / base ref,
-  and a nested list of every per-agent session (lead / reproducer / thinker /
-  review / echo) with that agent's `sessionId`, status, and last activity.
-- **Dev Servers** — for each repo with `devCommand` configured: holder thread,
-  branch, idle-TTL countdown, queued waiters. Reads `DevServerManager.status()`
-  and `DevServerQueue.readQueueDepth()` directly.
-- **Health** — uptime, version, totals.
-
-### Endpoints
+Binds `127.0.0.1` only — there is no auth. Do not put it behind a reverse proxy without adding one.
 
 | Path | Description |
 | --- | --- |
@@ -43,13 +86,162 @@ behind a reverse proxy without adding one.
 | `GET /api/sessions` | All threads with their agent sessions |
 | `GET /api/sessions/:threadId` | Full session detail |
 | `GET /api/dev-server` | Per-repo manager state + queue depth |
-| `GET /api/logs?date=YYYY-MM-DD&tail=50&tag=&level=` | Tail of structured logs |
-| `GET /api/memory` | List of `docs/**/*.md` |
-| `GET /api/memory/<path>` | Read a doc file |
+| `GET /api/logs?date=&tail=&tag=&level=` | Tail of structured logs |
+| `GET /api/memory` / `GET /api/memory/<path>` | Browse `docs/**/*.md` |
 
-### Credit
+Ported from [Friday](https://github.com/anmolm-growthx/Friday)'s `src/http/`. Junior-specific extensions: `/api/dev-server` exposes `DevServerQueue` state, and `/api/sessions` joins `agent_sessions` so the UI can render multi-agent threads.
 
-Ported from [Friday](https://github.com/anmolm-growthx/Friday)'s `src/http/`.
-Junior-specific extensions: `/api/dev-server` exposes `DevServerQueue` state,
-and `/api/sessions` joins the `agent_sessions` table to surface per-agent state
-on multi-agent threads. Friday's SSE chat routes are intentionally not ported.
+---
+
+## Quickstart
+
+```sh
+bun install
+cp .env.example .env  # if you have one — otherwise see "Configuration" below
+bun run dev
+```
+
+Junior connects to Slack over Socket Mode, so no public ingress is needed. You'll need a Slack app with:
+- Bot token (`SLACK_BOT_TOKEN`, starts with `xoxb-`)
+- App-level token with `connections:write` (`SLACK_APP_TOKEN`, starts with `xapp-`)
+- Subscriptions to `message.channels` and `app_mention`
+
+Then add the bot to a channel and message it.
+
+---
+
+## Configuration
+
+All config is loaded from environment variables in [`src/config.ts`](src/config.ts). The most useful knobs:
+
+| Env var | Default | Purpose |
+| --- | --- | --- |
+| `SLACK_BOT_TOKEN` | *(required)* | `xoxb-…` bot token |
+| `SLACK_APP_TOKEN` | *(required)* | `xapp-…` app token for Socket Mode |
+| `REPOS` | `[]` | JSON array of `RepoConfig` (see below) |
+| `CHANNEL_DEFAULTS` | `{"C05557KKV37":{"agentType":"lead"}}` | Per-channel default agent type. Channels with `agentType:"lead"` go through the support router (multi-agent dispatcher) |
+| `SESSION_STORE` | `sqlite` | `sqlite` or `memory` |
+| `SESSION_DB_PATH` | `data/sessions.db` | SQLite file path |
+| `HTTP_DASHBOARD_PORT` | *(unset)* | If set, starts the localhost dashboard |
+| `MCP_PORT` | `3456` | Port for the in-process Slack MCP server |
+| `CLAUDE_MAX_TURNS` | `25` | Max turns per `claude -p` invocation |
+| `CLAUDE_TIMEOUT_MS` | `300000` | Per-turn timeout before SIGINT |
+| `CLAUDE_MODEL` | *(unset)* | Override default Claude model |
+
+`REPOS` example:
+
+```json
+[
+  {
+    "name": "example-backend",
+    "path": "/Users/you/code/example-backend",
+    "defaultBase": "main",
+    "devCommand": "pnpm dev",
+    "devPort": 3000
+  }
+]
+```
+
+See [`src/config.ts`](src/config.ts) for the full set including `worktreeSetupCommand`, `readyUrl`, verbosity, cleanup intervals, etc.
+
+---
+
+## Commands and directives
+
+Slash-style commands are parsed in [`src/slack/commands.ts`](src/slack/commands.ts). Persistent-agent directives are parsed in [`src/support/router.ts`](src/support/router.ts).
+
+```
+!build [prompt]            -- spawn the build one-shot agent
+!frontend [prompt]         -- spawn the frontend one-shot agent
+!architect [prompt]        -- spawn the architect one-shot agent
+!review                    -- dispatch to the review persistent agent
+!reproducer / !thinker     -- ditto
+!echo / !lead              -- ditto
+
+!cancel                    -- cancel the in-flight turn
+!reset                     -- drop session + worktree state for this thread
+!status                    -- show this thread's session state
+!repo <name>               -- pin this thread to a target repo
+!branch <name>             -- pin this thread to a base ref
+!quiet | !normal | !verbose -- per-thread verbosity
+!mute | !unmute            -- silence/unsilence this thread
+!adhoc / !bugs / !help     -- channel-specific entry points
+
+!devserver <branch> [repo] -- acquire dev-server slot
+!devserver status          -- queue depth
+!devserver kill <repo>     -- drop slot
+```
+
+---
+
+## Architecture at a glance
+
+```
+Slack Event API (message.channels, app_mention)
+    |
+    v
+Bolt Socket Mode (src/slack/app.ts, events.ts)
+    |
+    v
+AgentDispatcher (src/support/router.ts)
+    |
+    +-- !devserver  -> DevServerQueue.acquire() -> DevServerManager
+    +-- !<agent>    -> SessionManager.handleAgentMessage(agentName)
+    +-- (default)   -> SessionManager.handleLeadMessage / handleMessage
+                          |
+                          v
+                  Spawn `claude -p`
+                    --resume <sessionId>          (continuity)
+                    --output-format stream-json   (tool/text/result events)
+                    --mcp-config <per-thread>     (Slack MCP)
+                    cwd = worktree per (repo, thread)
+                          |
+                          v
+                  Stream events  -> SlackResponder (status pills, final post)
+                  agent_sessions <- per-agent sessionId persistence
+```
+
+Three invariants that the rest of the code hangs off (see [CLAUDE.md](./CLAUDE.md) for the full list):
+
+1. **One `claude -p` process per turn.** Spawn → respond → exit. No long-lived processes between messages.
+2. **`--resume` for continuity.** Session IDs are extracted from the first stream-json event and cached.
+3. **Buffer, don't interrupt.** Messages arriving during a turn are queued and drained as a combined prompt afterwards.
+
+---
+
+## Project structure
+
+```
+src/
+  index.ts              entry point — wires everything
+  config.ts             env loading, RepoConfig
+  slack/                Bolt app, event handlers, formatting, home tab
+  session/              ThreadSession, SessionManager, SQLite + memory stores
+  claude/               spawner, args, stream-json parser
+  worktree/             per-(repo, thread) worktree manager
+  agents/               agent loader (.md frontmatter)
+  support/              AgentDispatcher, persistent-agent identities
+  lifecycle/            dev-server manager + queue, timeouts, shutdown, health
+  mcp/                  in-process Slack MCP server
+  http/                 localhost dashboard (this PR)
+public/                 static dashboard assets
+docs/                   feature design docs, code indexes, workflows
+```
+
+For per-feature deep dives, see the [`docs/`](docs/) tree — `docs/architecture.md` and `docs/features/<name>.md`.
+
+---
+
+## Running tests + typecheck
+
+```sh
+bun run typecheck   # tsc --noEmit
+bun test            # bun:test
+bun run cleanup     # remove stale worktrees + sessions
+```
+
+---
+
+## Origin and naming
+
+Junior is the orchestrator in a Star-Trek-named agent squad: Scotty (backend), Uhura (frontend), Bones (reviewer). Sub-agent dispatch is shared-context — agents don't have memory across runs, so the dispatcher passes relevant conventions and prior mistakes in the prompt. See the "Origin: OpenClaw Agent System" section in [CLAUDE.md](./CLAUDE.md) for what carried over from the previous incarnation and what changed.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,55 @@
+# junior
+
+Slack bot that acts as the control plane for Claude Code sessions. See [CLAUDE.md](./CLAUDE.md) for architecture, [docs/](./docs) for feature notes.
+
+## Run
+
+```sh
+bun install
+bun run dev
+```
+
+## Dashboard
+
+A localhost-only HTTP dashboard for inspecting live state — threads, per-agent
+sessions, dev-server queue depth, recent logs.
+
+**Off by default.** Enable by setting `HTTP_DASHBOARD_PORT`:
+
+```sh
+HTTP_DASHBOARD_PORT=8787 bun run dev
+# open http://127.0.0.1:8787
+```
+
+The server binds to `127.0.0.1` only — there is no auth. Do not put it
+behind a reverse proxy without adding one.
+
+### What it shows
+
+- **Threads** — every `ThreadSession` with its status, target repo / base ref,
+  and a nested list of every per-agent session (lead / reproducer / thinker /
+  review / echo) with that agent's `sessionId`, status, and last activity.
+- **Dev Servers** — for each repo with `devCommand` configured: holder thread,
+  branch, idle-TTL countdown, queued waiters. Reads `DevServerManager.status()`
+  and `DevServerQueue.readQueueDepth()` directly.
+- **Health** — uptime, version, totals.
+
+### Endpoints
+
+| Path | Description |
+| --- | --- |
+| `GET /` | Static dashboard (`public/index.html`) |
+| `GET /api/health` | Uptime + session/agent totals |
+| `GET /api/sessions` | All threads with their agent sessions |
+| `GET /api/sessions/:threadId` | Full session detail |
+| `GET /api/dev-server` | Per-repo manager state + queue depth |
+| `GET /api/logs?date=YYYY-MM-DD&tail=50&tag=&level=` | Tail of structured logs |
+| `GET /api/memory` | List of `docs/**/*.md` |
+| `GET /api/memory/<path>` | Read a doc file |
+
+### Credit
+
+Ported from [Friday](https://github.com/anmolm-growthx/Friday)'s `src/http/`.
+Junior-specific extensions: `/api/dev-server` exposes `DevServerQueue` state,
+and `/api/sessions` joins the `agent_sessions` table to surface per-agent state
+on multi-agent threads. Friday's SSE chat routes are intentionally not ported.

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,413 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Junior — Dashboard</title>
+    <style>
+      :root {
+        --bg: #0e0f12;
+        --bg-elev: #16181d;
+        --bg-elev-2: #1c1f26;
+        --border: #262a32;
+        --fg: #e6e8ec;
+        --fg-dim: #9aa0aa;
+        --fg-faint: #6b7180;
+        --accent: #7aa2f7;
+        --green: #9ece6a;
+        --yellow: #e0af68;
+        --red: #f7768e;
+        --purple: #bb9af7;
+      }
+      * { box-sizing: border-box; }
+      html, body {
+        margin: 0;
+        background: var(--bg);
+        color: var(--fg);
+        font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+        font-size: 13px;
+        line-height: 1.45;
+      }
+      header {
+        padding: 14px 20px;
+        border-bottom: 1px solid var(--border);
+        display: flex;
+        gap: 16px;
+        align-items: baseline;
+        position: sticky;
+        top: 0;
+        background: var(--bg);
+        z-index: 10;
+      }
+      header h1 {
+        margin: 0;
+        font-size: 14px;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+      }
+      header .meta { color: var(--fg-dim); font-size: 12px; }
+      header .meta b { color: var(--fg); font-weight: 500; }
+      header .pulse {
+        margin-left: auto;
+        color: var(--fg-faint);
+        font-size: 11px;
+      }
+      main { padding: 20px; max-width: 1280px; margin: 0 auto; }
+      section { margin-bottom: 32px; }
+      h2 {
+        margin: 0 0 10px;
+        font-size: 12px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: var(--fg-dim);
+      }
+      .panel {
+        background: var(--bg-elev);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        overflow: hidden;
+      }
+      .row {
+        display: grid;
+        gap: 12px;
+        padding: 12px 14px;
+        border-bottom: 1px solid var(--border);
+      }
+      .row:last-child { border-bottom: none; }
+      .row.session {
+        grid-template-columns: minmax(200px, 1.2fr) 1fr 1fr;
+        align-items: start;
+      }
+      .row.devserver {
+        grid-template-columns: minmax(160px, 1fr) 2fr 1fr;
+      }
+      .row .col-label {
+        font-size: 11px;
+        color: var(--fg-faint);
+        text-transform: uppercase;
+        letter-spacing: 0.06em;
+        margin-bottom: 2px;
+      }
+      .agent-list {
+        margin-top: 8px;
+        border-left: 2px solid var(--border);
+        padding-left: 10px;
+      }
+      .agent-row {
+        display: grid;
+        grid-template-columns: 90px 90px 1fr 1fr;
+        gap: 10px;
+        padding: 4px 0;
+        font-size: 12px;
+        color: var(--fg-dim);
+      }
+      .agent-row b { color: var(--fg); font-weight: 500; }
+      .pill {
+        display: inline-block;
+        padding: 1px 7px;
+        border-radius: 10px;
+        font-size: 11px;
+        background: var(--bg-elev-2);
+        color: var(--fg-dim);
+        border: 1px solid var(--border);
+      }
+      .pill.busy { color: var(--yellow); border-color: rgba(224,175,104,0.3); }
+      .pill.idle { color: var(--fg-dim); }
+      .pill.draining { color: var(--purple); border-color: rgba(187,154,247,0.3); }
+      .pill.done { color: var(--green); border-color: rgba(158,206,106,0.3); }
+      .pill.failed, .pill.error { color: var(--red); border-color: rgba(247,118,142,0.3); }
+      .pill.running { color: var(--green); border-color: rgba(158,206,106,0.3); }
+      .pill.stopped { color: var(--fg-faint); }
+      .mono { font-family: inherit; }
+      .dim { color: var(--fg-dim); }
+      .faint { color: var(--fg-faint); }
+      .empty { padding: 20px 14px; color: var(--fg-faint); font-style: italic; }
+      .stat-grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+        gap: 10px;
+      }
+      .stat {
+        background: var(--bg-elev);
+        border: 1px solid var(--border);
+        border-radius: 6px;
+        padding: 10px 12px;
+      }
+      .stat .num { font-size: 20px; font-weight: 600; }
+      .stat .lbl { color: var(--fg-dim); font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em; }
+      .waiters {
+        margin-top: 6px;
+        padding: 6px 8px;
+        background: var(--bg-elev-2);
+        border-radius: 4px;
+        font-size: 12px;
+        color: var(--fg-dim);
+      }
+      .waiters .wt { display: block; padding: 2px 0; }
+      a { color: var(--accent); text-decoration: none; }
+      a:hover { text-decoration: underline; }
+      code {
+        background: var(--bg-elev-2);
+        padding: 1px 5px;
+        border-radius: 3px;
+        font-size: 12px;
+      }
+      .threadId, .sessionId { color: var(--accent); word-break: break-all; }
+      .truncate { max-width: 100%; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>JUNIOR</h1>
+      <div class="meta" id="health-meta">loading…</div>
+      <div class="pulse" id="pulse">·</div>
+    </header>
+    <main>
+      <section>
+        <h2>Health</h2>
+        <div class="stat-grid" id="health-stats"></div>
+      </section>
+      <section>
+        <h2>Dev Servers</h2>
+        <div class="panel" id="devservers"><div class="empty">loading…</div></div>
+      </section>
+      <section>
+        <h2>Threads</h2>
+        <div class="panel" id="threads"><div class="empty">loading…</div></div>
+      </section>
+    </main>
+
+    <script>
+      const POLL_MS = 2000;
+      const pulseEl = document.getElementById("pulse");
+      let tick = 0;
+      const PULSE = ["·", ":", "·", " "];
+
+      function pillClass(status) {
+        if (!status) return "pill";
+        return "pill " + status;
+      }
+
+      function fmtAgo(ms) {
+        if (!ms) return "—";
+        const delta = Date.now() - ms;
+        if (delta < 0) return "0s";
+        const s = Math.floor(delta / 1000);
+        if (s < 60) return s + "s";
+        const m = Math.floor(s / 60);
+        if (m < 60) return m + "m " + (s % 60) + "s";
+        const h = Math.floor(m / 60);
+        return h + "h " + (m % 60) + "m";
+      }
+
+      function fmtRemaining(ms) {
+        if (ms == null) return "—";
+        const s = Math.max(0, Math.floor(ms / 1000));
+        const m = Math.floor(s / 60);
+        return m + "m " + (s % 60).toString().padStart(2, "0") + "s";
+      }
+
+      function fmtUptime(s) {
+        if (s == null) return "—";
+        const h = Math.floor(s / 3600);
+        const m = Math.floor((s % 3600) / 60);
+        const r = s % 60;
+        if (h > 0) return h + "h " + m + "m";
+        if (m > 0) return m + "m " + r + "s";
+        return r + "s";
+      }
+
+      function escapeHtml(s) {
+        if (s == null) return "";
+        return String(s)
+          .replaceAll("&", "&amp;")
+          .replaceAll("<", "&lt;")
+          .replaceAll(">", "&gt;")
+          .replaceAll('"', "&quot;");
+      }
+
+      function shortId(id) {
+        if (!id) return "—";
+        const s = String(id);
+        return s.length > 14 ? s.slice(0, 8) + "…" + s.slice(-4) : s;
+      }
+
+      async function fetchJson(path) {
+        const res = await fetch(path);
+        if (!res.ok) throw new Error(path + " " + res.status);
+        return await res.json();
+      }
+
+      function renderHealth(h) {
+        const meta = document.getElementById("health-meta");
+        meta.innerHTML =
+          "v<b>" + escapeHtml(h.version) + "</b> · uptime <b>" +
+          fmtUptime(h.uptime) + "</b> · repos <b>" +
+          escapeHtml(h.repos.join(", ") || "—") + "</b>";
+
+        const stats = document.getElementById("health-stats");
+        const s = h.sessions || {};
+        const a = h.agents || {};
+        stats.innerHTML = [
+          stat(s.total ?? 0, "Threads"),
+          stat(s.busy ?? 0, "Busy", "busy"),
+          stat(s.idle ?? 0, "Idle"),
+          stat(s.draining ?? 0, "Draining", "draining"),
+          stat(s.errors ?? 0, "Errors", (s.errors ?? 0) > 0 ? "failed" : ""),
+          stat(a.total ?? 0, "Agents"),
+          stat(a.busy ?? 0, "Agents busy", (a.busy ?? 0) > 0 ? "busy" : ""),
+        ].join("");
+      }
+
+      function stat(num, label, cls) {
+        return (
+          '<div class="stat"><div class="num ' + (cls || "") +
+          '">' + num + "</div><div class=\"lbl\">" + label + "</div></div>"
+        );
+      }
+
+      function renderDevServers(payload) {
+        const root = document.getElementById("devservers");
+        const items = payload.devServers || [];
+        if (items.length === 0) {
+          root.innerHTML = '<div class="empty">No repos with devCommand configured.</div>';
+          return;
+        }
+        root.innerHTML = items.map(renderDevServerRow).join("");
+      }
+
+      function renderDevServerRow(d) {
+        const statusPill = d.running
+          ? '<span class="' + pillClass("running") + '">running pid ' + d.pid + "</span>"
+          : '<span class="' + pillClass("stopped") + '">stopped</span>';
+        const branch = d.branch
+          ? '<code>' + escapeHtml(d.branch) + "</code>"
+          : '<span class="faint">no branch</span>';
+        const port = d.devPort ? ":" + d.devPort : "";
+        const idle = d.running
+          ? "idle TTL <b>" + fmtRemaining(d.idleMsRemaining) + "</b>"
+          : '<span class="faint">—</span>';
+
+        const holder = d.holder
+          ? "thread <code>" + escapeHtml(shortId(d.holder.holderThreadId)) +
+            "</code> · acquired " + fmtAgo(d.holder.acquiredAt) + " ago"
+          : '<span class="faint">no holder</span>';
+
+        const waiters = (d.waiters || []).length
+          ? '<div class="waiters"><div class="col-label">' + d.waiters.length +
+            ' waiter' + (d.waiters.length === 1 ? "" : "s") + '</div>' +
+            d.waiters
+              .map(
+                (w) =>
+                  '<span class="wt"><code>' + escapeHtml(shortId(w.threadId)) +
+                  "</code> → <code>" + escapeHtml(w.branch) +
+                  '</code> <span class="faint">' + fmtAgo(w.enqueuedAt) +
+                  " ago</span></span>",
+              )
+              .join("") +
+            "</div>"
+          : "";
+
+        return (
+          '<div class="row devserver">' +
+          "<div><div class=\"col-label\">repo</div><b>" +
+          escapeHtml(d.repo) + "</b><div class=\"dim\">" +
+          escapeHtml(d.devCommand || "—") + port + "</div></div>" +
+          "<div><div class=\"col-label\">status</div>" + statusPill +
+          " · " + branch + " · " + idle + waiters + "</div>" +
+          "<div><div class=\"col-label\">holder</div>" + holder + "</div>" +
+          "</div>"
+        );
+      }
+
+      function renderThreads(payload) {
+        const root = document.getElementById("threads");
+        const sessions = payload.sessions || [];
+        if (sessions.length === 0) {
+          root.innerHTML = '<div class="empty">No active threads.</div>';
+          return;
+        }
+        root.innerHTML = sessions.map(renderThreadRow).join("");
+      }
+
+      function renderThreadRow(s) {
+        const agents = (s.agents || [])
+          .map(
+            (a) =>
+              '<div class="agent-row">' +
+              "<b>" + escapeHtml(a.agentName) + "</b>" +
+              '<span class="' + pillClass(a.status) + '">' +
+              escapeHtml(a.status) + "</span>" +
+              '<span class="truncate">sid <code class="sessionId">' +
+              escapeHtml(shortId(a.sessionId)) + "</code></span>" +
+              '<span>last ' + fmtAgo(a.lastActivity) +
+              " ago" +
+              (a.pendingMessages
+                ? ' · <span class="faint">' + a.pendingMessages + " buffered</span>"
+                : "") +
+              "</span></div>",
+          )
+          .join("");
+
+        const agentBlock = agents
+          ? '<div class="agent-list">' + agents + "</div>"
+          : '<div class="agent-list faint">no agent sessions yet</div>';
+
+        const repoBits = [
+          s.targetRepo ? "<code>" + escapeHtml(s.targetRepo) + "</code>" : null,
+          s.baseRef ? "<code>" + escapeHtml(s.baseRef) + "</code>" : null,
+          s.agentType ? '<span class="dim">' + escapeHtml(s.agentType) + "</span>" : null,
+        ]
+          .filter(Boolean)
+          .join(" · ");
+
+        const errBlock = s.lastError
+          ? '<div class="dim" style="margin-top:4px;color:var(--red)">⚠ ' +
+            escapeHtml(s.lastError.type) + ": " +
+            escapeHtml(s.lastError.message) + "</div>"
+          : "";
+
+        return (
+          '<div class="row session">' +
+          "<div><div class=\"col-label\">thread</div><b class=\"threadId\">" +
+          escapeHtml(shortId(s.threadId)) + "</b><div class=\"dim\">channel " +
+          escapeHtml(s.channel) +
+          (s.muted ? ' · <span class="pill draining">muted</span>' : "") +
+          "</div>" + (repoBits ? '<div class="dim" style="margin-top:2px">' + repoBits + "</div>" : "") +
+          errBlock + "</div>" +
+          "<div><div class=\"col-label\">status</div>" +
+          '<span class="' + pillClass(s.status) + '">' + escapeHtml(s.status) + "</span>" +
+          " · last " + fmtAgo(s.lastActivity) + " ago" +
+          (s.pendingMessages
+            ? ' · <span class="faint">' + s.pendingMessages + " buffered</span>"
+            : "") +
+          "<div class=\"dim\">lead sid <code>" + escapeHtml(shortId(s.leadSessionId)) +
+          "</code></div></div>" +
+          "<div><div class=\"col-label\">agents (" +
+          (s.agents ? s.agents.length : 0) + ")</div>" + agentBlock + "</div>" +
+          "</div>"
+        );
+      }
+
+      async function refresh() {
+        try {
+          const [health, sessions, devServers] = await Promise.all([
+            fetchJson("/api/health"),
+            fetchJson("/api/sessions"),
+            fetchJson("/api/dev-server"),
+          ]);
+          renderHealth(health);
+          renderThreads(sessions);
+          renderDevServers(devServers);
+        } catch (err) {
+          console.error("refresh failed", err);
+        }
+        pulseEl.textContent = PULSE[tick++ % PULSE.length];
+      }
+
+      refresh();
+      setInterval(refresh, POLL_MS);
+    </script>
+  </body>
+</html>

--- a/src/config.ts
+++ b/src/config.ts
@@ -59,6 +59,11 @@ export interface Config {
     defaultVerbosity: SessionVerbosity;
   };
   channelDefaults: Record<string, { agentType: string }>;
+  http: {
+    /** Localhost dashboard. Off unless HTTP_DASHBOARD_PORT is set. */
+    enabled: boolean;
+    port: number;
+  };
 }
 
 function required(name: string): string {
@@ -105,6 +110,10 @@ export function loadConfig(): Config {
         '{"C05557KKV37":{"agentType":"lead"}}',
       ),
     ),
+    http: {
+      enabled: process.env.HTTP_DASHBOARD_PORT != null,
+      port: Number(optional("HTTP_DASHBOARD_PORT", "0")),
+    },
   };
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -110,11 +110,31 @@ export function loadConfig(): Config {
         '{"C05557KKV37":{"agentType":"lead"}}',
       ),
     ),
-    http: {
-      enabled: process.env.HTTP_DASHBOARD_PORT != null,
-      port: Number(optional("HTTP_DASHBOARD_PORT", "0")),
-    },
+    http: parseHttpDashboard(process.env.HTTP_DASHBOARD_PORT),
   };
+}
+
+/**
+ * Parse HTTP_DASHBOARD_PORT strictly.
+ *
+ * - Unset or empty → dashboard disabled (port 0).
+ * - Positive integer string → enabled on that port.
+ * - Anything else (NaN, 0, negative, decimal) → throw at config load. The
+ *   prior `Number(...)` fallback would silently let `Bun.serve` bind to a
+ *   random port for non-numeric values, which is surprising and makes the
+ *   dashboard unreachable at the configured URL.
+ */
+function parseHttpDashboard(raw: string | undefined): { enabled: boolean; port: number } {
+  if (raw == null || raw === "") {
+    return { enabled: false, port: 0 };
+  }
+  const port = Number(raw);
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    throw new Error(
+      `Invalid HTTP_DASHBOARD_PORT: ${JSON.stringify(raw)} (expected positive integer 1-65535, or unset to disable)`,
+    );
+  }
+  return { enabled: true, port };
 }
 
 function parseStoreKind(value: string): SessionStoreKind {

--- a/src/http/routes/dev-server.ts
+++ b/src/http/routes/dev-server.ts
@@ -2,14 +2,13 @@ import type { RepoConfig } from "../../config.ts";
 import type { DevServerManager, DevServerState } from "../../lifecycle/dev-server.ts";
 import type { DevServerQueue } from "../../lifecycle/dev-server-queue.ts";
 
-const IDLE_TTL_MS = 20 * 60 * 1_000;
-
 export async function handleDevServers(
   manager: DevServerManager,
   queue: DevServerQueue,
   repos: RepoConfig[],
 ): Promise<Response> {
   const statusMap = manager.status() as Map<string, DevServerState>;
+  const idleTtlMs = manager.getIdleTtlMs();
   const now = Date.now();
 
   const items = await Promise.all(
@@ -21,7 +20,7 @@ export async function handleDevServers(
 
         const idleMsRemaining =
           state?.lastUsedAt != null
-            ? Math.max(0, IDLE_TTL_MS - (now - state.lastUsedAt))
+            ? Math.max(0, idleTtlMs - (now - state.lastUsedAt))
             : null;
 
         return {
@@ -41,5 +40,5 @@ export async function handleDevServers(
       }),
   );
 
-  return Response.json({ devServers: items, idleTtlMs: IDLE_TTL_MS });
+  return Response.json({ devServers: items, idleTtlMs });
 }

--- a/src/http/routes/dev-server.ts
+++ b/src/http/routes/dev-server.ts
@@ -1,0 +1,45 @@
+import type { RepoConfig } from "../../config.ts";
+import type { DevServerManager, DevServerState } from "../../lifecycle/dev-server.ts";
+import type { DevServerQueue } from "../../lifecycle/dev-server-queue.ts";
+
+const IDLE_TTL_MS = 20 * 60 * 1_000;
+
+export async function handleDevServers(
+  manager: DevServerManager,
+  queue: DevServerQueue,
+  repos: RepoConfig[],
+): Promise<Response> {
+  const statusMap = manager.status() as Map<string, DevServerState>;
+  const now = Date.now();
+
+  const items = await Promise.all(
+    repos
+      .filter((r) => r.devCommand)
+      .map(async (repo) => {
+        const state = statusMap.get(repo.name);
+        const queueDepth = await queue.readQueueDepth(repo.name);
+
+        const idleMsRemaining =
+          state?.lastUsedAt != null
+            ? Math.max(0, IDLE_TTL_MS - (now - state.lastUsedAt))
+            : null;
+
+        return {
+          repo: repo.name,
+          devCommand: repo.devCommand ?? null,
+          devPort: repo.devPort ?? null,
+          readyUrl: repo.readyUrl ?? (repo.devPort ? `http://localhost:${repo.devPort}` : null),
+          running: state?.pid != null,
+          pid: state?.pid ?? null,
+          branch: state?.branch ?? queueDepth.holder?.branch ?? null,
+          startedAt: state?.startedAt ?? null,
+          lastUsedAt: state?.lastUsedAt ?? null,
+          idleMsRemaining,
+          holder: queueDepth.holder,
+          waiters: queueDepth.waiters,
+        };
+      }),
+  );
+
+  return Response.json({ devServers: items, idleTtlMs: IDLE_TTL_MS });
+}

--- a/src/http/routes/health.ts
+++ b/src/http/routes/health.ts
@@ -1,0 +1,34 @@
+import type { Config } from "../../config.ts";
+import type { SessionStore } from "../../session/store/interface.ts";
+
+export async function handleHealth(
+  store: SessionStore,
+  config: Config,
+  startedAt: string,
+): Promise<Response> {
+  const allSessions = await store.getAll();
+  let busy = 0, idle = 0, draining = 0, errors = 0;
+  let totalAgents = 0, busyAgents = 0;
+
+  for (const s of allSessions.values()) {
+    if (s.status === "busy") busy++;
+    else if (s.status === "draining") draining++;
+    else idle++;
+    if (s.lastError) errors++;
+
+    for (const agent of Object.values(s.agentSessions ?? {})) {
+      totalAgents++;
+      if (agent.status === "busy") busyAgents++;
+    }
+  }
+
+  return Response.json({
+    status: "ok",
+    uptime: Math.floor((Date.now() - new Date(startedAt).getTime()) / 1000),
+    startedAt,
+    version: "0.1.0",
+    sessions: { total: allSessions.size, busy, idle, draining, errors },
+    agents: { total: totalAgents, busy: busyAgents },
+    repos: config.repos.map((r) => r.name),
+  });
+}

--- a/src/http/routes/logs.test.ts
+++ b/src/http/routes/logs.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from "bun:test";
+import { handleLogs } from "./logs.ts";
+
+describe("handleLogs date validation", () => {
+  it("rejects path-traversal in ?date= with HTTP 400", async () => {
+    const params = new URLSearchParams({ date: "../../../etc/passwd" });
+    const res = await handleLogs(params);
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toContain("invalid date");
+  });
+
+  it("rejects garbage strings", async () => {
+    const params = new URLSearchParams({ date: "not-a-date" });
+    const res = await handleLogs(params);
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects partial-match exploits (regex must be anchored)", async () => {
+    // If DATE_RE were unanchored, `2024-01-01/../../etc/passwd` would slip through.
+    const params = new URLSearchParams({ date: "2024-01-01/../../etc/passwd" });
+    const res = await handleLogs(params);
+    expect(res.status).toBe(400);
+  });
+
+  it("accepts a well-formed YYYY-MM-DD even when the log file is absent", async () => {
+    // No log file for an arbitrary date — should return 200 with empty entries,
+    // not 400.
+    const params = new URLSearchParams({ date: "1999-01-01" });
+    const res = await handleLogs(params);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { date: string; entries: unknown[] };
+    expect(body.date).toBe("1999-01-01");
+    expect(body.entries).toEqual([]);
+  });
+});

--- a/src/http/routes/logs.ts
+++ b/src/http/routes/logs.ts
@@ -1,0 +1,48 @@
+import path from "node:path";
+
+const LOG_DIR = path.resolve(import.meta.dir, "../../../logs");
+
+interface LogEntry {
+  timestamp: string;
+  level: string;
+  tag: string;
+  message: string;
+}
+
+const LOG_LINE_RE = /^(.+?) \[(\w+)\] \[(.+?)\] (.*)$/;
+
+function parseLogLine(line: string): LogEntry | null {
+  const match = line.match(LOG_LINE_RE);
+  if (!match) return null;
+  return {
+    timestamp: match[1],
+    level: match[2],
+    tag: match[3],
+    message: match[4],
+  };
+}
+
+export async function handleLogs(searchParams: URLSearchParams): Promise<Response> {
+  const date = searchParams.get("date") ?? new Date().toISOString().split("T")[0];
+  const tail = Number(searchParams.get("tail") ?? "50");
+  const tag = searchParams.get("tag");
+  const level = searchParams.get("level");
+
+  const logFile = Bun.file(path.join(LOG_DIR, `${date}.log`));
+  if (!(await logFile.exists())) {
+    return Response.json({ date, entries: [] });
+  }
+
+  const content = await logFile.text();
+  const lines = content.trim().split("\n").filter(Boolean);
+  let entries = lines
+    .map(parseLogLine)
+    .filter((e): e is LogEntry => e !== null);
+
+  if (tag) entries = entries.filter((e) => e.tag === tag);
+  if (level) entries = entries.filter((e) => e.level === level);
+
+  const sliced = tail > 0 ? entries.slice(-tail) : entries;
+
+  return Response.json({ date, entries: sliced });
+}

--- a/src/http/routes/logs.ts
+++ b/src/http/routes/logs.ts
@@ -11,6 +11,15 @@ interface LogEntry {
 
 const LOG_LINE_RE = /^(.+?) \[(\w+)\] \[(.+?)\] (.*)$/;
 
+/**
+ * Strict ISO date matcher for the `?date=` query param. The value is concatenated
+ * into a filesystem path (`<LOG_DIR>/<date>.log`), so anything other than a
+ * literal YYYY-MM-DD string would let a caller escape `LOG_DIR` via traversal
+ * (e.g. `?date=../../../etc/passwd`). Reject at the input layer rather than
+ * trying to sanitize after the fact.
+ */
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
 function parseLogLine(line: string): LogEntry | null {
   const match = line.match(LOG_LINE_RE);
   if (!match) return null;
@@ -24,6 +33,12 @@ function parseLogLine(line: string): LogEntry | null {
 
 export async function handleLogs(searchParams: URLSearchParams): Promise<Response> {
   const date = searchParams.get("date") ?? new Date().toISOString().split("T")[0];
+  if (!DATE_RE.test(date)) {
+    return Response.json(
+      { error: "invalid date — expected YYYY-MM-DD" },
+      { status: 400 },
+    );
+  }
   const tail = Number(searchParams.get("tail") ?? "50");
   const tag = searchParams.get("tag");
   const level = searchParams.get("level");

--- a/src/http/routes/memory.ts
+++ b/src/http/routes/memory.ts
@@ -1,0 +1,44 @@
+/**
+ * Junior doesn't have a `memory/` directory like Friday — its long-form context
+ * lives under `docs/`. We expose the docs tree at `/api/memory` for parity with
+ * Friday's dashboard so operators can browse architecture / feature notes from
+ * the dashboard UI.
+ */
+import path from "node:path";
+
+const DOCS_DIR = path.resolve(import.meta.dir, "../../../docs");
+
+export async function handleMemoryList(): Promise<Response> {
+  const files: string[] = [];
+  const glob = new Bun.Glob("**/*.md");
+
+  try {
+    for await (const entry of glob.scan({ cwd: DOCS_DIR })) {
+      files.push(entry);
+    }
+  } catch {
+    return Response.json({ files: [] });
+  }
+
+  files.sort();
+  return Response.json({ files });
+}
+
+export async function handleMemoryRead(filePath: string): Promise<Response> {
+  if (filePath.includes("..") || filePath.startsWith("/")) {
+    return Response.json({ error: "invalid path" }, { status: 400 });
+  }
+
+  const fullPath = path.resolve(DOCS_DIR, filePath);
+  if (!fullPath.startsWith(DOCS_DIR)) {
+    return Response.json({ error: "invalid path" }, { status: 400 });
+  }
+
+  const file = Bun.file(fullPath);
+  if (!(await file.exists())) {
+    return Response.json({ error: "file not found" }, { status: 404 });
+  }
+
+  const content = await file.text();
+  return Response.json({ path: filePath, content });
+}

--- a/src/http/routes/sessions.ts
+++ b/src/http/routes/sessions.ts
@@ -1,0 +1,48 @@
+import type { SessionStore } from "../../session/store/interface.ts";
+
+export async function handleSessions(store: SessionStore): Promise<Response> {
+  const allSessions = await store.getAll();
+  const sessions = [...allSessions.values()]
+    .sort((a, b) => b.lastActivity - a.lastActivity)
+    .map((s) => ({
+      threadId: s.threadId,
+      channel: s.channel,
+      status: s.status,
+      sessionId: s.sessionId,
+      leadSessionId: s.leadSessionId,
+      activeAgentName: s.activeAgentName ?? null,
+      targetRepo: s.targetRepo,
+      baseRef: s.baseRef,
+      agentType: s.agentType,
+      verbosity: s.verbosity,
+      muted: s.muted,
+      model: s.model,
+      lastActivity: s.lastActivity,
+      createdAt: s.createdAt,
+      pendingMessages: s.pendingMessages.length,
+      lastError: s.lastError,
+      agents: Object.values(s.agentSessions ?? {})
+        .map((a) => ({
+          agentName: a.agentName,
+          sessionId: a.sessionId,
+          status: a.status,
+          lastActivity: a.lastActivity,
+          pid: a.pid,
+          pendingMessages: a.pendingMessages.length,
+        }))
+        .sort((a, b) => a.agentName.localeCompare(b.agentName)),
+    }));
+
+  return Response.json({ sessions });
+}
+
+export async function handleSessionDetail(
+  store: SessionStore,
+  threadId: string,
+): Promise<Response> {
+  const session = await store.get(threadId);
+  if (!session) {
+    return Response.json({ error: "session not found" }, { status: 404 });
+  }
+  return Response.json({ session });
+}

--- a/src/http/routes/sessions.ts
+++ b/src/http/routes/sessions.ts
@@ -4,34 +4,41 @@ export async function handleSessions(store: SessionStore): Promise<Response> {
   const allSessions = await store.getAll();
   const sessions = [...allSessions.values()]
     .sort((a, b) => b.lastActivity - a.lastActivity)
-    .map((s) => ({
-      threadId: s.threadId,
-      channel: s.channel,
-      status: s.status,
-      sessionId: s.sessionId,
-      leadSessionId: s.leadSessionId,
-      activeAgentName: s.activeAgentName ?? null,
-      targetRepo: s.targetRepo,
-      baseRef: s.baseRef,
-      agentType: s.agentType,
-      verbosity: s.verbosity,
-      muted: s.muted,
-      model: s.model,
-      lastActivity: s.lastActivity,
-      createdAt: s.createdAt,
-      pendingMessages: s.pendingMessages.length,
-      lastError: s.lastError,
-      agents: Object.values(s.agentSessions ?? {})
-        .map((a) => ({
-          agentName: a.agentName,
-          sessionId: a.sessionId,
-          status: a.status,
-          lastActivity: a.lastActivity,
-          pid: a.pid,
-          pendingMessages: a.pendingMessages.length,
-        }))
-        .sort((a, b) => a.agentName.localeCompare(b.agentName)),
-    }));
+    .map((s) => {
+      // Spread-based projection so new ThreadSession fields surface on the
+      // dashboard without per-field plumbing. Explicitly omit fields that
+      // are either internal (worktree/cwd/pid/systemPrompt — filesystem
+      // paths, kernel state, prompt-engineering details), redundant
+      // (agentSessions is reshaped below into `agents`), or non-JSON-safe
+      // (slackIdentity has no use in the UI). pendingMessages is replaced
+      // with its length to avoid leaking message bodies.
+      const {
+        worktreePath: _worktreePath,
+        worktreePaths: _worktreePaths,
+        systemPrompt: _systemPrompt,
+        cwd: _cwd,
+        pid: _pid,
+        slackIdentity: _slackIdentity,
+        agentSessions,
+        pendingMessages,
+        ...rest
+      } = s;
+      return {
+        ...rest,
+        activeAgentName: s.activeAgentName ?? null,
+        pendingMessages: pendingMessages.length,
+        agents: Object.values(agentSessions ?? {})
+          .map((a) => ({
+            agentName: a.agentName,
+            sessionId: a.sessionId,
+            status: a.status,
+            lastActivity: a.lastActivity,
+            pid: a.pid,
+            pendingMessages: a.pendingMessages.length,
+          }))
+          .sort((a, b) => a.agentName.localeCompare(b.agentName)),
+      };
+    });
 
   return Response.json({ sessions });
 }

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -22,13 +22,6 @@ import { log } from "../logger.ts";
 const PUBLIC_DIR = path.resolve(import.meta.dir, "../../public");
 const startedAt = new Date().toISOString();
 
-function cors(res: Response): Response {
-  res.headers.set("Access-Control-Allow-Origin", "*");
-  res.headers.set("Access-Control-Allow-Methods", "GET, OPTIONS");
-  res.headers.set("Access-Control-Allow-Headers", "Content-Type");
-  return res;
-}
-
 export interface HttpServerDeps {
   store: SessionStore;
   config: Config;
@@ -46,56 +39,54 @@ export function startHttpServer(deps: HttpServerDeps): void {
     async fetch(req) {
       const url = new URL(req.url);
 
+      // No CORS headers — the dashboard at public/index.html is served from
+      // the same origin (127.0.0.1:<port>) as the API, so cross-origin support
+      // would only let arbitrary websites read this server's data when the
+      // operator visits them. Loopback-only binding is the threat model.
       if (req.method === "OPTIONS") {
-        return cors(new Response(null, { status: 204 }));
+        return new Response(null, { status: 204 });
       }
 
       try {
-        let res: Response;
-
         if (url.pathname === "/" || url.pathname === "/index.html") {
           const file = Bun.file(path.join(PUBLIC_DIR, "index.html"));
           if (await file.exists()) {
-            res = new Response(file, {
+            return new Response(file, {
               headers: { "Content-Type": "text/html; charset=utf-8" },
             });
-          } else {
-            res = new Response("Dashboard not found. Create public/index.html", {
-              status: 404,
-            });
           }
-          return cors(res);
+          return new Response("Dashboard not found. Create public/index.html", {
+            status: 404,
+          });
         }
 
         if (url.pathname === "/api/health") {
-          res = await handleHealth(store, config, startedAt);
+          return await handleHealth(store, config, startedAt);
         } else if (url.pathname === "/api/sessions") {
-          res = await handleSessions(store);
+          return await handleSessions(store);
         } else if (url.pathname.startsWith("/api/sessions/")) {
           const threadId = decodeURIComponent(
             url.pathname.slice("/api/sessions/".length),
           );
-          res = await handleSessionDetail(store, threadId);
+          return await handleSessionDetail(store, threadId);
         } else if (url.pathname === "/api/dev-server") {
-          res = await handleDevServers(devServerManager, devServerQueue, repos);
+          return await handleDevServers(devServerManager, devServerQueue, repos);
         } else if (url.pathname === "/api/logs") {
-          res = await handleLogs(url.searchParams);
+          return await handleLogs(url.searchParams);
         } else if (url.pathname === "/api/memory") {
-          res = await handleMemoryList();
+          return await handleMemoryList();
         } else if (url.pathname.startsWith("/api/memory/")) {
           const filePath = decodeURIComponent(
             url.pathname.slice("/api/memory/".length),
           );
-          res = await handleMemoryRead(filePath);
-        } else {
-          res = Response.json({ error: "not found" }, { status: 404 });
+          return await handleMemoryRead(filePath);
         }
-
-        return cors(res);
+        return Response.json({ error: "not found" }, { status: 404 });
       } catch (err) {
         log.error("http", `${req.method} ${url.pathname} — ${err}`);
-        return cors(
-          Response.json({ error: "internal server error" }, { status: 500 }),
+        return Response.json(
+          { error: "internal server error" },
+          { status: 500 },
         );
       }
     },

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -1,0 +1,108 @@
+/**
+ * HTTP dashboard for Junior — ported from Friday's `src/http/` with
+ * Junior-specific extensions: the `/api/dev-server` endpoint surfaces
+ * DevServerManager + DevServerQueue state, and `/api/sessions` joins the
+ * `agent_sessions` table so the UI can render multi-agent threads.
+ *
+ * Localhost-only by design (binds 127.0.0.1, no auth). Gated on the
+ * `HTTP_DASHBOARD_PORT` env var; off by default.
+ */
+import path from "node:path";
+import type { Config, RepoConfig } from "../config.ts";
+import type { SessionStore } from "../session/store/interface.ts";
+import type { DevServerManager } from "../lifecycle/dev-server.ts";
+import type { DevServerQueue } from "../lifecycle/dev-server-queue.ts";
+import { handleHealth } from "./routes/health.ts";
+import { handleSessions, handleSessionDetail } from "./routes/sessions.ts";
+import { handleLogs } from "./routes/logs.ts";
+import { handleMemoryList, handleMemoryRead } from "./routes/memory.ts";
+import { handleDevServers } from "./routes/dev-server.ts";
+import { log } from "../logger.ts";
+
+const PUBLIC_DIR = path.resolve(import.meta.dir, "../../public");
+const startedAt = new Date().toISOString();
+
+function cors(res: Response): Response {
+  res.headers.set("Access-Control-Allow-Origin", "*");
+  res.headers.set("Access-Control-Allow-Methods", "GET, OPTIONS");
+  res.headers.set("Access-Control-Allow-Headers", "Content-Type");
+  return res;
+}
+
+export interface HttpServerDeps {
+  store: SessionStore;
+  config: Config;
+  devServerManager: DevServerManager;
+  devServerQueue: DevServerQueue;
+  repos: RepoConfig[];
+}
+
+export function startHttpServer(deps: HttpServerDeps): void {
+  const { store, config, devServerManager, devServerQueue, repos } = deps;
+
+  const server = Bun.serve({
+    port: config.http.port,
+    hostname: "127.0.0.1",
+    async fetch(req) {
+      const url = new URL(req.url);
+
+      if (req.method === "OPTIONS") {
+        return cors(new Response(null, { status: 204 }));
+      }
+
+      try {
+        let res: Response;
+
+        if (url.pathname === "/" || url.pathname === "/index.html") {
+          const file = Bun.file(path.join(PUBLIC_DIR, "index.html"));
+          if (await file.exists()) {
+            res = new Response(file, {
+              headers: { "Content-Type": "text/html; charset=utf-8" },
+            });
+          } else {
+            res = new Response("Dashboard not found. Create public/index.html", {
+              status: 404,
+            });
+          }
+          return cors(res);
+        }
+
+        if (url.pathname === "/api/health") {
+          res = await handleHealth(store, config, startedAt);
+        } else if (url.pathname === "/api/sessions") {
+          res = await handleSessions(store);
+        } else if (url.pathname.startsWith("/api/sessions/")) {
+          const threadId = decodeURIComponent(
+            url.pathname.slice("/api/sessions/".length),
+          );
+          res = await handleSessionDetail(store, threadId);
+        } else if (url.pathname === "/api/dev-server") {
+          res = await handleDevServers(devServerManager, devServerQueue, repos);
+        } else if (url.pathname === "/api/logs") {
+          res = await handleLogs(url.searchParams);
+        } else if (url.pathname === "/api/memory") {
+          res = await handleMemoryList();
+        } else if (url.pathname.startsWith("/api/memory/")) {
+          const filePath = decodeURIComponent(
+            url.pathname.slice("/api/memory/".length),
+          );
+          res = await handleMemoryRead(filePath);
+        } else {
+          res = Response.json({ error: "not found" }, { status: 404 });
+        }
+
+        return cors(res);
+      } catch (err) {
+        log.error("http", `${req.method} ${url.pathname} — ${err}`);
+        return cors(
+          Response.json({ error: "internal server error" }, { status: 500 }),
+        );
+      }
+    },
+  });
+
+  log.info(
+    "boot",
+    `HTTP dashboard listening on http://127.0.0.1:${server.port}`,
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -182,14 +182,25 @@ setInterval(() => {
   }, store, selfBotId, sessionManager.botUserId, autoTriggerChannels);
 
   if (config.http.enabled) {
-    const { startHttpServer } = await import("./http/server.ts");
-    startHttpServer({
-      store,
-      config,
-      devServerManager,
-      devServerQueue,
-      repos: config.repos,
-    });
+    // Bun.serve throws synchronously on port conflict (EADDRINUSE) and a few
+    // other I/O failures. The dashboard is non-critical — its failure must
+    // not bring down the bot before "Junior is running" prints, otherwise
+    // Slack disconnects. Mirror the bootstrap try/catch above.
+    try {
+      const { startHttpServer } = await import("./http/server.ts");
+      startHttpServer({
+        store,
+        config,
+        devServerManager,
+        devServerQueue,
+        repos: config.repos,
+      });
+    } catch (err) {
+      log.error(
+        "boot",
+        `HTTP dashboard failed to start: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   log.info("boot", "Junior is running (Socket Mode)");

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,5 +181,16 @@ setInterval(() => {
     supportRouter.handleMessage(event);
   }, store, selfBotId, sessionManager.botUserId, autoTriggerChannels);
 
+  if (config.http.enabled) {
+    const { startHttpServer } = await import("./http/server.ts");
+    startHttpServer({
+      store,
+      config,
+      devServerManager,
+      devServerQueue,
+      repos: config.repos,
+    });
+  }
+
   log.info("boot", "Junior is running (Socket Mode)");
 })();

--- a/src/lifecycle/dev-server.ts
+++ b/src/lifecycle/dev-server.ts
@@ -238,6 +238,11 @@ export class DevServerManager {
     return new Map(this.state);
   }
 
+  /** Configured idle TTL in ms. Surfaced for diagnostics (HTTP dashboard). */
+  getIdleTtlMs(): number {
+    return this.idleTtlMs;
+  }
+
   /**
    * Bootstrap step: run once at junior startup.
    *

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -97,6 +97,7 @@ const testConfig: Config = {
     defaultVerbosity: "quiet",
   },
   channelDefaults: {},
+  http: { enabled: false, port: 0 },
 };
 
 function makeEvent(overrides: Partial<SlackMessageEvent> = {}): SlackMessageEvent {


### PR DESCRIPTION
## Motivation

You asked Friday for this — port her HTTP dashboard over so Junior has a way to inspect live state without grepping logs or poking the SQLite DB by hand. This is that.

## What's in it

A Bun HTTP server that binds **127.0.0.1 only**, off by default. Enable with `HTTP_DASHBOARD_PORT=8787 bun run dev` and visit `http://127.0.0.1:8787`.

The dashboard polls every 2s and renders three panels:

- **Threads** — every `ThreadSession` with status, target repo / base ref, and a nested per-agent breakdown (lead / reproducer / thinker / review / echo) showing each agent's `sessionId`, status, last activity, and pending-message count.
- **Dev Servers** — for each repo with `devCommand` configured: holder thread, branch, idle-TTL countdown, waiter list. Reads `DevServerManager.status()` + `DevServerQueue.readQueueDepth()` directly.
- **Health** — uptime, version, session/agent totals.

## Endpoints

| Path | Description |
| --- | --- |
| `GET /` | Static dashboard (`public/index.html`) |
| `GET /api/health` | Uptime + session/agent totals |
| `GET /api/sessions` | All threads with their agent sessions |
| `GET /api/sessions/:threadId` | Full session detail |
| `GET /api/dev-server` | Per-repo manager state + queue depth |
| `GET /api/logs?date=&tail=&tag=&level=` | Tail of structured logs |
| `GET /api/memory` / `GET /api/memory/<path>` | Browse `docs/**/*.md` |

## What changed

- New `src/http/` (server + 5 route modules; **no SSE chat** — intentionally dropped).
- `src/index.ts` — gated `startHttpServer({...})` block at the end of boot.
- `src/config.ts` — adds `config.http.{enabled,port}`. `enabled` is `process.env.HTTP_DASHBOARD_PORT != null`.
- `src/session/manager.test.ts` — adds the new `http` field to its mock `Config`.
- `public/index.html` — vanilla JS, dark theme, no build step.
- `README.md` — was missing entirely; added with a Dashboard section.

## Constraints honored

- **Localhost only.** `Bun.serve({ hostname: "127.0.0.1" })`. No token auth.
- **Off by default.** Only enabled if `HTTP_DASHBOARD_PORT` is set.
- **No SSE chat.** Friday's `chat-manager.ts` and `routes/chat.ts` were not ported.

## Verification

- `bun run typecheck` — clean.
- `bun test` — 234 pass / 2 fail. Both failures are pre-existing on `main` (`createSession returns all expected keys` and the `DevServerManager (integration) > restarts the server when branch changes` integration test). Verified by running `bun test` on `main` with my changes stashed — same two failures.
- Smoke test: started the server with a seeded SQLite store, hit `/api/health`, `/api/sessions`, `/api/dev-server` — all return the expected shapes including the per-agent join.

## Credit

Ported from Friday's `src/http/`. Junior-specific extensions are the `/api/dev-server` route (which Friday doesn't have) and the agent-sessions join in `/api/sessions` (Friday's threads are single-agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)