### PR TITLE
chore: sanitize org-specific names + parametrize workspace safety rules

### DIFF
--- a/.claude/agents/lead.md
+++ b/.claude/agents/lead.md
@@ -25,9 +25,9 @@ If you find yourself doing ANY of the following, STOP — that work belongs to a
 | You're tempted to... | STOP. Dispatch instead: |
 |---|---|
 | Open Playwright / browser tools to verify something | `!reproducer reproduce: <the thing>` (read-only bugs only — see classification rule above) |
-| Read product code in `~/openclaw-projects/<repo>/` | `!thinker <hypothesis seed>` (thinker reads code as part of its job) |
+| Read product code in any bare repo | `!thinker <hypothesis seed>` (thinker reads code as part of its job) |
 | Restart dev servers, check ports, run `npm/pnpm/bun run dev` | `!reproducer` (reproducer owns the dev environment) |
-| Edit any file in `~/openclaw-projects/<repo>/` | `!thinker proceed` (thinker writes the fix in its scoping phase) |
+| Edit any file in a bare repo | `!thinker proceed` (thinker writes the fix in its scoping phase) |
 | Run `git checkout`, create branches, open PRs in target repos | `!thinker proceed` |
 | "Verify the fix works" with a browser | `!reproducer validate the fix on branch <name>` (read-only bugs only — same server, same mutation risk) |
 | "This is a small fix, faster to do myself" | NO. The architecture is the architecture. Dispatch. |

--- a/docs/features/bug-pipeline-worktrees.md
+++ b/docs/features/bug-pipeline-worktrees.md
@@ -12,9 +12,9 @@ Captures the discussion in a Slack thread on 2026-04-29.
 ## Problem
 
 For bug threads, junior's persistent agents (lead, thinker, reproducer) operate
-directly on the bare target repos under `~/openclaw-projects/<repo>/`. Specifically:
+directly on the bare target repos under `~/projects/<repo>/`. Specifically:
 
-- `runtime-environment.md` and the agent prompts hardcode `~/openclaw-projects/<repo>/` and tell agents to `cd` there for reading code, editing, `git checkout`, and `pnpm dev`.
+- `runtime-environment.md` and the agent prompts hardcode `~/projects/<repo>/` and tell agents to `cd` there for reading code, editing, `git checkout`, and `pnpm dev`.
 - `WorktreeManager` exists and `runClaudeWithAgent` will create a per-thread worktree at `<repo>.junior-worktrees/slack-<threadId>` — but only when `session.targetRepo` is set, which never happens on the lead-driven bug pipeline.
 
 Consequences:
@@ -28,9 +28,9 @@ The complaint: junior must run inside worktrees for bug work. The pieces to buil
 
 Three things tangle:
 
-1. **One thread can need multiple repos.** `repo-routing.yaml` routes a bug to e.g. `{frontend: gx-client-next, backend: gx-backend}`. The session model has a single `worktreePath`. Need `worktreePaths: Record<repoName, path>` (or equivalent).
+1. **One thread can need multiple repos.** `repo-routing.yaml` routes a bug to e.g. `{frontend: app-frontend, backend: app-backend}`. The session model has a single `worktreePath`. Need `worktreePaths: Record<repoName, path>` (or equivalent).
 2. **Reproducer's dev servers run on fixed ports (3000, 8000) from the bare repo.** Phase-2 validation is "checkout fix branch, restart dev server, walk the same path." If the dev server runs from a worktree, two concurrent validations on the same repo collide on the port. If it runs from the bare repo, we're back to corrupting the dev's branch.
-3. **Agent prompts hardcode the bare path.** Every reference to `~/openclaw-projects/<repo>/` needs to become a per-thread worktree path injected via the existing workspace block.
+3. **Agent prompts hardcode the bare path.** Every reference to `~/projects/<repo>/` needs to become a per-thread worktree path injected via the existing workspace block.
 
 ## Proposal
 
