### PR TITLE
feat(agents): private overlay search path + per-agent context profile

### DIFF
--- a/.claude/agents/common/merge-workflow.md
+++ b/.claude/agents/common/merge-workflow.md
@@ -1,50 +1,41 @@
-# Merge & PR workflow (junior invariants)
+# Merge & PR workflow (generic invariants)
 
-These rules apply to any junior-spawned agent that creates branches, opens PRs, or merges. They are not optional.
+These rules apply to any junior-spawned agent that creates branches, opens PRs, or merges code. They are not optional. Org-specific specifics (exact token names, credential paths, repo lists, multi-stage release flows) are appended below this section when an org context is configured; treat the appended block as authoritative and these generic rules as the baseline.
 
 ## Branching
 
-- **Branch from `main`, not `dev`.** Feature branches created from dev silently carry dev-only commits into the main PR diff. Pull `main`, then create the branch.
+- **Branch from `main`, not `dev` (or whatever your org's release branch is).** Feature branches created from a release branch silently carry release-only commits into the main PR diff.
+- Pull the base branch first, then create the feature branch.
 
 ## Creating PRs
 
-- Create PRs with the **regular bot account** — i.e. whatever `gh` is currently authenticated as. Do not switch tokens for `gh pr create`.
+- Create PRs with the **regular bot account** — i.e. whatever `gh` is currently authenticated as. Do not switch tokens or accounts for `gh pr create`.
 
 ## Merging — credential rule
 
-- **Always merge using the `gxt-admin` token, never the regular bot account.** Org branch protections require an admin to merge; the regular bot account fails or bypasses checks in ways that surface later as auditing problems.
-- Token location: `~/Projects/junior/support/admin-credentials.yaml` under `github.gxt_admin_token`. Read it from the file — do not paste the token into a prompt or commit it anywhere.
-- Invocation:
-  ```bash
-  GITHUB_TOKEN="$(yq '.github.gxt_admin_token' ~/Projects/junior/support/admin-credentials.yaml)" \
-    gh pr merge <pr> --merge
-  ```
-  (Or read the file with whatever yaml parser is available — the point is `GITHUB_TOKEN` must be set to the gxt-admin token for the duration of the merge command.)
-- If you find yourself running `gh pr merge` without `GITHUB_TOKEN=` prepended, **stop** — that is the failure mode this rule exists to catch.
+- **Always merge using your org's admin token, never the regular bot account.** Org branch protections typically require an admin role to merge; the regular bot account either fails or bypasses checks in ways that surface later as auditing problems.
+- The exact token name, credentials file path, and invocation appear in the org-specific section appended below — that is where the concrete values live.
+- Read tokens from a credentials file — never paste a token into a prompt, log, or commit.
+- If you find yourself running `gh pr merge` without first setting an admin `GITHUB_TOKEN`, **stop** — that is the failure mode this rule exists to catch.
 
 ## Merge strategy
 
 - **Always 3-way merge (`gh pr merge --merge`). Never squash.** Squash collapses authorship and breaks downstream cherry-picks. The `--merge` flag is mandatory.
 
-## GrowthX two-stage merge (`gx-backend`, `gx-client-next`, `gx-admin-client`)
+## Multi-stage release flows
 
-For changes targeting any GX repo:
-
-1. Open the feature → `main` PR (this is the canonical record).
-2. Open a parallel feature → `dev` PR from the same branch (`gh pr create --base dev --head <branch>`).
-3. Merge the **dev PR first** with the gxt-admin token. Verify on dev.
-4. The `main` PR is **human-gated** — leave it open. Do not merge it yourself unless the human explicitly says so.
+If your org runs a `dev` → `main` or `staging` → `prod` flow, the dev/staging PR is opened and merged automatically; the main PR is human-gated unless the human explicitly authorizes the merge. The overlay names the specific branch order, base names, and verification steps.
 
 ## Conflict resolution
 
-- Resolve conflicts **in the target branch (e.g. dev)**, never in the feature branch. Dev-side fixups must not poison the feature branch's main PR.
+- Resolve conflicts **in the target branch (e.g. dev)**, never in the feature branch. Downstream fixups must not poison the feature branch's main PR.
 
 ## Self-check before any merge command
 
-Before running `gh pr merge`, confirm out loud (or in your reasoning):
+Before running `gh pr merge`, confirm:
 
-1. Is `GITHUB_TOKEN` set to the gxt-admin token? If not, stop.
+1. Is `GITHUB_TOKEN` set to the admin token, not the regular bot? If not, stop.
 2. Is the strategy `--merge` (3-way), not `--squash`?
-3. Is the base branch the right one (dev for the dev PR, not main for GX repos unless human-gated)?
+3. Is the base branch correct for this stage?
 
 If any answer is uncertain, ask the human before merging.

--- a/.claude/agents/common/merge-workflow.md
+++ b/.claude/agents/common/merge-workflow.md
@@ -1,0 +1,50 @@
+# Merge & PR workflow (junior invariants)
+
+These rules apply to any junior-spawned agent that creates branches, opens PRs, or merges. They are not optional.
+
+## Branching
+
+- **Branch from `main`, not `dev`.** Feature branches created from dev silently carry dev-only commits into the main PR diff. Pull `main`, then create the branch.
+
+## Creating PRs
+
+- Create PRs with the **regular bot account** — i.e. whatever `gh` is currently authenticated as. Do not switch tokens for `gh pr create`.
+
+## Merging — credential rule
+
+- **Always merge using the `gxt-admin` token, never the regular bot account.** Org branch protections require an admin to merge; the regular bot account fails or bypasses checks in ways that surface later as auditing problems.
+- Token location: `~/Projects/junior/support/admin-credentials.yaml` under `github.gxt_admin_token`. Read it from the file — do not paste the token into a prompt or commit it anywhere.
+- Invocation:
+  ```bash
+  GITHUB_TOKEN="$(yq '.github.gxt_admin_token' ~/Projects/junior/support/admin-credentials.yaml)" \
+    gh pr merge <pr> --merge
+  ```
+  (Or read the file with whatever yaml parser is available — the point is `GITHUB_TOKEN` must be set to the gxt-admin token for the duration of the merge command.)
+- If you find yourself running `gh pr merge` without `GITHUB_TOKEN=` prepended, **stop** — that is the failure mode this rule exists to catch.
+
+## Merge strategy
+
+- **Always 3-way merge (`gh pr merge --merge`). Never squash.** Squash collapses authorship and breaks downstream cherry-picks. The `--merge` flag is mandatory.
+
+## GrowthX two-stage merge (`gx-backend`, `gx-client-next`, `gx-admin-client`)
+
+For changes targeting any GX repo:
+
+1. Open the feature → `main` PR (this is the canonical record).
+2. Open a parallel feature → `dev` PR from the same branch (`gh pr create --base dev --head <branch>`).
+3. Merge the **dev PR first** with the gxt-admin token. Verify on dev.
+4. The `main` PR is **human-gated** — leave it open. Do not merge it yourself unless the human explicitly says so.
+
+## Conflict resolution
+
+- Resolve conflicts **in the target branch (e.g. dev)**, never in the feature branch. Dev-side fixups must not poison the feature branch's main PR.
+
+## Self-check before any merge command
+
+Before running `gh pr merge`, confirm out loud (or in your reasoning):
+
+1. Is `GITHUB_TOKEN` set to the gxt-admin token? If not, stop.
+2. Is the strategy `--merge` (3-way), not `--squash`?
+3. Is the base branch the right one (dev for the dev PR, not main for GX repos unless human-gated)?
+
+If any answer is uncertain, ask the human before merging.

--- a/.claude/agents/common/runtime-environment.md
+++ b/.claude/agents/common/runtime-environment.md
@@ -2,6 +2,8 @@
 
 Static facts. Do NOT spend tool calls discovering these.
 
+> **Org-specific specifics** (concrete repo names, local dev URLs, credential file paths, impersonation flows) are appended below this section when an org context is configured. Treat the appended block as the source of truth for any value this section leaves abstract.
+
 ## Always read attached images
 
 Whenever a Slack message includes an image (screenshot, photo, diagram), **read it before responding**. Don't acknowledge the image and proceed without examining it — visual evidence usually holds the most directly useful signal in a bug report (the broken UI, the error toast, the failing screen, the URL in the address bar). Skipping the image and responding from text alone produces shallow analysis and makes you re-ask things the user already showed you.
@@ -17,33 +19,17 @@ For browser screenshots specifically, extract:
 
 **Repo paths for this thread are dynamic — read the `<workspace>` block at the top of your prompt.** When present, it lists each routed repo's per-thread worktree path, branch, and base. Use those paths for ALL reads, edits, and git commands.
 
-**NEVER use `~/openclaw-projects/<repo>/` directly.** Those bare repos are the human developer's working trees — touching them corrupts active branches. The canonical product → repo mapping lives in `~/Projects/junior/support/repo-routing.yaml` (reference only — don't cd into the paths it lists).
+Never touch repos outside the `<workspace>` block. If you need to touch a repo and there's no entry for it, STOP and post a Slack note instead of improvising. The lead is responsible for registering the worktrees you need; if one is missing, that's a state error to flag, not a reason to fall back to anything else.
 
