### PR TITLE
Fix dormant Slack thread catch-up

### DIFF
--- a/docs/features/codex-runner-codex.md
+++ b/docs/features/codex-runner-codex.md
@@ -1,0 +1,441 @@
+# Codex Runner — Codex Scope
+
+Date: 2026-05-15
+
+This is an independent implementation scope for replacing Junior's hard-coded
+`claude -p` runner with Codex support. It uses
+[`codex-runner.md`](codex-runner.md) as input, but does not treat its architecture
+as fixed.
+
+## Goal
+
+Junior should be able to run Codex as the local coding agent behind the same
+Slack/session experience it has today:
+
+- thread continuity
+- live status updates
+- final Slack responses
+- persistent per-agent sessions
+- worktree safety
+- Slack MCP/tool access where available
+- deterministic process lifecycle and timeout behavior
+
+The immediate goal is not to delete Claude support. The clean replacement path is
+to introduce a runner boundary, make Claude one adapter, make Codex another
+adapter, then switch the default provider once Codex has parity.
+
+## Current Reality
+
+The app is still Claude-shaped at the execution boundary:
+
+- `src/claude/args.ts` builds `claude -p ... --output-format stream-json`.
+- `src/claude/parser.ts` parses Claude stream-json.
+- `src/claude/spawner.ts` owns process launch, cwd selection, env injection,
+  MCP config forwarding, session id capture, and final response capture.
+- `src/session/manager.ts` calls `spawnClaude()` directly and listens for Claude
+  native event shapes.
+- `src/slack/formatting.ts` formats Claude assistant content blocks.
+- `src/lifecycle/timeout.ts` imports Claude spawn types.
+- `src/slack/home.ts` emits `claude --resume <sessionId>` hints.
+- `src/config.ts` only exposes `config.claude`.
+
+There is no `src/runners/` abstraction today.
+
+Important current behavior to preserve:
+
+- `spawnClaude()` injects `JUNIOR_SPAWNED`, Slack channel/thread env vars,
+  `JUNIOR_AGENT_NAME`, and optional agent identity env vars.
+- Worktree-backed runs receive Junior's project `.mcp.json`; `session.cwd`
+  utility runs intentionally skip that MCP config.
+- `SessionManager` stores one native session id per top-level session and one per
+  persistent agent session.
+- First turns get the full Slack/workspace preamble; resumed turns get a smaller
+  workspace block.
+
+## Codex CLI Facts Verified Locally
+
+Verified against `codex-cli 0.130.0`.
+
+Fresh non-interactive run:
+
+```sh
+codex --ask-for-approval never --sandbox read-only --cd /path/to/repo \
+  exec --json --skip-git-repo-check -m <model> "Reply exactly: OK"
+```
+
+Resume run:
+
+```sh
+codex --ask-for-approval never exec resume <thread_id> "next prompt"
+```
+
+JSONL event shape:
+
+```json
+{"type":"thread.started","thread_id":"019e29f4-7651-7673-8754-46600d48c139"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"OK"}}
+{"type":"turn.completed","usage":{"input_tokens":13012,"cached_input_tokens":2432,"output_tokens":22,"reasoning_output_tokens":15}}
+```
+
+Command events:
+
+```json
+{"type":"item.started","item":{"id":"item_2","type":"command_execution","command":"/bin/zsh -lc pwd","aggregated_output":"","exit_code":null,"status":"in_progress"}}
+{"type":"item.completed","item":{"id":"item_2","type":"command_execution","command":"/bin/zsh -lc pwd","aggregated_output":"/path\n","exit_code":0,"status":"completed"}}
+```
+
+Critical flag details:
+
+- `--ask-for-approval` is a top-level Codex flag. Put it before `exec`.
+- `--sandbox` is accepted before `exec`; use explicit values, not `--full-auto`.
+- `--full-auto` is not present in `codex exec --help` for 0.130.0.
+- `--image` / `-i` attaches image files. Use this instead of only putting image
+  paths into prompt text.
+- `--ignore-user-config` exists, but using it means Junior must inject all Codex
+  config it needs.
+- `--ephemeral` disables session persistence. Do not use it for Slack thread
+  sessions that need resume.
+- `codex exec` can read stdin. The spawner should set stdin to ignored/closed so
+  service stdin or hook output cannot contaminate the prompt.
+
+## Architecture Decision
+
+Add a provider-neutral runner contract and adapt native events at the edge.
+
+Do not make Slack/session code understand Claude and Codex native schemas. That
+will leak provider details everywhere and make the second provider brittle.
+
+Recommended app-level event model:
+
+```ts
+export type RunnerProvider = "claude" | "codex";
+
+export type RunnerEvent =
+  | { type: "init"; provider: RunnerProvider; sessionId: string }
+  | { type: "message"; provider: RunnerProvider; text: string }
+  | {
+      type: "tool";
+      provider: RunnerProvider;
+      name: string;
+      input: Record<string, unknown>;
+      status?: "started" | "completed";
+    }
+  | { type: "done"; provider: RunnerProvider; usage?: Record<string, unknown> };
+
+export interface SpawnResult {
+  provider: RunnerProvider;
+  sessionId: string | null;
+  response: string;
+  events: RunnerEvent[];
+  exitCode: number | null;
+  error: string | null;
+}
+```
+
+Keep provider-native event types inside adapter modules and adapter tests.
+
+## Session Shape
+
+Add provider metadata beside the existing native id:
+
+```ts
+provider: "claude" | "codex";
+sessionId: string | null;
+```
+
+For persistent agent sessions, add the same provider field:
+
+```ts
+agentSessions[name].provider
+agentSessions[name].sessionId
+```
+
+Reasoning:
+
+- Keeping a single native id field minimizes migration risk.
+- The provider field makes resume hints and future migrations unambiguous.
+- Mixing providers inside the same native conversation should be disallowed. A
+  provider switch starts a new native session id unless explicitly migrated.
+
+Migration default: existing sessions normalize to `provider: "claude"`.
+
+## Codex Prompt Strategy
+
+Claude has `--append-system-prompt`; Codex CLI does not expose an equivalent.
+
+For v1:
+
+- On first turn, prepend Junior's composed agent prompt to the user prompt in a
+  clearly delimited block.
+- On resumed turns, do not prepend the full agent prompt again.
+- Continue injecting the workspace safety block on resumed turns, matching the
+  current manager behavior.
+
+Example wrapper:
+
+```text
+<junior-agent-instructions>
+...
+</junior-agent-instructions>
+
+<user-request>
+...
+</user-request>
+```
+
+Do not generate or mutate `AGENTS.md` in target repos for v1. That is powerful,
+but it creates cleanup and ownership questions. Use prompt composition first.
+
+## Codex Spawner Requirements
+
+`spawnCodex()` should mirror the operational responsibilities of
+`spawnClaude()`:
+
+- choose cwd as `session.cwd ?? session.worktreePath ?? targetRepoCwd ?? process.cwd()`
+- create `session.cwd` if needed
+- pass `--cd <cwd>` even when spawn cwd is also set
+- set stdin to ignored/closed
+- inject the same Junior/Slack env vars as Claude
+- parse stdout JSONL incrementally
+- capture `thread.started.thread_id` as `sessionId`
+- use the last completed `agent_message` as the response candidate
+- collect stderr for non-zero exit
+- expose `kill()` and `pid`
+
+Suggested fresh args:
+
+```ts
+[
+  "--ask-for-approval", config.codex.askForApproval,
+  "--sandbox", config.codex.sandbox,
+  ...(config.codex.search ? ["--search"] : []),
+  "exec",
+  "--json",
+  "--cd", cwd,
+  ...(config.codex.skipGitRepoCheck ? ["--skip-git-repo-check"] : []),
+  ...(config.codex.ignoreUserConfig ? ["--ignore-user-config"] : []),
+  ...(model ? ["--model", model] : []),
+  ...imageArgs,
+  prompt,
+]
+```
+
+Suggested resume args:
+
+```ts
+[
+  "--ask-for-approval", config.codex.askForApproval,
+  "--sandbox", config.codex.sandbox,
+  ...(config.codex.search ? ["--search"] : []),
+  "exec",
+  "resume",
+  "--json",
+  ...(model ? ["--model", model] : []),
+  ...imageArgs,
+  session.sessionId,
+  prompt,
+]
+```
+
+Before implementation, verify whether `exec resume` accepts `--cd`; the current
+help output does not list it for the resume subcommand. If not, rely on spawn cwd
+for resumed turns.
+
+## MCP Strategy
+
+Claude consumes Junior's `.mcp.json` directly. Codex does not.
+
+Do not rely on a developer's global `~/.codex/config.toml` for Junior runtime.
+There are two viable approaches:
+
+1. Generate a temporary `CODEX_HOME` per Junior process or per spawn, containing
+   a Codex config with the needed MCP servers.
+2. Use Codex `-c key=value` overrides if the MCP config schema is verified.
+
+Preferred v1: generated `CODEX_HOME`.
+
+Reasoning:
+
+- It avoids mutating user global config.
+- It makes service behavior reproducible.
+- It can be tested by inspecting a generated config file.
+- It does not depend on undocumented dotted `-c` keys for MCP server tables.
+
+Minimum MCP parity target:
+
+- Slack bot MCP HTTP server: `http://localhost:3456/mcp`
+- Playwright MCP stdio server: `npx @playwright/mcp --headless`
+
+Validation task:
+
+- Run a Codex spawn in a test thread and confirm the model can see/call the
+  Slack MCP tool. Record the actual Codex tool names; do not assume Claude's
+  `mcp__slack-bot__*` naming.
+
+## Slack Formatting
+
+Slack should consume normalized events:
+
+- `message` events update live status with assistant text.
+- `tool` events update live status with provider-neutral tool labels.
+- `init` events update stored native session id.
+- `done` events are mostly for usage/logging.
+
+Codex mapping:
+
+- `item.completed` + `agent_message` -> `message`
+- `item.started` + `command_execution` -> `tool` with name `Bash`, status
+  `started`, input `{ command }`
+- `item.completed` + `command_execution` -> `tool` with name `Bash`, status
+  `completed`, input `{ command, exit_code }`
+- `thread.started` -> `init`
+- `turn.completed` -> `done`
+
+Claude mapping:
+
+- `system/init` -> `init`
+- assistant text blocks -> `message`
+- assistant `tool_use` blocks -> `tool`
+- `result` -> `done` plus final response capture in the adapter
+
+## Provider Selection
+
+Start with global selection:
+
+```env
+RUNNER_PROVIDER=claude|codex
+```
+
+Then add thread-level selection:
+
+```text
+!provider claude
+!provider codex
+```
+
+Thread-level switching rules:
+
+- If a thread has no native session id, switch provider immediately.
+- If a thread already has a native session id for a different provider, require
+  `!reset all` or a new `!provider <name> --reset` command.
+- Status/home output must show provider and correct resume hint.
+
+Resume hints:
+
+```text
+claude --resume <sessionId>
+codex exec resume <sessionId>
+```
+
+## Implementation Plan
+
+### 1. Runner Contract
+
+- Add `src/runners/types.ts`.
+- Move `SpawnHandle` and `SpawnResult` out of Claude-native types.
+- Update `lifecycle/timeout.ts`, `SessionManager`, and tests to use runner
+  types.
+- Keep runtime behavior Claude-only.
+
+Exit criteria:
+
+- Existing tests pass.
+- No Slack/session code imports `src/claude/types.ts`.
+
+### 2. Claude Adapter
+
+- Keep existing Claude parser and args builder.
+- Add a mapper from Claude stream events to normalized runner events.
+- Make `spawnClaude()` return normalized events.
+- Update Slack formatting to consume `RunnerEventTool` and
+  `RunnerEventMessage`.
+
+Exit criteria:
+
+- Existing Claude behavior unchanged.
+- Slack formatting tests cover normalized events.
+
+### 3. Codex Parser and Args
+
+- Add `src/codex/parser.ts`.
+- Add `src/codex/args.ts`.
+- Fixture-test plain response, command execution, malformed JSON, and split
+  chunks.
+- Unit-test fresh vs resume arg placement, especially top-level
+  `--ask-for-approval`.
+
+Exit criteria:
+
+- Parser captures thread id, messages, command status, and usage.
+- Args do not use `--ephemeral` for resumable sessions.
+
+### 4. Codex Spawner
+
+- Add `src/codex/spawner.ts`.
+- Mirror Claude env injection and lifecycle.
+- Set stdin closed/ignored.
+- Capture stderr and non-zero exits.
+- Add smoke test script or documented manual command.
+
+Exit criteria:
+
+- `RUNNER_PROVIDER=codex` can answer a Slack thread with a final message.
+- Session id is persisted and a second message resumes the same Codex thread.
+
+### 5. Config and Provider Selection
+
+- Add `config.runner.provider`.
+- Add `config.codex`.
+- Add `provider` to `ThreadSession` and `AgentSession`, defaulting old sessions
+  to Claude.
+- Add `!provider` command and home/status display.
+
+Exit criteria:
+
+- A Claude thread and Codex thread can coexist.
+- Provider switching cannot accidentally resume a Claude id with Codex or vice
+  versa.
+
+### 6. MCP and Attachments
+
+- Generate deterministic Codex MCP config through `CODEX_HOME` or verified
+  config overrides.
+- Pass image files with `--image`.
+- Keep prompt path fallback only as extra context.
+
+Exit criteria:
+
+- Codex can call Slack MCP from a Junior-spawned run.
+- Slack image attachment workflow works with Codex.
+
+## Tests to Add
+
+- Codex parser fixtures: simple answer, command execution, unknown event, split
+  JSON line.
+- Codex args: fresh run, resume run, image args, model override, permission
+  flags, cwd behavior.
+- Session manager: provider persisted, provider mismatch blocked, resume id
+  captured from normalized `init`.
+- Slack formatting: normalized Bash/tool/message events.
+- Home tab: provider-specific resume hints.
+
+## Main Risks
+
+- Codex MCP config is not Claude `.mcp.json`; deterministic setup is the largest
+  parity gap.
+- Prompt-injected "system" instructions are weaker than Claude's
+  `--append-system-prompt`.
+- Codex CLI flags can move; keep args tests small and fixture-driven.
+- Running with inherited stdin can accidentally feed Codex unrelated input.
+- Resuming Codex under a service user depends on that user's `$CODEX_HOME`
+  permissions and session storage.
+
+## Recommended First Patch
+
+Do not start with `spawnCodex()`.
+
+Start by extracting the runner contract and normalizing Claude events while
+keeping Claude as the only provider. That reduces the blast radius and gives the
+Codex adapter a stable target. Once Slack/session code no longer imports Claude
+native event types, Codex is a contained adapter rather than an app-wide rewrite.