@@ -38,7 +38,7 @@ Three things tangle:
 
 - Lead, on intake, reads `repo-routing.yaml` and creates one worktree per routed repo for this thread (`<repo>.junior-worktrees/slack-<threadId>`, branch `slack/<threadId>` off `defaultBase`).
 - Session schema gains `worktreePaths: Record<repoName, path>` alongside the existing `worktreePath` (or replaces it).
-- `runtime-environment.md` and agent prompts swap hardcoded `~/openclaw-projects/<repo>/` references for the per-thread worktree paths, injected via the workspace block.
+- `runtime-environment.md` and agent prompts swap hardcoded `~/projects/<repo>/` references for the per-thread worktree paths, injected via the workspace block.
 - `thinker` writes its fix branch in its repo's worktree. PR is opened from that branch.
 - `reproducer` phase-1 reads code in the worktree (or bare — read-only is fine either way; consistency is easier).
 
@@ -66,7 +66,7 @@ Even before queueing, today's reproducer has no kill path: when phase-2 spawns `
 Lifecycle policy proposed:
 
 - Junior tracks the dev server it spawns (PID + repo + current branch) per dev-server worktree.
-- **Reuse across validations on the same branch.** When the queue lock is acquired by a thread whose fix branch matches the running dev server, no restart — just walk. (Cold-starting `pnpm dev` for gx-client-next is ~30s, not free.)
+- **Reuse across validations on the same branch.** When the queue lock is acquired by a thread whose fix branch matches the running dev server, no restart — just walk. (Cold-starting `pnpm dev` for app-frontend is ~30s, not free.)
 - **Restart on branch change.** When the lock is acquired with a different branch than the running server, kill the running PID, `git checkout` the new branch in the dev-server worktree, spawn a fresh `pnpm dev`, wait for ready (curl the port until 200), then hand off.
 - **Idle TTL.** No validations for N minutes → kill the dev server. Default ~30 min.
 - **Junior shutdown.** Graceful shutdown kills all tracked dev-server PIDs. Same hook as the rest of the lifecycle teardown in `src/lifecycle/`.
@@ -77,7 +77,7 @@ This bumps the dev-server worktree from a passive checkout location to an active
 ## Decisions
 
 - **Session schema.** Extend, don't replace. Keep the existing `session.worktreePath` (single-repo flow for `!repo <name>` threads) and add `session.worktreePaths: Record<repoName, path>` for the bug pipeline. Bug threads populate the map; non-bug threads keep using the single field. Avoids regressing the existing flow.
-- **Lock granularity.** One queue per repo. We have three repo queues: `gx-client-next` (FE), `gx-admin-client` (FE), `gx-backend` (BE). A FE-only bug only contends with other FE-only bugs on the same FE repo; a full-stack bug acquires both its FE queue and `gx-backend` independently. Mixed-repo bugs may deadlock if two threads acquire repos in opposite order — acquire in a fixed alphabetical order to avoid this.
+- **Lock granularity.** One queue per repo. We have three repo queues: `app-frontend` (FE), `app-admin` (FE), `app-backend` (BE). A FE-only bug only contends with other FE-only bugs on the same FE repo; a full-stack bug acquires both its FE queue and `app-backend` independently. Mixed-repo bugs may deadlock if two threads acquire repos in opposite order — acquire in a fixed alphabetical order to avoid this.
 - **Slot timeout.** 5–10 min hard timeout on the validation slot. Lock auto-releases and posts a Slack note (`reproducer phase-2 timed out on <repo> after Nm — slot released, dev server killed`). Reproducer's outcome falls back to `needs-human`.
 - **Idle TTL.** 20 min of no validations → kill the dev server. Cold-start cost re-paid on the next validation but the host stays clean.
 - **Human's bare-repo dev server.** If a port is held when junior tries to spawn from the dev-server worktree, do NOT kill the listener. Detect the conflict, post "can't validate `<repo>` right now — port `<n>` is held by something junior didn't spawn. Free the port and re-dispatch `!reproducer validate`." Reproducer outcome → `needs-human`.
