### PR TITLE
chore: add opencode-with-mcp.sh script for manual dev sessions

### DIFF
--- a/bin/opencode-with-mcp.sh
+++ b/bin/opencode-with-mcp.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Launch an OpenCode session with MCP servers configured for Junior's project.
+#
+# This mirrors the MCP wiring that Junior's runtime provides to spawned
+# OpenCode processes, but for manual `opencode` use (e.g. running the
+# build agent in the TUI while developing Junior itself).
+#
+# MCP servers are controlled by the same env flags as Junior's runtime
+# (src/config.ts parseBooleanEnv), so behavior is consistent between
+# manual and spawned runs:
+#
+#   OPENCODE_MCP_ENABLED=true|false              default: true
+#   OPENCODE_SLACK_MCP_ENABLED=true|false         default: true
+#   OPENCODE_PLAYWRIGHT_MCP_ENABLED=true|false    default: false
+#
+# Boolean parsing matches src/config.ts: 1/true/yes/on and 0/false/no/off
+# (case-insensitive). Invalid values produce an error, matching the runtime.
+#
+# The generated config is passed via OPENCODE_CONFIG_CONTENT, which OpenCode
+# merges with project opencode.json at the highest precedence layer. This
+# avoids editing the project config file and keeps MCP gating under env-flag
+# control — the same pattern Junior's spawner uses for sub-agent runs.
+#
+# OPENCODE_CONFIG is unset to prevent a stale user-level config from
+# interfering with the inline content.
+#
+# Requires: jq (https://jqlang.github.io/jq/)
+
+set -e
+
+# --- Boolean parser (mirrors src/config.ts parseBooleanEnv) ---
+# Accepts: 1, true, yes, on (truthy) and 0, false, no, off (falsy),
+# case-insensitive. Empty/unset returns the default. Invalid values error.
+parse_bool() {
+  local name="$1" value="$2" default="$3"
+  if [ -z "$value" ]; then
+    echo "$default"
+    return
+  fi
+  local normalized
+  normalized=$(echo "$value" | tr '[:upper:]' '[:lower:]' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+  case "$normalized" in
+    1|true|yes|on) echo "true"; return ;;
+    0|false|no|off) echo "false"; return ;;
+    *) echo "Error: Invalid $name: \"$value\" (expected true|false)" >&2; exit 1 ;;
+  esac
+}
+
+# --- Env defaults (mirror src/config.ts) ---
+MCP_ENABLED=$(parse_bool "OPENCODE_MCP_ENABLED" "${OPENCODE_MCP_ENABLED:-}" true)
+SLACK_MCP=$(parse_bool "OPENCODE_SLACK_MCP_ENABLED" "${OPENCODE_SLACK_MCP_ENABLED:-}" true)
+PLAYWRIGHT_MCP=$(parse_bool "OPENCODE_PLAYWRIGHT_MCP_ENABLED" "${OPENCODE_PLAYWRIGHT_MCP_ENABLED:-}" false)
+
+# --- Build config ---
+CONFIG='{}'
+
+if [ "$MCP_ENABLED" = "true" ]; then
+  if [ "$SLACK_MCP" = "true" ]; then
+    CONFIG=$(echo "$CONFIG" | jq --arg url "http://localhost:3456/mcp" \
+      '.mcp["slack-bot"] = {type: "remote", url: $url, enabled: true}')
+  fi
+
+  if [ "$PLAYWRIGHT_MCP" = "true" ]; then
+    CONFIG=$(echo "$CONFIG" | jq \
+      '.mcp.playwright = {type: "local", command: ["npx", "@playwright/mcp", "--headless"], enabled: true}')
+  fi
+fi
+
+CONFIG=$(echo "$CONFIG" | jq '. + {"$schema": "https://opencode.ai/config.json", permission: "allow"}')
+
+export OPENCODE_CONFIG_CONTENT="$CONFIG"
+unset OPENCODE_CONFIG
+
+exec opencode "$@"


### PR DESCRIPTION
## Summary

Adds `bin/opencode-with-mcp.sh` — a wrapper script that launches OpenCode with MCP servers configured via `OPENCODE_CONFIG_CONTENT`, using the same env-flag gating as Junior's runtime (`src/config.ts` / `src/runners/index.ts`).

Replaces PR #36, which added static MCP config to `opencode.json`. That approach was unsafe because static project config always-on MCP servers, bypassing Junior's runtime flags (`OPENCODE_MCP_ENABLED`, `OPENCODE_SLACK_MCP_ENABLED`, `OPENCODE_PLAYWRIGHT_MCP_ENABLED`).

## How it works

```bash
# Default: slack-bot MCP only (matches Junior runtime defaults)
bin/opencode-with-mcp.sh

# Both MCP servers (playwright off by default, just like Junior)
OPENCODE_PLAYWRIGHT_MCP_ENABLED=true bin/opencode-with-mcp.sh

# Disable all MCP (e.g. for utility commands that don't need Slack)
OPENCODE_MCP_ENABLED=false bin/opencode-with-mcp.sh
```

The script generates an OpenCode config JSON with MCP servers conditionally included, passes it via `OPENCODE_CONFIG_CONTENT`, and unsets `OPENCODE_CONFIG` to prevent stale user-level configs from interfering. This matches how Junior's `spawnOpenCode()` wires MCP for sub-agent runs (highest precedence, no file edits).

## Boolean parsing matches runtime

The env-flag parser mirrors `src/config.ts parseBooleanEnv`:
- **Truthy**: `1`, `true`, `yes`, `on` (case-insensitive)
- **Falsy**: `0`, `false`, `no`, `off` (case-insensitive)
- **Unset**: falls back to the default (`true` for MCP and Slack, `false` for Playwright)
- **Invalid**: errors with a clear message, matching the runtime behavior

## Why not `opencode.json`

Per the review on #36: static MCP config in `opencode.json` is always enabled for any local `opencode` run in this repo, overriding the runtime gating in `spawnOpenCode()`. Since OpenCode merges project config with `OPENCODE_CONFIG_CONTENT`, the static entries persist even when Junior's runtime flags try to disable them. The script avoids this by only providing MCP via the env var, which has the highest precedence and leaves no file footprint.

Requires: `jq`