### PR TITLE
chore: sanitize real names in onboard-member test fixtures

### DIFF
--- a/src/slack/events.test.ts
+++ b/src/slack/events.test.ts
@@ -150,7 +150,7 @@ describe("registerEventHandlers — ✽ filter", () => {
     await handlers.get("message")!({
       event: {
         type: "message",
-        text: "!onboard-member onboard Ruta Bhatt",
+        text: "!onboard-member onboard Test Member",
         channel: "C_OTHER",
         channel_type: "channel",
         ts: "1700000000.000011",

--- a/src/support/router.test.ts
+++ b/src/support/router.test.ts
@@ -225,7 +225,7 @@ describe("AgentDispatcher", () => {
 
     await router.handleMessage(
       makeEvent({
-        text: "!onboard-member onboard Ruta Bhatt\n!review take a look at PR 21",
+        text: "!onboard-member onboard Test Member\n!review take a look at PR 21",
         isSelfBot: true,
         botUsername: "Junior",
         channel: "C_TECH",


### PR DESCRIPTION
## Summary

Two test files had a real member's name baked into the text field of self-bot dispatch event fixtures. The fixtures only assert that `!onboard-member` directives route correctly — the name is incidental — so replaced with "Test Member" across both.

Also a submodule pointer bump that picks up the matching PII cleanup inside the private agents-org overlay (real names + phone numbers in example asks → placeholder shapes like `<name>`, `<10-digit>`, `<name>@example.com`).

## Why now

The user asked whether the recent onboard-member work kept the junior/agents-org split clean. The architectural answer is yes — junior holds only generic agent names + slack identities, agents-org holds the playbooks, and nothing crosses. But the audit turned up PII (real names, real phone numbers) leaking through test fixtures and example prose. That's a privacy issue regardless of the architectural split — sanitising before it propagates further.

## What's NOT changed

- The architectural split is unchanged. Junior public stays generic; agents-org private retains the org-specific behaviors.
- No behavior change. Tests still cover the same routing/dispatch paths.

## Test plan

- [x] \`bun test src/support/ src/slack/events.test.ts\` — 53/53 pass after the rename
- [x] \`bun run typecheck\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)