@@ -123,16 +123,16 @@ Lead's prompt grows by ~3 lines: "after `state.json`, call `register_worktree` f
 <workspace>
 You have isolated git worktrees for this thread. ALWAYS use these paths
 for reading code, editing files, and running git commands. NEVER touch
-the bare repos under ~/openclaw-projects/. NEVER run dev servers
+the bare repos under ~/projects/. NEVER run dev servers
 yourself — post `!devserver <branch>` instead.
 
-repo: gx-client-next
-  worktree: /Users/.../openclaw-projects/growthx/gx-client-next.junior-worktrees/slack-<tid>
+repo: app-frontend
+  worktree: /Users/.../projects/app-frontend.junior-worktrees/slack-<tid>
   branch:   slack/<tid>
   base:     origin/main
 
-repo: gx-backend
-  worktree: /Users/.../openclaw-projects/growthx/gx-backend.junior-worktrees/slack-<tid>
+repo: app-backend
+  worktree: /Users/.../projects/app-backend.junior-worktrees/slack-<tid>
   branch:   slack/<tid>
   base:     origin/main
 </workspace>
@@ -142,11 +142,11 @@ For non-bug threads (single `worktreePath`), keep the existing single-workspace 
 
 ### Agent prompt rewrite plan (lands WITH Scope-1, not after)
 
-These edits ship in the same commit as the `register_worktree` tool — otherwise agents still cd into `~/openclaw-projects/` and the worktree creation does nothing.
+These edits ship in the same commit as the `register_worktree` tool — otherwise agents still cd into `~/projects/` and the worktree creation does nothing.
 
-- **`runtime-environment.md`**: replace the "Repo locations" section. New text says: "Repo paths for THIS thread are listed in the `<workspace>` block at the top of your prompt. Use those — never `~/openclaw-projects/<repo>/` directly. The bare repos are the human developer's working trees; touching them corrupts active branches." Also: "Don't run `pnpm dev` / `npm run dev` / any dev server yourself. Post `!devserver <branch> [repo]` in the thread; junior owns the dev-server slot. Wait for junior's ready message before walking."
+- **`runtime-environment.md`**: replace the "Repo locations" section. New text says: "Repo paths for THIS thread are listed in the `<workspace>` block at the top of your prompt. Use those — never `~/projects/<repo>/` directly. The bare repos are the human developer's working trees; touching them corrupts active branches." Also: "Don't run `pnpm dev` / `npm run dev` / any dev server yourself. Post `!devserver <branch> [repo]` in the thread; junior owns the dev-server slot. Wait for junior's ready message before walking."
 - **`lead.md`**: add an intake step after `state.json`: "For each routed repo in `repo-routing.yaml`, call the `register_worktree` MCP tool. Capture the returned paths and reference them in the dispatch prompt to reproducer/thinker so they know which workspace to use."
-- **`reproducer.md`**: replace "check out the fix branch in `~/openclaw-projects/<repo>/`" with "post `!devserver <branch> <repo>` and wait for junior's `ready` reply. Walk against `localhost:<port>` as before."
+- **`reproducer.md`**: replace "check out the fix branch in `~/projects/<repo>/`" with "post `!devserver <branch> <repo>` and wait for junior's `ready` reply. Walk against `localhost:<port>` as before."
 - **`thinker.md`**: no path edits needed — it already follows whatever cwd it's spawned in (which will be the worktree once Scope-1 lands). Add one sentence: "the workspace block at the top of your prompt has the repo paths. Use them; don't cd elsewhere."
 
 ### `RepoConfig` schema additions
@@ -182,7 +182,7 @@ Flow on `!devserver <branch>`:
 
 The reproducer's `!reproducer validate ...` is dispatched by lead AFTER junior posts `ready`. Lead reads junior's reply in its next turn and only then dispatches reproducer.
 
