### PR TITLE
fix(worktree): move worktree path out of .claude/ to a sibling directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Implementation: [`src/lifecycle/dev-server.ts`](src/lifecycle/dev-server.ts), [`
 
 ### Worktrees per (repo, thread)
 
-Each thread that touches a target repo gets its own git worktree under `<repo>/.claude/worktrees/slack-<threadId>`. A thread can have worktrees in multiple repos at once (full-stack bug → backend + frontend). See [`src/worktree/manager.ts`](src/worktree/manager.ts) and the `worktreePaths` field on `ThreadSession`.
+Each thread that touches a target repo gets its own git worktree at `<repo>.junior-worktrees/slack-<threadId>` (sibling to the repo, deliberately outside `.claude/` so target-repo setup scripts that recursively copy `.claude/` don't pull every sibling thread's source tree into a fresh worktree). A thread can have worktrees in multiple repos at once (full-stack bug → backend + frontend). See [`src/worktree/manager.ts`](src/worktree/manager.ts) and the `worktreePaths` field on `ThreadSession`.
 
 ### SQLite persistence
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -185,7 +185,7 @@ Slack message ("!build fix auth")
   → Worktree Manager: create worktree in example-backend
   → Agent Router: load example-backend/.claude/agents/build.md → compose systemPrompt
   → Claude Spawner: spawn claude -p "fix auth" --resume --append-system-prompt "..." 
-      cwd=example-backend/.claude/worktrees/slack-<threadId>
+      cwd=example-backend.junior-worktrees/slack-<threadId>
   → Stream Parser: parse stdout events
       → init event: extract sessionId, store in session
       → tool_use events: emit to Stream-to-Slack → edit status message

--- a/docs/features/bug-pipeline-worktrees.md
+++ b/docs/features/bug-pipeline-worktrees.md
@@ -15,7 +15,7 @@ For bug threads, junior's persistent agents (lead, thinker, reproducer) operate
 directly on the bare target repos under `~/openclaw-projects/<repo>/`. Specifically:
 
 - `runtime-environment.md` and the agent prompts hardcode `~/openclaw-projects/<repo>/` and tell agents to `cd` there for reading code, editing, `git checkout`, and `pnpm dev`.
-- `WorktreeManager` exists and `runClaudeWithAgent` will create a per-thread worktree at `<repo>/.claude/worktrees/slack-<threadId>` — but only when `session.targetRepo` is set, which never happens on the lead-driven bug pipeline.
+- `WorktreeManager` exists and `runClaudeWithAgent` will create a per-thread worktree at `<repo>.junior-worktrees/slack-<threadId>` — but only when `session.targetRepo` is set, which never happens on the lead-driven bug pipeline.
 
 Consequences:
 
@@ -36,7 +36,7 @@ Three things tangle:
 
 ### Scope-1 — per-thread worktrees for read/write
 
-- Lead, on intake, reads `repo-routing.yaml` and creates one worktree per routed repo for this thread (`<repo>/.claude/worktrees/slack-<threadId>`, branch `slack/<threadId>` off `defaultBase`).
+- Lead, on intake, reads `repo-routing.yaml` and creates one worktree per routed repo for this thread (`<repo>.junior-worktrees/slack-<threadId>`, branch `slack/<threadId>` off `defaultBase`).
 - Session schema gains `worktreePaths: Record<repoName, path>` alongside the existing `worktreePath` (or replaces it).
 - `runtime-environment.md` and agent prompts swap hardcoded `~/openclaw-projects/<repo>/` references for the per-thread worktree paths, injected via the workspace block.
 - `thinker` writes its fix branch in its repo's worktree. PR is opened from that branch.
@@ -109,7 +109,7 @@ Trap to watch:
 
 1. Resolves the repo's `RepoConfig`. Errors if unknown.
 2. If `repo.worktreeSetupCommand` is configured (e.g. `"bin/setup-worktree.sh"`), runs `<repo.path>/<command> <worktreePath> <branch>`. Otherwise runs `git fetch origin && git worktree add <worktreePath> -b <branch> <baseRef>` directly.
-3. Sets `worktreePath = <repo.path>/.claude/worktrees/slack-<threadId>` and `branch = slack/<threadId>` (unless caller overrides).
+3. Sets `worktreePath = <repo.path>.junior-worktrees/slack-<threadId>` and `branch = slack/<threadId>` (unless caller overrides).
 4. Persists `session.worktreePaths[repo] = worktreePath` via `SessionManager.updateSession`.
 5. Returns `{ path, branch }` to the caller.
 
@@ -127,12 +127,12 @@ the bare repos under ~/openclaw-projects/. NEVER run dev servers
 yourself — post `!devserver <branch>` instead.
 
 repo: gx-client-next
-  worktree: /Users/.../openclaw-projects/growthx/gx-client-next/.claude/worktrees/slack-<tid>
+  worktree: /Users/.../openclaw-projects/growthx/gx-client-next.junior-worktrees/slack-<tid>
   branch:   slack/<tid>
   base:     origin/main
 
 repo: gx-backend
-  worktree: /Users/.../openclaw-projects/growthx/gx-backend/.claude/worktrees/slack-<tid>
+  worktree: /Users/.../openclaw-projects/growthx/gx-backend.junior-worktrees/slack-<tid>
   branch:   slack/<tid>
   base:     origin/main
 </workspace>

--- a/docs/features/process-lifecycle.md
+++ b/docs/features/process-lifecycle.md
@@ -127,7 +127,7 @@ When the bot itself shuts down (SIGINT, SIGTERM, restart), handle running proces
 `DevServerManager` (`src/lifecycle/dev-server.ts`) owns long-lived dev servers for the bug-pipeline validation flow. The full design is in [bug-pipeline-worktrees.md](bug-pipeline-worktrees.md); the runtime invariants:
 
 - **One dev server per repo.** Tracked as `Map<repoName, DevServerState>` where `DevServerState = { pid, branch, startedAt, lastUsedAt }`. Never two on the same configured `devPort`.
-- **Dev servers always run from a dedicated worktree.** Bootstrapped to `<repo.path>/.claude/worktrees/slack-dev-server` on branch `dev-server-slot/<repo>`. Bare repos are never touched by junior.
+- **Dev servers always run from a dedicated worktree.** Bootstrapped to `<repo.path>.junior-worktrees/slack-dev-server` (sibling to the repo, not under `.claude/`) on branch `dev-server-slot/<repo>`. Bare repos are never touched by junior.
 - **Branch-keyed reuse.** `ensure(repoName, branch)` reuses the running process if its branch matches; otherwise kills, `git fetch && git reset --hard origin/<branch>` (reset, not checkout — checkout rejects branches checked out elsewhere), respawns, polls `<readyUrl>` until 200 (90s timeout).
 - **Idle TTL** = 20 min default. `setInterval` sweeper kills servers whose `lastUsedAt` is past the TTL. Tunable via `DevServerManagerOptions` for tests.
 - **Junior shutdown.** `setupGracefulShutdown` calls `devServerManager.killAll()` in parallel with session teardown. SIGINT first, 5s grace, SIGKILL fallback.
@@ -138,7 +138,7 @@ When the bot itself shuts down (SIGINT, SIGTERM, restart), handle running proces
 
 Wraps `DevServerManager.ensure` with a `proper-lockfile`-based per-repo queue (`src/lifecycle/dev-server-queue.ts`). Accessed via the `!devserver` directive (`src/support/router.ts`); humans and agents post the same form.
 
-- **Lock dir.** `<repo.path>/.claude/worktrees/slack-dev-server` — the dev-server worktree itself. `proper-lockfile.lock(...)` creates a `.lock` directory inside.
+- **Lock dir.** `<repo.path>.junior-worktrees/slack-dev-server` — the dev-server worktree itself. `proper-lockfile.lock(...)` creates a `.lock` directory inside.
 - **Holder metadata.** `<lockDir>/.lock.meta.json` written atomically (`write-tmp + rename`) on acquire with `{ holderThreadId, holderPid, branch, acquiredAt }`. Cleared on release.
 - **Waiter queue.** `<lockDir>/.queue` — append-only NDJSON, one line per waiter. Append uses O_APPEND atomic semantics. On release, the line is removed via read-modify-write under the lock that's about to be released. Read by `!devserver status` for "you're 3rd in line" UX.
 - **Slot timeout.** 10 min default. The auto-release timer lives in `handleDevserverAcquire` (`src/support/router.ts`), NOT inside `acquire()` itself: after the queue acquires and junior posts the ready message, the handler `await sleep(slotTimeoutMs)` then calls `release()` in a `finally`. `acquire()` itself has no built-in timer — direct callers (i.e. anything that bypasses the `!devserver` directive) are responsible for calling `release()` themselves. The `proper-lockfile` `stale` config (passed through `acquire()`) is the secondary backstop: a held lock that lives past `stale` is eligible for takeover by the next acquirer, which fires `onCompromised` on the original holder.

--- a/docs/features/project-setup.md
+++ b/docs/features/project-setup.md
@@ -158,7 +158,7 @@ Prove Bun + Bolt + Socket Mode works.
 - `bun run dev` — watch mode with `--watch` flag
 - `bun run build` — production build
 - `bun run typecheck` — type checking without emit
-- `.gitignore` — node_modules, .env, dist, .claude/worktrees
+- `.gitignore` — node_modules, .env, dist, `.claude/worktrees/` (used by other tooling like ultrareview/Agent isolation; junior itself stores worktrees in a sibling directory)
 - `.env.example` — all required and optional env vars documented
 
 **Test:** Edit a file → dev server reloads. `bun run typecheck` → clean. `.env` not tracked by git.

--- a/docs/features/thread-commands.md
+++ b/docs/features/thread-commands.md
@@ -57,7 +57,7 @@ The two most critical control commands.
 - `!status`: reply with session info or "No active session."
   ```
   Agent: build
-  Worktree: example-backend/.claude/worktrees/slack-1234
+  Worktree: example-backend.junior-worktrees/slack-1234
   Status: idle
   Last activity: 2 min ago
   Pending messages: 0

--- a/docs/features/worktree-manager.md
+++ b/docs/features/worktree-manager.md
@@ -49,7 +49,7 @@ The bug-pipeline + dev-server fields are optional. Repos that only need the `!re
 
 `WorktreeManager` (`src/worktree/manager.ts`):
 
-- `createWorktree(repoName, threadId, baseRef?, branchOverride?) → Promise<worktreePath>` — creates a worktree at `<repo.path>/.claude/worktrees/slack-<threadId>` (or whatever path `getWorktreePath` derives). The new branch is `branchOverride ?? slack/<threadId>`; the starting ref is `baseRef ?? repo.defaultBase`. If `repo.worktreeSetupCommand` is set, the manager runs `<repo.path>/<command> <worktreePath> <branch>` instead of `git fetch + git worktree add`.
+- `createWorktree(repoName, threadId, baseRef?, branchOverride?) → Promise<worktreePath>` — creates a worktree at `<repo.path>.junior-worktrees/slack-<threadId>` (or whatever path `getWorktreePath` derives — note this is a sibling directory to the repo, deliberately outside `.claude/`). The new branch is `branchOverride ?? slack/<threadId>`; the starting ref is `baseRef ?? repo.defaultBase`. If `repo.worktreeSetupCommand` is set, the manager runs `<repo.path>/<command> <worktreePath> <branch>` instead of `git fetch + git worktree add`.
 - `removeWorktree(repoName, threadId) → Promise<void>` — reads the actual current branch via `git -C <wt> branch --show-current` before deletion (so cleanup works for `branchOverride` callers), force-removes the worktree, and `git branch -D`s the branch. Both lookup and delete are wrapped in try/catch so missing/detached state is non-fatal.
 - `worktreeExists(repoName, threadId) → Promise<boolean>` and `isWorktreeDirty(worktreePath) → Promise<boolean>` — used by cleanup.
 - `getWorktreePath(repoName, threadId) → string` and `getBranchName(threadId) → string` — pure helpers (no I/O).

--- a/src/config.ts
+++ b/src/config.ts
@@ -91,7 +91,14 @@ export function loadConfig(): Config {
       permissionMode: optional("CLAUDE_PERMISSION_MODE", "bypassPermissions"),
       defaultModel: process.env.CLAUDE_MODEL ?? null,
     },
-    repos: JSON.parse(optional("REPOS", "[]")) as RepoConfig[],
+    repos: (JSON.parse(optional("REPOS", "[]")) as RepoConfig[]).map((r) => ({
+      ...r,
+      // Strip any trailing slashes so path-construction sites can do
+      // `${r.path}.junior-worktrees/...` without producing
+      // `<repo>//.junior-worktrees/...` (which collapses to a path INSIDE
+      // the repo and recreates the recursive-copy bug).
+      path: r.path.replace(/\/+$/, ""),
+    })),
     session: {
       staleTimeoutMs: Number(optional("SESSION_STALE_TIMEOUT_MS", "86400000")),
       cleanupIntervalMs: Number(

--- a/src/lifecycle/dev-server-queue.test.ts
+++ b/src/lifecycle/dev-server-queue.test.ts
@@ -251,6 +251,7 @@ describe("DevServerQueue (integration — real lockfile)", () => {
 
   afterAll(() => {
     rmSync(repoRoot, { recursive: true, force: true });
+    rmSync(`${repoRoot}.junior-worktrees`, { recursive: true, force: true });
   });
 
   beforeEach(() => {
@@ -266,7 +267,7 @@ describe("DevServerQueue (integration — real lockfile)", () => {
   });
 
   it("acquire / release happy path: lock metadata + queue round-trip", async () => {
-    const lockDir = join(repoRoot, ".claude", "worktrees", "slack-dev-server");
+    const lockDir = `${repoRoot}.junior-worktrees/slack-dev-server`;
     mkdirSync(lockDir, { recursive: true });
 
     const managerMock = makeMockDevServerManager();
@@ -309,7 +310,7 @@ describe("DevServerQueue (integration — real lockfile)", () => {
   }, 15_000);
 
   it("release is idempotent — second call does not throw", async () => {
-    const lockDir = join(repoRoot, ".claude", "worktrees", "slack-dev-server");
+    const lockDir = `${repoRoot}.junior-worktrees/slack-dev-server`;
     mkdirSync(lockDir, { recursive: true });
 
     const managerMock = makeMockDevServerManager();
@@ -386,7 +387,7 @@ describe("DevServerQueue (integration — real lockfile)", () => {
 
   it("second acquire serializes behind first (sequential acquire + release)", async () => {
     // Set up the lock dir.
-    const lockDir = join(repoRoot, ".claude", "worktrees", "slack-dev-server");
+    const lockDir = `${repoRoot}.junior-worktrees/slack-dev-server`;
     mkdirSync(lockDir, { recursive: true });
 
     const order: string[] = [];
@@ -462,9 +463,9 @@ describe("DevServerQueue (integration — real lockfile)", () => {
     );
 
     // The acquire path needs the dev-server worktree to exist at the
-    // expected path (acquire uses repo.path/.claude/worktrees/slack-dev-server,
+    // expected path (acquire uses repo.path.junior-worktrees/slack-dev-server,
     // not our compromise-check subdir) — set that up.
-    const realLockDir = join(repoRoot, ".claude", "worktrees", "slack-dev-server");
+    const realLockDir = `${repoRoot}.junior-worktrees/slack-dev-server`;
     mkdirSync(realLockDir, { recursive: true });
 
     const { release } = await queue.acquire("test-repo", "main", "thread-comp-1");

--- a/src/lifecycle/dev-server-queue.test.ts
+++ b/src/lifecycle/dev-server-queue.test.ts
@@ -438,9 +438,6 @@ describe("DevServerQueue (integration — real lockfile)", () => {
     // is present on every lock acquisition. Triggering an actual compromise is
     // timer-driven and brittle to test directly; this guards against the option
     // being silently dropped in a future refactor.
-    const lockDir = join(repoRoot, ".claude", "worktrees", "slack-dev-server-compromise-check");
-    mkdirSync(lockDir, { recursive: true });
-
     // Spy on proper-lockfile.lock by re-importing through a wrapper.
     // Bun's module mocking is limited — we use a different angle: spy on the
     // queue's stealStale method, then synthesize a compromise by manipulating

--- a/src/lifecycle/dev-server-queue.ts
+++ b/src/lifecycle/dev-server-queue.ts
@@ -6,7 +6,7 @@
  * PRECONDITION comment in DevServerManager.ensure() — callers should go through
  * DevServerQueue.acquire() rather than calling ensure() directly.
  *
- * Lock file layout (all under <repo>/.claude/worktrees/slack-dev-server/):
+ * Lock file layout (all under <repo>.junior-worktrees/slack-dev-server/):
  *   .lock            — proper-lockfile's lock directory (created by the library)
  *   .lock.meta.json  — holder metadata: { holderThreadId, holderPid, branch, acquiredAt }
  *   .queue           — NDJSON, one line per waiter: { threadId, branch, enqueuedAt }
@@ -322,16 +322,15 @@ export class DevServerQueue {
 
   /**
    * Resolve the lock directory path for a repo.
-   * This is the dev-server worktree: <repo.path>/.claude/worktrees/slack-dev-server
+   * This is the dev-server worktree: <repo.path>.junior-worktrees/slack-dev-server
+   * Path shape mirrors WorktreeManager.getWorktreePath — keep them in sync.
    */
   private getLockDir(repoName: string): string {
     const repo = this.repos.find((r) => r.name === repoName);
     if (!repo) {
       throw new Error(`Unknown repo: ${repoName}`);
     }
-    // The dev-server worktree uses the fixed thread-ID "dev-server", same as
-    // DevServerManager internally. Path: <repo.path>/.claude/worktrees/slack-dev-server
-    return join(repo.path, ".claude", "worktrees", "slack-dev-server");
+    return `${repo.path}.junior-worktrees/slack-dev-server`;
   }
 }
 

--- a/src/lifecycle/dev-server-queue.ts
+++ b/src/lifecycle/dev-server-queue.ts
@@ -330,7 +330,9 @@ export class DevServerQueue {
     if (!repo) {
       throw new Error(`Unknown repo: ${repoName}`);
     }
-    return `${repo.path}.junior-worktrees/slack-dev-server`;
+    // Strip trailing slashes — see WorktreeManager.getWorktreePath for why.
+    const base = repo.path.replace(/\/+$/, "");
+    return `${base}.junior-worktrees/slack-dev-server`;
   }
 }
 

--- a/src/lifecycle/dev-server.test.ts
+++ b/src/lifecycle/dev-server.test.ts
@@ -149,6 +149,7 @@ process.on('SIGTERM', () => { server.close(); process.exit(0); });
 
   afterAll(() => {
     rmSync(repoRoot, { recursive: true, force: true });
+    rmSync(`${repoRoot}.junior-worktrees`, { recursive: true, force: true });
   });
 
   it("bootstrap creates the dev-server worktree if it does not exist", async () => {

--- a/src/lifecycle/dev-server.ts
+++ b/src/lifecycle/dev-server.ts
@@ -4,7 +4,8 @@
  * Junior owns the lifecycle of dev servers that are used for bug-pipeline
  * validation. Each repo with `devCommand` configured gets a single shared
  * dev-server process running from a dedicated worktree at
- * `<repo>/.claude/worktrees/slack-dev-server`.
+ * `<repo>.junior-worktrees/slack-dev-server` (sibling to the repo, NOT under
+ * `.claude/` — see WorktreeManager.getWorktreePath for why).
  *
  * Scope-2b will layer the per-repo lock/queue on top; this module only handles
  * spawn / probe / kill / idle-TTL.

--- a/src/slack/thread-context.test.ts
+++ b/src/slack/thread-context.test.ts
@@ -16,7 +16,7 @@ describe("buildWorkspaceBlock", () => {
 
   it("renders the single-repo format from a WorkspaceContext", () => {
     const ws: WorkspaceContext = {
-      worktreePath: "/repos/gx-backend/.claude/worktrees/slack-t1",
+      worktreePath: "/repos/gx-backend.junior-worktrees/slack-t1",
       repoName: "gx-backend",
       repoPath: "/repos/gx-backend",
       branchName: "slack/t1",
@@ -24,15 +24,15 @@ describe("buildWorkspaceBlock", () => {
     const block = buildWorkspaceBlock(ws);
     expect(block).toContain("<workspace>");
     expect(block).toContain("Target repo: gx-backend");
-    expect(block).toContain("Worktree (your sandbox): /repos/gx-backend/.claude/worktrees/slack-t1");
+    expect(block).toContain("Worktree (your sandbox): /repos/gx-backend.junior-worktrees/slack-t1");
     expect(block).toContain("Worktree branch: slack/t1");
     expect(block).toContain("</workspace>");
   });
 
   it("renders the multi-repo format when worktreePaths is non-empty", () => {
     const paths = {
-      "gx-backend": "/repos/gx-backend/.claude/worktrees/slack-t1",
-      "gx-client-next": "/repos/gx-client-next/.claude/worktrees/slack-t1",
+      "gx-backend": "/repos/gx-backend.junior-worktrees/slack-t1",
+      "gx-client-next": "/repos/gx-client-next.junior-worktrees/slack-t1",
     };
     const block = buildWorkspaceBlock(undefined, paths, repos, "t1");
 
@@ -41,11 +41,11 @@ describe("buildWorkspaceBlock", () => {
     expect(block).toContain("NEVER touch");
     expect(block).toContain("~/openclaw-projects/");
     expect(block).toContain("repo: gx-backend");
-    expect(block).toContain("worktree: /repos/gx-backend/.claude/worktrees/slack-t1");
+    expect(block).toContain("worktree: /repos/gx-backend.junior-worktrees/slack-t1");
     expect(block).toContain("branch:   slack/t1");
     expect(block).toContain("base:     origin/main");
     expect(block).toContain("repo: gx-client-next");
-    expect(block).toContain("worktree: /repos/gx-client-next/.claude/worktrees/slack-t1");
+    expect(block).toContain("worktree: /repos/gx-client-next.junior-worktrees/slack-t1");
     expect(block).toContain("</workspace>");
   });
 
@@ -56,7 +56,7 @@ describe("buildWorkspaceBlock", () => {
       repoPath: "/should/not/appear",
       branchName: "should-not-appear",
     };
-    const paths = { "gx-backend": "/repos/gx-backend/.claude/worktrees/slack-t1" };
+    const paths = { "gx-backend": "/repos/gx-backend.junior-worktrees/slack-t1" };
     const block = buildWorkspaceBlock(ws, paths, repos, "t1");
 
     expect(block).not.toContain("should-not-appear");

--- a/src/worktree/manager.test.ts
+++ b/src/worktree/manager.test.ts
@@ -140,6 +140,7 @@ git worktree add "$ABS_TARGET" -b "$BRANCH" origin/main
 
 afterAll(() => {
   rmSync(repoRoot, { recursive: true, force: true });
+  rmSync(`${repoRoot}.junior-worktrees`, { recursive: true, force: true });
 });
 
 /**
@@ -170,9 +171,7 @@ describe("WorktreeManager.createWorktree", () => {
     const freshFile = await addFreshCommitOnMain("default-flow");
 
     const wtPath = await wm.createWorktree("default-flow", "default-thread");
-    expect(wtPath).toBe(
-      join(repoRoot, ".claude/worktrees/slack-default-thread"),
-    );
+    expect(wtPath).toBe(`${repoRoot}.junior-worktrees/slack-default-thread`);
     expect(existsSync(wtPath)).toBe(true);
     expect(existsSync(join(wtPath, "README.md"))).toBe(true);
     // Inline-path autofetch regression guard: fetch ran, so origin/main is fresh.
@@ -208,13 +207,11 @@ describe("WorktreeManager.createWorktree", () => {
     expect(args).toEqual([
       "slack/custom-thread",
       "--path",
-      join(repoRoot, ".claude/worktrees/slack-custom-thread"),
+      `${repoRoot}.junior-worktrees/slack-custom-thread`,
       "--base",
       "origin/main",
     ]);
-    expect(wtPath).toBe(
-      join(repoRoot, ".claude/worktrees/slack-custom-thread"),
-    );
+    expect(wtPath).toBe(`${repoRoot}.junior-worktrees/slack-custom-thread`);
 
     await wm.removeWorktree("custom-flow", "custom-thread");
   });

--- a/src/worktree/manager.test.ts
+++ b/src/worktree/manager.test.ts
@@ -424,4 +424,21 @@ describe("WorktreeManager.createWorktree", () => {
 
     await wm.removeWorktree("delegate-branch-override", "delegate-override-thread");
   });
+
+  it("getWorktreePath strips trailing slashes from repo.path", () => {
+    // Regression guard: a config with a trailing slash on `path` must NOT
+    // produce a path INSIDE the repo (`<repo>/.junior-worktrees/...`) — that
+    // would re-introduce the recursive-copy bug this directory move solves.
+    const repos: RepoConfig[] = [
+      {
+        name: "trailing-slash",
+        path: `${repoRoot}/`,
+        defaultBase: "origin/main",
+      },
+    ];
+    const wm = new WorktreeManager(repos);
+    expect(wm.getWorktreePath("trailing-slash", "t1")).toBe(
+      `${repoRoot}.junior-worktrees/slack-t1`,
+    );
+  });
 });

--- a/src/worktree/manager.ts
+++ b/src/worktree/manager.ts
@@ -147,7 +147,12 @@ export class WorktreeManager {
     if (!repo) {
       throw new Error(`Unknown repo: ${repoName}`);
     }
-    return `${repo.path}.junior-worktrees/slack-${threadId}`;
+    // Strip trailing slashes — without this, a config with `path: "/r/"` would
+    // resolve to `/r/.junior-worktrees/...`, a hidden subdir INSIDE the repo
+    // rather than a sibling, recreating the recursive-copy bug. Belt-and-
+    // suspenders with the same normalization at config load.
+    const base = repo.path.replace(/\/+$/, "");
+    return `${base}.junior-worktrees/slack-${threadId}`;
   }
 
   getBranchName(threadId: string): string {

--- a/src/worktree/manager.ts
+++ b/src/worktree/manager.ts
@@ -135,13 +135,19 @@ export class WorktreeManager {
 
   /**
    * Get the worktree path for a thread (without creating it).
+   *
+   * Worktrees live in a sibling directory to the repo, NOT under `.claude/`.
+   * Setup scripts that recursively copy `.claude/` (e.g. `cp -R .claude/.`)
+   * would otherwise pull every sibling thread's worktree — and the destination
+   * itself — into a freshly-creating worktree, producing a recursive copy
+   * that loops on its own destination.
    */
   getWorktreePath(repoName: string, threadId: string): string {
     const repo = this.getRepo(repoName);
     if (!repo) {
       throw new Error(`Unknown repo: ${repoName}`);
     }
-    return `${repo.path}/.claude/worktrees/slack-${threadId}`;
+    return `${repo.path}.junior-worktrees/slack-${threadId}`;
   }
 
   getBranchName(threadId: string): string {


### PR DESCRIPTION
## Summary
- Move worktree path from `<repo>/.claude/worktrees/slack-<thread>` to `<repo>.junior-worktrees/slack-<thread>` (sibling to the repo, not under `.claude/`).
- Update the duplicate path-construction site in `DevServerQueue.getLockDir` so locks land at the same place as the worktree.
- Tests + doc comments updated; `afterAll` teardown extended to clean the new sibling directory.

## Why
Target repos' `setup-worktree.sh` recursively copies `.claude/` into a freshly-creating worktree (e.g., gx-client-next did `cp -R .claude/. <new-worktree>/.claude/`). Because junior's worktrees lived under `.claude/worktrees/`, the copy source contained the destination plus every sibling thread's full source tree — and `cp -R` recursed into the destination itself. Observed runaway: 100 GB of nested duplicates after 7 minutes at 83% CPU on gx-client-next before npm install ever started.

Two clashing decisions were producing the bug together: (1) junior nested its worktrees inside an in-repo dir, (2) the setup scripts did unfiltered recursive copies of that dir. Either decision alone was fine; together they pathologically interacted. The setup scripts in all three GX repos have been patched separately (`rsync -a --exclude='worktrees' .claude/ dst/.claude/`) as defense-in-depth. This PR is the durable architectural fix on junior's side: worktrees now live outside any in-repo dir a setup script could walk.

## Side effects
- Existing worktrees at the old `<repo>/.claude/worktrees/slack-*` paths become orphans. Junior won't find them on next boot.
  - Dev-server bootstrap recreates fresh at the new path — no continuity needed.
  - Active thread sessions persisted in SQLite reference old paths — `--resume` continuity breaks for those threads until they're re-bootstrapped.
- The pre-existing flaky test `DevServerManager (integration) > ensure() restarts the server when branch changes` still fails on `main` without these changes (the failing test relies on a `fake-server.js` file that's not on the `fix/test` branch in the test fixture). Not addressed in this PR.

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun test` — 244/245 pass; the one failure is the pre-existing flake unrelated to this change
- [ ] Manual: stop junior, delete any old `.claude/worktrees/slack-*` dirs in target repos, restart junior, confirm new worktrees are created at `<repo>.junior-worktrees/slack-dev-server` and that the setup script's `rsync` copy completes cleanly
- [ ] Manual: confirm `npm install` succeeds against `npm.pkg.github.com` (depends on the direnv-export fix in target repos' setup-worktree.sh, also pushed to `main` in each repo)