### PR TITLE
chore: add playwright and slack-bot MCP servers to opencode.json

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,4 +1,16 @@
 {
   "$schema": "https://opencode.ai/config.json",
-  "permission": "allow"
+  "permission": "allow",
+  "mcp": {
+    "playwright": {
+      "type": "local",
+      "command": ["npx", "@playwright/mcp", "--headless"],
+      "enabled": true
+    },
+    "slack-bot": {
+      "type": "remote",
+      "url": "http://localhost:3456/mcp",
+      "enabled": true
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Add `playwright` MCP server (local, `npx @playwright/mcp --headless`) to `opencode.json`
- Add `slack-bot` MCP server (remote, `http://localhost:3456/mcp`) to `opencode.json`

Both are `enabled: true`. The slack-bot server requires junior's bot server to be running. This config mirrors the existing `.mcp.json` (Claude Code format) but in OpenCode's schema format so both CLIs have equivalent MCP access.

## Context

- Translated from `.mcp.json` which uses Claude Code's `{ "mcpServers": { "name": { "command": ..., "args": [...] } } }` format
- OpenCode uses `{ "mcp": { "name": { "type": "local", "command": [...] } } }` for local servers and `type: "remote"` for HTTP