### PR TITLE
Admin-gate destructive commands + filter sibling-bot ✽ noise

### DIFF
--- a/docs/features/project-setup.md
+++ b/docs/features/project-setup.md
@@ -65,6 +65,9 @@ interface Config {
     staleTimeoutMs: number; // SESSION_STALE_TIMEOUT_MS (default: 86400000)
     cleanupIntervalMs: number; // SESSION_CLEANUP_INTERVAL_MS (default: 900000)
   };
+  // Single Slack user ID allowed to run !mute, !unmute, !reset.
+  // Unset → gate is open (local dev). Production must set this.
+  adminSlackUserId: string | null; // ADMIN_SLACK_USER_ID
   redis?: {
     url: string; // REDIS_URL (optional — in-memory if not set)
   };

--- a/docs/features/thread-commands.md
+++ b/docs/features/thread-commands.md
@@ -11,7 +11,7 @@ Users need to control thread behavior beyond just sending messages. Reset a brok
 
 ## Full Vision
 
-- `!reset` — Clear session (kill process if running, remove session state, optionally remove worktree)
+- `!reset <agent|all>` — Clear one agent's slice of the session, or the whole thread. Bare `!reset` is rejected with usage help so admins don't accidentally nuke an active reproducer/thinker turn. (admin only)
 - `!status` — Show session state (agent type, worktree, busy/idle, last activity, pending messages count)
 - `!build [prompt]` — Set agent to build, create worktree if needed, run prompt
 - `!frontend [prompt]` — Set agent to frontend, create worktree, run prompt
@@ -20,9 +20,15 @@ Users need to control thread behavior beyond just sending messages. Reset a brok
 - `!repo <name>` — Switch target repo for this thread
 - `!branch <ref>` — Set worktree base ref (next worktree creation uses this)
 - `!quiet` / `!normal` / `!verbose` — Set verbosity
-- `!mute` — Stop seeing or replying to any messages until `!unmute`
-- `!unmute` — Resume normal operation
+- `!mute` — Stop seeing or replying to any messages until `!unmute` (admin only)
+- `!unmute` — Resume normal operation (admin only)
 - `!help` — List available commands
+
+## Admin-only commands
+
+`!mute`, `!unmute`, and `!reset` are gated behind `ADMIN_SLACK_USER_ID` (single Slack user ID, env-configured). Non-admin invocations are silently rejected with a ❌ reaction on the trigger message — no thread reply, no log noise. When `ADMIN_SLACK_USER_ID` is unset (local dev), the gate is open.
+
+This is intentionally a single-admin model. The "elevation list lives in SQLite" idea was scoped out for v1 — see [v2-backlog.md](v2-backlog.md).
 
 ## Design Decision: `!` prefix, not Slack slash commands
 

--- a/docs/features/v2-backlog.md
+++ b/docs/features/v2-backlog.md
@@ -27,6 +27,35 @@ Features explicitly deferred from MVP. To be scoped when MVP is running.
 
 **Priority:** Low — current thread sizes are small. Becomes relevant when threads regularly exceed ~20 unique participants.
 