-If you need to touch a repo and there's no entry for it in your `<workspace>` block, STOP and post a Slack note instead of improvising. The lead is responsible for registering the worktrees you need; if one is missing, that's a state error to flag, not a reason to fall back to the bare repo.
+**Always read each repo's `CLAUDE.md` before working in it.** Each product repo has its own conventions (naming, patterns, deprecated paths, test/build commands, gotchas). Read it from the worktree path in the workspace block. The repo's `CLAUDE.md` overrides anything generic — if it says "use X pattern," use X even if your default would have been Y.
 
-**Always read each repo's `CLAUDE.md` before working in it.** Each product repo has its own conventions (naming, patterns, deprecated paths, test/build commands, gotchas). Read it from the worktree path in the workspace block, not the bare repo. The repo's `CLAUDE.md` overrides anything generic — if it says "use X pattern," use X even if your default would have been Y.
+## Local dev servers
 
-## Local dev servers + FE↔BE wiring
+Concrete services, ports, and start commands are in the org-specific section appended below. Use a fixed-port pattern — do NOT `lsof`/`ps`/`curl`-loop to discover ports.
 
-Fixed ports — do NOT `lsof`/`ps`/`curl`-loop to discover them:
-- Frontend: `http://localhost:3000` (gx-client-next, `pnpm dev`)
-- Backend: `http://localhost:8000` (gx-backend, `pnpm dev`)
+## FE↔BE wiring
 
-To check up:
-```sh
-curl -s -o /dev/null -w "fe=%{http_code} " http://localhost:3000
-curl -s -o /dev/null -w "be=%{http_code}\n" http://localhost:8000
-```
-
-To start if down: `cd <repo-path>; pnpm dev`. Backend usually wants the frontend up too if the bug touches the UI.
-
-**FE↔BE call path** (active dev config):
-
-`gx-client-next/.env` sets `API_URL=http://localhost:8000/api/v1` and `COOKIE_DOMAIN=localhost`. So when you load the FE at `http://localhost:3000`, browser-side API calls go directly to `http://localhost:8000` (NOT through `backend-local.growthx.club`). Cookies are per-host and apply to both `localhost:3000` and `localhost:8000`, so auth carries automatically once cookies are set on the `localhost` domain.
-
-Some FE calls go through Next.js API routes (server-side proxies running in the Next.js process at port 3000) — e.g. `GET /api/proof-of-works/<id>` hits a Next.js handler that itself calls the backend. These show up in the network tab as `localhost:3000/api/...` even though they ultimately resolve to backend logic.
-
-**Parallel "production-like" path (NOT current default):** `/etc/hosts` maps `community-local.growthx.club` and `backend-local.growthx.club` to `127.0.0.1`. A local reverse proxy (nginx/Caddy with self-signed SSL) listens on 443 and forwards to the same dev servers. Activated by uncommenting `API_URL=https://backend-local.growthx.club/api/v1` and changing `COOKIE_DOMAIN` to `.growthx.club`. If the bug is reproducible only at the prod-like FQDN (cookies, SSL, CORS specifics), switch to this path.
+The active dev config and any production-like fallback paths (e.g. `/etc/hosts` SSL proxy) are in the org-specific section below. If a bug only reproduces on a non-default path, switch as described there.
 
 ## Available MCP tools
 
@@ -53,9 +39,9 @@ Pre-loaded — do NOT `ToolSearch` for them:
 - **MongoDB (read-only)**: `mcp__mongodb__find`, `mcp__mongodb__aggregate`, `mcp__mongodb__count`, `mcp__mongodb__collection-schema`, `mcp__mongodb__list-collections`, `mcp__mongodb__list-databases`. Use to verify data shape during research / reproduction. NEVER mutate.
 - **Playwright** (browser automation, reproducer's primary tool): `mcp__playwright__browser_navigate`, `browser_click`, `browser_type`, `browser_snapshot`, `browser_take_screenshot`, `browser_console_messages`, `browser_network_requests`, `browser_evaluate`, `browser_wait_for`, `browser_navigate_back`, `browser_fill_form`, `browser_close`.
 
-## Admin credentials
+## Admin credentials & access-gated reproduction
 
-`~/Projects/junior/support/admin-credentials.yaml` (gitignored) holds the superadmin login + admin-API impersonation flow + Cloudfront signed-URL flow. The reproducer uses these for access-gated bugs (403 → impersonate as the affected user → re-call). Read this file directly when you need the exact API sequence — don't re-derive it.
+When a bug requires admin/impersonation access, the credential file path, admin-API impersonation flow, and any signed-URL conventions are in the org-specific section appended below. Read the credentials file by the path named there; never paste contents into prompts or commit them.
 
 ## Bug folder layout
 

--- a/.claude/agents/lead.md
+++ b/.claude/agents/lead.md
@@ -172,11 +172,11 @@ If junior posts `failed: <reason>` or the slot times out before reproducer finis
 
 ## Post-review merge flow (CATEGORICAL — do not improvise)
 
-When the gating signals above are clean, **do NOT merge the feature → main PR**. The pipeline NEVER merges to main. Main is human-gated. The flow is:
+The cross-cutting merge rules (gxt-admin token, 3-way merge, two-stage GX flow) live in `common/merge-workflow.md` and are loaded into your prompt automatically. Read them — they are non-negotiable. The bug-pipeline adds the following orchestration on top:
 
-1. **The original PR** (opened by `!thinker proceed`) targets `main`. Leave it open. Do NOT merge it.
-2. **Open a parallel PR** from the same `feature/<bug-id>` branch to `dev`. Use `gh pr create --base dev --head <branch>`.
-3. **Merge the dev PR** using `gxt-admin` credentials (not the regular bot account). The token is in `~/Projects/junior/support/admin-credentials.yaml` under `github.gxt_admin_token`. Set `GITHUB_TOKEN=<token>` for the merge command. 3-way merge (`gh pr merge --merge`), never squash.
+1. **The original PR** (opened by `!thinker proceed`) targets `main`. Leave it open. Do NOT merge it. The pipeline NEVER merges to main — main is human-gated.
+2. **Open the parallel feature → `dev` PR** as described in `common/merge-workflow.md`.
+3. **Merge the dev PR** following the gxt-admin + 3-way rules in `common/merge-workflow.md`.
 4. **Post a Slack message and STOP.** Format: "Merged feature → dev (PR <url>). PR <main-pr-url> is ready for human to verify on dev and then merge to main."
 
 Dev verification is currently a HUMAN step (dev's data quality isn't reliable enough for automated reproducer validation). Do NOT dispatch `!reproducer` against dev. Do NOT merge feature → main. Both are explicit human responsibilities at this stage.

--- a/.claude/agents/lead.md
+++ b/.claude/agents/lead.md
@@ -38,7 +38,7 @@ The temptation to do work yourself is strongest when the fix looks small. That's
 
 - **Observability sub-agents (`nr-research`, `sentry-fetch`, `vercel-status`)** ARE expected to be dispatched via Task by you — they're stateless data fetchers, not persistent participants. The categorical rule above is about persistent agents (reproducer, thinker, review).
 - **Reading bug-folder files** under `support/bugs/<product>/<bug-id>/` IS your job — that's where you synthesize. Just don't read product source.
-- **Reading `support/repo-routing.yaml`, `support/admin-credentials.yaml`, your own past Slack posts** IS your job.
+- **Reading the config files named in the runtime-environment notes above (routing map, admin credentials) and your own past Slack posts** IS your job.
 
 ## Persistent agent dispatch
 
@@ -172,11 +172,11 @@ If junior posts `failed: <reason>` or the slot times out before reproducer finis
 
 ## Post-review merge flow (CATEGORICAL — do not improvise)
 
-The cross-cutting merge rules (gxt-admin token, 3-way merge, two-stage GX flow) live in `common/merge-workflow.md` and are loaded into your prompt automatically. Read them — they are non-negotiable. The bug-pipeline adds the following orchestration on top:
+The cross-cutting merge rules (admin token, 3-way merge, multi-stage release flow) are already in your prompt — see the merge-workflow rules above. They are non-negotiable. The bug-pipeline adds the following orchestration on top:
 
 1. **The original PR** (opened by `!thinker proceed`) targets `main`. Leave it open. Do NOT merge it. The pipeline NEVER merges to main — main is human-gated.
-2. **Open the parallel feature → `dev` PR** as described in `common/merge-workflow.md`.
-3. **Merge the dev PR** following the gxt-admin + 3-way rules in `common/merge-workflow.md`.
+2. **Open the parallel feature → `dev` PR** following the merge-workflow rules above.
+3. **Merge the dev PR** following the admin-token + 3-way rules above.
 4. **Post a Slack message and STOP.** Format: "Merged feature → dev (PR <url>). PR <main-pr-url> is ready for human to verify on dev and then merge to main."
 
 Dev verification is currently a HUMAN step (dev's data quality isn't reliable enough for automated reproducer validation). Do NOT dispatch `!reproducer` against dev. Do NOT merge feature → main. Both are explicit human responsibilities at this stage.

--- a/.claude/agents/reproducer.md
+++ b/.claude/agents/reproducer.md
@@ -46,7 +46,7 @@ If `scoping.md` lists a "user story" or "expected fixed behavior," walk THAT exp
 The runtime environment (Playwright tool list, repo paths, dev-server ports + FE↔BE wiring, MCP inventory, admin credentials path) is in the common preamble. Highlights:
 
 - **Playwright MCP** is your primary tool — navigate, click, fill forms, capture network/console, screenshot.
-- **Admin credentials** (`support/admin-credentials.yaml`) — read this file directly for the impersonation API sequence when access blocks the walk.
+- **Admin credentials** — the credential file path and impersonation API sequence are in the runtime-environment notes above. Read the file by the path named there when access blocks the walk; never paste contents into Slack or prompts.
 - **Bash + curl** for direct API calls when you need to verify a response without going through the browser.
 
 If a tool you need is unavailable or returns an unexpected error, do NOT fail silently — set status `needs-human` and explain.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "identity"]
 	path = identity
 	url = git@github.com:PranavBakre/junior-identity.git