-Humans posting `!devserver fix/foo gx-client-next` from a thread (or even outside any bug pipeline) get the same flow. Useful for quick "is this branch broken?" checks.
+Humans posting `!devserver fix/foo app-frontend` from a thread (or even outside any bug pipeline) get the same flow. Useful for quick "is this branch broken?" checks.
 
 ### Lockfile bootstrap
 

--- a/docs/features/persistent-agents.md
+++ b/docs/features/persistent-agents.md
@@ -20,12 +20,12 @@ When a bug is reported in `#bugs-backlog`, Junior needs to triage it: pull obser
                 (status pill: "calling nr-research, sentry-fetch, vercel-status (3 in progress)")
                 (status pill updates: "nr-research done, 2 in progress" → "all 3 done")
 [Junior]        observability done.
-                NR: 1,247 errors / 860 users, deploy gx-backend@a3f2c1 correlation strong
+                NR: 1,247 errors / 860 users, deploy app-backend@a3f2c1 correlation strong
                 Sentry: no client-side exceptions for /events in last 2h
                 Vercel: a3f2c1 deployed 2h before first error
                 Full findings in research.md, sentry.md, vercel.md.
                 Blast radius is wide — bumping P1 → P0 before reproducing.
-                !reproducer GET /api/v1/events?past_events=true returning 500 for priya@growthx.club
+                !reproducer GET /api/v1/events?past_events=true returning 500 for user@example.com
 [Reproducer]    reproduced — blank page on /events, 500 on GET /api/v1/events    by reproducer
 [Junior]        scope this fix.
                 !thinker reproduction shows stale cache, NRQL points at events-service.ts deploy a3f2c1
