### PR TITLE
refactor(agents): move private agent identities to frontmatter

### DIFF
--- a/docs/features/persistent-agents.md
+++ b/docs/features/persistent-agents.md
@@ -124,8 +124,11 @@ const AGENT_IDENTITIES: Record<
   reproducer: { username: "Reproducer", iconEmoji: ":mag:" },
   thinker: { username: "Thinker", iconEmoji: ":wrench:" },
   review: { username: "Reviewer", iconEmoji: ":eyes:" },
-  "onboard-member": { username: "Onboarder", iconEmoji: ":handshake:" },
 };
+// Private / org-specific worker identities are NOT registered here — they
+// declare `username` + `iconEmoji` in their own .md frontmatter and get
+// merged in at startup by `loadOverlayIdentities` from the org overlay
+// directory. This keeps the public repo free of org-specific agent names.
 ```
 
 ### Persistent agents vs sub-agents

--- a/src/agents/loader.test.ts
+++ b/src/agents/loader.test.ts
@@ -34,6 +34,36 @@ describe("loadAgentDefinition", () => {
     expect(def!.model).toBe("opus");
   });
 
+  it("parses optional username + iconEmoji frontmatter fields", async () => {
+    const tmpPath = path.join(import.meta.dir, "__test_identity_fm.md");
+    const content = `---
+name: example-worker
+description: Test
+username: Examplor
+iconEmoji: ":wave:"
+---
+
+body`;
+    await Bun.write(tmpPath, content);
+
+    try {
+      const def = await loadAgentDefinition(tmpPath);
+      expect(def).not.toBeNull();
+      expect(def!.username).toBe("Examplor");
+      expect(def!.iconEmoji).toBe(":wave:");
+    } finally {
+      const fs = await import("node:fs/promises");
+      await fs.unlink(tmpPath).catch(() => {});
+    }
+  });
+
+  it("identity fields are null when not declared", async () => {
+    const def = await loadAgentDefinition(path.join(agentsDir, "build.md"));
+    expect(def).not.toBeNull();
+    expect(def!.username).toBeNull();
+    expect(def!.iconEmoji).toBeNull();
+  });
+
   it("body is the content after the second ---", async () => {
     const def = await loadAgentDefinition(path.join(agentsDir, "build.md"));
     expect(def).not.toBeNull();

--- a/src/agents/loader.ts
+++ b/src/agents/loader.ts
@@ -38,6 +38,14 @@ export interface AgentDefinition {
   model: string | null;
   prompt: string;
   context: AgentContextProfile;
+  /**
+   * Optional slack identity declared in frontmatter. Lets private/overlay
+   * agents register their visual identity (username + emoji) without
+   * touching the public AGENT_IDENTITIES literal. Both fields must be
+   * present to take effect; a partial declaration is ignored.
+   */
+  username: string | null;
+  iconEmoji: string | null;
 }
 
 export async function loadAgentDefinition(
@@ -57,6 +65,8 @@ export async function loadAgentDefinition(
     model: frontmatter["model"] ?? null,
     prompt: body.trim(),
     context: readContextProfile(frontmatter),
+    username: frontmatter["username"] ?? null,
+    iconEmoji: frontmatter["iconEmoji"] ?? null,
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import { checkOrphanedSessions } from "./lifecycle/health.ts";
 import { cleanupStaleSessions } from "./lifecycle/cleanup.ts";
 import { AgentRouter } from "./agents/router.ts";
 import { AgentDispatcher } from "./support/router.ts";
+import { loadOverlayIdentities } from "./support/agents.ts";
 import { WorktreeManager } from "./worktree/manager.ts";
 import { DevServerManager } from "./lifecycle/dev-server.ts";
 import { DevServerQueue } from "./lifecycle/dev-server-queue.ts";
@@ -153,6 +154,20 @@ setInterval(() => {
 }, config.session.cleanupIntervalMs);
 
 (async () => {
+  // Load private/overlay agent identities BEFORE accepting events. Each
+  // `.claude/agents-org/*.md` file may declare `username` + `iconEmoji` in
+  // frontmatter; those get merged into `AGENT_IDENTITIES` so dispatch,
+  // `agentForUsername`, and slack posting all see them. Failure is
+  // non-fatal — overlay is optional.
+  try {
+    await loadOverlayIdentities(".claude/agents-org");
+  } catch (err) {
+    log.error(
+      "boot",
+      `overlay-identity load failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
   // Bootstrap dev-server worktrees and check for external port conflicts before
   // accepting any Slack events. Failure here is non-fatal — log loudly and
   // continue so other features keep working even if a single repo's worktree

--- a/src/slack/events.test.ts
+++ b/src/slack/events.test.ts
@@ -150,7 +150,7 @@ describe("registerEventHandlers — ✽ filter", () => {
     await handlers.get("message")!({
       event: {
         type: "message",
-        text: "!onboard-member onboard Ruta Bhatt",
+        text: "!review take a look at PR 21",
         channel: "C_OTHER",
         channel_type: "channel",
         ts: "1700000000.000011",
@@ -160,7 +160,7 @@ describe("registerEventHandlers — ✽ filter", () => {
     });
 
     expect(onMessage).toHaveBeenCalledTimes(1);
-    expect(onMessage.mock.calls[0][0].text).toContain("!onboard-member");
+    expect(onMessage.mock.calls[0][0].text).toContain("!review");
     expect(onMessage.mock.calls[0][0].isSelfBot).toBe(true);
   });
 

--- a/src/support/agents.test.ts
+++ b/src/support/agents.test.ts
@@ -1,23 +1,43 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
+import path from "node:path";
+import fs from "node:fs/promises";
 import {
   AGENT_IDENTITIES,
   agentForUsername,
   buildDispatchAllowBlock,
   dispatchableAgentsFor,
   isOrchestratorAgent,
+  loadOverlayIdentities,
+  registerAgentIdentity,
   workerMayDispatch,
 } from "./agents.ts";
 
 describe("dispatchableAgentsFor", () => {
+  const cleanupKeys: string[] = [];
+  afterEach(() => {
+    for (const key of cleanupKeys) {
+      delete AGENT_IDENTITIES[key];
+    }
+    cleanupKeys.length = 0;
+  });
+
   it("lets lead dispatch every worker except itself, default, and echo", () => {
     const allowed = dispatchableAgentsFor("lead");
     expect(allowed).toContain("thinker");
     expect(allowed).toContain("review");
     expect(allowed).toContain("reproducer");
-    expect(allowed).toContain("onboard-member");
     expect(allowed).not.toContain("lead");
     expect(allowed).not.toContain("default");
     expect(allowed).not.toContain("echo");
+  });
+
+  it("includes overlay-registered workers in lead's allow-list once registered", () => {
+    cleanupKeys.push("overlay-worker-test");
+    registerAgentIdentity("overlay-worker-test", {
+      username: "OverlayTest",
+      iconEmoji: ":test_tube:",
+    });
+    expect(dispatchableAgentsFor("lead")).toContain("overlay-worker-test");
   });
 
   it("gives default Junior the same full dispatch power as lead", () => {
@@ -36,7 +56,6 @@ describe("dispatchableAgentsFor", () => {
   it("returns empty for workers with no allow-list", () => {
     expect(dispatchableAgentsFor("review")).toEqual([]);
     expect(dispatchableAgentsFor("reproducer")).toEqual([]);
-    expect(dispatchableAgentsFor("onboard-member")).toEqual([]);
   });
 
   it("returns empty for unknown agents", () => {
@@ -118,17 +137,109 @@ describe("buildDispatchAllowBlock", () => {
     expect(block).not.toContain("may NOT emit");
   });
 
-  it("lists every dispatchable agent for default Junior too", () => {
+  it("lists every dispatchable core agent for default Junior too", () => {
     const block = buildDispatchAllowBlock("default");
     expect(block).toContain("`thinker`");
     expect(block).toContain("`review`");
     expect(block).toContain("`reproducer`");
-    expect(block).toContain("`onboard-member`");
     expect(block).not.toContain("may NOT emit");
   });
 
   it("emits a deny-all block for unknown agents (safe default)", () => {
     const block = buildDispatchAllowBlock("unknown-agent");
     expect(block).toContain("may NOT emit");
+  });
+});
+
+describe("registerAgentIdentity", () => {
+  const cleanupKeys: string[] = [];
+  afterEach(() => {
+    for (const key of cleanupKeys) {
+      delete AGENT_IDENTITIES[key];
+    }
+    cleanupKeys.length = 0;
+  });
+
+  it("registers a new overlay agent identity", () => {
+    cleanupKeys.push("test-worker");
+    const ok = registerAgentIdentity("test-worker", {
+      username: "Tester",
+      iconEmoji: ":test_tube:",
+    });
+    expect(ok).toBe(true);
+    expect(AGENT_IDENTITIES["test-worker"]).toEqual({
+      username: "Tester",
+      iconEmoji: ":test_tube:",
+    });
+  });
+
+  it("refuses to overwrite a core agent identity", () => {
+    const before = AGENT_IDENTITIES.lead;
+    const ok = registerAgentIdentity("lead", {
+      username: "HijackedLead",
+      iconEmoji: ":skull:",
+    });
+    expect(ok).toBe(false);
+    expect(AGENT_IDENTITIES.lead).toEqual(before);
+  });
+});
+
+describe("loadOverlayIdentities", () => {
+  const tmpDir = path.join(import.meta.dir, "__overlay_test");
+  const cleanupKeys: string[] = [];
+
+  afterEach(async () => {
+    for (const key of cleanupKeys) {
+      delete AGENT_IDENTITIES[key];
+    }
+    cleanupKeys.length = 0;
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("registers identities from .md frontmatter in the overlay dir", async () => {
+    await fs.mkdir(tmpDir, { recursive: true });
+    await Bun.write(
+      path.join(tmpDir, "overlay-worker.md"),
+      `---
+name: overlay-worker
+description: Test overlay worker
+username: OverlayPerson
+iconEmoji: ":construction:"
+---
+
+body
+`,
+    );
+
+    cleanupKeys.push("overlay-worker");
+    await loadOverlayIdentities(tmpDir);
+
+    expect(AGENT_IDENTITIES["overlay-worker"]).toEqual({
+      username: "OverlayPerson",
+      iconEmoji: ":construction:",
+    });
+  });
+
+  it("skips .md files that declare only one of username/iconEmoji", async () => {
+    await fs.mkdir(tmpDir, { recursive: true });
+    await Bun.write(
+      path.join(tmpDir, "half-identity.md"),
+      `---
+name: half-identity
+description: Missing iconEmoji
+username: OnlyUsername
+---
+
+body
+`,
+    );
+
+    await loadOverlayIdentities(tmpDir);
+    expect(AGENT_IDENTITIES["half-identity"]).toBeUndefined();
+  });
+
+  it("does not throw when the overlay directory is missing", async () => {
+    const missing = path.join(import.meta.dir, "__definitely_not_here");
+    await expect(loadOverlayIdentities(missing)).resolves.toBeUndefined();
   });
 });

--- a/src/support/agents.test.ts
+++ b/src/support/agents.test.ts
@@ -83,7 +83,7 @@ describe("identity / username collision (the footgun this guards)", () => {
     expect(isOrchestratorAgent("default")).toBe(true);
     expect(isOrchestratorAgent("junior")).toBe(true);
     expect(isOrchestratorAgent("thinker")).toBe(false);
-    expect(isOrchestratorAgent("onboard-member")).toBe(false);
+    expect(isOrchestratorAgent("review")).toBe(false);
     expect(isOrchestratorAgent(null)).toBe(false);
   });
 });
@@ -236,6 +236,25 @@ body
 
     await loadOverlayIdentities(tmpDir);
     expect(AGENT_IDENTITIES["half-identity"]).toBeUndefined();
+  });
+
+  it("skips .md files that have identity fields but no name", async () => {
+    await fs.mkdir(tmpDir, { recursive: true });
+    await Bun.write(
+      path.join(tmpDir, "no-name-but-identity.md"),
+      `---
+description: Forgot to put a name on this one
+username: Anonymous
+iconEmoji: ":ghost:"
+---
+
+body
+`,
+    );
+
+    // Should not throw and should not register anything (no name to key on).
+    await loadOverlayIdentities(tmpDir);
+    expect(AGENT_IDENTITIES["Anonymous"]).toBeUndefined();
   });
 
   it("does not throw when the overlay directory is missing", async () => {

--- a/src/support/agents.ts
+++ b/src/support/agents.ts
@@ -10,9 +10,9 @@ import type { AgentIdentity } from "../session/types.ts";
  * `isOrchestratorAgent` set, attribution-suffix logic, etc.) — they're part
  * of the contract any fork of junior inherits.
  *
- * Private / org-specific workers (e.g. `onboard-member`) register their
- * identities via `username` + `iconEmoji` frontmatter on their `.md` files,
- * loaded at startup by `loadOverlayIdentities` from the org overlay
+ * Private / org-specific workers (e.g. an org-specific worker) register
+ * their identities via `username` + `iconEmoji` frontmatter on their `.md`
+ * files, loaded at startup by `loadOverlayIdentities` from the org overlay
  * directory. This keeps the public repo free of org-specific names.
  */
 export const AGENT_IDENTITIES: Record<string, AgentIdentity> = {
@@ -70,11 +70,32 @@ export async function loadOverlayIdentities(dirPath: string): Promise<void> {
     }
     for (const entry of entries) {
       const def = await loadAgentDefinition(`${dirPath}/${entry}`);
-      if (!def || !def.name) continue;
-      if (!def.username || !def.iconEmoji) continue;
+      if (!def) continue;
+      const hasUsername = !!def.username;
+      const hasIcon = !!def.iconEmoji;
+      // Genuine "no slack identity declared" — fine. Many overlay files are
+      // pure prompt with no slack-posting role (Task-tool sub-agents, etc.).
+      if (!hasUsername && !hasIcon) continue;
+      // Identity declared but incomplete — likely a typo. Warn so the author
+      // can fix it; without this signal the agent silently has no identity
+      // and the next observable failure is at dispatch time.
+      if (!hasUsername || !hasIcon) {
+        log.warn(
+          "agents",
+          `loadOverlayIdentities: ${entry} declares ${hasUsername ? "username" : "iconEmoji"} but not ${hasUsername ? "iconEmoji" : "username"} — both fields are required; skipping`,
+        );
+        continue;
+      }
+      if (!def.name) {
+        log.warn(
+          "agents",
+          `loadOverlayIdentities: ${entry} declares username + iconEmoji but no name — skipping; add a 'name:' field in frontmatter`,
+        );
+        continue;
+      }
       registerAgentIdentity(def.name, {
-        username: def.username,
-        iconEmoji: def.iconEmoji,
+        username: def.username!,
+        iconEmoji: def.iconEmoji!,
       });
     }
   } catch (err) {

--- a/src/support/agents.ts
+++ b/src/support/agents.ts
@@ -1,5 +1,20 @@
+import { loadAgentDefinition } from "../agents/loader.ts";
+import { log } from "../logger.ts";
 import type { AgentIdentity } from "../session/types.ts";
 
+/**
+ * Core agents — part of the open-source architecture. Orchestrators (lead,
+ * default) and bug-pipeline workers (reproducer, thinker, review) plus the
+ * echo debug agent. Identities live in code because these names are
+ * referenced from junior's source (special-cases in `manager.ts`, the
+ * `isOrchestratorAgent` set, attribution-suffix logic, etc.) — they're part
+ * of the contract any fork of junior inherits.
+ *
+ * Private / org-specific workers (e.g. `onboard-member`) register their
+ * identities via `username` + `iconEmoji` frontmatter on their `.md` files,
+ * loaded at startup by `loadOverlayIdentities` from the org overlay
+ * directory. This keeps the public repo free of org-specific names.
+ */
 export const AGENT_IDENTITIES: Record<string, AgentIdentity> = {
   // Default Junior — the bot's main face, responds to @mentions in any channel.
   default: { username: "Junior", iconEmoji: ":face_with_cowboy_hat:" },
@@ -11,8 +26,65 @@ export const AGENT_IDENTITIES: Record<string, AgentIdentity> = {
   thinker: { username: "Thinker", iconEmoji: ":wrench:" },
   review: { username: "Reviewer", iconEmoji: ":eyes:" },
   echo: { username: "Echo", iconEmoji: ":speech_balloon:" },
-  "onboard-member": { username: "Onboarder", iconEmoji: ":handshake:" },
 };
+
+/**
+ * Register a slack identity for a private/overlay agent. Called by
+ * `loadOverlayIdentities` during startup; can also be called directly by
+ * tests. Refuses to override an existing entry — overlay agents shouldn't
+ * silently re-skin core ones.
+ */
+export function registerAgentIdentity(
+  name: string,
+  identity: AgentIdentity,
+): boolean {
+  if (AGENT_IDENTITIES[name]) {
+    log.warn(
+      "agents",
+      `registerAgentIdentity: refusing to overwrite existing identity for "${name}" (core agent or duplicate overlay entry)`,
+    );
+    return false;
+  }
+  AGENT_IDENTITIES[name] = identity;
+  return true;
+}
+
+/**
+ * Scan a directory of agent `.md` files (typically the org overlay at
+ * `.claude/agents-org/`) and register slack identities for any agent that
+ * declares both `username` and `iconEmoji` in its frontmatter. Files
+ * without those fields are skipped silently — agents are free to declare
+ * just a prompt without a slack identity (e.g. they only run as Task-tool
+ * sub-agents and never post to slack).
+ *
+ * Idempotent: re-running won't double-register. Call once at startup before
+ * any session spawns; the registry is read at call-time by every consumer
+ * of `AGENT_IDENTITIES`.
+ */
+export async function loadOverlayIdentities(dirPath: string): Promise<void> {
+  try {
+    const glob = new Bun.Glob("*.md");
+    const entries: string[] = [];
+    for await (const entry of glob.scan({ cwd: dirPath })) {
+      entries.push(entry);
+    }
+    for (const entry of entries) {
+      const def = await loadAgentDefinition(`${dirPath}/${entry}`);
+      if (!def || !def.name) continue;
+      if (!def.username || !def.iconEmoji) continue;
+      registerAgentIdentity(def.name, {
+        username: def.username,
+        iconEmoji: def.iconEmoji,
+      });
+    }
+  } catch (err) {
+    // Directory doesn't exist or not readable — overlay is optional.
+    log.info(
+      "agents",
+      `loadOverlayIdentities(${dirPath}): ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
 
 /**
  * Orchestrator agents — they may dispatch any registered worker. Both share

--- a/src/support/router.test.ts
+++ b/src/support/router.test.ts
@@ -214,7 +214,7 @@ describe("AgentDispatcher", () => {
     expect(managerMock.handleLeadMessage).not.toHaveBeenCalled();
   });
 
-  it("default Junior may dispatch any registered worker (not just onboard-member)", async () => {
+  it("default Junior may dispatch multiple core workers in a non-support channel", async () => {
     const managerMock = {
       handleMessage: mock(async (_event: SlackMessageEvent) => {}),
       handleLeadMessage: mock(async (_event: SlackMessageEvent) => {}),
@@ -225,7 +225,7 @@ describe("AgentDispatcher", () => {
 
     await router.handleMessage(
       makeEvent({
-        text: "!onboard-member onboard Ruta Bhatt\n!review take a look at PR 21",
+        text: "!review take a look at PR 21\n!thinker root-cause the timeout",
         isSelfBot: true,
         botUsername: "Junior",
         channel: "C_TECH",
@@ -233,8 +233,8 @@ describe("AgentDispatcher", () => {
     );
 
     const targets = managerMock.handleAgentMessage.mock.calls.map((c) => c[1]);
-    expect(targets).toContain("onboard-member");
     expect(targets).toContain("review");
+    expect(targets).toContain("thinker");
   });
 
   it("forwards worker no-directive responses to lead", async () => {


### PR DESCRIPTION
## Summary

Removes the last leak of an org-specific agent name from the public junior repo.

**Before:** `AGENT_IDENTITIES` in `src/support/agents.ts` had `"onboard-member": { username: "Onboarder", iconEmoji: ":handshake:" }` hardcoded. Every fork of junior inherited this entry even though the worker's actual playbook lives in the private agents-org overlay — leaking both the existence of the org-specific workflow and its slack identity.

**After:** private/overlay agents declare their slack identity in their own `.md` frontmatter. Junior loads the overlay directory at startup, parses the new `username` and `iconEmoji` fields, and registers the identities into `AGENT_IDENTITIES` dynamically. The public AGENT_IDENTITIES literal contains only the six core architectural agents.

## What changed

| File | Change |
|---|---|
| `src/agents/loader.ts` | Parses optional `username` + `iconEmoji` from frontmatter; adds to `AgentDefinition` interface |
| `src/support/agents.ts` | Removes `onboard-member` from `AGENT_IDENTITIES` literal. Adds `registerAgentIdentity(name, identity)` (refuses to overwrite core agents) and `loadOverlayIdentities(dir)` (scans .md files, registers identities for any agent declaring both fields). |
| `src/index.ts` | Calls `loadOverlayIdentities(".claude/agents-org")` before `app.start()`. Non-fatal on failure (overlay is optional). |
| `docs/features/persistent-agents.md` | Example AGENT_IDENTITIES block matches the new shape; comment explains the overlay mechanism. |
| `.claude/agents-org/onboard-member.md` | Declares `username: Onboarder` + `iconEmoji: ":handshake:"` in frontmatter (in the submodule). |

## Backward compat

- Agents without `username`/`iconEmoji` frontmatter keep working — those fields are optional on `AgentDefinition`.
- Existing core agents are untouched; their identities stay in code.
- `registerAgentIdentity` refuses to overwrite core agents — overlay can't silently re-skin lead, thinker, etc.

## Architectural intent (the user's original question)

The junior/agents-org split now holds **both** structurally and content-wise:

- **Junior public:** core agent names + generic dispatch architecture. No `gx-backend`, `MEMBERSHIP_PRO`, `growthx`, or any org-specific name reaches the public repo.
- **Agents-org private:** full playbooks AND identities for org-specific workers. Self-contained — adding a new private agent is one .md file with the right frontmatter, no code change required in junior.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` — 311/312 (one pre-existing dev-server integration flake, unrelated)
- [x] New tests:
  - `loader.test.ts`: parses `username`/`iconEmoji` from frontmatter; both default to `null` when absent.
  - `agents.test.ts`: `registerAgentIdentity` registers + refuses to overwrite core; `loadOverlayIdentities` registers from a temp dir, skips half-declared identities, doesn't throw on missing dir; overlay-registered agent appears in `dispatchableAgentsFor("lead")` after registration.

## Supersedes #23

PR #23 was a small PII sanitization (replacing real names in test fixtures with "Test Member"). This refactor changes those same fixtures more thoroughly — they now use core agent names (\`!review\`, \`!thinker\`) because the refactor's tests don't depend on the overlay being loaded. Closing #23 as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)