+[submodule ".claude/agents-org"]
+	path = .claude/agents-org
+	url = https://github.com/GrowthX-Club/junior-private-agents.git

--- a/docs/code_index/agent-routing.md
+++ b/docs/code_index/agent-routing.md
@@ -1,60 +1,81 @@
 # Code Index: Agent Routing
 
-Loads agent definitions from target repos and composes system prompts for spawned Claude processes.
+Resolves agent definitions across a layered search chain (target repo → private overlay → public fallback) and composes the system prompt that's injected via `--append-system-prompt`. Per-agent context profiles (frontmatter flags) control how much preamble the agent receives on its first turn.
 
 ## Code Index
 
 ### src/agents
 
-| Function | File | Purpose |
-|----------|------|---------|
-| `AgentRouter(repos, agentDir)` | `router.ts` | Constructor: `agentDir` is relative path within repos (e.g., `.claude/agents`) |
-| `AgentRouter.getSystemPrompt(agentType, targetRepo?)` | `router.ts` | Loads agent definition, merges with common preamble, returns composed prompt |
-| `AgentRouter.getAvailableAgents(targetRepo?)` | `router.ts` | Lists agent `.md` files in the repo's agent directory |
-| `loadAgentDefinition(filePath)` | `loader.ts` | Reads `.md` file, parses YAML frontmatter, returns definition |
+| Symbol | File | Purpose |
+|---|---|---|
+| `AgentRouter(repos, fallbackAgentsDir, orgAgentsDir?)` | `router.ts` | Constructor. `orgAgentsDir` is the optional private-overlay mount (e.g. `.claude/agents-org/`); when omitted, only public layers are searched. |
+| `AgentRouter.resolveAgent(session)` | `router.ts` | Searches target repo → org overlay → public fallback. First match wins. Returns `AgentDefinition \| null`. |
+| `AgentRouter.composeSystemPrompt(session)` | `router.ts` | Builds the full system prompt = common preamble + agent body. Common preamble is `(target_repo_common OR public_common)` plus the org overlay's common (additive, always appended when overlay is configured). Returns common-only if no agent resolves; returns null if both are empty. |
+| `loadAgentDefinition(filePath)` | `loader.ts` | Reads a `.md` file, parses frontmatter (flat `key: value` plus dot-notation `context.<flag>: bool`), returns `AgentDefinition`. Returns `null` if file doesn't exist. |
+| `DEFAULT_CONTEXT_PROFILE` | `loader.ts` | All five flags (`identity`, `slack`, `workspace`, `threadHistory`, `agentState`) set to `true`. Used when an agent declares no `context.*` overrides. |
 
 ### Types
 
-| Type | File | Purpose |
-|------|------|---------|
-| `AgentDefinition` | `loader.ts` | `{ name, description, tools?, model?, prompt }` |
+| Type | File | Shape |
+|---|---|---|
+| `AgentContextProfile` | `loader.ts` | `{ identity, slack, workspace, threadHistory, agentState: boolean }` |
+| `AgentDefinition` | `loader.ts` | `{ name, description, tools, model, prompt, context: AgentContextProfile }` |
 
-## Agent Resolution
+## Resolution flow
 
 ```
-!build fix auth
+runClaudeWithAgent(session)
   │
-  ├── AgentRouter.getSystemPrompt("build", "example-backend")
-  │     ├── Look for: /path/to/example-backend/.claude/agents/build.md
-  │     ├── Look for: /path/to/example-backend/.claude/agents/common/building-philosophy.md
-  │     ├── loadAgentDefinition() → parse frontmatter + body
-  │     ├── Merge: common preamble + agent prompt
-  │     └── Return composed system prompt
+  ├── agentRouter.resolveAgent(session)
+  │     │  (search order, first match wins)
+  │     ├── <repo.path>/.claude/agents/<agentType>.md   if session.targetRepo
+  │     ├── <orgAgentsDir>/<agentType>.md               if orgAgentsDir configured
+  │     └── <fallbackAgentsDir>/<agentType>.md          (junior public)
   │
-  └── SessionManager sets session.systemPrompt
-        └── buildClaudeArgs() adds --append-system-prompt
+  ├── buildPromptPreamble(..., contextProfile)
+  │     │  (each block emitted only if its flag is true)
+  │     ├── <identity>      (persona + bot user ID)
+  │     ├── <slack-context> (channel, thread, NO_SLACK_MESSAGE rules)
+  │     ├── <workspace>     (target repo, worktree paths, safety rules)
+  │     └── <thread-history>
+  │
+  ├── agentRouter.composeSystemPrompt(session)
+  │     │  (common preamble)
+  │     ├── repo.path>/.claude/agents/common/*.md   if session.targetRepo has its own
+  │     │   OR  <fallbackAgentsDir>/common/*.md     (else)
+  │     ├── + <orgAgentsDir>/common/*.md            (always, additive)
+  │     └── + agent definition body                 (if resolved)
+  │
+  └── --append-system-prompt <composed>
 ```
 
-## Key Concepts
+## Key concepts
 
-### Agent Definition Format
+### Layered load chain
 
-```markdown
+Agent definitions use **exclusive resolution** (first match wins): target repo overrides org overlay overrides public.
+
+Common preamble files use a **two-tier mix**: target-repo-or-public-fallback is exclusive (one tier or the other, never both), then the org overlay is **additive** on top. So a worker agent targeting a repo with its own `common/` will see *that repo's common* + *the org overlay's common* — but not junior's public `common/`. This asymmetry matters when adding new files to public common: they won't reach agents whose target repo has its own common dir.
+
+### Context profile
+
+Lightweight agents opt out of preamble blocks via flat dot-notation frontmatter:
+
+```yaml
 ---
-name: build
-description: Backend builder agent
-tools: ["Read", "Edit", "Write", "Bash", "Grep", "Glob"]
-model: sonnet
+name: pr-summarize
+context.workspace: false
+context.threadHistory: false
 ---