@@ -90,7 +90,7 @@ interface ThreadSession {
   // populated by lead via the `mcp__slack-bot__register_worktree` MCP tool on
   // intake. Subsequent agents see the paths in the multi-repo `<workspace>`
   // block at the top of their prompt and use them for ALL reads/edits/git
-  // ops — never the bare repos under `~/openclaw-projects/`. See
+  // ops — never the bare repos under `~/projects/`. See
   // [bug-pipeline-worktrees.md](bug-pipeline-worktrees.md) and
   // [worktree-manager.md](worktree-manager.md).
   worktreePaths: Record<string, string>;
@@ -194,7 +194,7 @@ For stateless data fetches (NR, Sentry, Vercel, email drafting), the lead invoke
 
 ```
 (inside lead's session, one assistant message, parallel)
-Task(subagent_type: "nr-research",   prompt: "events errors last 2h, user priya@growthx.club")
+Task(subagent_type: "nr-research",   prompt: "events errors last 2h, user user@example.com")
 Task(subagent_type: "sentry-fetch",  prompt: "/events exceptions last 2h")
 Task(subagent_type: "vercel-status", prompt: "latest deploy state")
 ```
@@ -295,7 +295,7 @@ Validates the sub-agent (Task tool) tier end-to-end. nr-research is invoked from
 - Output contract: writes `$BUG_DIR/research.md` with the structured findings; returns a one-line summary like `"DONE: 1,247 errors across 860 users — see research.md"` as the Task tool result
 - Status pill: a `"Task"` case in `formatToolBlock` renders `Calling nr-research`
 
-**Test:** Operator triggers an interactive Claude session in a real bug thread, invokes `Task(subagent_type: "nr-research", prompt: "events errors last 2h, user priya@growthx.club")`. Verify status pill shows `Calling nr-research`, then clears at turn end. Verify `research.md` exists in the bug folder with the findings. Verify the sub-agent never posts to Slack directly.
+**Test:** Operator triggers an interactive Claude session in a real bug thread, invokes `Task(subagent_type: "nr-research", prompt: "events errors last 2h, user user@example.com")`. Verify status pill shows `Calling nr-research`, then clears at turn end. Verify `research.md` exists in the bug folder with the findings. Verify the sub-agent never posts to Slack directly.
 
 **Defers:** Sentry, Vercel, parallel fan-out, lead orchestration.
 

--- a/docs/features/worktree-manager.md
+++ b/docs/features/worktree-manager.md
@@ -32,8 +32,8 @@ When a Slack thread needs to edit code in a target repo (example-backend, exampl
 
 ```typescript
 interface RepoConfig {
-  name: string;                       // "gx-backend"
-  path: string;                       // "/Users/.../openclaw-projects/growthx/gx-backend"
+  name: string;                       // "app-backend"
+  path: string;                       // "/Users/.../projects/app-backend"
   defaultBase: string;                // "origin/main"
   // Optional — bug-pipeline / dev-server fields:
   worktreeSetupCommand?: string;      // e.g. "bin/setup-worktree.sh" — resolved relative to `path`

--- a/src/lifecycle/dev-server-queue.test.ts
+++ b/src/lifecycle/dev-server-queue.test.ts
@@ -188,10 +188,10 @@ describe("parseDevserverDirective (unit)", () => {
   });
 
   it("parses !devserver <branch> <repo>", () => {
-    expect(parseDevserverDirective("!devserver fix/foo gx-backend")).toEqual({
+    expect(parseDevserverDirective("!devserver fix/foo app-backend")).toEqual({
       kind: "acquire",
       branch: "fix/foo",
-      repos: ["gx-backend"],
+      repos: ["app-backend"],
     });
   });
 
@@ -200,9 +200,9 @@ describe("parseDevserverDirective (unit)", () => {
   });
 
   it("parses !devserver kill <repo>", () => {
-    expect(parseDevserverDirective("!devserver kill gx-client-next")).toEqual({
+    expect(parseDevserverDirective("!devserver kill app-frontend")).toEqual({
       kind: "kill",
-      repo: "gx-client-next",
+      repo: "app-frontend",
     });
   });
 

--- a/src/mcp/slack-server.ts
+++ b/src/mcp/slack-server.ts
@@ -243,7 +243,7 @@ function registerTools(server: McpServer) {
         "Returns the worktree path and branch name.",
       inputSchema: {
         thread_id: z.string().describe("Slack thread timestamp (the session key)"),
-        repo: z.string().describe("Repo name as configured in REPOS (e.g. 'gx-backend')"),
+        repo: z.string().describe("Repo name as configured in REPOS"),
         branch: z.string().optional().describe("Branch name override. Defaults to slack/<thread_id>"),
       },
     },

--- a/src/slack/events.ts
+++ b/src/slack/events.ts
@@ -86,7 +86,7 @@ export function registerEventHandlers(
     }
 
     // Auto-trigger channels (e.g. #bugs-backlog) accept messages from other bots
-    // like growthx-bug-reporter that have no `user` field — fall back to bot_id.
+    // like service-account reporters that have no `user` field — fall back to bot_id.
     let user = "user" in event ? event.user : undefined;
     if (!user && isSelfBot && selfUserId) {
       user = selfUserId;

--- a/src/slack/thread-context.test.ts
+++ b/src/slack/thread-context.test.ts
@@ -3,8 +3,8 @@ import { buildWorkspaceBlock, type WorkspaceContext } from "./thread-context.ts"
 import type { RepoConfig } from "../config.ts";
 
 const repos: RepoConfig[] = [
-  { name: "gx-backend", path: "/repos/gx-backend", defaultBase: "origin/main" },
-  { name: "gx-client-next", path: "/repos/gx-client-next", defaultBase: "origin/main" },
+  { name: "app-backend", path: "/repos/app-backend", defaultBase: "origin/main" },
+  { name: "app-frontend", path: "/repos/app-frontend", defaultBase: "origin/main" },
 ];
 
 describe("buildWorkspaceBlock", () => {
@@ -16,36 +16,41 @@ describe("buildWorkspaceBlock", () => {
 
   it("renders the single-repo format from a WorkspaceContext", () => {
     const ws: WorkspaceContext = {
-      worktreePath: "/repos/gx-backend.junior-worktrees/slack-t1",
-      repoName: "gx-backend",
-      repoPath: "/repos/gx-backend",
+      worktreePath: "/repos/app-backend.junior-worktrees/slack-t1",
+      repoName: "app-backend",
+      repoPath: "/repos/app-backend",
       branchName: "slack/t1",
     };
     const block = buildWorkspaceBlock(ws);
     expect(block).toContain("<workspace>");
-    expect(block).toContain("Target repo: gx-backend");
-    expect(block).toContain("Worktree (your sandbox): /repos/gx-backend.junior-worktrees/slack-t1");
+    expect(block).toContain("Target repo: app-backend");
+    expect(block).toContain("Worktree (your sandbox): /repos/app-backend.junior-worktrees/slack-t1");
     expect(block).toContain("Worktree branch: slack/t1");
     expect(block).toContain("</workspace>");
   });
 
   it("renders the multi-repo format when worktreePaths is non-empty", () => {
     const paths = {
-      "gx-backend": "/repos/gx-backend.junior-worktrees/slack-t1",
-      "gx-client-next": "/repos/gx-client-next.junior-worktrees/slack-t1",
+      "app-backend": "/repos/app-backend.junior-worktrees/slack-t1",
+      "app-frontend": "/repos/app-frontend.junior-worktrees/slack-t1",
     };
     const block = buildWorkspaceBlock(undefined, paths, repos, "t1");
 
     expect(block).toContain("<workspace>");
-    expect(block).toContain("ALWAYS use these paths");
-    expect(block).toContain("NEVER touch");
-    expect(block).toContain("~/openclaw-projects/");
-    expect(block).toContain("repo: gx-backend");
-    expect(block).toContain("worktree: /repos/gx-backend.junior-worktrees/slack-t1");
-    expect(block).toContain("branch:   slack/t1");
-    expect(block).toContain("base:     origin/main");
-    expect(block).toContain("repo: gx-client-next");
-    expect(block).toContain("worktree: /repos/gx-client-next.junior-worktrees/slack-t1");
+    expect(block).toContain("Work ONLY inside the worktree paths listed below");
+    // Per-repo blocks list both the worktree (sandbox) and the bare repo (off-limits).
+    expect(block).toContain("repo: app-backend");
+    expect(block).toContain("worktree (your sandbox): /repos/app-backend.junior-worktrees/slack-t1");
+    expect(block).toContain("bare repo (OFF-LIMITS):  /repos/app-backend");
+    expect(block).toContain("branch:                 slack/t1");
+    expect(block).toContain("base:                   origin/main");
+    expect(block).toContain("repo: app-frontend");
+    expect(block).toContain("worktree (your sandbox): /repos/app-frontend.junior-worktrees/slack-t1");
+    expect(block).toContain("bare repo (OFF-LIMITS):  /repos/app-frontend");
+    // Rules anchor to the listed paths.
+    expect(block).toContain("RULES — non-negotiable:");
+    expect(block).toContain("inside the worktree paths listed above");
+    expect(block).toContain("at any bare-repo path listed above");
     expect(block).toContain("</workspace>");
   });
 
@@ -56,24 +61,26 @@ describe("buildWorkspaceBlock", () => {
       repoPath: "/should/not/appear",
       branchName: "should-not-appear",
     };
-    const paths = { "gx-backend": "/repos/gx-backend.junior-worktrees/slack-t1" };
+    const paths = { "app-backend": "/repos/app-backend.junior-worktrees/slack-t1" };
     const block = buildWorkspaceBlock(ws, paths, repos, "t1");
 
     expect(block).not.toContain("should-not-appear");
-    expect(block).toContain("repo: gx-backend");
+    expect(block).toContain("repo: app-backend");
   });
 
   it("falls back to defaults when repos config is missing", () => {
-    const paths = { "gx-backend": "/some/path" };
+    const paths = { "app-backend": "/some/path" };
     const block = buildWorkspaceBlock(undefined, paths, undefined, "t1");
 
-    expect(block).toContain("base:     origin/main");
+    expect(block).toContain("base:                   origin/main");
+    // No bare-repo line should be emitted when repos config is missing.
+    expect(block).not.toContain("bare repo (OFF-LIMITS):");
   });
 
   it("uses placeholder branch when threadId is missing", () => {
-    const paths = { "gx-backend": "/some/path" };
+    const paths = { "app-backend": "/some/path" };
     const block = buildWorkspaceBlock(undefined, paths, repos);
 
-    expect(block).toContain("branch:   slack/<thread>");
+    expect(block).toContain("branch:                 slack/<thread>");
   });
 });

--- a/src/slack/thread-context.test.ts
+++ b/src/slack/thread-context.test.ts
@@ -51,6 +51,10 @@ describe("buildWorkspaceBlock", () => {
     expect(block).toContain("RULES — non-negotiable:");
     expect(block).toContain("inside the worktree paths listed above");
     expect(block).toContain("at any bare-repo path listed above");
+    // Rule 3: cd prohibition. Rule 4: devserver prohibition.
+    expect(block).toContain("NEVER `cd` out of your worktree");
+    expect(block).toContain("NEVER run dev servers yourself");
+    expect(block).toContain("`!devserver <branch>`");
     expect(block).toContain("</workspace>");
   });
 

--- a/src/slack/thread-context.ts
+++ b/src/slack/thread-context.ts
@@ -110,22 +110,33 @@ export function buildWorkspaceBlock(
       const repoConfig = repos?.find((r) => r.name === repoName);
       const branch = threadId ? `slack/${threadId}` : "slack/<thread>";
       const base = repoConfig?.defaultBase ?? "origin/main";
-      return [
+      const lines = [
         `repo: ${repoName}`,
-        `  worktree: ${wPath}`,
-        `  branch:   ${branch}`,
-        `  base:     ${base}`,
-      ].join("\n");
+        `  worktree (your sandbox): ${wPath}`,
+      ];
+      if (repoConfig?.path) {
+        lines.push(`  bare repo (OFF-LIMITS):  ${repoConfig.path}`);
+      }
+      lines.push(
+        `  branch:                 ${branch}`,
+        `  base:                   ${base}`,
+      );
+      return lines.join("\n");
     });
 
     return [
       `<workspace>`,
-      `You have isolated git worktrees for this thread. ALWAYS use these paths`,
-      `for reading code, editing files, and running git commands. NEVER touch`,
-      `the bare repos under ~/openclaw-projects/. NEVER run dev servers`,
-      `yourself — post \`!devserver <branch>\` instead.`,
+      `You have isolated git worktrees for this thread. The bare repos at the`,
+      `paths shown below are shared across all threads — DO NOT touch them.`,
+      `Work ONLY inside the worktree paths listed below.`,
       ``,
       ...repoBlocks.flatMap((block, i) => (i < repoBlocks.length - 1 ? [block, ""] : [block])),
+      ``,
+      `RULES — non-negotiable:`,
+      `1. ALL reads, writes, edits, and git commands MUST happen inside the worktree paths listed above.`,
+      `2. NEVER write, edit, or commit files at any bare-repo path listed above — those are the shared origin repos.`,
+      `3. NEVER \`cd\` out of your worktree to do work. Read-only references to other paths are OK via absolute Read paths, but do not Edit or Write outside the worktrees.`,
+      `4. NEVER run dev servers yourself — post \`!devserver <branch>\` instead.`,
       `</workspace>`,
     ].join("\n");
   }

