### PR TITLE
Fix OpenCode MCP and support agent access

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ All config is loaded from environment variables in [`src/config.ts`](src/config.
 | `OPENCODE_MODEL` | *(unset)* | Override default OpenCode model |
 | `OPENCODE_TIMEOUT_MS` | `300000` | Per-turn OpenCode timeout before SIGINT |
 | `JUNIOR_OPENCODE_PERMISSION` | `allow` | OpenCode permission mode for generated agent config |
-| `OPENCODE_MCP_ENABLED` | `true` | Enables generated OpenCode MCP config for worktree-backed runs |
-| `OPENCODE_PLAYWRIGHT_MCP_ENABLED` | `false` | Opt in to Playwright MCP for OpenCode worktree-backed runs |
+| `OPENCODE_MCP_ENABLED` | `true` | Enables generated OpenCode MCP config for normal non-utility runs |
+| `OPENCODE_PLAYWRIGHT_MCP_ENABLED` | `true` | Include Playwright MCP in generated OpenCode config; set `false` to disable |
 
 `REPOS` example:
 

--- a/bin/opencode-with-mcp.sh
+++ b/bin/opencode-with-mcp.sh
@@ -11,7 +11,7 @@
 #
 #   OPENCODE_MCP_ENABLED=true|false              default: true
 #   OPENCODE_SLACK_MCP_ENABLED=true|false         default: true
-#   OPENCODE_PLAYWRIGHT_MCP_ENABLED=true|false    default: false
+#   OPENCODE_PLAYWRIGHT_MCP_ENABLED=true|false    default: true
 #
 # Boolean parsing matches src/config.ts: 1/true/yes/on and 0/false/no/off
 # (case-insensitive). Invalid values produce an error, matching the runtime.
@@ -49,7 +49,7 @@ parse_bool() {
 # --- Env defaults (mirror src/config.ts) ---
 MCP_ENABLED=$(parse_bool "OPENCODE_MCP_ENABLED" "${OPENCODE_MCP_ENABLED:-}" true)
 SLACK_MCP=$(parse_bool "OPENCODE_SLACK_MCP_ENABLED" "${OPENCODE_SLACK_MCP_ENABLED:-}" true)
-PLAYWRIGHT_MCP=$(parse_bool "OPENCODE_PLAYWRIGHT_MCP_ENABLED" "${OPENCODE_PLAYWRIGHT_MCP_ENABLED:-}" false)
+PLAYWRIGHT_MCP=$(parse_bool "OPENCODE_PLAYWRIGHT_MCP_ENABLED" "${OPENCODE_PLAYWRIGHT_MCP_ENABLED:-}" true)
 
 # --- Build config ---
 CONFIG='{}'

--- a/docs/code_index/runner-providers.md
+++ b/docs/code_index/runner-providers.md
@@ -14,7 +14,7 @@ and MCP wiring.
 | `buildOpenCodeMcpConfig(config)` | `index.ts` | Builds OpenCode MCP entries (`slack-bot`, `playwright` by default unless disabled). |
 | `buildRunnerRuntime(options)` | `runtime.ts` | Shared cwd/env contract for provider adapters. |
 | `resolveRunnerCwd(session, targetRepoCwd?)` | `runtime.ts` | Cwd priority: `session.cwd` → `worktreePath` → target repo → Junior root. |
-| `needsProjectMcp(session, cwd)` | `runtime.ts` | Claude project-MCP policy for worktree-backed runs. OpenCode has its own generated-config policy. |
+| `needsProjectMcp(session, cwd)` | `runtime.ts` | Claude-only project-MCP policy for worktree-backed runs. OpenCode has its own generated-config policy. |
 
 ### src/opencode
 
@@ -23,7 +23,7 @@ and MCP wiring.
 | `spawnOpenCode(...)` | `spawner.ts` | Runs `opencode run --format json`, generates `OPENCODE_CONFIG_CONTENT`, parses events. |
 | `buildOpenCodeArgs(...)` | `args.ts` | Builds fresh/resume CLI args using `--session`, `--dir`, `--agent build`, and attachments. |
 | `buildOpenCodeConfig(...)` | `config.ts` | Generates model, permissions, primary `agent.build`, MCP entries, and subagent entries. |
-| `loadOpenCodeSupportSubagents()` | `support-agents.ts` | Mirrors stateless support prompts into generated OpenCode subagents. |
+| `loadOpenCodeSupportSubagents()` | `support-agents.ts` | Exposes standalone stateless support prompts as generated OpenCode subagents. |
 | `buildOpenCodeAgentPrompt(...)` | `prompt.ts` | Wraps Junior core + active-agent prompt in the OpenCode provider baseline. |
 | `createOpenCodeStreamParser()` / `createOpenCodeEventMapper()` | `parser.ts` | Converts OpenCode JSON events into normalized runner events. |
 
@@ -35,6 +35,7 @@ and MCP wiring.
   lead run from Junior root. It is omitted only for explicit `session.cwd`
   utility runs.
 - Generated subagents include only stateless support fetchers:
-  `nr-research`, `sentry-fetch`, `vercel-status`.
+  `nr-research`, `sentry-fetch`, `vercel-status`. They are omitted for utility
+  `session.cwd` runs and use a constrained read/search/MCP permission surface.
 - Persistent workers (`reproducer`, `thinker`, `review`) are not generated as
   OpenCode Task subagents; they are Slack-dispatched persistent sessions.

--- a/docs/code_index/runner-providers.md
+++ b/docs/code_index/runner-providers.md
@@ -1,0 +1,40 @@
+# Code Index: Runner Providers
+
+Provider boundary for Claude/OpenCode spawning. App code talks to normalized
+runner events; provider adapters own CLI args, config, parsing, resume, cwd, env,
+and MCP wiring.
+
+## Code Index
+
+### src/runners
+
+| Symbol | File | Purpose |
+|---|---|---|
+| `spawnRunner(session, prompt, config, ...)` | `index.ts` | Selects Claude/OpenCode provider and dispatches to the adapter. |
+| `buildOpenCodeMcpConfig(config)` | `index.ts` | Builds OpenCode MCP entries (`slack-bot`, `playwright` by default unless disabled). |
+| `buildRunnerRuntime(options)` | `runtime.ts` | Shared cwd/env contract for provider adapters. |
+| `resolveRunnerCwd(session, targetRepoCwd?)` | `runtime.ts` | Cwd priority: `session.cwd` → `worktreePath` → target repo → Junior root. |
+| `needsProjectMcp(session, cwd)` | `runtime.ts` | Claude project-MCP policy for worktree-backed runs. OpenCode has its own generated-config policy. |
+
+### src/opencode
+
+| Symbol | File | Purpose |
+|---|---|---|
+| `spawnOpenCode(...)` | `spawner.ts` | Runs `opencode run --format json`, generates `OPENCODE_CONFIG_CONTENT`, parses events. |
+| `buildOpenCodeArgs(...)` | `args.ts` | Builds fresh/resume CLI args using `--session`, `--dir`, `--agent build`, and attachments. |
+| `buildOpenCodeConfig(...)` | `config.ts` | Generates model, permissions, primary `agent.build`, MCP entries, and subagent entries. |
+| `loadOpenCodeSupportSubagents()` | `support-agents.ts` | Mirrors stateless support prompts into generated OpenCode subagents. |
+| `buildOpenCodeAgentPrompt(...)` | `prompt.ts` | Wraps Junior core + active-agent prompt in the OpenCode provider baseline. |
+| `createOpenCodeStreamParser()` / `createOpenCodeEventMapper()` | `parser.ts` | Converts OpenCode JSON events into normalized runner events. |
+
+## Current OpenCode Runtime Rules
+
+- Runtime uses provider agent `build`; Junior's actual role is carried in the
+  generated prompt and env (`JUNIOR_AGENT_NAME`).
+- Slack MCP is included for every normal OpenCode run, including the initial
+  lead run from Junior root. It is omitted only for explicit `session.cwd`
+  utility runs.
+- Generated subagents include only stateless support fetchers:
+  `nr-research`, `sentry-fetch`, `vercel-status`.
+- Persistent workers (`reproducer`, `thinker`, `review`) are not generated as
+  OpenCode Task subagents; they are Slack-dispatched persistent sessions.

--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -69,6 +69,10 @@ Status pill updates that agents post mid-run go through `slack_send_message` wit
 - `.claude/settings.json` grants `mcp__slack-bot__*` permissions
 - Port configurable via `MCP_PORT` env var (default 3456)
 - `--mcp-config` flag injected by `spawner.ts` when cwd differs from project root (worktree scenarios)
+- OpenCode receives the same `slack-bot` MCP through generated
+  `OPENCODE_CONFIG_CONTENT` for all normal runs, including initial lead intake
+  from Junior's project root. Explicit `session.cwd` utility runs still skip
+  Junior's local MCP wiring.
 
 ## What it replaced
 

--- a/docs/features/project-setup.md
+++ b/docs/features/project-setup.md
@@ -105,9 +105,9 @@ interface Config {
 | `OPENCODE_MODEL` | no | unset | passed through to `opencode run --model` |
 | `OPENCODE_TIMEOUT_MS` | no | `300000` | |
 | `JUNIOR_OPENCODE_PERMISSION` | no | `allow` | OpenCode permission mode in generated agent config |
-| `OPENCODE_MCP_ENABLED` | no | `true` | enables generated OpenCode MCP config for worktree-backed runs |
+| `OPENCODE_MCP_ENABLED` | no | `true` | enables generated OpenCode MCP config for normal non-utility runs |
 | `OPENCODE_SLACK_MCP_ENABLED` | no | `true` | includes the local Slack MCP entry when MCP is enabled |
-| `OPENCODE_PLAYWRIGHT_MCP_ENABLED` | no | `false` | opt-in Playwright MCP for OpenCode worktree-backed runs |
+| `OPENCODE_PLAYWRIGHT_MCP_ENABLED` | no | `true` | includes Playwright MCP in generated OpenCode config; set `false` to disable |
 | `REPOS` | no | `[]` | JSON array of `RepoConfig` |
 | `CHANNEL_DEFAULTS` | no | `{"C05557KKV37":{"agentType":"lead"}}` | JSON, validated |
 | `SESSION_STORE` | no | `sqlite` | `sqlite` \| `memory` |

--- a/docs/features/runner-providers.md
+++ b/docs/features/runner-providers.md
@@ -323,9 +323,13 @@ OpenCode setup:
   `mcp` entirely (utility runs with no worktree), those globals become the
   *only* MCPs the child sees.
 - Junior includes the local Slack MCP by default for OpenCode worktree-backed
-  runs, but Playwright MCP is opt-in via
-  `OPENCODE_PLAYWRIGHT_MCP_ENABLED=true` because `npx @playwright/mcp` is cold
-  per runner spawn.
+  runs and for normal Junior-root lead/default runs. The only carve-out is an
+  explicit `session.cwd` utility run, where Junior intentionally omits its local
+  MCP wiring so utility commands can rely on their own cloud integrations. This
+  matters for bug intake: lead must call `register_worktree` before any target
+  worktree exists. Playwright MCP is enabled by default for OpenCode parity with
+  Claude's project `.mcp.json`; set `OPENCODE_PLAYWRIGHT_MCP_ENABLED=false` if a
+  deployment needs to avoid `npx @playwright/mcp` cold-start cost.
 - Global `agent.<other>` definitions coexist with Junior's `agent.build`,
   expanding the agent set available inside the spawn.
 - A shell-set `OPENCODE_CONFIG=/path/to/file` is inherited via the child's
@@ -340,6 +344,12 @@ Mitigations in code today:
   `agent.build.permission` explicitly when Junior has a value. Agent permission
   is object-shaped because OpenCode does not accept the string shorthand at that
   layer. Missing keys are the merge surface.
+- The generated config mirrors Junior's stateless support prompts
+  (`nr-research`, `sentry-fetch`, `vercel-status`) into OpenCode `mode:
+  "subagent"` entries so Task fan-out works even when the child cwd is a target
+  repo or Junior's root. Persistent workers (`reproducer`, `thinker`, `review`)
+  are intentionally not exposed as OpenCode Task subagents; they must remain
+  Slack-dispatched persistent sessions with their own audit trail.
 
 If full isolation is required for a deployment (production, shared service
 accounts), run Junior with `HOME` / `XDG_CONFIG_HOME` pointed at an empty

--- a/docs/features/runner-providers.md
+++ b/docs/features/runner-providers.md
@@ -344,12 +344,14 @@ Mitigations in code today:
   `agent.build.permission` explicitly when Junior has a value. Agent permission
   is object-shaped because OpenCode does not accept the string shorthand at that
   layer. Missing keys are the merge surface.
-- The generated config mirrors Junior's stateless support prompts
-  (`nr-research`, `sentry-fetch`, `vercel-status`) into OpenCode `mode:
-  "subagent"` entries so Task fan-out works even when the child cwd is a target
-  repo or Junior's root. Persistent workers (`reproducer`, `thinker`, `review`)
-  are intentionally not exposed as OpenCode Task subagents; they must remain
-  Slack-dispatched persistent sessions with their own audit trail.
+- The generated config exposes Junior's standalone stateless support prompts
+  (`nr-research`, `sentry-fetch`, `vercel-status`) as OpenCode `mode:
+  "subagent"` entries so Task fan-out works when the child cwd is a target repo
+  or Junior's root. These subagents use a constrained permission surface:
+  read/search tools and MCP tools only. Utility `session.cwd` runs do not receive
+  these support subagents. Persistent workers (`reproducer`, `thinker`,
+  `review`) are intentionally not exposed as OpenCode Task subagents; they must
+  remain Slack-dispatched persistent sessions with their own audit trail.
 
 If full isolation is required for a deployment (production, shared service
 accounts), run Junior with `HOME` / `XDG_CONFIG_HOME` pointed at an empty

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -63,7 +63,7 @@ describe("loadConfig runner providers", () => {
       permission: "allow",
       mcpEnabled: true,
       slackMcpEnabled: true,
-      playwrightMcpEnabled: false,
+      playwrightMcpEnabled: true,
     });
   });
 
@@ -74,7 +74,7 @@ describe("loadConfig runner providers", () => {
     process.env.JUNIOR_OPENCODE_PERMISSION = "ask";
     process.env.OPENCODE_MCP_ENABLED = "false";
     process.env.OPENCODE_SLACK_MCP_ENABLED = "0";
-    process.env.OPENCODE_PLAYWRIGHT_MCP_ENABLED = "true";
+    process.env.OPENCODE_PLAYWRIGHT_MCP_ENABLED = "false";
 
     const config = loadConfig();
 
@@ -85,7 +85,7 @@ describe("loadConfig runner providers", () => {
       permission: "ask",
       mcpEnabled: false,
       slackMcpEnabled: false,
-      playwrightMcpEnabled: true,
+      playwrightMcpEnabled: false,
     });
   });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -138,7 +138,7 @@ export function loadConfig(): Config {
       slackMcpEnabled: parseBooleanEnv("OPENCODE_SLACK_MCP_ENABLED", true),
       playwrightMcpEnabled: parseBooleanEnv(
         "OPENCODE_PLAYWRIGHT_MCP_ENABLED",
-        false,
+        true,
       ),
     },
     repos: (JSON.parse(optional("REPOS", "[]")) as RepoConfig[]).map((r) => ({

--- a/src/opencode/config.test.ts
+++ b/src/opencode/config.test.ts
@@ -58,6 +58,51 @@ describe("OpenCode config generation", () => {
     ]);
   });
 
+  it("includes generated subagent prompts", () => {
+    const config = buildOpenCodeConfig({
+      agentName: "build",
+      agentPrompt: "Prompt",
+      permission: "allow",
+      subagents: [
+        {
+          name: "nr-research",
+          description: "New Relic research",
+          prompt: "Research prompt",
+        },
+      ],
+    });
+
+    expect(config.agent["nr-research"]).toEqual({
+      description: "New Relic research",
+      mode: "subagent",
+      permission: { "*": "allow" },
+      prompt: "Research prompt",
+    });
+  });
+
+  it("rejects subagents that collide with the primary agent", () => {
+    expect(() =>
+      buildOpenCodeConfig({
+        agentName: "build",
+        agentPrompt: "Prompt",
+        subagents: [{ name: "build", prompt: "Other prompt" }],
+      }),
+    ).toThrow('OpenCode subagent "build" conflicts with primary agent');
+  });
+
+  it("rejects duplicate subagent names", () => {
+    expect(() =>
+      buildOpenCodeConfig({
+        agentName: "build",
+        agentPrompt: "Prompt",
+        subagents: [
+          { name: "nr-research", prompt: "One" },
+          { name: "nr-research", prompt: "Two" },
+        ],
+      }),
+    ).toThrow('Duplicate OpenCode subagent "nr-research"');
+  });
+
   it("serializes OPENCODE_CONFIG_CONTENT JSON", () => {
     const content = buildOpenCodeConfigContent({
       agentName: "build",

--- a/src/opencode/config.ts
+++ b/src/opencode/config.ts
@@ -1,5 +1,6 @@
 export type OpenCodePermissionConfig = string | Record<string, unknown>;
 type OpenCodeAgentPermissionConfig = Record<string, unknown>;
+type OpenCodeAgentMode = "primary" | "subagent";
 
 export interface OpenCodeMcpEntry {
   type?: string;
@@ -18,28 +19,36 @@ export interface BuildOpenCodeConfigOptions {
   permission?: OpenCodePermissionConfig;
   description?: string;
   mcp?: OpenCodeMcpConfig | null;
+  subagents?: OpenCodeSubagentConfig[];
+}
+
+export interface OpenCodeSubagentConfig {
+  name: string;
+  prompt: string;
+  description?: string;
+  permission?: OpenCodePermissionConfig;
+}
+
+export interface OpenCodeGeneratedAgentConfig {
+  description: string;
+  mode: OpenCodeAgentMode;
+  permission: OpenCodeAgentPermissionConfig;
+  prompt: string;
 }
 
 export interface OpenCodeGeneratedConfig {
   $schema: string;
   model?: string;
   permission: OpenCodePermissionConfig;
-  agent: Record<
-    string,
-    {
-      description: string;
-      mode: "primary";
-      permission: OpenCodeAgentPermissionConfig;
-      prompt: string;
-    }
-  >;
+  agent: Record<string, OpenCodeGeneratedAgentConfig>;
   mcp?: OpenCodeMcpConfig;
 }
 
 export function buildOpenCodeConfig(
   options: BuildOpenCodeConfigOptions,
 ): OpenCodeGeneratedConfig {
-  if (!options.agentName.trim()) {
+  const primaryAgentName = options.agentName.trim();
+  if (!primaryAgentName) {
     throw new Error("OpenCode agentName is required");
   }
 
@@ -47,7 +56,7 @@ export function buildOpenCodeConfig(
     $schema: "https://opencode.ai/config.json",
     permission: options.permission ?? "allow",
     agent: {
-      [options.agentName]: {
+      [primaryAgentName]: {
         description: options.description ?? "Junior Slack runner",
         mode: "primary",
         permission: toAgentPermissionConfig(options.permission ?? "allow"),
@@ -55,6 +64,28 @@ export function buildOpenCodeConfig(
       },
     },
   };
+
+  for (const subagent of options.subagents ?? []) {
+    const name = subagent.name.trim();
+    if (!name) {
+      throw new Error("OpenCode subagent name is required");
+    }
+    if (name === primaryAgentName) {
+      throw new Error(`OpenCode subagent "${name}" conflicts with primary agent`);
+    }
+    if (config.agent[name]) {
+      throw new Error(`Duplicate OpenCode subagent "${name}"`);
+    }
+
+    config.agent[name] = {
+      description: subagent.description ?? `Junior support subagent: ${name}`,
+      mode: "subagent",
+      permission: toAgentPermissionConfig(
+        subagent.permission ?? options.permission ?? "allow",
+      ),
+      prompt: subagent.prompt,
+    };
+  }
 
   if (options.model) {
     config.model = options.model;

--- a/src/opencode/spawner.test.ts
+++ b/src/opencode/spawner.test.ts
@@ -29,7 +29,7 @@ describe("spawnOpenCode", () => {
     expect(configContent).toBeDefined();
     const parsed = JSON.parse(configContent!);
 
-    expect(Object.keys(parsed.agent)).toEqual(["build"]);
+    expect(parsed.agent.build).toBeDefined();
     const prompt = parsed.agent.build.prompt as string;
     expect(prompt).toContain("Slack-controlled coding agent");
     expect(prompt).toContain("<junior-core>");
@@ -63,5 +63,93 @@ describe("spawnOpenCode", () => {
     const parsed = JSON.parse(configContent!);
     const prompt = parsed.agent.build.prompt as string;
     expect(prompt).toContain("<junior-active-agent>build</junior-active-agent>");
+  });
+
+  it("includes Slack MCP for non-utility root runs", async () => {
+    const session = createSession("thread-1", "C01");
+    session.provider = "opencode";
+
+    let configContent: string | undefined;
+    const handle = spawnOpenCode(
+      session,
+      "intake bug",
+      {
+        command: "/usr/bin/true",
+        mcp: {
+          "slack-bot": {
+            type: "remote",
+            url: "http://localhost:3456/mcp",
+            enabled: true,
+          },
+        },
+        env: (_env) => {
+          configContent = _env.OPENCODE_CONFIG_CONTENT;
+        },
+      },
+    );
+
+    await handle.result;
+
+    const parsed = JSON.parse(configContent!);
+    expect(parsed.mcp["slack-bot"]).toEqual({
+      type: "remote",
+      url: "http://localhost:3456/mcp",
+      enabled: true,
+    });
+  });
+
+  it("keeps the MCP carve-out for utility cwd overrides", async () => {
+    const session = createSession("thread-1", "C01");
+    session.provider = "opencode";
+    session.cwd = "/tmp/junior-utility";
+
+    let configContent: string | undefined;
+    const handle = spawnOpenCode(
+      session,
+      "update calendar",
+      {
+        command: "/usr/bin/true",
+        mcp: {
+          "slack-bot": {
+            type: "remote",
+            url: "http://localhost:3456/mcp",
+            enabled: true,
+          },
+        },
+        env: (_env) => {
+          configContent = _env.OPENCODE_CONFIG_CONTENT;
+        },
+      },
+    );
+
+    await handle.result;
+
+    const parsed = JSON.parse(configContent!);
+    expect(parsed.mcp).toBeUndefined();
+  });
+
+  it("exposes stateless support agents to OpenCode Task", async () => {
+    const session = createSession("thread-1", "C01");
+    session.provider = "opencode";
+
+    let configContent: string | undefined;
+    const handle = spawnOpenCode(
+      session,
+      "run observability",
+      {
+        command: "/usr/bin/true",
+        env: (_env) => {
+          configContent = _env.OPENCODE_CONFIG_CONTENT;
+        },
+      },
+    );
+
+    await handle.result;
+
+    const parsed = JSON.parse(configContent!);
+    expect(parsed.agent["nr-research"].mode).toBe("subagent");
+    expect(parsed.agent["sentry-fetch"].mode).toBe("subagent");
+    expect(parsed.agent["vercel-status"].mode).toBe("subagent");
+    expect(parsed.agent.reproducer).toBeUndefined();
   });
 });

--- a/src/opencode/spawner.test.ts
+++ b/src/opencode/spawner.test.ts
@@ -126,6 +126,9 @@ describe("spawnOpenCode", () => {
 
     const parsed = JSON.parse(configContent!);
     expect(parsed.mcp).toBeUndefined();
+    expect(parsed.agent["nr-research"]).toBeUndefined();
+    expect(parsed.agent["sentry-fetch"]).toBeUndefined();
+    expect(parsed.agent["vercel-status"]).toBeUndefined();
   });
 
   it("exposes stateless support agents to OpenCode Task", async () => {
@@ -148,6 +151,16 @@ describe("spawnOpenCode", () => {
 
     const parsed = JSON.parse(configContent!);
     expect(parsed.agent["nr-research"].mode).toBe("subagent");
+    expect(parsed.agent["nr-research"].permission).toEqual({
+      read: "allow",
+      glob: "allow",
+      grep: "allow",
+      edit: "deny",
+      write: "deny",
+      bash: "deny",
+      task: "deny",
+      "mcp__*": "allow",
+    });
     expect(parsed.agent["sentry-fetch"].mode).toBe("subagent");
     expect(parsed.agent["vercel-status"].mode).toBe("subagent");
     expect(parsed.agent.reproducer).toBeUndefined();

--- a/src/opencode/spawner.ts
+++ b/src/opencode/spawner.ts
@@ -76,7 +76,9 @@ export function spawnOpenCode(
     // Slack MCP even when cwd is Junior's project root so intake can call
     // register_worktree before any worktree exists.
     mcp: session.cwd ? null : config.mcp,
-    subagents: config.subagents ?? loadOpenCodeSupportSubagents(),
+    subagents: session.cwd
+      ? []
+      : (config.subagents ?? loadOpenCodeSupportSubagents()),
   });
   const env = extendOpenCodeEnv(
     {

--- a/src/opencode/spawner.ts
+++ b/src/opencode/spawner.ts
@@ -6,6 +6,7 @@ import {
   buildOpenCodeConfigContent,
   type OpenCodeMcpConfig,
   type OpenCodePermissionConfig,
+  type OpenCodeSubagentConfig,
 } from "./config.ts";
 import {
   createOpenCodeEventMapper,
@@ -13,6 +14,7 @@ import {
   type OpenCodeEvent,
 } from "./parser.ts";
 import { buildOpenCodeAgentPrompt, OPENCODE_PROVIDER_AGENT } from "./prompt.ts";
+import { loadOpenCodeSupportSubagents } from "./support-agents.ts";
 
 export interface OpenCodeEnvContext {
   session: ThreadSession;
@@ -36,6 +38,7 @@ export interface OpenCodeSpawnerConfig {
   defaultModel?: string | null;
   permission?: OpenCodePermissionConfig;
   mcp?: OpenCodeMcpConfig | null;
+  subagents?: OpenCodeSubagentConfig[];
   env?: OpenCodeEnvExtension;
 }
 
@@ -67,7 +70,13 @@ export function spawnOpenCode(
     description: config.description,
     model,
     permission: config.permission,
-    mcp: runtime.needsProjectMcp ? config.mcp : null,
+    // OpenCode receives MCP via generated config, not Claude's project
+    // .mcp.json. Keep the utility cwd carve-out (calendar/cloud utilities rely
+    // on their own integrations), but all normal Junior/lead/worker runs need
+    // Slack MCP even when cwd is Junior's project root so intake can call
+    // register_worktree before any worktree exists.
+    mcp: session.cwd ? null : config.mcp,
+    subagents: config.subagents ?? loadOpenCodeSupportSubagents(),
   });
   const env = extendOpenCodeEnv(
     {

--- a/src/opencode/support-agents.ts
+++ b/src/opencode/support-agents.ts
@@ -1,5 +1,16 @@
-import { existsSync, readFileSync } from "node:fs";
+import { readFileSync } from "node:fs";
 import type { OpenCodeSubagentConfig } from "./config.ts";
+
+export const OPENCODE_SUPPORT_SUBAGENT_PERMISSION = {
+  read: "allow",
+  glob: "allow",
+  grep: "allow",
+  edit: "deny",
+  write: "deny",
+  bash: "deny",
+  task: "deny",
+  "mcp__*": "allow",
+} as const;
 
 const STATELESS_SUPPORT_AGENTS = [
   "nr-research",
@@ -9,8 +20,8 @@ const STATELESS_SUPPORT_AGENTS = [
 
 /**
  * OpenCode only sees agents declared in its effective config for the spawned
- * cwd. Junior's stateless observability prompts live under support/agents, not
- * .opencode/agents, so mirror them into generated OPENCODE_CONFIG_CONTENT.
+ * cwd. Junior's stateless observability prompts live under support/agents, so
+ * expose those standalone prompts through generated OPENCODE_CONFIG_CONTENT.
  *
  * Deliberately do NOT expose persistent workers (reproducer/thinker/review)
  * here. Lead must dispatch those through Slack directives so they get their own
@@ -25,11 +36,10 @@ export function loadOpenCodeSupportSubagents(): OpenCodeSubagentConfig[] {
       import.meta.url,
     );
 
-    if (!existsSync(promptPath)) continue;
-
     agents.push({
       name,
       description: `Junior stateless support subagent: ${name}`,
+      permission: OPENCODE_SUPPORT_SUBAGENT_PERMISSION,
       prompt: readFileSync(promptPath, "utf8").trim(),
     });
   }

--- a/src/opencode/support-agents.ts
+++ b/src/opencode/support-agents.ts
@@ -1,0 +1,38 @@
+import { existsSync, readFileSync } from "node:fs";
+import type { OpenCodeSubagentConfig } from "./config.ts";
+
+const STATELESS_SUPPORT_AGENTS = [
+  "nr-research",
+  "sentry-fetch",
+  "vercel-status",
+] as const;
+
+/**
+ * OpenCode only sees agents declared in its effective config for the spawned
+ * cwd. Junior's stateless observability prompts live under support/agents, not
+ * .opencode/agents, so mirror them into generated OPENCODE_CONFIG_CONTENT.
+ *
+ * Deliberately do NOT expose persistent workers (reproducer/thinker/review)
+ * here. Lead must dispatch those through Slack directives so they get their own
+ * session, identity, and audit trail.
+ */
+export function loadOpenCodeSupportSubagents(): OpenCodeSubagentConfig[] {
+  const agents: OpenCodeSubagentConfig[] = [];
+
+  for (const name of STATELESS_SUPPORT_AGENTS) {
+    const promptPath = new URL(
+      `../../support/agents/${name}/prompt.md`,
+      import.meta.url,
+    );
+
+    if (!existsSync(promptPath)) continue;
+
+    agents.push({
+      name,
+      description: `Junior stateless support subagent: ${name}`,
+      prompt: readFileSync(promptPath, "utf8").trim(),
+    });
+  }
+
+  return agents;
+}

--- a/src/runners/runtime.test.ts
+++ b/src/runners/runtime.test.ts
@@ -93,4 +93,39 @@ describe("runner runtime", () => {
     expect(env.JUNIOR_SLACK_USERNAME).toBe("Junior");
     expect(env.JUNIOR_SLACK_ICON_EMOJI).toBeUndefined();
   });
+
+  it("clears inherited Junior Slack identity env when not explicitly set", () => {
+    const previousUsername = process.env.JUNIOR_SLACK_USERNAME;
+    const previousIcon = process.env.JUNIOR_SLACK_ICON_EMOJI;
+    process.env.JUNIOR_SLACK_USERNAME = "Stale Agent";
+    process.env.JUNIOR_SLACK_ICON_EMOJI = ":face_with_cowboy_hat:";
+
+    try {
+      const defaultEnv = buildRunnerEnv(
+        makeSession({ activeAgentName: "default" }),
+        "xoxb-test",
+        { username: "Junior" },
+      );
+      expect(defaultEnv.JUNIOR_SLACK_USERNAME).toBe("Junior");
+      expect(defaultEnv.JUNIOR_SLACK_ICON_EMOJI).toBeUndefined();
+
+      const noIdentityEnv = buildRunnerEnv(
+        makeSession({ activeAgentName: "lead" }),
+        "xoxb-test",
+      );
+      expect(noIdentityEnv.JUNIOR_SLACK_USERNAME).toBeUndefined();
+      expect(noIdentityEnv.JUNIOR_SLACK_ICON_EMOJI).toBeUndefined();
+    } finally {
+      if (previousUsername === undefined) {
+        delete process.env.JUNIOR_SLACK_USERNAME;
+      } else {
+        process.env.JUNIOR_SLACK_USERNAME = previousUsername;
+      }
+      if (previousIcon === undefined) {
+        delete process.env.JUNIOR_SLACK_ICON_EMOJI;
+      } else {
+        process.env.JUNIOR_SLACK_ICON_EMOJI = previousIcon;
+      }
+    }
+  });
 });

--- a/src/runners/runtime.ts
+++ b/src/runners/runtime.ts
@@ -34,6 +34,10 @@ export function resolveRunnerCwd(
 }
 
 export function needsProjectMcp(session: ThreadSession, cwd: string): boolean {
+  // Claude-specific project .mcp.json policy: Claude auto-loads project MCPs
+  // from Junior's root, so it only needs --mcp-config for off-root/worktree
+  // runs. OpenCode generates its MCP config on every normal spawn and uses a
+  // different predicate in src/opencode/spawner.ts.
   return !session.cwd && cwd !== process.cwd();
 }
 
@@ -42,20 +46,26 @@ export function buildRunnerEnv(
   botToken?: string,
   agentIdentity?: AgentIdentity,
 ): Record<string, string> {
-  return {
-    ...process.env,
+  const env: Record<string, string> = {
+    ...(process.env as Record<string, string>),
     JUNIOR_SPAWNED: "1",
     SLACK_CHANNEL: session.channel,
     SLACK_THREAD_TS: session.threadId,
     JUNIOR_AGENT_NAME: session.activeAgentName ?? "lead",
-    ...(agentIdentity
-      ? {
-          JUNIOR_SLACK_USERNAME: agentIdentity.username,
-          ...(agentIdentity.iconEmoji
-            ? { JUNIOR_SLACK_ICON_EMOJI: agentIdentity.iconEmoji }
-            : {}),
-        }
-      : {}),
     ...(botToken ? { SLACK_BOT_TOKEN: botToken } : {}),
   };
+
+  if (agentIdentity) {
+    env.JUNIOR_SLACK_USERNAME = agentIdentity.username;
+    if (agentIdentity.iconEmoji) {
+      env.JUNIOR_SLACK_ICON_EMOJI = agentIdentity.iconEmoji;
+    } else {
+      delete env.JUNIOR_SLACK_ICON_EMOJI;
+    }
+  } else {
+    delete env.JUNIOR_SLACK_USERNAME;
+    delete env.JUNIOR_SLACK_ICON_EMOJI;
+  }
+
+  return env;
 }


### PR DESCRIPTION
## Summary
- Include generated OpenCode MCP config for normal non-utility runs, including initial lead intake from Junior root.
- Mirror stateless support prompts into generated OpenCode subagents for `nr-research`, `sentry-fetch`, and `vercel-status`.
- Enable Playwright MCP by default for OpenCode parity and update related docs/tests.

## Verification
- `bun run typecheck` (twice)
- `bun test`
- `bun test src/opencode/config.test.ts src/opencode/spawner.test.ts src/config.test.ts` (twice)