### PR TITLE
feat(admins): support additional admins via sqlite alongside env bootstrap

### DIFF
--- a/docs/features/project-setup.md
+++ b/docs/features/project-setup.md
@@ -65,8 +65,9 @@ interface Config {
     staleTimeoutMs: number; // SESSION_STALE_TIMEOUT_MS (default: 86400000)
     cleanupIntervalMs: number; // SESSION_CLEANUP_INTERVAL_MS (default: 900000)
   };
-  // Single Slack user ID allowed to run !mute, !unmute, !reset.
-  // Unset → gate is open (local dev). Production must set this.
+  // Bootstrap admin Slack user ID. Additional admins live in the `admins`
+  // table in the session DB (added via direct SQL — see thread-commands.md).
+  // Gate is open only when env is unset AND the admins table is empty.
   adminSlackUserId: string | null; // ADMIN_SLACK_USER_ID
   redis?: {
     url: string; // REDIS_URL (optional — in-memory if not set)

--- a/docs/features/session-persistence.md
+++ b/docs/features/session-persistence.md
@@ -40,7 +40,7 @@ Write volume: `updateActivity` and `set` are called on status transitions and tu
 
 ### Schema
 
-One table, one row per thread, the session as a JSON blob:
+One row per thread for `sessions`, plus a small `admins` table colocated in the same DB:
 
 ```sql
 CREATE TABLE sessions (
@@ -51,6 +51,13 @@ CREATE TABLE sessions (
 );
 CREATE INDEX idx_sessions_last_activity ON sessions(last_activity);
 CREATE INDEX idx_sessions_status ON sessions(status);
+
+-- Additional admins beyond the env-var bootstrap. Added by direct SQL.
+-- See thread-commands.md for the gate semantics.
+CREATE TABLE admins (
+  slack_user_id  TEXT PRIMARY KEY,
+  added_at       INTEGER NOT NULL
+);
 ```
 
 - `json` holds the full `ThreadSession` (including ephemeral `pendingMessages` — accepted as stale on restart per rule 11).
@@ -69,6 +76,9 @@ interface SessionStore {
   getAll(): Promise<Map<string, ThreadSession>>;
   getRecent(sinceMs: number): Promise<Map<string, ThreadSession>>;
   updateActivity(threadId): Promise<void>;
+  // Slack user IDs of admins beyond the env-var bootstrap. Memory store
+  // returns empty; sqlite queries the `admins` table on every call.
+  extraAdmins(): Promise<Set<string>>;
 }
 ```
 

--- a/docs/features/thread-commands.md
+++ b/docs/features/thread-commands.md
@@ -26,9 +26,21 @@ Users need to control thread behavior beyond just sending messages. Reset a brok
 
 ## Admin-only commands
 
-`!mute`, `!unmute`, and `!reset` are gated behind `ADMIN_SLACK_USER_ID` (single Slack user ID, env-configured). Non-admin invocations are silently rejected with a ❌ reaction on the trigger message — no thread reply, no log noise. When `ADMIN_SLACK_USER_ID` is unset (local dev), the gate is open.
+`!mute`, `!unmute`, and `!reset` are admin-gated. Two tiers:
 
-This is intentionally a single-admin model. The "elevation list lives in SQLite" idea was scoped out for v1 — see [v2-backlog.md](v2-backlog.md).
+1. **Env bootstrap** — `ADMIN_SLACK_USER_ID` names one Slack user ID. This is the bootstrap admin; the system stays bootable on a fresh DB.
+2. **SQLite extras** — the `admins` table in the session DB (`data/sessions.db`) lists additional admins. Added by **direct SQL only** (no Slack command, no CLI script — intentional minimal UX):
+   ```sql
+   INSERT INTO admins (slack_user_id, added_at)
+   VALUES ('U0XXXX', strftime('%s','now') * 1000);
+   ```
+   `isAdmin` reads the table on every check (no cache), so inserts take effect on the next command without a restart.
+
+Permissions are flat — anyone in either tier can run any admin command. Non-admin invocations are silently rejected with a ❌ reaction on the trigger message — no thread reply, no log noise.
+
+**Open-mode** (everyone admitted): only when **both** tiers are empty (env unset AND `admins` table empty). A partial misconfiguration — env unset but DB populated — still rejects unlisted users. This guards against an env-reload misfire silently promoting everyone in prod.
+
+The thread-owner-can-run-elevated-commands idea is still v2 — see [v2-backlog.md](v2-backlog.md).
 
 ## Design Decision: `!` prefix, not Slack slash commands
 

--- a/docs/features/v2-backlog.md
+++ b/docs/features/v2-backlog.md
@@ -44,12 +44,14 @@ Features explicitly deferred from MVP. To be scoped when MVP is running.
 
 ## Thread-owner-based command access
 
-**Problem:** Today admin gating is a single env var (`ADMIN_SLACK_USER_ID`). The original sketch was richer — env admin + a SQLite-backed list of additional admins, plus letting the *thread owner* (first non-bot author) run elevated commands in their own thread.
+**Status:** Two-tier admin (env + SQLite `admins` table) shipped — see [thread-commands.md](thread-commands.md#admin-only-commands). Thread-owner branch is still open.
+
+**Problem:** Today admin gating is env + SQLite. The original sketch also let the *thread owner* (first non-bot author) run elevated commands in their own thread.
 
 **Scope (to be refined):**
 - Persist `ownerSlackUserId` on `ThreadSession`, set from the first user message that creates the session. Survives `!reset all`.
-- `isAdmin(userId, session?)` returns true if `userId === envAdmin` OR `userId === session.ownerSlackUserId`.
-- Optional: SQLite `admins` table (`slack_user_id PRIMARY KEY, granted_by, granted_at`) plus `!admin add @user` / `!admin remove @user` / `!admin list`. Env admin is the bootstrap and cannot be removed via the command (they're not in the table).
+- `isAdmin(userId, session?)` returns true if env-match OR DB-match OR `userId === session.ownerSlackUserId`.
+- Slack-command admin management (`!admin add @user` / `!admin remove @user` / `!admin list`) was deliberately scoped out — admins added by direct SQL is the v1 UX. Revisit only if admin churn becomes frequent enough that SQL access is a bottleneck.
 - Decide: do owners get *all* elevated commands, or only a safe subset (e.g. mute/unmute on their own thread but not reset)?
 
 **Open questions:**

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -484,6 +484,41 @@ describe("SessionManager", () => {
         expect(onReaction).not.toHaveBeenCalled();
         expect((await store.get("thread-1"))!.muted).toBe(true);
       });
+
+      it("admin listed in store.extraAdmins() is admitted", async () => {
+        store.extraAdmins = async () => new Set(["U-DB-ADMIN"]);
+        const adminManager = new SessionManager(store, adminConfig);
+        const onReaction = mock((_e: SlackMessageEvent, _emoji: string) => {});
+        adminManager.onReaction = onReaction;
+        await adminManager.handleMessage(makeEvent({ user: "U-ADMIN", text: "go" }));
+
+        await adminManager.handleMessage(
+          makeEvent({ user: "U-DB-ADMIN", command: "mute", text: "", ts: "ts-mute" }),
+        );
+
+        expect(onReaction).not.toHaveBeenCalled();
+        expect((await store.get("thread-1"))!.muted).toBe(true);
+      });
+
+      it("env unset but DB has admins → gate is CLOSED (not open-mode)", async () => {
+        // Regression test: a missing ADMIN_SLACK_USER_ID must NOT silently
+        // promote everyone when the admins table is populated. Open-mode
+        // only kicks in when neither tier is configured.
+        store.extraAdmins = async () => new Set(["U-DB-ADMIN"]);
+        const openConfig: Config = { ...testConfig, adminSlackUserId: null };
+        const adminManager = new SessionManager(store, openConfig);
+        const onReaction = mock((_e: SlackMessageEvent, _emoji: string) => {});
+        adminManager.onReaction = onReaction;
+        await adminManager.handleMessage(makeEvent({ user: "U-DB-ADMIN", text: "go" }));
+
+        await adminManager.handleMessage(
+          makeEvent({ user: "U-RANDOM", command: "mute", text: "", ts: "ts-mute" }),
+        );
+
+        expect(onReaction).toHaveBeenCalledTimes(1);
+        expect(onReaction.mock.calls[0][1]).toBe("x");
+        expect((await store.get("thread-1"))!.muted).toBe(false);
+      });
     });
   });
 

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -198,18 +198,21 @@ export class SessionManager {
     return touched;
   }
 
-  isAdmin(userId: string): boolean {
-    const adminId = this.config.adminSlackUserId;
-    if (!adminId) return true;
-    return userId === adminId;
+  async isAdmin(userId: string): Promise<boolean> {
+    const envAdmin = this.config.adminSlackUserId;
+    // No env admin configured = open mode (local dev). Skip DB lookup.
+    if (!envAdmin) return true;
+    if (userId === envAdmin) return true;
+    const extras = await this.store.extraAdmins();
+    return extras.has(userId);
   }
 
   /**
    * Returns true if the user is denied (and a ❌ reaction was queued).
    * Caller should `return true` from the command handler to short-circuit.
    */
-  private denyIfNotAdmin(event: SlackMessageEvent): boolean {
-    if (this.isAdmin(event.user)) return false;
+  private async denyIfNotAdmin(event: SlackMessageEvent): Promise<boolean> {
+    if (await this.isAdmin(event.user)) return false;
     this.onReaction?.(event, "x");
     return true;
   }
@@ -248,7 +251,7 @@ export class SessionManager {
         // bare `!reset` gets the usage hint posted to the thread, contradicting
         // the documented "silent ❌ reaction, no thread reply" promise — and
         // leaks the gating model to anyone probing.
-        if (this.denyIfNotAdmin(event)) return true;
+        if (await this.denyIfNotAdmin(event)) return true;
         const arg = event.text.trim();
         if (!arg) {
           this.onCommandResponse?.(
@@ -435,7 +438,7 @@ export class SessionManager {
       }
 
       case "mute": {
-        if (this.denyIfNotAdmin(event)) return true;
+        if (await this.denyIfNotAdmin(event)) return true;
         session.muted = true;
         await this.store.set(session.threadId, session);
         this.onCommandResponse?.(event, "Muted. I'll stop responding until you `!unmute`.");
@@ -443,7 +446,7 @@ export class SessionManager {
       }
 
       case "unmute": {
-        if (this.denyIfNotAdmin(event)) return true;
+        if (await this.denyIfNotAdmin(event)) return true;
         session.muted = false;
         await this.store.set(session.threadId, session);
         this.onCommandResponse?.(event, "Unmuted.");

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -200,11 +200,13 @@ export class SessionManager {
 
   async isAdmin(userId: string): Promise<boolean> {
     const envAdmin = this.config.adminSlackUserId;
-    // No env admin configured = open mode (local dev). Skip DB lookup.
-    if (!envAdmin) return true;
-    if (userId === envAdmin) return true;
+    if (envAdmin && userId === envAdmin) return true;
     const extras = await this.store.extraAdmins();
-    return extras.has(userId);
+    if (extras.has(userId)) return true;
+    // Open-mode (local dev) only when NEITHER tier is configured. Without
+    // this guard, an env-var misfire in prod that unsets ADMIN_SLACK_USER_ID
+    // would silently promote everyone AND ignore the populated admins table.
+    return !envAdmin && extras.size === 0;
   }
 
   /**

--- a/src/session/store/interface.ts
+++ b/src/session/store/interface.ts
@@ -7,4 +7,10 @@ export interface SessionStore {
   getAll(): Promise<Map<string, ThreadSession>>;
   getRecent(sinceMs: number): Promise<Map<string, ThreadSession>>;
   updateActivity(threadId: string): Promise<void>;
+  /**
+   * Slack user IDs of additional admins beyond the env-var bootstrap admin.
+   * Rule: one admin in `ADMIN_SLACK_USER_ID` (env), rest in the SQLite DB.
+   * Memory store always returns empty.
+   */
+  extraAdmins(): Promise<Set<string>>;
 }

--- a/src/session/store/memory.ts
+++ b/src/session/store/memory.ts
@@ -37,4 +37,8 @@ export class InMemorySessionStore implements SessionStore {
       session.lastActivity = Date.now();
     }
   }
+
+  async extraAdmins(): Promise<Set<string>> {
+    return new Set();
+  }
 }

--- a/src/session/store/sqlite.ts
+++ b/src/session/store/sqlite.ts
@@ -37,6 +37,15 @@ export class SqliteSessionStore implements SessionStore {
         FOREIGN KEY (thread_id) REFERENCES sessions(thread_id)
       )
     `);