--- a/docs/features/codex-runner.md
+++ b/docs/features/codex-runner.md
@@ -1,0 +1,359 @@
+# Codex Runner
+
+> Last audited 2026-05-15 against `src/` at `4aa25ab` (main) and `codex-cli 0.130.0`. Original draft 2026-04-28 against `codex-cli 0.125.0`.
+
+## Problem
+
+Junior currently assumes Claude Code is the only local coding agent. The execution layer, session IDs, streamed events, Slack status formatting, MCP wiring, and resume hints are all shaped around `claude -p --output-format stream-json`.
+
+We want Junior to be able to run Codex as well, without forking the whole app or making Slack/session code understand every provider's native event format.
+
+**Who has this problem:** Anyone who wants to choose Codex for a Junior thread, channel, or agent type.
+**What happens today:** Junior always calls `spawnClaude()` and parses Claude stream-json.
+**Painful part:** Codex has equivalents for the core runner features, but its CLI flags, JSONL stream schema, permissions model, and MCP configuration are different enough that it is not a drop-in replacement.
+**"Finally" moment:** Junior can run either Claude or Codex behind the same session manager contract, while Slack still gets useful live status updates and final responses.
+
+## Current Claude Surface
+
+Junior's Claude-specific behavior lives primarily in `src/claude`:
+
+- `args.ts` builds `claude` flags: `-p`, `--output-format stream-json`, `--verbose`, `--max-turns`, `--resume`, `--append-system-prompt`, `--model`, `--permission-mode`, `--mcp-config`.
+- `spawner.ts` starts `claude`, selects cwd, injects Slack env (`SLACK_BOT_TOKEN`, `SLACK_CHANNEL`, `SLACK_THREAD_TS`) plus Junior env (`JUNIOR_SPAWNED=1`, `JUNIOR_AGENT_NAME`, identity vars `JUNIOR_SLACK_USERNAME` / `JUNIOR_SLACK_ICON_EMOJI`), parses stdout, captures session ID and final response.
+- `parser.ts` parses Claude JSONL events.
+- `types.ts` defines the event model consumed by session lifecycle and Slack formatting.
+
+Claude assumptions also leak into:
+
+- `src/session/manager.ts` imports `spawnClaude` and Claude event types.
+- `src/slack/formatting.ts` expects Claude `assistant.message.content` blocks and `tool_use` blocks.
+- `src/slack/home.ts` prints `claude --resume <sessionId>`.
+- `src/lifecycle/timeout.ts` and several test files import Claude types directly.
+- `src/config.ts` exposes only `config.claude` (`maxTurns`, `timeoutMs`, `permissionMode`, `defaultModel`).
+- `src/agents/router.ts` looks for repo-local agent definitions under `.claude/agents`.
+- `.mcp.json` at the junior repo root is passed to Claude with `--mcp-config`.
+
+**Two behaviors worth preserving in any port:**
+
+- **`session.cwd` override bypasses MCP config.** Spawner skips `--mcp-config` when `session.cwd` is set (utility commands need cloud integrations, not local MCP). The Codex spawner needs the same carve-out.
+- **MCP config is project-wide, not per-thread.** Despite CLAUDE.md rule #9 saying "MCP config is per-thread", the spawner today reads a single `PROJECT_MCP_CONFIG` resolved from the junior repo root. Either fix the rule or fix the code before layering Codex on top of an unstated discrepancy.
+
+## Codex Equivalents
+
+Re-checked against `codex-cli 0.130.0`. Confirmed flags marked ✓; flags that drifted from the 0.125.0 draft are flagged.
+
+| Junior/Claude usage | Codex equivalent | Notes |
+|---|---|---|
+| `claude -p <prompt>` | `codex exec <prompt>` | ✓ Non-interactive runner. |
+| `--output-format stream-json` | `codex exec --json` | ✓ Emits JSONL with a different schema (see below). |
+| `--resume <sessionId>` | `codex exec resume <session_id> <prompt>` | ✓ Accepts UUID or thread name; `--last` picks most recent. |
+| Claude init `session_id` | `thread.started.thread_id` | Store in Junior's existing session ID field. |
+| Claude final `result.result` | Last completed `agent_message`, or `--output-last-message <file>` | Prefer stream parsing for live Slack updates. |
+| `--model <model>` | `-m, --model <model>` | ✓ Direct equivalent. |
+| Process cwd | `-C, --cd <dir>` plus spawn cwd | Pass explicit `--cd` for clarity. New in 0.130.0: `--add-dir <DIR>` for extra writable dirs. |
+| Image file paths in prompt | `-i, --image <FILE>...` | ✓ Variadic. Better than telling Codex to read paths manually. |
+| `--permission-mode bypassPermissions` | `--sandbox workspace-write` + global `--ask-for-approval never` | **Drift:** `--full-auto` is no longer in `codex exec --help`. Don't depend on it. |
+| `--mcp-config .mcp.json` | `-c key=value` overrides + `--ignore-user-config` | **New in 0.130.0**, see "MCP Configuration" — resolves the original "ephemeral config" open question. |
+| `--append-system-prompt` | No CLI flag. Compose into first turn, or use `AGENTS.md` in the worktree | Same recommendation as 0.125.0. |
+| `--max-turns` | No equivalent | Timeout remains Junior's outer guard. |
+
+**Top-level vs per-exec flags — easy silent misconfig:** `--ask-for-approval` is a **global** flag. Place it before the subcommand: `codex --ask-for-approval never exec ...`. Putting it after `exec` won't error, but the approval policy may not apply.
+
+## Codex JSONL Shape
+
+Re-verified 2026-05-15 — the shape from the original draft is unchanged. `codex --ask-for-approval never exec --json --ephemeral --skip-git-repo-check --sandbox read-only "Reply exactly: OK"` emits:
+
+```json
+{"type":"thread.started","thread_id":"019dd2c8-5b26-7d70-b7a1-89232b0f9db9"}
+{"type":"turn.started"}
+{"type":"item.completed","item":{"id":"item_0","type":"agent_message","text":"OK"}}
+{"type":"turn.completed","usage":{"input_tokens":11536,"cached_input_tokens":10112,"output_tokens":26,"reasoning_output_tokens":19}}
+```
+
+When Codex runs a shell command:
+
+```json
+{"type":"item.started","item":{"id":"item_1","type":"command_execution","command":"/bin/zsh -lc pwd","aggregated_output":"","exit_code":null,"status":"in_progress"}}
+{"type":"item.completed","item":{"id":"item_1","type":"command_execution","command":"/bin/zsh -lc pwd","aggregated_output":"/Users/psbakre/Projects/junior\n","exit_code":0,"status":"completed"}}
+```
+
+Junior needs a Codex parser and a provider-neutral normalized event model. Pretending Codex events are Claude `assistant` events will make Slack formatting brittle.
+
+## Proposed Architecture
+
+Introduce a runner abstraction. **Status:** `src/runners/` does not yet exist. The whole abstraction is greenfield.
+
+```ts
+export type RunnerProvider = "claude" | "codex";
+
+export interface RunnerEventInit {
+  type: "init";
+  provider: RunnerProvider;
+  sessionId: string;
+}
+
+export interface RunnerEventMessage {
+  type: "message";
+  provider: RunnerProvider;
+  text: string;
+}
+
+export interface RunnerEventTool {
+  type: "tool";
+  provider: RunnerProvider;
+  name: string;
+  input: Record<string, unknown>;
+  status?: "started" | "completed";
+}
+
+export interface RunnerEventDone {
+  type: "done";
+  provider: RunnerProvider;
+  usage?: Record<string, unknown>;
+}
+
+export type RunnerEvent =
+  | RunnerEventInit
+  | RunnerEventMessage
+  | RunnerEventTool
+  | RunnerEventDone;
+
+export interface SpawnResult {
+  provider: RunnerProvider;
+  sessionId: string | null;
+  response: string;
+  events: RunnerEvent[];
+  exitCode: number | null;
+  error: string | null;
+}
+```
+
+Then:
+
+- Move `src/claude/*` under `src/runners/claude` as a thin port of the current implementation.
+- Add `src/runners/codex` with its own args builder, parser, and spawner.
+- Update `SessionManager` to depend on a `spawnRunner()` function rather than `spawnClaude()`.
+- Update Slack formatting to consume normalized `RunnerEventTool` and `RunnerEventMessage`.
+- Keep provider-native raw events inside adapter tests, not in app-level types.
+- The Codex spawner must inject the same env vars the Claude spawner does today: `JUNIOR_SPAWNED`, `JUNIOR_AGENT_NAME`, `JUNIOR_SLACK_USERNAME`, `JUNIOR_SLACK_ICON_EMOJI`, plus the Slack trio. Sub-agents read these to attribute Slack posts; missing them is a silent attribution bug.
+
+## MCP Configuration
+
+Current `.mcp.json` (unchanged):
+
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["@playwright/mcp", "--headless"]
+    },
+    "slack-bot": {
+      "type": "http",
+      "url": "http://localhost:3456/mcp"
+    }
+  }
+}
+```
+
+Claude consumes this with `--mcp-config`. Codex doesn't accept Claude's file format, but **0.130.0's `-c key=value` overrides + `--ignore-user-config` together solve the ephemeral-config problem** that the original draft left open. Per-spawn:
+
+```sh
+codex --ask-for-approval never exec \
+  --json --skip-git-repo-check --ignore-user-config \
+  -c 'mcp_servers.slack-bot.url="http://localhost:3456/mcp"' \
+  -c 'mcp_servers.slack-bot.transport="http"' \
+  -c 'mcp_servers.playwright.command="npx"' \
+  -c 'mcp_servers.playwright.args=["@playwright/mcp","--headless"]' \
+  --sandbox workspace-write -m <model> "<prompt>"
+```
+
+This means:
+
+- Junior never mutates the developer's `~/.codex/config.toml`.
+- The MCP set per spawn is reproducible from the args alone.
+- The original Iter 5 ("MCP parity") mostly collapses into Iter 2 ("args builder").
+
+Remaining open: the **tool-name shape** Codex shows the model. Claude exposes MCP tools as `mcp__<server>__<tool>`. Verify Codex's naming so prompts and prohibitions still match.
+
+**Alternative integration shape worth noting:** `codex mcp-server` (top-level subcommand new in 0.130.0) runs Codex itself as an MCP server. Junior could expose Codex as a tool to Claude rather than as a peer runner. That's a different architecture — flagged here, not planned.
+
+## Agent Prompts
+
+Claude supports `--append-system-prompt`, used for `.claude/agents/<agent>.md`. Codex still has no equivalent flag. Options:
+
+1. Compose Junior's agent prompt into the first user prompt.
+2. Generate an `AGENTS.md` in each worktree for Codex runs (`AGENTS.md` discovery is real in Codex).
+3. Add Codex-specific agent definitions later if Codex-native subagent support becomes useful.
+
+Recommended v1: compose the agent prompt into the first user prompt, preserving the existing `AgentRouter` behavior. Provider-independent, no per-worktree side effects.
+
+## Permission Model
+
+Claude today uses `--permission-mode bypassPermissions`. Codex 0.130.0 provides:
+
+- `-s, --sandbox read-only`
+- `-s, --sandbox workspace-write`
+- `-s, --sandbox danger-full-access`
+- `--dangerously-bypass-approvals-and-sandbox`
+- global `--ask-for-approval never|on-request|untrusted` (note: top-level, not per-exec)
+
+`--full-auto` from the original draft is **not** in `codex exec --help` output — treat it as removed. Use the explicit `--sandbox workspace-write` + `--ask-for-approval never` combination instead.
+
+Recommended v1:
+
+- For code worktrees: `--sandbox workspace-write` + global `--ask-for-approval never`.
+- For read-only/review agents: `--sandbox read-only` + global `--ask-for-approval never`.
+- Avoid `--dangerously-bypass-approvals-and-sandbox` unless Junior is running in an external sandbox.
+- Keep Junior's worktree safety rule as the primary guard against editing shared repo roots.
+
+## New Codex Flags Worth Knowing (0.125.0 → 0.130.0)
+
+None of these existed when the original draft was written:
+
+- `--ephemeral` — skip session persistence. Useful for one-shot reads.
+- `--skip-git-repo-check` — needed when Junior runs in non-git cwds.
+- `--ignore-user-config` — load no `~/.codex/config.toml`. Pair with `-c` for fully deterministic spawns.
+- `--ignore-rules` — bypass project `.rules` execpolicy files.
+- `--add-dir <DIR>` — extra writable dirs alongside primary workspace. Relevant for shared-workspace sub-agent flows.
+- `--output-schema <FILE>` — JSON Schema for final response. Could replace ad-hoc parsing for structured agent results.
+- `--enable <feature>` / `--disable <feature>` — feature flags surface; check `codex features` before relying on any.
+- `-p, --profile` — config.toml profile selector. Conflicts notation-wise with Claude's `-p` (prompt); be careful in shared docs and helpers.
+
+New top-level subcommands of interest (won't drive v1 but worth knowing):
+
+- `codex mcp-server` — Codex as an MCP server (stdio).
+- `codex apply` — apply Codex's last diff via `git apply`.
+- `codex exec-server` (experimental) — long-lived exec service. Possible future to avoid per-message process spawn cost; not stable.
+
+## Open Questions
+
+| Question | Status |
+|---|---|
+| Provider selection global (`RUNNER_PROVIDER=codex`) or per thread (`!provider codex`)? | Open. |
+| Should `session.sessionId` store provider-native IDs directly, or should `ThreadSession` gain `provider` and provider-specific session ID fields? | Leaning toward single `sessionId` + `provider: "claude" \| "codex"`. |
+| Does Codex reliably persist and resume thread IDs in service mode? | Partial: `--ephemeral` for skip; default sessions persist under `$CODEX_HOME/sessions`. Verify perms when Junior runs as a service user. |
+| Codex web search exposure? | Codex 0.130.0 `exec --help` no longer mentions `--search`. Either gone or moved behind feature flags (`--enable web-search`?). Verify before relying on. |
+| Codex MCP tool naming shape? | Open. Claude uses `mcp__<server>__<tool>`. Run a spawn against the slack-bot MCP and read what Codex actually shows the model. |
+
+Resolved since 0.125.0:
+
+- **"Generate temporary Codex config per spawn":** answered by `-c` overrides + `--ignore-user-config`.
+- **`--image` for Slack image attachments:** still recommended; flag confirmed.
+
+## Iterations
+
+### Iteration 0: Runner Contract (~45 min)
+
+Extract provider-neutral runner types.
+
+**What it adds:**
+- `src/runners/types.ts` with `RunnerEvent`, `SpawnHandle`, `SpawnResult`.
+- App-level code imports runner types, not Claude types.
+
+**Test:** Existing Claude-path tests pass with behavior unchanged.
+
+**Defers:** Codex spawning.
+
+### Iteration 1: Port Claude Adapter (~45 min)
+
+Move current Claude code under `src/runners/claude`.
+
+**What it adds:**
+- Claude adapter maps native Claude events to normalized runner events.
+- Slack formatter consumes normalized events.
+- `SessionManager` still defaults to Claude.
+- `home.ts` resume hint still uses `claude --resume` (changes in Iter 4).
+
+**Test:** Existing Claude parser/args tests pass after path updates. Slack formatting tests assert normalized tool status output.
+
+**Defers:** Provider selection.
+
+### Iteration 1.5: CLAUDE.md Alignment (~15 min)
+
+Before adding a per-thread provider story, fix CLAUDE.md rule #9 ("MCP config is per-thread") to match the current single-`PROJECT_MCP_CONFIG` reality, **or** make the code per-thread first. Don't ship Codex on top of an unstated discrepancy.
+
+### Iteration 2: Codex Args, Parser, MCP Injection (~1.5h)
+
+Build the Codex CLI command and parse JSONL. (Original Iter 2 + Iter 5 merged — `-c` overrides collapse the MCP-parity work.)
+
+**What it adds:**
+- `buildCodexArgs(session, prompt, config)` emitting:
+  - `-c mcp_servers.<name>.*` derived from `.mcp.json`
+  - `--ignore-user-config`
+  - `--json`, `--skip-git-repo-check`
+  - `-m <model>`, `-C <cwd>`
+  - sandbox flags (see Iter 3)
+- `createCodexStreamParser()`:
+  - `thread.started` → `RunnerEventInit`
+  - `item.completed agent_message` → `RunnerEventMessage` and final-response candidate
+  - `item.started` / `item.completed` `command_execution` → `RunnerEventTool` with status
+  - `turn.completed` → `RunnerEventDone` with usage
+
+**Test:** Unit tests using captured JSONL fixtures (capture fresh against the version being shipped — don't reuse 0.125.0 fixtures from this doc).
+
+**Defers:** Real spawning.
+
+### Iteration 3: Codex Spawner (~1h)
+
+Spawn Codex non-interactively.
+
+**What it adds:**
+- `spawnCodex()`:
+  - Top-level `--ask-for-approval never` (NOT per-exec).
+  - `--sandbox workspace-write` for code worktrees, `--sandbox read-only` for review agents.
+  - Supports fresh runs and `exec resume <thread_id> <prompt>`.
+  - Sets cwd via spawn cwd plus `-C`.
+  - Injects `JUNIOR_SPAWNED`, `JUNIOR_AGENT_NAME`, `JUNIOR_SLACK_USERNAME`, `JUNIOR_SLACK_ICON_EMOJI`, `SLACK_BOT_TOKEN`, `SLACK_CHANNEL`, `SLACK_THREAD_TS`.
+  - Honors the `session.cwd` override → no MCP injection (matches Claude carve-out).
+  - Captures stderr and non-zero exits like Claude.
+
+**Test:** Manual smoke test:
+
+```sh
+codex --ask-for-approval never exec --json --ephemeral --skip-git-repo-check --sandbox read-only -m <model> "Reply exactly: OK"
+```
+
+### Iteration 4: Provider Selection (~45 min)
+
+Let Junior choose Claude or Codex.
+
+**What it adds:**
+- Config: `RUNNER_PROVIDER=claude|codex`, plus a `config.codex` block (`timeoutMs`, `defaultModel`, `defaultSandbox`).
+- Optional command: `!provider claude|codex`.
+- Home/status display includes provider.
+- `home.ts` resume hint uses the correct CLI command per provider.
+
+**Test:** Start one thread on Claude and one on Codex. Verify session IDs do not collide and resume commands are correct.
+
+**Defers:** Per-agent provider defaults.
+
+### Iteration 5: Attachments and Agent Prompt Polish (~1h)
+
+Match Junior's existing Claude UX on Codex.
+
+**What it adds:**
+- Use `-i, --image` for Slack image attachments in Codex runs.
+- Ensure agent prompt injection only happens on the first turn (composed into the first user message).
+- On resumed turns, preserve the existing workspace safety block behavior.
+- Verify Codex MCP tool-name shape — update prompts/prohibitions if the naming differs from Claude's `mcp__<server>__<tool>`.
+
+**Test:** Slack image thread works with Codex. Build/review/support-lead prompts still apply across at least one Codex-driven thread.
+
+## Risks
+
+- Codex CLI is moving fast (0.125 → 0.130 in three weeks added several flags and removed `--full-auto`). Keep adapter tests fixture-based and small; recapture fixtures per release before relying on shape claims.
+- Codex session persistence may depend on service-user permissions for `~/.codex/sessions`. Verify before assuming `exec resume` works in production.
+- `-c key=value` overrides depend on TOML parsing on the CLI side. Quote values that contain shell metacharacters; one-line URL configs should be safe.
+- Prompt-injected "system" behavior is weaker than a true system prompt flag.
+- `--ask-for-approval` flag-position mistake (per-exec instead of global) is a silent permission misconfig, not an error. Add a test that asserts the flag's absolute position in `buildCodexArgs` output.
+- Slack status updates will initially be less rich for Codex until more `item` types are mapped.
+
+## Cut List
+
+- Provider-specific subagent orchestration.
+- Automatic migration of all `.claude/agents` into Codex-native files.
+- Full Codex config management UI.
+- Mixing Claude and Codex within the same persisted conversation.
+- `danger-full-access` unattended mode.
+- `codex mcp-server` integration (Codex-as-MCP-tool-for-Claude) — interesting but a different architecture.
+- `codex exec-server` long-lived service — wait for stability.

--- a/src/claude/args.test.ts
+++ b/src/claude/args.test.ts
@@ -21,6 +21,7 @@ function makeSession(overrides: Partial<ThreadSession> = {}): ThreadSession {
     verbosity: "normal",
     muted: false,
     dormant: false,
+    needsThreadCatchup: false,
     dormantAnnounced: false,
     humanParticipants: [],
     model: null,

--- a/src/claude/tmux-driver.test.ts
+++ b/src/claude/tmux-driver.test.ts
@@ -33,6 +33,7 @@ function makeSession(overrides: Partial<ThreadSession> = {}): ThreadSession {
     tmuxSessionName: null,
     topLevelTmuxAgent: null,
     dormant: false,
+    needsThreadCatchup: false,
     dormantAnnounced: false,
     humanParticipants: [],
     ...overrides,

--- a/src/runners/runtime.test.ts
+++ b/src/runners/runtime.test.ts
@@ -24,6 +24,7 @@ function makeSession(overrides: Partial<ThreadSession> = {}): ThreadSession {
     verbosity: "normal",
     muted: false,
     dormant: false,
+    needsThreadCatchup: false,
     dormantAnnounced: false,
     humanParticipants: [],
     model: null,

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -8,6 +8,7 @@ import type {
 import type { SlackMessageEvent } from "../slack/events.ts";
 import type { Config } from "../config.ts";
 import { createSession } from "./types.ts";
+import type { App } from "@slack/bolt";
 
 // --- Mock setup ---
 
@@ -1093,8 +1094,67 @@ describe("SessionManager", () => {
       expect(reactions).toEqual(["ear"]);
       const after = (await store.get("thread-1"))!;
       expect(after.dormant).toBe(false);
+      expect(after.needsThreadCatchup).toBe(true);
       // sticky flag stays — re-trigger is suppressed for life of thread
       expect(after.dormantAnnounced).toBe(true);
+    });
+
+    it("after !listen, next resumed turn sees previous messages except !aside", async () => {
+      manager.slackApp = {
+        client: {
+          users: {
+            info: async ({ user }: { user: string }) => ({
+              user: { profile: { display_name: user } },
+            }),
+          },
+          conversations: {
+            info: async () => ({ channel: { name: "test" } }),
+            replies: async () => ({
+              messages: [
+                { ts: "1", user: "U-A", text: "root" },
+                { ts: "2", user: "U-B", text: "details while dormant" },
+                { ts: "3", user: "U-A", text: "!aside private fix note" },
+                { ts: "4", user: "U-A", text: "!listen" },
+                { ts: "5", user: "U-A", text: "please continue" },
+              ],
+            }),
+          },
+        },
+      } as unknown as App;
+
+      const seeded = createSession(
+        "thread-1",
+        "C123",
+        testConfig.session.defaultVerbosity,
+        testConfig.runner.provider,
+        testConfig.claude.defaultDriver,
+      );
+      seeded.sessionId = "existing-session";
+      seeded.leadSessionId = "existing-session";
+      seeded.humanParticipants = ["U-A", "U-B"];
+      seeded.dormant = true;
+      seeded.dormantAnnounced = true;
+      await store.set("thread-1", seeded);
+
+      await manager.gateAttention(
+        makeEvent({ command: "listen", text: "", user: "U-A", ts: "4" }),
+      );
+
+      currentHandle = createMockHandle();
+      mockSpawnFn = mock(() => currentHandle);
+      await manager.handleMessage(
+        makeEvent({ user: "U-A", text: "please continue", ts: "5" }),
+      );
+      for (let i = 0; i < 10 && mockSpawnFn.mock.calls.length === 0; i++) {
+        await new Promise((r) => setTimeout(r, 5));
+      }
+
+      const prompt = mockSpawnFn.mock.calls[0][1] as string;
+      expect(prompt).toContain("details while dormant");
+      expect(prompt).toContain("!listen");
+      expect(prompt).not.toContain("private fix note");
+      expect(prompt).toContain("please continue");
+      expect((await store.get("thread-1"))!.needsThreadCatchup).toBe(false);
     });
 
     it("@mention wakes dormant and falls through to routing", async () => {

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -39,7 +39,6 @@ import { isDuplicateSlackToolResponse } from "../slack/formatting.ts";
 import { DEFAULT_CONTEXT_PROFILE, type AgentContextProfile } from "../agents/loader.ts";
 import { downloadSlackFiles } from "../slack/files.ts";
 import { log as _log } from "../logger.ts";
-import { isAsideText } from "../slack/commands.ts";
 
 export class SessionManager {
   private store: SessionStore;
@@ -122,7 +121,7 @@ export class SessionManager {
     // alternative (skip tracking) creates a corner where U-B posts only
     // asides, then a real non-mention message, and the gate fails to fire
     // because U-B was never registered as present.
-    if (event.command === "aside" || isAsideText(event.text)) {
+    if (event.command === "aside") {
       const isHuman = !event.isSelfBot && !event.botId;
       if (isHuman && event.user) {
         const session = await this.store.get(event.threadId);

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -39,6 +39,7 @@ import { isDuplicateSlackToolResponse } from "../slack/formatting.ts";
 import { DEFAULT_CONTEXT_PROFILE, type AgentContextProfile } from "../agents/loader.ts";
 import { downloadSlackFiles } from "../slack/files.ts";
 import { log as _log } from "../logger.ts";
+import { isAsideText } from "../slack/commands.ts";
 
 export class SessionManager {
   private store: SessionStore;
@@ -121,7 +122,7 @@ export class SessionManager {
     // alternative (skip tracking) creates a corner where U-B posts only
     // asides, then a real non-mention message, and the gate fails to fire
     // because U-B was never registered as present.
-    if (event.command === "aside") {
+    if (event.command === "aside" || isAsideText(event.text)) {
       const isHuman = !event.isSelfBot && !event.botId;
       if (isHuman && event.user) {
         const session = await this.store.get(event.threadId);
@@ -144,6 +145,7 @@ export class SessionManager {
     if (event.command === "listen") {
       if (session && session.dormant) {
         session.dormant = false;
+        session.needsThreadCatchup = true;
         await this.store.set(event.threadId, session);
       }
       this.onReaction?.(event, "ear");
@@ -154,6 +156,7 @@ export class SessionManager {
     // processed normally.
     if (event.mentionsJunior && session?.dormant) {
       session.dormant = false;
+      session.needsThreadCatchup = true;
       await this.store.set(event.threadId, session);
     }
 
@@ -889,8 +892,21 @@ export class SessionManager {
       // the workspace context at all.
       if (this.slackApp && latestTs) {
         const isFirstTurn = !runSession.sessionId;
+        const needsThreadCatchup = !!session.needsThreadCatchup;
         const readablePrompt = await resolveSlackMentions(this.slackApp, prompt);
-        if (isFirstTurn) {
+        if (isFirstTurn || needsThreadCatchup) {
+          const preambleProfile: AgentContextProfile = needsThreadCatchup
+            ? {
+                ...contextProfile,
+                identity: false,
+                slack: true,
+                threadHistory: true,
+                threadHistoryLimit: Math.max(
+                  contextProfile.threadHistoryLimit,
+                  1000,
+                ),
+              }
+            : contextProfile;
           const preamble = await buildPromptPreamble(
             this.slackApp,
             session.channel,
@@ -900,9 +916,13 @@ export class SessionManager {
             workspace,
             worktreePaths,
             this.config.repos,
-            contextProfile,
+            preambleProfile,
           );
           prompt = preamble ? `${preamble}\n\n${readablePrompt}` : readablePrompt;
+          if (needsThreadCatchup) {
+            session.needsThreadCatchup = false;
+            await this.store.set(session.threadId, session);
+          }
         } else if (contextProfile.workspace) {
           const workspaceBlock = buildWorkspaceBlock(
             workspace,
@@ -1219,6 +1239,7 @@ export class SessionManager {
     session.agentSessions ??= {};
     session.provider ??= "claude";
     session.humanParticipants ??= [];
+    session.needsThreadCatchup ??= false;
 
     // Track human participants for the attention gate. Bots — Junior, its
     // agents, and foreign bots — are excluded by design (see gateAttention).

--- a/src/session/types.test.ts
+++ b/src/session/types.test.ts
@@ -123,6 +123,7 @@ describe("createSession", () => {
       "leadSessionId",
       "model",
       "muted",
+      "needsThreadCatchup",
       "pendingMessages",
       "pid",
       "provider",
@@ -142,6 +143,11 @@ describe("createSession", () => {
   it("has dormant set to false by default", () => {
     const session = createSession("t1", "C01");
     expect(session.dormant).toBe(false);
+  });
+
+  it("has needsThreadCatchup set to false by default", () => {
+    const session = createSession("t1", "C01");
+    expect(session.needsThreadCatchup).toBe(false);
   });
 
   it("has dormantAnnounced set to false by default", () => {

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -90,6 +90,13 @@ export interface ThreadSession {
    */
   dormant: boolean;
   /**
+   * Set when a dormant thread is woken by `!listen` or an @mention. The next
+   * runner turn injects recent Slack thread history even when resuming an
+   * existing model session, so the agent sees messages that arrived while it
+   * was intentionally staying out. Cleared after that catch-up prompt is built.
+   */
+  needsThreadCatchup: boolean;
+  /**
    * Sticky: set once when the attention gate fires its one-shot announcement
    * for this thread, and never reset. Suppresses re-trigger thrashing after
    * the human takes manual action (`!listen` / @mention). If they want to
@@ -168,6 +175,7 @@ export function createSession(
     verbosity: defaultVerbosity,
     muted: false,
     dormant: false,
+    needsThreadCatchup: false,
     dormantAnnounced: false,
     humanParticipants: [],
     model: null,

--- a/src/slack/commands.test.ts
+++ b/src/slack/commands.test.ts
@@ -51,6 +51,13 @@ describe("parseCommand", () => {
     });
   });
 
+  it("parses punctuated !aside as aside", () => {
+    expect(parseCommand("!aside. I need to fix both")).toEqual({
+      command: "aside",
+      text: "I need to fix both",
+    });
+  });
+
   describe("recognizes all known commands", () => {
     const knownCommands = [
       "build",

--- a/src/slack/commands.test.ts
+++ b/src/slack/commands.test.ts
@@ -58,6 +58,24 @@ describe("parseCommand", () => {
     });
   });
 
+  it("parses uppercase !aside as aside", () => {
+    expect(parseCommand("!ASIDE this is a side note")).toEqual({
+      command: "aside",
+      text: "this is a side note",
+    });
+  });
+
+  it("does not parse longer !aside-like words as aside", () => {
+    expect(parseCommand("!asider thing")).toEqual({
+      command: null,
+      text: "!asider thing",
+    });
+    expect(parseCommand("!asides thing")).toEqual({
+      command: null,
+      text: "!asides thing",
+    });
+  });
+
   describe("recognizes all known commands", () => {
     const knownCommands = [
       "build",

--- a/src/slack/commands.ts
+++ b/src/slack/commands.ts
@@ -37,6 +37,10 @@ export interface ParsedCommand {
   text: string;
 }
 
+export function isAsideText(text: string): boolean {
+  return /^!aside(?:$|\s|[.,:;!?-])/i.test(text.trim());
+}
+
 export function parseCommand(text: string): ParsedCommand {
   if (!text.startsWith("!")) {
     return { command: null, text };
@@ -48,6 +52,12 @@ export function parseCommand(text: string): ParsedCommand {
   const remaining = spaceIndex === -1 ? "" : text.slice(spaceIndex + 1).trim();
 
   if (!KNOWN_COMMANDS.has(commandWord)) {
+    if (isAsideText(text)) {
+      return {
+        command: "aside",
+        text: text.replace(/^!aside(?:[.,:;!?-])?\s*/i, "").trim(),
+      };
+    }
     return { command: null, text };
   }
 

--- a/src/slack/commands.ts
+++ b/src/slack/commands.ts
@@ -32,13 +32,19 @@ const KNOWN_COMMANDS = new Set([
   "listen",
 ]);
 
+const ASIDE_PREFIX_RE = /^!aside(?:$|\s|[.,:;!?-]\s*)/i;
+
 export interface ParsedCommand {
   command: string | null;
   text: string;
 }
 
 export function isAsideText(text: string): boolean {
-  return /^!aside(?:$|\s|[.,:;!?-])/i.test(text.trim());
+  return ASIDE_PREFIX_RE.test(text.trim());
+}
+
+function stripAsidePrefix(text: string): string {
+  return text.trim().replace(ASIDE_PREFIX_RE, "").trim();
 }
 
 export function parseCommand(text: string): ParsedCommand {
@@ -55,7 +61,7 @@ export function parseCommand(text: string): ParsedCommand {
     if (isAsideText(text)) {
       return {
         command: "aside",
-        text: text.replace(/^!aside(?:[.,:;!?-])?\s*/i, "").trim(),
+        text: stripAsidePrefix(text),
       };
     }
     return { command: null, text };

--- a/src/slack/thread-context.test.ts
+++ b/src/slack/thread-context.test.ts
@@ -129,4 +129,51 @@ describe("buildPromptPreamble", () => {
 
     expect(observedLimit).toBe(12);
   });
+
+  it("includes previous thread messages but filters !aside messages", async () => {
+    const app = {
+      client: {
+        users: {
+          info: async ({ user }: { user: string }) => ({
+            user: { profile: { display_name: user } },
+          }),
+        },
+        conversations: {
+          replies: async () => ({
+            messages: [
+              { ts: "1", user: "U1", text: "root message" },
+              { ts: "2", user: "U2", text: "dormant detail to keep" },
+              { ts: "3", user: "U3", text: "!aside private aside" },
+              { ts: "4", user: "U4", text: "!aside. punctuated private aside" },
+              { ts: "5", user: "U5", text: "current message" },
+            ],
+          }),
+        },
+      },
+    } as unknown as App;
+
+    const preamble = await buildPromptPreamble(
+      app,
+      "C1",
+      "1",
+      "5",
+      "UBOT",
+      null,
+      undefined,
+      undefined,
+      {
+        identity: false,
+        slack: false,
+        workspace: false,
+        threadHistory: true,
+        threadHistoryLimit: 100,
+        agentState: false,
+      },
+    );
+
+    expect(preamble).toContain("root message");
+    expect(preamble).toContain("dormant detail to keep");
+    expect(preamble).not.toContain("private aside");
+    expect(preamble).not.toContain("User(U5 <@U5>): current message");
+  });
 });

--- a/src/slack/thread-context.ts
+++ b/src/slack/thread-context.ts
@@ -2,6 +2,7 @@ import type { App } from "@slack/bolt";
 import type { RepoConfig } from "../config.ts";
 import { loadPersona } from "../persona.ts";
 import { NO_SLACK_MESSAGE } from "./formatting.ts";
+import { isAsideText } from "./commands.ts";
 import type { AgentContextProfile } from "../agents/loader.ts";
 import { DEFAULT_CONTEXT_PROFILE } from "../agents/loader.ts";
 
@@ -262,6 +263,7 @@ async function fetchThreadHistory(
     // TODO: pre-collect unique user IDs and batch-resolve to avoid Slack rate limits on large threads
     const messages: ThreadMessage[] = await Promise.all(result.messages
       .filter((m) => m.ts !== latestTs)
+      .filter((m) => !isAsideText(m.text ?? ""))
       .map(async (m) => {
         // Extract file names from message attachments
         const files = (m as Record<string, unknown>).files;


### PR DESCRIPTION
## Summary
- Add dormant Slack thread catch-up on !listen/@mention for resumed sessions.
- Filter !aside messages from injected thread history, including punctuated !aside variants.
- Add tests covering catch-up prompts, session defaults, and aside filtering.
- Add Codex runner scope/CLI notes under docs/features.
- Update agents-org to be04031, adding the admin-account worker and tightening credential delivery guidance.

## Verification
- [x] bun run typecheck
- [x] bun test
- [x] bun run typecheck (second pass)
- [x] bun test (second pass)