### PR TITLE
Improve OpenCode runner prompt quality

### DIFF
--- a/docs/features/runner-providers.md
+++ b/docs/features/runner-providers.md
@@ -20,7 +20,7 @@ specific needs because it has:
 - `--session <id>` for resume
 - `--dir <path>` for worktree cwd
 - `--file <path>` for attachments
-- `--agent <name>` and config-level agent prompts
+- `--agent build` and config-level agent prompts
 - native MCP config in `opencode.json`
 - `OPENCODE_CONFIG_CONTENT` / `OPENCODE_CONFIG` for deterministic generated
   runtime config
@@ -40,8 +40,8 @@ repo-local overlays. Claude handles that with `--append-system-prompt`.
 OpenCode has a credible provider-native replacement:
 
 - generate config per spawn with `OPENCODE_CONFIG_CONTENT` or `OPENCODE_CONFIG`
-- define a primary agent with `agent.<name>.prompt`
-- run `opencode run --agent <name>`
+- override the built-in `build` primary agent with `agent.build.prompt`
+- run `opencode run --agent build`
 
 Codex does not currently expose an equivalent system-prompt flag. Its realistic
 v1 option is to prepend Junior's agent prompt to the first user prompt, which is
@@ -145,18 +145,18 @@ The Claude adapter maps:
 
 ## OpenCode Mapping
 
-Verified locally with OpenCode `1.4.0`.
+Verified locally with OpenCode `1.14.48`.
 
 Fresh run:
 
 ```sh
-opencode run --format json --dir <worktree> --agent junior "<prompt>"
+opencode run --format json --dir <worktree> --agent build "<prompt>"
 ```
 
 Resume:
 
 ```sh
-opencode run --format json --dir <worktree> --session <sessionID> --agent junior "<prompt>"
+opencode run --format json --dir <worktree> --session <sessionID> --agent build "<prompt>"
 ```
 
 Observed JSON events:
@@ -216,9 +216,14 @@ Recommended v1:
 
 - Generate `OPENCODE_CONFIG_CONTENT` per spawn, or generate a temp config file
   and point `OPENCODE_CONFIG` at it.
-- Define a primary agent named for the Junior agent being run.
-- Set that agent's `prompt` to Junior's composed system prompt.
-- Run `opencode run --agent <generated-agent-name> ...`.
+- Override OpenCode's built-in `build` primary agent by default, instead of
+  generating a new provider agent per Junior agent. Local `opencode debug agent`
+  checks on OpenCode `1.14.48` show that custom-named generated agents resolve
+  as `native: false`, while `agent.build.prompt` keeps the native build agent
+  tool/permission surface.
+- Set that agent's `prompt` to a Junior-owned OpenCode prompt: a compact
+  provider baseline first, then Junior's composed dynamic persona/system prompt.
+- Run `opencode run --agent build ...`.
 - Keep first-turn Slack/thread preamble behavior in Junior's prompt builder.
 - On resumed turns, avoid re-injecting full Slack history unless OpenCode resume
   proves it does not preserve it.
@@ -243,8 +248,9 @@ global OpenCode config for correctness.
 Generate config with:
 
 - `model` if thread/session selected one
-- `agent.<name>.prompt`
-- `agent.<name>.mode = "primary"`
+- `agent.build.prompt`, composed by Junior as OpenCode provider baseline plus
+  dynamic Junior persona/system prompt
+- `agent.build.mode = "primary"`
 - `permission`
 - `mcp`
 