-
-You are a backend builder. Build features, fix bugs, refactor code.
 ```
 
-### Target Repo vs Junior
+Missing flags default to `true` (safe-but-heavy). Invalid values (anything other than the literal `"true"`/`"false"`) fall back to default — silent typo protection. The skipped blocks are not just elided from the prompt; the underlying fetches (persona load, Slack history fetch) are also skipped, so opting out saves API calls and latency.
 
-Agent definitions live in **target repos** (not junior). Spawning Claude with `cwd` set to the target repo makes them available. Only agents about Junior itself belong in `junior/.claude/agents/`.
+### Target repo vs junior
+
+Agent definitions for org-specific work belong in the target repo's `.claude/agents/`. Pure junior agents (lead, default-utility-tasks) live in junior's `.claude/agents/`. Org-specific agents that don't belong in a single product repo live in the org overlay (`.claude/agents-org/`).
 
 ## Dependencies
 
-- **Uses**: filesystem (reads `.md` files from target repos), `config` (RepoConfig paths)
-- **Used by**: `SessionManager` (sets `session.systemPrompt` from agent routing)
+- **Uses**: filesystem (reads `.md` files), `config.repos` (target-repo paths), `Bun.Glob` (common-dir scanning).
+- **Used by**: `SessionManager.runClaudeWithAgent` (resolves agent definition early, threads context profile through to preamble building, composes system prompt, sets `session.systemPrompt`).

--- a/docs/features/agent-definitions.md
+++ b/docs/features/agent-definitions.md
@@ -15,17 +15,49 @@ The spawned Claude Code instances need personality and context. A bare `claude -
 
 | Agent | Purpose |
 |---|---|
-| `build.md` | Generic backend builder — for junior itself and repos without their own build agent |
-| `review.md` | Code reviewer — Bones equivalent. 6-pass methodology, inline GitHub comments |
-| `frontend.md` | Generic frontend builder — for repos without their own frontend agent |
-| `architect.md` | System architect — specs, data models, state machines |
-| `pm.md` | Product manager — scoping, iterations, scope cuts |
-| `common/building-philosophy.md` | Shared preamble for all builder agents |
+| `lead.md` | Bug-pipeline orchestrator. Routes between thinker, reproducer, review; gates the dev-mirror merge. |
+| `thinker.md` | Two-phase root-cause hypothesizer + fix-scoper. |
+| `reproducer.md` | Two-phase Playwright walker — reproduces the bug, then validates the fix. |
+| `review.md` | Code reviewer (6-pass methodology, inline GitHub comments). |
+| `build.md` | Generic backend builder — for junior itself and repos without their own build agent. |
+| `frontend.md` | Generic frontend builder — for repos without their own frontend agent. |
+| `architect.md` | System architect — specs, data models, state machines. |
+| `pm.md` | Product manager — scoping, iterations, scope cuts. |
+| `common/building-philosophy.md` | Shared preamble — generic building principles. |
+| `common/merge-workflow.md` | Shared preamble — generic merge invariants (admin token, 3-way, branch from main). Org-specifics live in the overlay. |
+| `common/runtime-environment.md` | Shared preamble — generic runtime rules (image-reading, repo-locations meta-rule, MCP tool list, bug folder layout). Org-specifics live in the overlay. |
 