--- a/src/support/router.test.ts
+++ b/src/support/router.test.ts
@@ -326,9 +326,9 @@ describe("parseDevserverDirective (router smoke)", () => {
   });
 
   it("parses !devserver kill <repo>", () => {
-    expect(parseDevserverDirective("!devserver kill gx-backend")).toEqual({
+    expect(parseDevserverDirective("!devserver kill app-backend")).toEqual({
       kind: "kill",
-      repo: "gx-backend",
+      repo: "app-backend",
     });
   });
 
@@ -372,8 +372,8 @@ describe("AgentDispatcher !devserver interception", () => {
         slackClient: slackClientMock as unknown as import("@slack/web-api").WebClient,
         repos: [
           {
-            name: "gx-backend",
-            path: "/tmp/gx-backend",
+            name: "app-backend",
+            path: "/tmp/app-backend",
             defaultBase: "origin/main",
             devCommand: "echo dev",
             devPort: 8000,


### PR DESCRIPTION
Stacked on top of #18. Two commits, two concerns.

## 1. `chore: sanitize org-specific names in tests, code comments, and design docs`

Pure rename pass for the Tier 2 items surfaced in #18's sweep matrix:

| Surface | Before | After |
|---|---|---|
| test fixtures (`dev-server-queue`, `router`) | `gx-backend`, `gx-client-next` | `app-backend`, `app-frontend` |
| MCP tool example (`mcp/slack-server.ts:246`) | `(e.g. 'gx-backend')` | example dropped |
| auto-trigger comment (`slack/events.ts:89`) | `growthx-bug-reporter` | `service-account reporters` |
| design docs | `gx-*`, `growthx.club`, `~/openclaw-projects/...` | `app-*`, `example.com`, `~/projects/...` |

No agent-loaded surface — those moved into the private overlay in #18.

## 2. `feat(workspace-block): interpolate paths into the multi-repo safety rules`

Functional change. The multi-repo workspace block had a generic safety rule (\"NEVER work outside these worktree paths\") that named no paths — agents had to *infer* what \"these\" meant, which is the exact step a safety rule should skip.

Restructured to mirror the single-repo format's pattern:
- Per-repo block now lists both `worktree (your sandbox)` and `bare repo (OFF-LIMITS)` paths explicitly. The bare-repo line is only emitted when \`repos\` config is provided; gracefully degrades when the path isn't known.
- Numbered rules follow and reference \"the worktree paths listed above\" / \"any bare-repo path listed above\" — deictic words now have proximate, unambiguous referents.
- Removes the org-specific `~/openclaw-projects/` string (the original Tier 1 leak in the agent-facing prompt).

Sample of the rendered output (from a verification run):

\`\`\`
<workspace>
You have isolated git worktrees for this thread. The bare repos at the
paths shown below are shared across all threads — DO NOT touch them.
Work ONLY inside the worktree paths listed below.

repo: app-backend
  worktree (your sandbox): /Users/dev/repos/app-backend.junior-worktrees/slack-T123
  bare repo (OFF-LIMITS):  /Users/dev/repos/app-backend
  branch:                 slack/T123
  base:                   origin/main

repo: app-frontend
  worktree (your sandbox): /Users/dev/repos/app-frontend.junior-worktrees/slack-T123
  bare repo (OFF-LIMITS):  /Users/dev/repos/app-frontend
  branch:                 slack/T123
  base:                   origin/main

RULES — non-negotiable:
1. ALL reads, writes, edits, and git commands MUST happen inside the worktree paths listed above.
2. NEVER write, edit, or commit files at any bare-repo path listed above — those are the shared origin repos.
3. NEVER \`cd\` out of your worktree to do work. Read-only references to other paths are OK via absolute Read paths, but do not Edit or Write outside the worktrees.
4. NEVER run dev servers yourself — post \`!devserver <branch>\` instead.
</workspace>
\`\`\`

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` — full suite passes (146/146 in src/slack + src/lifecycle + src/support + src/agents). One pre-existing dev-server integration flake unrelated to this PR.
- [ ] Visual sanity-check of the rendered workspace block in a live Slack thread once #18 merges.

## Merge ordering

Merge after #18. Rebasing onto main after #18 lands is the right path; the only file overlap with #18 is `src/slack/thread-context.ts` and the touch sites are different functions (#18 changes `buildPromptPreamble`; this PR changes `buildWorkspaceBlock`).