@@ -256,10 +262,10 @@ Sketch:
   "model": "openai/gpt-5.1",
   "permission": "allow",
   "agent": {
-    "junior-lead": {
+    "build": {
       "description": "Junior Slack runner",
       "mode": "primary",
-      "prompt": "<composed Junior system prompt>"
+      "prompt": "<OpenCode provider baseline>\n\n<junior-system-prompt>\n<dynamic Junior system prompt>\n</junior-system-prompt>"
     }
   },
   "mcp": {
@@ -303,8 +309,10 @@ OpenCode setup:
   runs, but Playwright MCP is opt-in via
   `OPENCODE_PLAYWRIGHT_MCP_ENABLED=true` because `npx @playwright/mcp` is cold
   per runner spawn.
-- Global `agent.<other>` definitions coexist with Junior's `agent.<name>`,
-  expanding the agent set available inside the spawn.
+- Global `agent.<other>` definitions coexist with Junior's `agent.build`
+  override. Global `build` customization may still contribute fields Junior
+  does not override, so the generated config must explicitly set Junior's
+  prompt, mode, and permission shape.
 - A shell-set `OPENCODE_CONFIG=/path/to/file` is inherited via the child's
   environment and loads before `OPENCODE_CONFIG_CONTENT` with the same
   merge semantics.
@@ -451,6 +459,9 @@ Exit criteria:
 
 - Add `src/opencode/spawner.ts`.
 - Generate config through `OPENCODE_CONFIG_CONTENT` or temp `OPENCODE_CONFIG`.
+- Compose `agent.build.prompt` with a Junior-owned OpenCode provider baseline
+  before appending the dynamic Junior system prompt; do not run OpenCode with
+  only the persona overlay.
 - Use the centralized Junior/Slack env contract.
 - Honor the centralized `session.cwd` MCP skip rule.
 - Set stdin ignored/closed.

--- a/src/opencode/prompt.test.ts
+++ b/src/opencode/prompt.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "bun:test";
+import {
+  OPENCODE_PROVIDER_BASE_PROMPT,
+  buildOpenCodeAgentPrompt,
+} from "./prompt.ts";
+
+describe("buildOpenCodeAgentPrompt", () => {
+  it("returns the provider baseline when no Junior prompt is present", () => {
+    const prompt = buildOpenCodeAgentPrompt();
+
+    expect(prompt).toBe(OPENCODE_PROVIDER_BASE_PROMPT);
+    expect(prompt).toContain("Slack-controlled coding agent");
+    expect(prompt).toContain("Read the relevant code before changing it");
+  });
+
+  it("appends Junior's dynamic system prompt after the provider baseline", () => {
+    const prompt = buildOpenCodeAgentPrompt({
+      juniorPrompt: "You are the review persona.",
+    });
+
+    expect(prompt.indexOf(OPENCODE_PROVIDER_BASE_PROMPT)).toBe(0);
+    expect(prompt).toContain("<junior-system-prompt>");
+    expect(prompt).toContain("You are the review persona.");
+    expect(prompt).toContain("</junior-system-prompt>");
+  });
+
+  it("trims blank persona prompts instead of emitting empty persona tags", () => {
+    expect(buildOpenCodeAgentPrompt({ juniorPrompt: "  \n " })).toBe(
+      OPENCODE_PROVIDER_BASE_PROMPT,
+    );
+  });
+});

--- a/src/opencode/prompt.ts
+++ b/src/opencode/prompt.ts
@@ -1,0 +1,38 @@
+export interface BuildOpenCodeAgentPromptOptions {
+  juniorPrompt?: string | null;
+}
+
+/**
+ * OpenCode's `agent.<name>.prompt` replaces the provider's native agent
+ * prompt. Keep a compact provider baseline here so Junior does not run with
+ * only a role/persona overlay.
+ */
+export const OPENCODE_PROVIDER_BASE_PROMPT = [
+  "You are Junior running inside OpenCode as a Slack-controlled coding agent.",
+  "",
+  "Use OpenCode's available tools to inspect files, search the workspace, edit code, and run verification commands. Prefer fast codebase navigation such as `rg` for text search. Read the relevant code before changing it.",
+  "",
+  "Respect the active workspace. Work in the current directory and explicit user-provided paths. Do not modify unrelated repositories, shared origin checkouts, generated secrets, or user changes you did not make. Avoid destructive git operations unless the user explicitly asked for them.",
+  "",
+  "Keep changes scoped to the request and aligned with local patterns. Do not introduce new abstractions, dependencies, or broad refactors unless they are needed to finish the task safely.",
+  "",
+  "For code changes, verify with the most relevant typecheck, tests, linters, or targeted commands available in the project. Report any command you could not run and the concrete blocker.",
+  "",
+  "Communicate concisely in Slack. Use progress updates for long work, lead with outcomes and blockers, and avoid dumping raw command output unless it is needed. When sending Slack messages through tools, use the Junior agent identity from the environment when present.",
+  "",
+  "If provider instructions, runtime safety rules, or explicit user instructions conflict with a persona below, follow the higher-priority provider/runtime/user instruction.",
+].join("\n");
+
+export function buildOpenCodeAgentPrompt(
+  options: BuildOpenCodeAgentPromptOptions = {},
+): string {
+  const persona = options.juniorPrompt?.trim();
+  if (!persona) return OPENCODE_PROVIDER_BASE_PROMPT;
+
+  return [
+    OPENCODE_PROVIDER_BASE_PROMPT,
+    "<junior-system-prompt>",
+    persona,
+    "</junior-system-prompt>",
+  ].join("\n\n");
+}

--- a/src/opencode/spawner.test.ts
+++ b/src/opencode/spawner.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "bun:test";
+import { createSession } from "../session/types.ts";
+import { spawnOpenCode } from "./spawner.ts";
+
+describe("spawnOpenCode", () => {
+  it("generates OPENCODE_CONFIG_CONTENT with provider baseline plus Junior prompt", async () => {
+    const session = createSession("thread-1", "C01");
+    session.systemPrompt = "You are the review persona.";
+    session.activeAgentName = "review";
+
+    let configContent: string | undefined;
+    const handle = spawnOpenCode(
+      session,
+      "inspect this",
+      {
+        command: "/usr/bin/true",
+        env: (env) => {
+          configContent = env.OPENCODE_CONFIG_CONTENT;
+        },
+      },
+    );
+
+    await handle.result;
+
+    expect(configContent).toBeDefined();
+    const parsed = JSON.parse(configContent!);
+    const prompt = parsed.agent.build.prompt as string;
+
+    expect(prompt).toContain("Slack-controlled coding agent");
+    expect(prompt).toContain("<junior-system-prompt>");
+    expect(prompt).toContain("You are the review persona.");
+  });
+});

--- a/src/opencode/spawner.ts
+++ b/src/opencode/spawner.ts
@@ -12,6 +12,7 @@ import {
   createOpenCodeStreamParser,
   type OpenCodeEvent,
 } from "./parser.ts";
+import { buildOpenCodeAgentPrompt } from "./prompt.ts";
 
 export interface OpenCodeEnvContext {
   session: ThreadSession;
@@ -52,11 +53,14 @@ export function spawnOpenCode(
     botToken,
     agentIdentity,
   });
-  const agentName = config.agentName ?? session.activeAgentName ?? "junior";
+  const agentName = config.agentName ?? "build";
   const model = session.model ?? config.defaultModel ?? null;
+  const agentPrompt = buildOpenCodeAgentPrompt({
+    juniorPrompt: config.agentPrompt ?? session.systemPrompt,
+  });
   const configContent = buildOpenCodeConfigContent({
     agentName,
-    agentPrompt: config.agentPrompt ?? session.systemPrompt ?? "",
+    agentPrompt,
     description: config.description,
     model,
     permission: config.permission,


### PR DESCRIPTION
## Summary
- compose OpenCode agent prompts from a Junior-owned provider baseline plus the dynamic Junior system prompt
- default OpenCode runs to the built-in `build` agent so native build-agent tools/permissions are preserved while the prompt is overridden
- document the prompt strategy and add prompt/spawner coverage

## Verification
- `bun test`
- `bun run typecheck && git diff --check && bun test`
- local `opencode debug agent` check on OpenCode 1.14.48 confirmed custom generated agents resolve `native: false`, while overriding `agent.build.prompt` keeps `native: true`