-**Loading priority:**
-1. Target repo's `.claude/agents/<type>.md` (e.g., example-backend has its own build.md)
-2. Junior's `.claude/agents/<type>.md` (fallback)
-3. No agent (generic Claude with just CLAUDE.md)
+**Private org overlay (`.claude/agents-org/`, mounted as a private submodule):**
+
+Contains org-specific agents and common preamble files that don't belong in the public repo:
+- `common/merge-workflow.md` — concrete token name, credentials path, exact merge invocation, multi-stage release flow.
+- `common/runtime-environment.md` — concrete repo names, local dev URLs, production-like FQDN config, admin-credentials.yaml usage, impersonation flow.
+- Any org-specific agents (e.g. internal task agents that name proprietary tooling).
+
+**Loading priority for an agent `.md`:**
+1. Target repo's `.claude/agents/<type>.md` (if `session.targetRepo` is set)
+2. Org overlay's `<orgAgentsDir>/<type>.md`
+3. Junior's `.claude/agents/<type>.md` (public fallback)
+4. No agent (generic Claude with the common preamble alone)
+
+**Loading order for common preamble:**
+1. Exclusive tier — target repo's `.claude/agents/common/*.md` **OR** Junior's public `.claude/agents/common/*.md` (target wins if non-empty; never both).
+2. Additive tier — org overlay's `<orgAgentsDir>/common/*.md` (always appended when overlay is configured).
+
+**Per-agent context profile:**
+
+Agents can opt out of preamble blocks via frontmatter dot-notation flags. Useful for lightweight task agents that don't need the full thread context.
+
+```yaml
+---
+name: pr-summarize
+description: One-sentence PR summary.
+context.workspace: false
+context.threadHistory: false
+---
+```
+
+Flags: `identity`, `slack`, `workspace`, `threadHistory`, `agentState`. Missing or invalid values default to `true` (safe-but-heavy).
 
 **What already exists in example-backend (DON'T duplicate):**
 - build.md, domain-eng.md, design-fe.md, content.md, pm.md, audit.md, retention.md, strategy.md, provocateur.md, domain-ops.md

--- a/docs/features/agent-routing.md
+++ b/docs/features/agent-routing.md
@@ -11,14 +11,18 @@ Different Slack threads need different Claude Code personalities. A thread askin
 
 ## Full Vision
 
-- Command selects agent type: `!build`, `!frontend`, `!review`, `!architect`, `!pm`, `!audit`
-- Agent definitions loaded from target repo's `.claude/agents/<type>.md`
-- Fallback to junior's own `.claude/agents/` if target repo doesn't have the agent
+- Command selects agent type: `!build`, `!frontend`, `!review`, `!architect`, `!pm`, `!audit`, `!reproducer`, `!thinker`, …
+- Agent definitions resolved across a **layered search chain** — first match wins:
+  1. Target repo's `.claude/agents/<type>.md`
+  2. Private org overlay's `<orgAgentsDir>/<type>.md` (e.g. `.claude/agents-org/`, a gitignored or submodule-mounted private repo)
+  3. Junior's own `.claude/agents/<type>.md` (fallback)
 - Agent definition injected via `--append-system-prompt`
-- Agent type persists across turns in a thread
-- Can be changed mid-thread with a new slash command
-- Default agent (no command) = generic Claude with CLAUDE.md context only
-- Common preamble loaded alongside agent definition (like example-backend's `common/building-philosophy.md`)
+- Agent type persists across turns in a thread; can be changed mid-thread with a new command
+- Lead and the default `@junior` path also flow through this composition (the public `lead.md` is the lead's system prompt; the default agent gets common preamble only since no `default.md` exists)
+- Common preamble loaded alongside agent definition:
+  - **Exclusive tier:** target repo's `common/*.md` if any, else junior's public `common/*.md`
+  - **Additive tier:** the org overlay's `common/*.md` is **always** appended after the exclusive tier, so org-wide invariants (credential paths, merge protocol, infra URLs) reach every agent regardless of which repo's common loaded first
+- **Per-agent context profile** (frontmatter flags) lets lightweight task agents opt out of preamble blocks (`identity`, `slack`, `workspace`, `threadHistory`, `agentState`). Defaults are all-true; missing or invalid flags preserve the heavy preamble.
 
 ## Dependencies
 
@@ -84,7 +88,7 @@ Load and prepend the common preamble that all agents share.
 - example-backend already has `common/building-philosophy.md` — this gets loaded for all example-backend agents
 
 **Test:** Load "build" agent for example-backend → prompt starts with building-philosophy.md content, then build.md content.
-**Defers:** Caching, hot reload.
+**Defers:** Caching, hot reload, additive overlay (see Iteration 5).
 
 ### Iteration 3: Agent type from message context (~30 min)
 
@@ -115,6 +119,21 @@ Different agent types get different MCP server configurations.
 **Test:** Build session → MCP config includes DB server. Review session → MCP config excludes DB write tools. Temp files cleaned up after session ends.
 **Defers:** Dynamic MCP config updates mid-session.
 
+### Iteration 5: Private org overlay + per-agent context profile (~1 hr)
+
+Separate the public Junior repo from org-specific specifics, and let lightweight agents opt out of the heavy preamble.
+
+**What it adds:**
+- `AgentRouter` accepts a third constructor arg `orgAgentsDir` (e.g. `.claude/agents-org/`) — a gitignored or submodule-mounted private repo.
+- `resolveAgent`: search order becomes target repo → org overlay → public fallback (first match wins).
+- `composeSystemPrompt`: org overlay's `common/*.md` is appended **additively** after the public/target common — so org-wide invariants (credential paths, merge protocol, infra URLs) reach every agent regardless of which repo's common loaded first.
+- `composeSystemPrompt` also now returns the common preamble alone when no agent definition resolves — covers the default `@junior` path so it picks up the same invariants.
+- Per-agent **context profile** via frontmatter dot-notation flags: `context.identity`, `context.slack`, `context.workspace`, `context.threadHistory`, `context.agentState`. Each gates the corresponding block in `buildPromptPreamble`. Defaults are all-true; missing/invalid flags preserve the heavy preamble (safe-but-heavy).
+- `lead`/`default` agentName branches in `buildRunSession` set `agentType` so they participate in the new compose path (previously short-circuited).
+
+**Test:** Six-scenario load-path matrix (default-no-target, default-target-with-no-common, default-target-with-common, lead variants, worker-with-target) confirms overlay common reaches every agent; public common reaches all agents except those whose target repo has its own common; agent body resolves correctly per the search-chain order.
+**Defers:** Caching, hot reload of overlay files, additive merging across all three tiers (currently target-or-fallback is still exclusive).
+
 ## Shortcuts
 
 | Shortcut | Replaced in |
@@ -122,6 +141,8 @@ Different agent types get different MCP server configurations.
 | Hardcoded agent prompts | Iteration 1 (file-based) |
 | No auto-detection | Iteration 3 |
 | No MCP config | Iteration 4 |
+| Single tier of agent/common files | Iteration 5 (overlay) |
+| All agents get the full preamble | Iteration 5 (context profile) |
 | No caching of agent definitions | Post-MVP |
 
 ## Cut List (true v2)

--- a/src/agents/loader.test.ts
+++ b/src/agents/loader.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { loadAgentDefinition } from "./loader.ts";
+import { loadAgentDefinition, DEFAULT_CONTEXT_PROFILE } from "./loader.ts";
 import path from "node:path";
 
 const agentsDir = path.resolve(
@@ -106,5 +106,60 @@ This has no closing delimiter`;
       const fs = await import("node:fs/promises");
       await fs.unlink(tmpPath).catch(() => {});
     }
+  });
+
+  describe("context profile", () => {
+    it("defaults all flags to true when no context.* keys are declared", async () => {
+      const def = await loadAgentDefinition(path.join(agentsDir, "build.md"));
+      expect(def).not.toBeNull();
+      expect(def!.context).toEqual(DEFAULT_CONTEXT_PROFILE);
+    });
+
+    it("parses individual context.* flags as overrides", async () => {
+      const tmpPath = path.join(import.meta.dir, "__test_ctx.md");
+      const content = `---
+name: pr-summarize
+description: Summarize a PR in one sentence.
+context.workspace: false
+context.threadHistory: false
+---
+
+body`;
+      await Bun.write(tmpPath, content);
+
+      try {
+        const def = await loadAgentDefinition(tmpPath);
+        expect(def).not.toBeNull();
+        expect(def!.context.identity).toBe(true);
+        expect(def!.context.slack).toBe(true);
+        expect(def!.context.workspace).toBe(false);
+        expect(def!.context.threadHistory).toBe(false);
+        expect(def!.context.agentState).toBe(true);
+      } finally {
+        const fs = await import("node:fs/promises");
+        await fs.unlink(tmpPath).catch(() => {});
+      }
+    });
+
+    it("ignores invalid context.* values (not 'true'/'false')", async () => {
+      const tmpPath = path.join(import.meta.dir, "__test_ctx_bad.md");
+      const content = `---
+name: bad
+context.workspace: maybe
+context.threadHistory: 0
+---
+body`;
+      await Bun.write(tmpPath, content);
+
+      try {
+        const def = await loadAgentDefinition(tmpPath);
+        // Bad values fall back to default (true) — safe-but-heavy.
+        expect(def!.context.workspace).toBe(true);
+        expect(def!.context.threadHistory).toBe(true);
+      } finally {
+        const fs = await import("node:fs/promises");
+        await fs.unlink(tmpPath).catch(() => {});
+      }
+    });
   });
 });

--- a/src/agents/loader.ts
+++ b/src/agents/loader.ts
@@ -1,9 +1,43 @@
+/**
+ * Per-agent preamble context profile. Each flag controls whether the
+ * corresponding block in `buildPromptPreamble` is emitted on the first turn.
+ *
+ * Defaults are ALL TRUE — existing agents that don't declare flags keep their
+ * current heavy preamble. Lightweight task agents opt out per-block via
+ * frontmatter:
+ *
+ *   ---
+ *   name: pr-summarize
+ *   context.workspace: false
+ *   context.threadHistory: false
+ *   ---
+ *
+ * Missing flag → true (safe-but-heavy). Unknown `context.*` keys are ignored
+ * silently; values must be the literal strings "true" or "false".
+ */
+export interface AgentContextProfile {
+  identity: boolean;
+  slack: boolean;
+  workspace: boolean;
+  threadHistory: boolean;
+  agentState: boolean;
+}
+
+export const DEFAULT_CONTEXT_PROFILE: AgentContextProfile = {
+  identity: true,
+  slack: true,
+  workspace: true,
+  threadHistory: true,
+  agentState: true,
+};
+
 export interface AgentDefinition {
   name: string;
   description: string;
   tools: string | null;
   model: string | null;
   prompt: string;
+  context: AgentContextProfile;
 }
 
 export async function loadAgentDefinition(
@@ -22,7 +56,29 @@ export async function loadAgentDefinition(
     tools: frontmatter["tools"] ?? null,
     model: frontmatter["model"] ?? null,
     prompt: body.trim(),
+    context: readContextProfile(frontmatter),
   };
+}
+
+function readContextProfile(
+  fm: Record<string, string>,
+): AgentContextProfile {
+  return {
+    identity: parseBool(fm["context.identity"]) ?? DEFAULT_CONTEXT_PROFILE.identity,
+    slack: parseBool(fm["context.slack"]) ?? DEFAULT_CONTEXT_PROFILE.slack,
+    workspace: parseBool(fm["context.workspace"]) ?? DEFAULT_CONTEXT_PROFILE.workspace,
+    threadHistory:
+      parseBool(fm["context.threadHistory"]) ?? DEFAULT_CONTEXT_PROFILE.threadHistory,
+    agentState: parseBool(fm["context.agentState"]) ?? DEFAULT_CONTEXT_PROFILE.agentState,
+  };
+}
+
+function parseBool(value: string | undefined): boolean | undefined {
+  if (value === undefined) return undefined;
+  const v = value.trim().toLowerCase();
+  if (v === "true") return true;
+  if (v === "false") return false;
+  return undefined;
 }
 
 function parseFrontmatter(content: string): {

--- a/src/agents/router.test.ts
+++ b/src/agents/router.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { AgentRouter } from "./router.ts";
+import type { ThreadSession } from "../session/types.ts";
+import path from "node:path";
+import fs from "node:fs/promises";
+
+function makeSession(overrides: Partial<ThreadSession> = {}): ThreadSession {
+  return {
+    threadId: "T1",
+    channel: "C1",
+    sessionId: null,
+    leadSessionId: null,
+    agentSessions: {},
+    status: "idle",
+    worktreePath: null,
+    worktreePaths: null,
+    agentType: null,
+    targetRepo: null,
+    baseRef: null,
+    systemPrompt: null,
+    pid: null,
+    lastError: null,
+    pendingMessages: [],
+    verbosity: "normal",
+    muted: false,
+    lastActivity: Date.now(),
+    createdAt: Date.now(),
+    ...overrides,
+  } as ThreadSession;
+}
+
+describe("AgentRouter overlay", () => {
+  let tmpRoot: string;
+  let fallbackDir: string;
+  let orgDir: string;
+
+  beforeEach(async () => {
+    tmpRoot = await fs.mkdtemp("/tmp/junior-router-test-");
+    fallbackDir = path.join(tmpRoot, "public");
+    orgDir = path.join(tmpRoot, "org");
+    await fs.mkdir(path.join(fallbackDir, "common"), { recursive: true });
+    await fs.mkdir(path.join(orgDir, "common"), { recursive: true });
+  });
+
+  afterEach(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  it("falls back to the org overlay when an agent .md isn't in the public dir", async () => {
+    await fs.writeFile(
+      path.join(orgDir, "gx-debug.md"),
+      `---\nname: gx-debug\n---\n\nprivate agent body`,
+    );
+
+    const router = new AgentRouter([], fallbackDir, orgDir);
+    const def = await router.resolveAgent(makeSession({ agentType: "gx-debug" }));
+
+    expect(def).not.toBeNull();
+    expect(def!.name).toBe("gx-debug");
+    expect(def!.prompt).toBe("private agent body");
+  });
+
+  it("public dir takes precedence over overlay when both define the same agent", async () => {
+    await fs.writeFile(
+      path.join(orgDir, "build.md"),
+      `---\nname: build\n---\n\nORG VERSION`,
+    );
+    await fs.writeFile(
+      path.join(fallbackDir, "build.md"),
+      `---\nname: build\n---\n\nPUBLIC VERSION`,
+    );
+
+    const router = new AgentRouter([], fallbackDir, orgDir);
+    const def = await router.resolveAgent(makeSession({ agentType: "build" }));
+
+    // Search order is target-repo → org → public, so when only public + org
+    // exist (no targetRepo on the session), org wins.
+    expect(def!.prompt).toBe("ORG VERSION");
+  });
+
+  it("composeSystemPrompt appends org common files additively to public common", async () => {
+    await fs.writeFile(
+      path.join(fallbackDir, "common", "philosophy.md"),
+      "# public philosophy",
+    );
+    await fs.writeFile(
+      path.join(orgDir, "common", "merge-workflow.md"),
+      "# org merge rules",
+    );
+    await fs.writeFile(
+      path.join(fallbackDir, "lead.md"),
+      `---\nname: lead\n---\n\nLEAD BODY`,
+    );
+
+    const router = new AgentRouter([], fallbackDir, orgDir);
+    const prompt = await router.composeSystemPrompt(
+      makeSession({ agentType: "lead" }),
+    );
+
+    expect(prompt).not.toBeNull();
+    expect(prompt!).toContain("# public philosophy");
+    expect(prompt!).toContain("# org merge rules");
+    expect(prompt!).toContain("LEAD BODY");
+    // Org appears AFTER public common (more authoritative trailing block).
+    expect(prompt!.indexOf("# public philosophy")).toBeLessThan(
+      prompt!.indexOf("# org merge rules"),
+    );
+  });
+
+  it("returns only common preamble when no agent definition resolves", async () => {
+    await fs.writeFile(
+      path.join(fallbackDir, "common", "philosophy.md"),
+      "# only common",
+    );
+
+    const router = new AgentRouter([], fallbackDir, orgDir);
+    // No agentType → no agent definition; composeSystemPrompt should still
+    // emit the common preamble (this is the default-agent path).
+    const prompt = await router.composeSystemPrompt(makeSession());
+
+    expect(prompt).toBe("# only common");
+  });
+
+  it("no org dir configured → still works, just no overlay", async () => {
+    await fs.writeFile(
+      path.join(fallbackDir, "build.md"),
+      `---\nname: build\n---\n\nPUBLIC ONLY`,
+    );
+
+    const router = new AgentRouter([], fallbackDir);
+    const def = await router.resolveAgent(makeSession({ agentType: "build" }));
+
+    expect(def!.prompt).toBe("PUBLIC ONLY");
+  });
+});

--- a/src/agents/router.test.ts
+++ b/src/agents/router.test.ts
@@ -60,7 +60,7 @@ describe("AgentRouter overlay", () => {
     expect(def!.prompt).toBe("private agent body");
   });
 
-  it("public dir takes precedence over overlay when both define the same agent", async () => {
+  it("overlay takes precedence over public fallback when both define the same agent (no targetRepo)", async () => {
     await fs.writeFile(
       path.join(orgDir, "build.md"),
       `---\nname: build\n---\n\nORG VERSION`,
@@ -73,9 +73,47 @@ describe("AgentRouter overlay", () => {
     const router = new AgentRouter([], fallbackDir, orgDir);
     const def = await router.resolveAgent(makeSession({ agentType: "build" }));
 
-    // Search order is target-repo → org → public, so when only public + org
-    // exist (no targetRepo on the session), org wins.
+    // Search order is target-repo → org → public. With no targetRepo on the
+    // session, the org overlay matches before the public fallback, so org wins.
     expect(def!.prompt).toBe("ORG VERSION");
+  });
+
+  it("composeSystemPrompt appends org common to target-repo common (skipping public common)", async () => {
+    // Asymmetric load chain: target-repo OR public is exclusive; overlay is
+    // additive. Regression guard for the case where a target repo has its own
+    // common dir — public common is bypassed but overlay still appends.
+    const targetRepoDir = path.join(tmpRoot, "target-repo");
+    await fs.mkdir(path.join(targetRepoDir, ".claude/agents/common"), { recursive: true });
+    await fs.writeFile(
+      path.join(targetRepoDir, ".claude/agents/common/repo-rules.md"),
+      "# target-repo common",
+    );
+    await fs.writeFile(
+      path.join(orgDir, "common", "org-rules.md"),
+      "# org common",
+    );
+    await fs.writeFile(
+      path.join(fallbackDir, "common", "public-rules.md"),
+      "# public common (should NOT appear when target has its own common)",
+    );
+
+    const router = new AgentRouter(
+      [{ name: "target-repo", path: targetRepoDir, defaultBase: "origin/main" }],
+      fallbackDir,
+      orgDir,
+    );
+    const prompt = await router.composeSystemPrompt(
+      makeSession({ targetRepo: "target-repo" }),
+    );
+
+    expect(prompt).not.toBeNull();
+    expect(prompt!).toContain("# target-repo common");
+    expect(prompt!).toContain("# org common");
+    expect(prompt!).not.toContain("# public common");
+    // Order: target-repo common first, then overlay.
+    expect(prompt!.indexOf("# target-repo common")).toBeLessThan(
+      prompt!.indexOf("# org common"),
+    );
   });
 
   it("composeSystemPrompt appends org common files additively to public common", async () => {

--- a/src/agents/router.ts
+++ b/src/agents/router.ts
@@ -3,13 +3,33 @@ import type { ThreadSession } from "../session/types.ts";
 import { loadAgentDefinition } from "./loader.ts";
 import type { AgentDefinition } from "./loader.ts";
 
+/**
+ * Resolves agent definitions and composes the system prompt.
+ *
+ * Search order for an agent .md file (first match wins):
+ *   1. target repo's .claude/agents/<name>.md (if session has a targetRepo)
+ *   2. org overlay dir (private submodule mount, if configured)
+ *   3. fallback dir (junior's public .claude/agents)
+ *
+ * Common preamble files load in this order:
+ *   - target repo's .claude/agents/common/*.md (if any), OR fallback common/*.md
+ *   - then org overlay common/*.md is appended additively (so org-wide
+ *     invariants like the merge-workflow rules reach every agent regardless
+ *     of which repo the public common came from)
+ */
 export class AgentRouter {
   private repos: RepoConfig[];
   private fallbackAgentsDir: string;
+  private orgAgentsDir: string | null;
 
-  constructor(repos: RepoConfig[], fallbackAgentsDir: string) {
+  constructor(
+    repos: RepoConfig[],
+    fallbackAgentsDir: string,
+    orgAgentsDir?: string | null,
+  ) {
     this.repos = repos;
     this.fallbackAgentsDir = fallbackAgentsDir;
+    this.orgAgentsDir = orgAgentsDir ?? null;
   }
 
   async resolveAgent(
@@ -17,19 +37,24 @@ export class AgentRouter {
   ): Promise<AgentDefinition | null> {
     if (!session.agentType) return null;
 
-    // Try target repo first
+    const candidates: string[] = [];
+
     if (session.targetRepo) {
       const repo = this.repos.find((r) => r.name === session.targetRepo);
       if (repo) {
-        const repoPath = `${repo.path}/.claude/agents/${session.agentType}.md`;
-        const definition = await loadAgentDefinition(repoPath);
-        if (definition) return definition;
+        candidates.push(`${repo.path}/.claude/agents/${session.agentType}.md`);
       }
     }
+    if (this.orgAgentsDir) {
+      candidates.push(`${this.orgAgentsDir}/${session.agentType}.md`);
+    }
+    candidates.push(`${this.fallbackAgentsDir}/${session.agentType}.md`);
 
-    // Fallback
-    const fallbackPath = `${this.fallbackAgentsDir}/${session.agentType}.md`;
-    return loadAgentDefinition(fallbackPath);
+    for (const path of candidates) {
+      const definition = await loadAgentDefinition(path);
+      if (definition) return definition;
+    }
+    return null;
   }
 
   async composeSystemPrompt(
@@ -54,6 +79,15 @@ export class AgentRouter {
       const fallbackCommonDir = `${this.fallbackAgentsDir}/common`;
       const fallbackFiles = await readMarkdownFiles(fallbackCommonDir);
       preambleParts.push(...fallbackFiles);
+    }
+
+    // Always append org overlay common files (additive). This keeps org-wide
+    // invariants — credentials, merge protocol, infra paths — visible to every
+    // agent regardless of which repo's public common loaded above.
+    if (this.orgAgentsDir) {
+      const orgCommonDir = `${this.orgAgentsDir}/common`;
+      const orgFiles = await readMarkdownFiles(orgCommonDir);
+      preambleParts.push(...orgFiles);
     }
 
     const commonPreamble = preambleParts.join("\n\n");

--- a/src/agents/router.ts
+++ b/src/agents/router.ts
@@ -36,7 +36,6 @@ export class AgentRouter {
     session: ThreadSession,
   ): Promise<string | null> {
     const definition = await this.resolveAgent(session);
-    if (!definition) return null;
 
     const preambleParts: string[] = [];
 
@@ -59,11 +58,12 @@ export class AgentRouter {
 
     const commonPreamble = preambleParts.join("\n\n");
 
-    if (commonPreamble) {
+    if (commonPreamble && definition) {
       return commonPreamble + "\n\n" + definition.prompt;
     }
-
-    return definition.prompt;
+    if (commonPreamble) return commonPreamble;
+    if (definition) return definition.prompt;
+    return null;
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import { loadConfig } from "./config.ts";
 import { createSlackApp } from "./slack/app.ts";
 import { registerEventHandlers } from "./slack/events.ts";
-import { formatToolStatuses, extractAssistantText, shouldPostResponseToSlack } from "./slack/formatting.ts";
+import { formatToolStatuses, extractAssistantText, prepareSlackResponse } from "./slack/formatting.ts";
 import { SlackResponder } from "./slack/responder.ts";
 import { SessionManager } from "./session/manager.ts";
 import { createSessionStore } from "./session/store/factory.ts";
@@ -49,18 +49,18 @@ const supportRouter = new AgentDispatcher(sessionManager, supportChannels, {
 });
 
 sessionManager.onResponse = (session, response) => {
-  const willPost = shouldPostResponseToSlack(response);
+  const prepared = prepareSlackResponse(response);
   const agentName = session.activeAgentName ?? "lead";
   log.info(
     "response",
-    `thread=${session.threadId} agent=${agentName} len=${response.length} willPost=${willPost}`,
+    `thread=${session.threadId} agent=${agentName} len=${response.length} willPost=${prepared !== null}`,
   );
   responder.deleteStatus(session.channel, session.threadId, agentName);
-  if (willPost) {
+  if (prepared !== null) {
     responder.postResponse(
       session.channel,
       session.threadId,
-      response,
+      prepared,
       session.slackIdentity,
     );
   } else {
@@ -80,14 +80,16 @@ sessionManager.onEvent = (session, event) => {
   if (event.type === "assistant") {
     // Show text content as live status (gets overwritten each turn)
     const text = extractAssistantText(event);
-    if (text && !shouldPostResponseToSlack(text)) {
-      log.info(
-        "response",
-        `thread=${session.threadId} status.suppressed reason=${text.trim() ? "sentinel" : "empty"}`,
-      );
-    }
-    if (text && shouldPostResponseToSlack(text)) {
-      responder.updateStatus(session.channel, session.threadId, text, agentName);
+    if (text) {
+      const prepared = prepareSlackResponse(text);
+      if (prepared === null) {
+        log.info(
+          "response",
+          `thread=${session.threadId} status.suppressed reason=${text.trim() ? "sentinel" : "empty"}`,
+        );
+      } else {
+        responder.updateStatus(session.channel, session.threadId, prepared, agentName);
+      }
     }
 
     // Show tool use as status

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,11 @@ const app = createSlackApp(config);
 const store = createSessionStore(config);
 log.info("boot", `Session store: ${config.session.store}`);
 const sessionManager = new SessionManager(store, config);
-const agentRouter = new AgentRouter(config.repos, ".claude/agents");
+const agentRouter = new AgentRouter(
+  config.repos,
+  ".claude/agents",
+  ".claude/agents-org",
+);
 const worktreeManager = new WorktreeManager(config.repos);
 const devServerManager = new DevServerManager(config.repos, worktreeManager);
 const devServerQueue = new DevServerQueue(devServerManager, config.repos);

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -24,6 +24,7 @@ import {
   resolveSlackMentions,
   type WorkspaceContext,
 } from "../slack/thread-context.ts";
+import { DEFAULT_CONTEXT_PROFILE, type AgentContextProfile } from "../agents/loader.ts";
 import { downloadSlackFiles } from "../slack/files.ts";
 import { log as _log } from "../logger.ts";
 
@@ -522,11 +523,20 @@ export class SessionManager {
           ? session.worktreePaths
           : undefined;
 
-      // Build the prompt. On the first turn (no sessionId yet), inject the full
-      // preamble (identity, slack-context, workspace, thread history). On resumed
-      // turns, --resume already carries identity/context/history — sending them
-      // again duplicates tokens and pollutes the conversation. Keep just the
-      // workspace block (cheap insurance for the worktree safety rule).
+      // Resolve the agent definition early so its declared context profile
+      // gates the preamble. Default agent (no .md) and missing-flag cases
+      // fall back to DEFAULT_CONTEXT_PROFILE (all blocks on).
+      const agentDefinition = this.agentRouter
+        ? await this.agentRouter.resolveAgent(runSession)
+        : null;
+      const contextProfile: AgentContextProfile =
+        agentDefinition?.context ?? DEFAULT_CONTEXT_PROFILE;
+
+      // Build the prompt. On the first turn (no sessionId yet), inject the
+      // preamble blocks the agent asked for. On resumed turns, --resume already
+      // carries identity/context/history — keep just the workspace block (cheap
+      // insurance for the worktree safety rule), and only if the agent wants
+      // the workspace context at all.
       if (this.slackApp && latestTs) {
         const isFirstTurn = !runSession.sessionId;
         const readablePrompt = await resolveSlackMentions(this.slackApp, prompt);
@@ -540,9 +550,10 @@ export class SessionManager {
             workspace,
             worktreePaths,
             this.config.repos,
+            contextProfile,
           );
-          prompt = `${preamble}\n\n${readablePrompt}`;
-        } else {
+          prompt = preamble ? `${preamble}\n\n${readablePrompt}` : readablePrompt;
+        } else if (contextProfile.workspace) {
           const workspaceBlock = buildWorkspaceBlock(
             workspace,
             worktreePaths,
@@ -552,6 +563,8 @@ export class SessionManager {
           prompt = workspaceBlock
             ? `${workspaceBlock}\n\n${readablePrompt}`
             : readablePrompt;
+        } else {
+          prompt = readablePrompt;
         }
       }
 
@@ -597,9 +610,11 @@ export class SessionManager {
         ? undefined
         : targetRepo?.path;
 
-      const agentStateBlock = this.buildAgentStateBlock(session);
-      if (agentStateBlock) {
-        prompt = `${agentStateBlock}\n\n${prompt}`;
+      if (contextProfile.agentState) {
+        const agentStateBlock = this.buildAgentStateBlock(session);
+        if (agentStateBlock) {
+          prompt = `${agentStateBlock}\n\n${prompt}`;
+        }
       }
 
       // We don't log the prompt to avoid spamming the logs. unless we are debugging it

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -572,8 +572,11 @@ export class SessionManager {
         }
       }
 
-      // Compose agent system prompt
-      if (runSession.agentType && this.agentRouter) {
+      // Compose agent system prompt. Note: composeSystemPrompt now returns
+      // the common preamble even when no agent .md resolves (e.g. the
+      // "default" agent has no definition file but should still receive
+      // junior's invariants like the merge-workflow rules).
+      if (this.agentRouter) {
         const composed =
           (await this.agentRouter.composeSystemPrompt(runSession)) ?? null;
         runSession.systemPrompt = this.withAgentIdentityPrompt(
@@ -832,7 +835,16 @@ export class SessionManager {
     agentName: string,
     agentIdentity?: AgentIdentity,
   ): ThreadSession {
-    if (agentName === "lead" || agentName === "default") {
+    if (agentName === "lead") {
+      return {
+        ...session,
+        sessionId: session.leadSessionId ?? session.sessionId,
+        activeAgentName: agentName,
+        slackIdentity: agentIdentity,
+        agentType: "lead",
+      };
+    }
+    if (agentName === "default") {
       return {
         ...session,
         sessionId: session.leadSessionId ?? session.sessionId,

--- a/src/slack/formatting.ts
+++ b/src/slack/formatting.ts
@@ -34,12 +34,28 @@ export function extractAssistantText(event: StreamEventAssistant): string | null
 
 export const NO_SLACK_MESSAGE = "NO_SLACK_MESSAGE";
 
-export function shouldPostResponseToSlack(text: string): boolean {
-  const normalized = text.trim();
-  if (!normalized) return false;
-  if (normalized === NO_SLACK_MESSAGE) return false;
-  if (normalized.endsWith(NO_SLACK_MESSAGE)) return false;
-  return true;
+/**
+ * Decide whether to post `text` to Slack and what to post.
+ * Returns null to suppress entirely; otherwise the cleaned text to post.
+ *
+ * Suppress when:
+ *   - text is empty/whitespace
+ *   - text is exactly the sentinel
+ *
+ * Strip + post when:
+ *   - text has real content followed by a trailing sentinel — the agent
+ *     intended to reply and habitually appended the sentinel; the reply
+ *     itself is what humans need.
+ */
+export function prepareSlackResponse(text: string): string | null {
+  let normalized = text.trim();
+  if (!normalized) return null;
+  if (normalized === NO_SLACK_MESSAGE) return null;
+  if (normalized.endsWith(NO_SLACK_MESSAGE)) {
+    normalized = normalized.slice(0, -NO_SLACK_MESSAGE.length).trimEnd();
+    if (!normalized) return null;
+  }
+  return normalized;
 }
 
 function formatToolBlock(block: ContentBlockToolUse): string {

--- a/src/slack/thread-context.ts
+++ b/src/slack/thread-context.ts
@@ -2,6 +2,8 @@ import type { App } from "@slack/bolt";
 import type { RepoConfig } from "../config.ts";
 import { loadPersona } from "../persona.ts";
 import { NO_SLACK_MESSAGE } from "./formatting.ts";
+import type { AgentContextProfile } from "../agents/loader.ts";
+import { DEFAULT_CONTEXT_PROFILE } from "../agents/loader.ts";
 
 interface ThreadMessage {
   user: string;
@@ -163,43 +165,60 @@ export async function buildPromptPreamble(
   workspace?: WorkspaceContext | null,
   worktreePaths?: Record<string, string>,
   repos?: RepoConfig[],
+  contextProfile: AgentContextProfile = DEFAULT_CONTEXT_PROFILE,
 ): Promise<string> {
+  // Only fetch the data we'll actually emit — skipping thread history matters
+  // for lightweight task agents, both for tokens and for latency.
   const [persona, channelName, threadContext] = await Promise.all([
-    loadPersona(),
-    resolveChannelName(app, channel),
-    fetchThreadHistory(app, channel, threadTs, latestTs, botUserId),
+    contextProfile.identity ? loadPersona() : Promise.resolve(""),
+    contextProfile.slack ? resolveChannelName(app, channel) : Promise.resolve(channel),
+    contextProfile.threadHistory
+      ? fetchThreadHistory(app, channel, threadTs, latestTs, botUserId)
+      : Promise.resolve(""),
   ]);
 
-  const parts: string[] = [
-    `<identity>`,
-    persona,
-    ``,
-    `Your Slack user ID is ${botUserId ?? "unknown"}. Messages from this user ID in the thread are yours.`,
-    `</identity>`,
-    ``,
-    `<slack-context>`,
-    `Channel: #${channelName} (${channel})`,
-    `Thread: ${threadTs}`,
-    `You are responding in this thread. You already have the full thread history below.`,
-    `Do NOT use Slack search or read tools to find this thread — you already have all the context you need.`,
-    `To tag a user, use their Slack mention format \`<@USERID>\` (shown in thread history as \`User(Name <@USERID>)\`). Plain \`@Name\` does not notify them.`,
-    ``,
-    `If you decide this message does NOT need a reply (e.g. it's noise, already handled, or you've finished silent work), your final response must be exactly the sentinel \`${NO_SLACK_MESSAGE}\` and nothing else — no surrounding text, no explanation, no quotes. Anything else will be posted to the channel verbatim.`,
-    ``,
-    `CRITICAL — no double-posting: if you used \`slack_send_message\` (or any other Slack post tool) during this turn, that tool call IS your reply. Your final response in this turn MUST be exactly \`${NO_SLACK_MESSAGE}\`. Do NOT also return a recap, summary, or "Posted X..." narration — the human already saw what you posted, and a second message restating it is a duplicate. Pick one channel: either post via the tool and return \`${NO_SLACK_MESSAGE}\`, or skip the tool and return prose as your reply. Never both.`,
-    `</slack-context>`,
-  ];
+  const parts: string[] = [];
 
-  const workspaceBlock = buildWorkspaceBlock(workspace, worktreePaths, repos, threadTs);
-  if (workspaceBlock) {
-    parts.push(``, workspaceBlock);
+  if (contextProfile.identity) {
+    parts.push(
+      `<identity>`,
+      persona,
+      ``,
+      `Your Slack user ID is ${botUserId ?? "unknown"}. Messages from this user ID in the thread are yours.`,
+      `</identity>`,
+      ``,
+    );
   }
 
-  if (threadContext) {
+  if (contextProfile.slack) {
+    parts.push(
+      `<slack-context>`,
+      `Channel: #${channelName} (${channel})`,
+      `Thread: ${threadTs}`,
+      `You are responding in this thread. You already have the full thread history below.`,
+      `Do NOT use Slack search or read tools to find this thread — you already have all the context you need.`,
+      `To tag a user, use their Slack mention format \`<@USERID>\` (shown in thread history as \`User(Name <@USERID>)\`). Plain \`@Name\` does not notify them.`,
+      ``,
+      `If you decide this message does NOT need a reply (e.g. it's noise, already handled, or you've finished silent work), your final response must be exactly the sentinel \`${NO_SLACK_MESSAGE}\` and nothing else — no surrounding text, no explanation, no quotes. Anything else will be posted to the channel verbatim.`,
+      ``,
+      `CRITICAL — no double-posting: if you used \`slack_send_message\` (or any other Slack post tool) during this turn, that tool call IS your reply. Your final response in this turn MUST be exactly \`${NO_SLACK_MESSAGE}\`. Do NOT also return a recap, summary, or "Posted X..." narration — the human already saw what you posted, and a second message restating it is a duplicate. Pick one channel: either post via the tool and return \`${NO_SLACK_MESSAGE}\`, or skip the tool and return prose as your reply. Never both.`,
+      `</slack-context>`,
+    );
+  }
+
+  if (contextProfile.workspace) {
+    const workspaceBlock = buildWorkspaceBlock(workspace, worktreePaths, repos, threadTs);
+    if (workspaceBlock) {
+      parts.push(``, workspaceBlock);
+    }
+  }
+
+  if (contextProfile.threadHistory && threadContext) {
     parts.push("", threadContext);
   }
 
-  return parts.join("\n");
+  // Trim leading/trailing empty separators left by skipped blocks.
+  return parts.join("\n").replace(/^\n+|\n+$/g, "");
 }
 
 async function fetchThreadHistory(


### PR DESCRIPTION
## Summary

Two related additions to the agent-router and prompt-composition path, plus a private submodule mount that the new overlay search path consumes.

**Per-agent context profile.** Frontmatter dot-notation flags (`context.identity`, `context.slack`, `context.workspace`, `context.threadHistory`, `context.agentState`) let an agent opt out of preamble blocks. Defaults are all-true (safe-but-heavy); invalid values fall back to default. `buildPromptPreamble` reads the profile and gates each block *including* the underlying fetches (persona, thread history), so lightweight task agents save API calls and latency, not just tokens.

**Private overlay search path.** `AgentRouter` takes an optional `orgAgentsDir` (mounted at `.claude/agents-org/` via a private submodule). `resolveAgent` searches target repo → org overlay → public fallback (first match wins). `composeSystemPrompt` returns common preamble even when no agent definition resolves (covers the default @-mention path) and appends the overlay's `common/*.md` additively after the target-or-fallback common, so org-wide invariants (credentials, merge protocol, infra URLs) reach every agent regardless of which repo's common loaded first. `buildRunSession` sets `agentType: \"lead\"` for the lead branch so `lead.md` actually loads (previously short-circuited).

**Public sanitization.** Public `common/merge-workflow.md` and `common/runtime-environment.md` now hold only generic invariants; concrete repo names, dev URLs, credential paths, and the multi-stage release flow live in the private overlay. Cross-file path references inside agent prompts (`.claude/agents-org/...`) were stripped — content is already loaded; pointing at the source path tempts the agent to chase a file that won't resolve from its worktree cwd.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test src/agents` — 15 pass (3 new loader tests for context profile, 5 new router tests for overlay)
- [x] `bun test src/session src/slack` — 148 pass
- [x] Empirically verified composeSystemPrompt across 7 scenarios (default × no/with target × with/without target-repo-common; lead, reproducer, build worker variants) — overlay content reaches every agent, no `.claude/agents-org/...` path strings leak into the composed prompt, public sanitized files carry no GX-specific strings
- [ ] Smoke-test in Slack: `@junior` in a non-bug-pipeline thread should now know the org merge workflow without grepping the repo

## Notes for reviewer

- The overlay submodule is at `GrowthX-Club/junior-private-agents` (private). The pointer in this PR is at the tip of the overlay's `main` containing both `merge-workflow.md` and `runtime-environment.md` with self-references sanitized.
- One pre-existing rough edge made more visible: target-repo's `common/` and public fallback `common/` are loaded **exclusively** (target wins if non-empty; never both), while the overlay is **additive**. So a new file added to public `common/` won't reach agents whose target repo has its own `common/` dir. Mitigations and the rationale are captured in the updated docs.