+## Per-agent mute
+
+**Problem:** `session.muted` is a single boolean on the parent `ThreadSession`. There is no way to mute *just* the reproducer (e.g. when it's looping noisily) while keeping the lead agent responsive.
+
+**Scope (to be refined):**
+- Move `muted: boolean` from `ThreadSession` onto each `agentSessions[name]` entry. Lead lives on the parent — either keep `ThreadSession.muted` as the lead's flag, or carve out a synthetic `agentSessions["lead"]` for symmetry.
+- `!mute <agent>` / `!unmute <agent>` toggle the per-agent flag. `!mute all` mutes every agent currently registered in `agentSessions`.
+- Update the home tab counter (`src/slack/home.ts`) to count *any* muted agent rather than `session.muted`.
+- SQLite migration: add a `muted` column to the `agent_sessions` table (or store on the existing JSON blob). Old `muted` column on the parent stays for the lead until the model is unified.
+- Buffer/drain logic in `src/session/manager.ts:86,127,651` must consult the agent in question, not the parent.
+
+**Open questions:**
+- Does `!mute` (no arg) become an alias for `!mute all`, or a usage error like `!reset`? Leaning toward usage error to stay consistent with `!reset`.
+- Should muting an agent kill an in-flight process for that agent, or only suppress *future* turns? Today muting mid-turn discards the buffer (`manager.ts:651`) but lets the running process complete — that behavior probably ports over.
+
+## Thread-owner-based command access
+
+**Problem:** Today admin gating is a single env var (`ADMIN_SLACK_USER_ID`). The original sketch was richer — env admin + a SQLite-backed list of additional admins, plus letting the *thread owner* (first non-bot author) run elevated commands in their own thread.
+
+**Scope (to be refined):**
+- Persist `ownerSlackUserId` on `ThreadSession`, set from the first user message that creates the session. Survives `!reset all`.
+- `isAdmin(userId, session?)` returns true if `userId === envAdmin` OR `userId === session.ownerSlackUserId`.
+- Optional: SQLite `admins` table (`slack_user_id PRIMARY KEY, granted_by, granted_at`) plus `!admin add @user` / `!admin remove @user` / `!admin list`. Env admin is the bootstrap and cannot be removed via the command (they're not in the table).
+- Decide: do owners get *all* elevated commands, or only a safe subset (e.g. mute/unmute on their own thread but not reset)?
+
+**Open questions:**
+- Legacy threads have no `ownerSlackUserId`. Fall back to admin-only, or backfill from the first message?
+- DMs — is the DM partner the "owner" by default? Probably yes.
+
 ## Image & Media Support from Slack
 
 **Problem:** Users send screenshots, diagrams, error images, and file uploads in Slack threads. The bot currently ignores them — only `event.text` is passed to Claude. Claude Code can read images, so the capability is there but not wired.

--- a/src/config.ts
+++ b/src/config.ts
@@ -59,6 +59,12 @@ export interface Config {
     defaultVerbosity: SessionVerbosity;
   };
   channelDefaults: Record<string, { agentType: string }>;
+  /**
+   * Single Slack user ID allowed to run elevated commands (`!mute`, `!unmute`,
+   * `!reset`). When unset, those commands are open to anyone — useful for local
+   * dev. In production this should always be set.
+   */
+  adminSlackUserId: string | null;
   http: {
     /** Localhost dashboard. Off unless HTTP_DASHBOARD_PORT is set. */
     enabled: boolean;
@@ -117,6 +123,7 @@ export function loadConfig(): Config {
         '{"C05557KKV37":{"agentType":"lead"}}',
       ),
     ),
+    adminSlackUserId: process.env.ADMIN_SLACK_USER_ID?.trim() || null,
     http: parseHttpDashboard(process.env.HTTP_DASHBOARD_PORT),
   };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -109,6 +109,10 @@ sessionManager.onCommandResponse = (event, response) => {
   responder.postResponse(event.channel, event.threadId, response);
 };
 
+sessionManager.onReaction = (event, emoji) => {
+  responder.addReaction(event.channel, event.ts, emoji);
+};
+
 sessionManager.onError = (session, error) => {
   const agentName = session.activeAgentName ?? "lead";
   log.error("error", `thread=${session.threadId} agent=${agentName} ${error ?? "Unknown error"}`);

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -97,6 +97,7 @@ const testConfig: Config = {
     defaultVerbosity: "quiet",
   },
   channelDefaults: {},
+  adminSlackUserId: null,
   http: { enabled: false, port: 0 },
 };
 
@@ -297,27 +298,131 @@ describe("SessionManager", () => {
   // --- Commands ---
 
   describe("!reset", () => {
-    it("kills running process and deletes session", async () => {
+    it("rejects bare !reset with usage help", async () => {
       const onCmd = mock((_e: SlackMessageEvent, _r: string) => {});
       manager.onCommandResponse = onCmd;
-
-      // Start a session
       await manager.handleMessage(makeEvent({ text: "Work on this" }));
 
-      // Now reset
-      const resetEvent = makeEvent({ command: "reset", text: "", ts: "ts-reset" });
-      await manager.handleMessage(resetEvent);
+      await manager.handleMessage(makeEvent({ command: "reset", text: "", ts: "ts-reset" }));
 
-      // Session should be deleted
-      const session = await store.get("thread-1");
-      expect(session).toBeUndefined();
+      // Session must NOT be deleted — bare !reset is a usage error
+      expect(await store.get("thread-1")).toBeDefined();
+      expect(currentHandle.kill).not.toHaveBeenCalled();
+      expect(onCmd).toHaveBeenCalledTimes(1);
+      expect(onCmd.mock.calls[0][1]).toContain("Usage:");
+    });
 
-      // kill should have been called on the handle
+    it("!reset all kills running process and deletes session", async () => {
+      const onCmd = mock((_e: SlackMessageEvent, _r: string) => {});
+      manager.onCommandResponse = onCmd;
+      await manager.handleMessage(makeEvent({ text: "Work on this" }));
+
+      await manager.handleMessage(makeEvent({ command: "reset", text: "all", ts: "ts-reset" }));
+
+      expect(await store.get("thread-1")).toBeUndefined();
       expect(currentHandle.kill).toHaveBeenCalled();
-
-      // Command response should fire
       expect(onCmd).toHaveBeenCalledTimes(1);
       expect(onCmd.mock.calls[0][1]).toBe("Session reset.");
+    });
+
+    it("!reset <agent> clears only that agent's slice", async () => {
+      const onCmd = mock((_e: SlackMessageEvent, _r: string) => {});
+      manager.onCommandResponse = onCmd;
+      await manager.handleAgentMessage(makeEvent({ text: "hello" }), "echo");
+      currentHandle._complete("echo response", "echo-session-1");
+      await new Promise((r) => setTimeout(r, 10));
+
+      // Set lead state too so we can verify it's untouched
+      let session = await store.get("thread-1");
+      session!.sessionId = "lead-session-1";
+      session!.leadSessionId = "lead-session-1";
+      await store.set("thread-1", session!);
+
+      await manager.handleMessage(makeEvent({ command: "reset", text: "echo", ts: "ts-reset" }));
+
+      session = await store.get("thread-1");
+      expect(session!.agentSessions.echo).toBeUndefined();
+      // Lead state untouched
+      expect(session!.leadSessionId).toBe("lead-session-1");
+      expect(onCmd.mock.calls[0][1]).toContain("Reset *echo*");
+    });
+
+    it("!reset <unknown-agent> reports nothing to reset", async () => {
+      const onCmd = mock((_e: SlackMessageEvent, _r: string) => {});
+      manager.onCommandResponse = onCmd;
+      await manager.handleMessage(makeEvent({ text: "Work on this" }));
+
+      await manager.handleMessage(
+        makeEvent({ command: "reset", text: "nonexistent", ts: "ts-reset" }),
+      );
+
+      expect(onCmd.mock.calls[0][1]).toContain("Nothing to reset");
+    });
+
+    describe("admin gating", () => {
+      const adminConfig: Config = { ...testConfig, adminSlackUserId: "U-ADMIN" };
+
+      it("non-admin gets ❌ reaction and command is ignored", async () => {
+        const adminManager = new SessionManager(store, adminConfig);
+        const onReaction = mock((_e: SlackMessageEvent, _emoji: string) => {});
+        const onCmd = mock((_e: SlackMessageEvent, _r: string) => {});
+        adminManager.onReaction = onReaction;
+        adminManager.onCommandResponse = onCmd;
+        await adminManager.handleMessage(makeEvent({ user: "U-ADMIN", text: "go" }));
+
+        await adminManager.handleMessage(
+          makeEvent({ user: "U-OTHER", command: "reset", text: "all", ts: "ts-reset" }),
+        );
+
+        expect(onReaction).toHaveBeenCalledTimes(1);
+        expect(onReaction.mock.calls[0][1]).toBe("x");
+        // Session not deleted
+        expect(await store.get("thread-1")).toBeDefined();
+        expect(onCmd).not.toHaveBeenCalled();
+      });
+
+      it("admin can run !reset all", async () => {
+        const adminManager = new SessionManager(store, adminConfig);
+        const onCmd = mock((_e: SlackMessageEvent, _r: string) => {});
+        adminManager.onCommandResponse = onCmd;
+        await adminManager.handleMessage(makeEvent({ user: "U-ADMIN", text: "go" }));
+
+        await adminManager.handleMessage(
+          makeEvent({ user: "U-ADMIN", command: "reset", text: "all", ts: "ts-reset" }),
+        );
+
+        expect(await store.get("thread-1")).toBeUndefined();
+        expect(onCmd.mock.calls[0][1]).toBe("Session reset.");
+      });
+
+      it("non-admin !mute is ignored with ❌", async () => {
+        const adminManager = new SessionManager(store, adminConfig);
+        const onReaction = mock((_e: SlackMessageEvent, _emoji: string) => {});
+        adminManager.onReaction = onReaction;
+        await adminManager.handleMessage(makeEvent({ user: "U-ADMIN", text: "go" }));
+
+        await adminManager.handleMessage(
+          makeEvent({ user: "U-OTHER", command: "mute", text: "", ts: "ts-mute" }),
+        );
+
+        expect(onReaction).toHaveBeenCalledTimes(1);
+        expect(onReaction.mock.calls[0][1]).toBe("x");
+        expect((await store.get("thread-1"))!.muted).toBe(false);
+      });
+
+      it("when adminSlackUserId is null, gate is open", async () => {
+        // testConfig has adminSlackUserId: null
+        const onReaction = mock((_e: SlackMessageEvent, _emoji: string) => {});
+        manager.onReaction = onReaction;
+        await manager.handleMessage(makeEvent({ user: "U-ANYONE", text: "go" }));
+
+        await manager.handleMessage(
+          makeEvent({ user: "U-ANYONE", command: "mute", text: "", ts: "ts-mute" }),
+        );
+
+        expect(onReaction).not.toHaveBeenCalled();
+        expect((await store.get("thread-1"))!.muted).toBe(true);
+      });
     });
   });
 

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -347,6 +347,48 @@ describe("SessionManager", () => {
       expect(onCmd.mock.calls[0][1]).toContain("Reset *echo*");
     });
 
+    it("!reset <agent> mid-flight survives the killed run completing", async () => {
+      // Regression: previously, a !reset that killed an in-flight run was
+      // clobbered by the killed run's onRunComplete writing back the stale
+      // sessionId / recreating the agent slice via getOrCreateAgentSession.
+      await manager.handleAgentMessage(makeEvent({ text: "go" }), "echo");
+      let session = await store.get("thread-1");
+      expect(session!.agentSessions.echo.status).toBe("busy");
+
+      // Reset while the run is still in flight (no _complete yet)
+      await manager.handleMessage(
+        makeEvent({ command: "reset", text: "echo", ts: "ts-reset" }),
+      );
+      session = await store.get("thread-1");
+      expect(session!.agentSessions.echo).toBeUndefined();
+      expect(currentHandle.kill).toHaveBeenCalled();
+
+      // Killed process exits with a "normal" result — must NOT recreate the slice
+      currentHandle._complete("late response", "stale-session-id");
+      await new Promise((r) => setTimeout(r, 10));
+
+      session = await store.get("thread-1");
+      expect(session!.agentSessions.echo).toBeUndefined();
+    });
+
+    it("!reset all mid-flight survives the killed run completing", async () => {
+      // Same race as above but for the top-level lead/default path
+      await manager.handleMessage(makeEvent({ text: "go" }));
+      expect((await store.get("thread-1"))!.status).toBe("busy");
+
+      await manager.handleMessage(
+        makeEvent({ command: "reset", text: "all", ts: "ts-reset-all" }),
+      );
+      expect(await store.get("thread-1")).toBeUndefined();
+      expect(currentHandle.kill).toHaveBeenCalled();
+
+      // Killed process exits — must NOT recreate the row from the snapshot
+      currentHandle._complete("late response", "stale-session-id");
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect(await store.get("thread-1")).toBeUndefined();
+    });
+
     it("!reset <unknown-agent> reports nothing to reset", async () => {
       const onCmd = mock((_e: SlackMessageEvent, _r: string) => {});
       manager.onCommandResponse = onCmd;
@@ -378,6 +420,25 @@ describe("SessionManager", () => {
         expect(onReaction.mock.calls[0][1]).toBe("x");
         // Session not deleted
         expect(await store.get("thread-1")).toBeDefined();
+        expect(onCmd).not.toHaveBeenCalled();
+      });
+
+      it("non-admin bare !reset is silently ❌'d (no usage leak)", async () => {
+        const adminManager = new SessionManager(store, adminConfig);
+        const onReaction = mock((_e: SlackMessageEvent, _emoji: string) => {});
+        const onCmd = mock((_e: SlackMessageEvent, _r: string) => {});
+        adminManager.onReaction = onReaction;
+        adminManager.onCommandResponse = onCmd;
+        await adminManager.handleMessage(makeEvent({ user: "U-ADMIN", text: "go" }));
+
+        await adminManager.handleMessage(
+          makeEvent({ user: "U-OTHER", command: "reset", text: "", ts: "ts-reset" }),
+        );
+
+        expect(onReaction).toHaveBeenCalledTimes(1);
+        expect(onReaction.mock.calls[0][1]).toBe("x");
+        // CRITICAL: the usage hint must NOT have been posted to thread —
+        // would leak the gating model and contradict the silent-deny promise.
         expect(onCmd).not.toHaveBeenCalled();
       });
 

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -45,6 +45,7 @@ export class SessionManager {
   onMessageBuffered?: (event: SlackMessageEvent) => void;
   onError?: (session: ThreadSession, error: string | null) => void;
   onCommandResponse?: (event: SlackMessageEvent, response: string) => void;
+  onReaction?: (event: SlackMessageEvent, emoji: string) => void;
 
   constructor(
     store: SessionStore,
@@ -158,6 +159,60 @@ export class SessionManager {
     await this.store.delete(threadId);
   }
 
+  /**
+   * Reset a single agent's slice of a thread session, leaving other agents'
+   * state intact. Returns true if the agent had state to clear.
+   *
+   * "lead"/"default" live on the parent ThreadSession (sessionId,
+   * leadSessionId, pendingMessages); everything else lives in
+   * agentSessions[agentName].
+   */
+  async resetAgent(threadId: string, agentName: string): Promise<boolean> {
+    const session = await this.store.get(threadId);
+    if (!session) return false;
+
+    const handleKey = this.handleKey(threadId, agentName);
+    const handle = this.handles.get(handleKey);
+    if (handle) {
+      handle.kill();
+      this.handles.delete(handleKey);
+    }
+
+    let touched = false;
+    if (agentName === "lead" || agentName === "default") {
+      if (session.sessionId || session.leadSessionId || session.pendingMessages.length > 0 || session.status !== "idle") {
+        touched = true;
+      }
+      session.sessionId = null;
+      session.leadSessionId = null;
+      session.pendingMessages = [];
+      session.status = "idle";
+      session.pid = null;
+    } else if (session.agentSessions?.[agentName]) {
+      delete session.agentSessions[agentName];
+      touched = true;
+    }
+
+    await this.store.set(threadId, session);
+    return touched;
+  }
+
+  isAdmin(userId: string): boolean {
+    const adminId = this.config.adminSlackUserId;
+    if (!adminId) return true;
+    return userId === adminId;
+  }
+
+  /**
+   * Returns true if the user is denied (and a ❌ reaction was queued).
+   * Caller should `return true` from the command handler to short-circuit.
+   */
+  private denyIfNotAdmin(event: SlackMessageEvent): boolean {
+    if (this.isAdmin(event.user)) return false;
+    this.onReaction?.(event, "x");
+    return true;
+  }
+
   private async handleCommand(
     session: ThreadSession,
     event: SlackMessageEvent,
@@ -188,8 +243,29 @@ export class SessionManager {
       }
 
       case "reset": {
-        await this.resetSession(session.threadId);
-        this.onCommandResponse?.(event, "Session reset.");
+        const arg = event.text.trim();
+        if (!arg) {
+          this.onCommandResponse?.(
+            event,
+            "Usage: `!reset <agent>` (e.g. `!reset lead`, `!reset reproducer`) or `!reset all` to clear the entire thread session.",
+          );
+          return true;
+        }
+        if (this.denyIfNotAdmin(event)) return true;
+        if (arg === "all") {
+          await this.resetSession(session.threadId);
+          this.onCommandResponse?.(event, "Session reset.");
+          return true;
+        }
+        const touched = await this.resetAgent(session.threadId, arg);
+        if (touched) {
+          this.onCommandResponse?.(event, `Reset *${arg}*.`);
+        } else {
+          this.onCommandResponse?.(
+            event,
+            `No state for *${arg}* in this thread. Nothing to reset.`,
+          );
+        }
         return true;
       }
 
@@ -222,15 +298,15 @@ export class SessionManager {
           "`!branch <ref>` — Set base branch ref",
           "`!agent <junior|lead>` — Set thread default agent",
           "`!cancel` — Kill running process, keep session",
-          "`!reset` — Reset session",
+          "`!reset <agent|all>` — Reset one agent's state, or the whole thread (admin only)",
           "`!status` — Show session status",
           "`!quiet` — Minimal output",
           "`!normal` — Normal output",
           "`!verbose` — Verbose output",
           "`!adhoc <text>` — Add ad-hoc item to calendar",
           "`!bugs <text>` — Add bug item to calendar",
-          "`!mute` — Stop responding until !unmute",
-          "`!unmute` — Resume responding",
+          "`!mute` — Stop responding until !unmute (admin only)",
+          "`!unmute` — Resume responding (admin only)",
           "`!help` — Show this help",
         ].join("\n");
         this.onCommandResponse?.(event, helpText);
@@ -354,6 +430,7 @@ export class SessionManager {
       }
 
       case "mute": {
+        if (this.denyIfNotAdmin(event)) return true;
         session.muted = true;
         await this.store.set(session.threadId, session);
         this.onCommandResponse?.(event, "Muted. I'll stop responding until you `!unmute`.");
@@ -361,6 +438,7 @@ export class SessionManager {
       }
 
       case "unmute": {
+        if (this.denyIfNotAdmin(event)) return true;
         session.muted = false;
         await this.store.set(session.threadId, session);
         this.onCommandResponse?.(event, "Unmuted.");

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -243,6 +243,11 @@ export class SessionManager {
       }
 
       case "reset": {
+        // Gate on admin BEFORE inspecting args. Otherwise a non-admin sending
+        // bare `!reset` gets the usage hint posted to the thread, contradicting
+        // the documented "silent ❌ reaction, no thread reply" promise — and
+        // leaks the gating model to anyone probing.
+        if (this.denyIfNotAdmin(event)) return true;
         const arg = event.text.trim();
         if (!arg) {
           this.onCommandResponse?.(
@@ -251,7 +256,6 @@ export class SessionManager {
           );
           return true;
         }
-        if (this.denyIfNotAdmin(event)) return true;
         if (arg === "all") {
           await this.resetSession(session.threadId);
           this.onCommandResponse?.(event, "Session reset.");
@@ -636,7 +640,7 @@ export class SessionManager {
       });
 
       handle.result.then(
-        (result: SpawnResult) => this.onRunComplete(session, result, agentName),
+        (result: SpawnResult) => this.onRunComplete(session, result, agentName, handle),
         (err: unknown) =>
           this.onRunComplete(session, {
             sessionId: null,
@@ -644,7 +648,7 @@ export class SessionManager {
             events: [],
             exitCode: null,
             error: err instanceof Error ? err.message : String(err),
-          }, agentName),
+          }, agentName, handle),
       );
     } catch (err) {
       // Agent prompt composition or worktree creation failed fatally
@@ -672,10 +676,21 @@ export class SessionManager {
     session: ThreadSession,
     result: SpawnResult,
     agentName: string,
+    ownHandle?: SpawnHandle,
   ): Promise<void> {
     const isTopLevel = agentName === "lead" || agentName === "default";
     const agentIdentity = identityForAgent(agentName);
-    this.handles.delete(this.handleKey(session.threadId, agentName));
+    const handleKey = this.handleKey(session.threadId, agentName);
+
+    // If our handle no longer owns the slot, this run was killed by !reset
+    // (handle deleted from map) or replaced by a newer spawn. Either way,
+    // persisting our stale sessionId / status would clobber authoritative
+    // state — bail without writing anything. Also skip onResponse: a discarded
+    // run shouldn't post its final message to Slack.
+    if (ownHandle && this.handles.get(handleKey) !== ownHandle) {
+      return;
+    }
+    this.handles.delete(handleKey);
 
     // Refetch the authoritative session before mutating. The `session` we hold
     // is a snapshot from spawn time — long-running agents can be minutes stale.

--- a/src/slack/events.test.ts
+++ b/src/slack/events.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, mock } from "bun:test";
+import type { App } from "@slack/bolt";
+import {
+  registerEventHandlers,
+  isForeignBotThinking,
+  type SlackMessageEvent,
+} from "./events.ts";
+
+type EventHandler = (args: { event: Record<string, unknown> }) => Promise<void> | void;
+
+function makeMockApp() {
+  const handlers = new Map<string, EventHandler>();
+  const app = {
+    event: (name: string, handler: EventHandler) => {
+      handlers.set(name, handler);
+    },
+  } as unknown as App;
+  return { app, handlers };
+}
+
+describe("isForeignBotThinking", () => {
+  it("matches a leading ✽", () => {
+    expect(isForeignBotThinking("✽ Thinking…")).toBe(true);
+  });
+
+  it("matches ✽ after leading whitespace", () => {
+    expect(isForeignBotThinking("   ✽ Brewing…")).toBe(true);
+    expect(isForeignBotThinking("\n✽ ...")).toBe(true);
+  });
+
+  it("does not match ✽ that appears later in the text", () => {
+    expect(isForeignBotThinking("Hello ✽ world")).toBe(false);
+  });
+
+  it("does not match a normal user message", () => {
+    expect(isForeignBotThinking("hey junior")).toBe(false);
+  });
+
+  it("does not match empty string", () => {
+    expect(isForeignBotThinking("")).toBe(false);
+  });
+});
+
+describe("registerEventHandlers — ✽ filter", () => {
+  it("message handler drops a sibling-bot ✽ thinking line", async () => {
+    const { app, handlers } = makeMockApp();
+    const onMessage = mock((_e: SlackMessageEvent) => {});
+    registerEventHandlers(app, onMessage);
+
+    const messageHandler = handlers.get("message")!;
+    await messageHandler({
+      event: {
+        type: "message",
+        text: "✽ Thinking… (esc to interrupt)",
+        channel: "C123",
+        channel_type: "im",
+        ts: "1700000000.000001",
+        user: "U_BOT",
+      },
+    });
+
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+
+  it("message handler drops ✽ even with leading whitespace", async () => {
+    const { app, handlers } = makeMockApp();
+    const onMessage = mock((_e: SlackMessageEvent) => {});
+    registerEventHandlers(app, onMessage);
+
+    await handlers.get("message")!({
+      event: {
+        type: "message",
+        text: "   ✽ still working",
+        channel: "C123",
+        channel_type: "im",
+        ts: "1700000000.000002",
+        user: "U_BOT",
+      },
+    });
+
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+
+  it("message handler passes through a normal message", async () => {
+    const { app, handlers } = makeMockApp();
+    const onMessage = mock((_e: SlackMessageEvent) => {});
+    registerEventHandlers(app, onMessage);
+
+    await handlers.get("message")!({
+      event: {
+        type: "message",
+        text: "hello junior",
+        channel: "C123",
+        channel_type: "im",
+        ts: "1700000000.000003",
+        user: "U_HUMAN",
+      },
+    });
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onMessage.mock.calls[0][0].text).toBe("hello junior");
+  });
+
+  it("app_mention handler drops a ✽ thinking line", async () => {
+    const { app, handlers } = makeMockApp();
+    const onMessage = mock((_e: SlackMessageEvent) => {});
+    registerEventHandlers(app, onMessage);
+
+    await handlers.get("app_mention")!({
+      event: {
+        type: "app_mention",
+        text: "✽ Thinking…",
+        channel: "C123",
+        ts: "1700000000.000004",
+        user: "U_BOT",
+        thread_ts: "1700000000.000000",
+      },
+    });
+
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+
+  it("app_mention handler passes through a normal mention", async () => {
+    const { app, handlers } = makeMockApp();
+    const onMessage = mock((_e: SlackMessageEvent) => {});
+    registerEventHandlers(app, onMessage, undefined, undefined, "U_BOT");
+
+    await handlers.get("app_mention")!({
+      event: {
+        type: "app_mention",
+        text: "<@U_BOT> hello",
+        channel: "C123",
+        ts: "1700000000.000005",
+        user: "U_HUMAN",
+      },
+    });
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onMessage.mock.calls[0][0].text).toBe("hello");
+  });
+});

--- a/src/slack/events.ts
+++ b/src/slack/events.ts
@@ -71,6 +71,13 @@ export function registerEventHandlers(
       return;
     }
 
+    // Sibling Claude bots (Friday, Doraemon) post their streaming "thinking"
+    // updates with a leading ✽ glyph. Drop those — they're not user input.
+    if (text.trimStart().startsWith("✽")) {
+      logDrop("foreign-bot-thinking", evMeta);
+      return;
+    }
+
     // Auto-trigger channels (e.g. #bugs-backlog) accept messages from other bots
     // like growthx-bug-reporter that have no `user` field — fall back to bot_id.
     let user = "user" in event ? event.user : undefined;

--- a/src/slack/events.ts
+++ b/src/slack/events.ts
@@ -3,6 +3,15 @@ import type { SessionStore } from "../session/store/interface.ts";
 import { parseCommand } from "./commands.ts";
 import { log } from "../logger.ts";
 
+/**
+ * Sibling Claude bots (Friday, Doraemon) post their streaming "thinking"
+ * updates with a leading ✽ glyph. Drop those — they're not user input, and
+ * treating them as input creates cross-bot reply loops.
+ */
+export function isForeignBotThinking(text: string): boolean {
+  return text.trimStart().startsWith("✽");
+}
+
 function logDrop(
   reason: string,
   ev: { channel?: string; ts?: string; subtype?: string; thread_ts?: string },
@@ -71,9 +80,7 @@ export function registerEventHandlers(
       return;
     }
 
-    // Sibling Claude bots (Friday, Doraemon) post their streaming "thinking"
-    // updates with a leading ✽ glyph. Drop those — they're not user input.
-    if (text.trimStart().startsWith("✽")) {
+    if (isForeignBotThinking(text)) {
       logDrop("foreign-bot-thinking", evMeta);
       return;
     }
@@ -138,6 +145,14 @@ export function registerEventHandlers(
 
   app.event("app_mention", async ({ event }) => {
     if (!event.user) return;
+    if (isForeignBotThinking(event.text)) {
+      logDrop("foreign-bot-thinking", {
+        channel: event.channel,
+        ts: event.ts,
+        thread_ts: event.thread_ts,
+      });
+      return;
+    }
 
     const threadId = event.thread_ts ?? event.ts;
 


### PR DESCRIPTION
## Summary

Two related-but-distinct hardening changes to message handling, in separate commits:

1. **`fix(events): drop messages starting with ✽`** — Sibling Claude bots (Friday, Doraemon) post their streaming "thinking" updates with a leading ✽ glyph. Junior was treating those as user input. New guard at the event boundary drops them; foreign bots' real messages still flow through.
2. **`feat(commands): admin-gate !mute/!unmute/!reset and require !reset arg`**
   - New env var `ADMIN_SLACK_USER_ID` (single Slack user). When set, only that user can run `!mute`, `!unmute`, `!reset`. Non-admin → ❌ reaction, no thread reply, no log noise. Unset → gate is open (local dev).
   - `!reset` now requires an arg. `!reset all` is the old full-session wipe. `!reset <agent>` clears just that agent's slice (lead lives on the parent `ThreadSession`; others in `agentSessions`). Bare `!reset` is a usage error so admins don't accidentally nuke an in-flight reproducer/thinker turn.

Per-agent `!mute` and a richer thread-owner-based access model were considered and explicitly scoped to v2 — see `docs/features/v2-backlog.md`.

## Test plan
- [ ] Set `ADMIN_SLACK_USER_ID=<your-id>`, restart bot. As admin: `!mute`, `!unmute`, `!reset all` work. As non-admin: ❌ reacts, no reply, session unchanged.
- [ ] Unset `ADMIN_SLACK_USER_ID`: any user can run all three (local-dev fallback).
- [ ] Bare `!reset` → reply with usage, no session change.
- [ ] `!reset lead` clears lead-side state (`sessionId`, `leadSessionId`, pending) but leaves `agentSessions` entries intact.
- [ ] `!reset reproducer` deletes `agentSessions.reproducer`, leaves lead state intact.
- [ ] `!reset nonexistent` → "Nothing to reset", no state change.
- [ ] Paste a message starting with `✽` from another bot in a watched channel — Junior logs `dropped reason=foreign-bot-thinking` and ignores it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)