+    // Extra admins beyond the env-var bootstrap. Added by direct SQL —
+    // process restart picks up changes; isAdmin() reads from this table each
+    // call so no cache invalidation is needed.
+    this.db.run(`
+      CREATE TABLE IF NOT EXISTS admins (
+        slack_user_id TEXT PRIMARY KEY,
+        added_at INTEGER NOT NULL
+      )
+    `);
   }
 
   close(): void {
@@ -108,6 +117,15 @@ export class SqliteSessionStore implements SessionStore {
       out.set(row.thread_id, session);
     }
     return out;
+  }
+
+  async extraAdmins(): Promise<Set<string>> {
+    const rows = this.db
+      .query<{ slack_user_id: string }, []>(
+        "SELECT slack_user_id FROM admins",
+      )
+      .all();
+    return new Set(rows.map((r) => r.slack_user_id));
   }
 
   async updateActivity(threadId: string): Promise<void> {

--- a/src/session/store/sqlite.ts
+++ b/src/session/store/sqlite.ts
@@ -37,9 +37,9 @@ export class SqliteSessionStore implements SessionStore {
         FOREIGN KEY (thread_id) REFERENCES sessions(thread_id)
       )
     `);
-    // Extra admins beyond the env-var bootstrap. Added by direct SQL —
-    // process restart picks up changes; isAdmin() reads from this table each
-    // call so no cache invalidation is needed.
+    // Extra admins beyond the env-var bootstrap. Added by direct SQL.
+    // isAdmin() reads from this table on each call (no cache), so inserts
+    // take effect on the next command without a restart.
     this.db.run(`
       CREATE TABLE IF NOT EXISTS admins (
         slack_user_id TEXT PRIMARY KEY,


### PR DESCRIPTION
## Summary
- Adds an `admins` table to the sqlite session DB so additional admins can be granted via direct SQL, while `ADMIN_SLACK_USER_ID` remains the bootstrap admin (keeps the system bootable on a fresh DB).
- New `SessionStore.extraAdmins()` method — memory store returns empty, sqlite store reads the `admins` table on each `isAdmin` check (no cache, so SQL inserts take effect on the next command without a restart).
- `SessionManager.isAdmin` is now async and checks env first, then DB. Permissions stay flat — anyone listed in either tier gets mute/unmute/reset/cancel.

## Admin lifecycle
New admins are added by direct SQL — no Slack command, no CLI script. Example:

```sql
INSERT INTO admins (slack_user_id, added_at) VALUES ('U0XXXX', strftime('%s','now') * 1000);
```

## Test plan
- [x] `bun run typecheck` clean
- [x] `bun test src/session/manager.test.ts` — 35/35 pass
- [x] Full `bun test` — only pre-existing DevServer integration failure, unrelated
- [ ] Confirm on deploy that the env-var admin still passes the gate
- [ ] Confirm an admin added via direct SQL can run `!mute` without a restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)