### PR TITLE
Scope Mixpanel MCP to feature metrics

### DIFF
--- a/bin/opencode-agent-with-mcp.sh
+++ b/bin/opencode-agent-with-mcp.sh
@@ -1,0 +1,256 @@
+#!/bin/bash
+# Launch an OpenCode session with Junior agent prompts and MCP servers configured.
+#
+# This is the manual-dev companion to Junior's generated OpenCode runtime config:
+# it composes a Junior agent prompt from .claude/agents/<agent>.md plus its
+# declared common preamble, wires the same local MCP servers as
+# opencode-with-mcp.sh, and injects everything through OPENCODE_CONFIG_CONTENT.
+#
+# Usage:
+#   bin/opencode-agent-with-mcp.sh [agent] [opencode args...]
+#   JUNIOR_AGENT=review bin/opencode-agent-with-mcp.sh [opencode args...]
+#
+# Examples:
+#   bin/opencode-agent-with-mcp.sh build
+#   bin/opencode-agent-with-mcp.sh review --debug
+#
+# MCP env flags mirror bin/opencode-with-mcp.sh / src/config.ts:
+#   OPENCODE_MCP_ENABLED=true|false              default: true
+#   OPENCODE_SLACK_MCP_ENABLED=true|false        default: true
+#   OPENCODE_PLAYWRIGHT_MCP_ENABLED=true|false   default: true
+#   OPENCODE_MIXPANEL_MCP_ENABLED=true|false     default: true (feature-metrics only)
+#
+# Requires: jq (https://jqlang.github.io/jq/)
+
+set -e
+
+usage() {
+  cat <<'EOF'
+Usage: bin/opencode-agent-with-mcp.sh [agent] [opencode args...]
+
+Launch OpenCode with a generated Junior agent config and MCP wiring.
+
+Arguments:
+  agent                 Agent markdown stem under .claude/agents (default: build)
+  opencode args...      Remaining args are passed to opencode unchanged
+
+Environment:
+  JUNIOR_AGENT                         Alternative way to choose the agent
+  OPENCODE_MCP_ENABLED                 default: true
+  OPENCODE_SLACK_MCP_ENABLED           default: true
+  OPENCODE_PLAYWRIGHT_MCP_ENABLED      default: true
+  OPENCODE_MIXPANEL_MCP_ENABLED        default: true (feature-metrics only)
+  JUNIOR_OPENCODE_PERMISSION           default: allow
+  OPENCODE_MODEL                       optional model override
+EOF
+}
+
+if [ "${1:-}" = "-h" ] || [ "${1:-}" = "--help" ]; then
+  usage
+  exit 0
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Error: jq is required but was not found on PATH" >&2
+  exit 1
+fi
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_ROOT=$(cd "$SCRIPT_DIR/.." && pwd)
+AGENTS_DIR="$PROJECT_ROOT/.claude/agents"
+COMMON_DIR="$AGENTS_DIR/common"
+ORG_AGENTS_DIR="${JUNIOR_ORG_AGENTS_DIR:-$PROJECT_ROOT/agents-org}"
+ORG_COMMON_DIR="$ORG_AGENTS_DIR/common"
+
+AGENT_NAME="${JUNIOR_AGENT:-build}"
+if [ $# -gt 0 ] && [[ "${1:-}" != -* ]]; then
+  AGENT_NAME="$1"
+  shift
+fi
+
+AGENT_FILE="$ORG_AGENTS_DIR/$AGENT_NAME.md"
+if [ ! -f "$AGENT_FILE" ]; then
+  AGENT_FILE="$AGENTS_DIR/$AGENT_NAME.md"
+fi
+if [ ! -f "$AGENT_FILE" ]; then
+  echo "Error: agent not found: $AGENT_NAME" >&2
+  echo "Searched:" >&2
+  echo "  $ORG_AGENTS_DIR/$AGENT_NAME.md" >&2
+  echo "  $AGENTS_DIR/$AGENT_NAME.md" >&2
+  echo "Available agents:" >&2
+  if [ -d "$ORG_AGENTS_DIR" ]; then
+    for file in "$ORG_AGENTS_DIR"/*.md; do
+      [ -f "$file" ] || continue
+      basename "$file" .md >&2
+    done
+  fi
+  for file in "$AGENTS_DIR"/*.md; do
+    [ -f "$file" ] || continue
+    basename "$file" .md >&2
+  done
+  exit 1
+fi
+
+# --- Boolean parser (mirrors src/config.ts parseBooleanEnv) ---
+# Accepts: 1, true, yes, on (truthy) and 0, false, no, off (falsy),
+# case-insensitive. Empty/unset returns the default. Invalid values error.
+parse_bool() {
+  local name="$1" value="$2" default="$3"
+  if [ -z "$value" ]; then
+    echo "$default"
+    return
+  fi
+  local normalized
+  normalized=$(echo "$value" | tr '[:upper:]' '[:lower:]' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+  case "$normalized" in
+    1|true|yes|on) echo "true"; return ;;
+    0|false|no|off) echo "false"; return ;;
+    *) echo "Error: Invalid $name: \"$value\" (expected true|false)" >&2; exit 1 ;;
+  esac
+}
+
+strip_frontmatter() {
+  awk '
+    NR == 1 && $0 == "---" { in_fm = 1; next }
+    in_fm && $0 == "---" { in_fm = 0; next }
+    !in_fm { print }
+  ' "$1"
+}
+
+frontmatter_value() {
+  local key="$1" file="$2"
+  awk -v key="$key" '
+    NR == 1 && $0 == "---" { in_fm = 1; next }
+    in_fm && $0 == "---" { exit }
+    in_fm {
+      split($0, parts, ":")
+      if (parts[1] == key) {
+        sub("^[^:]*:[[:space:]]*", "")
+        print
+        exit
+      }
+    }
+  ' "$file"
+}
+
+append_file_if_exists() {
+  local file="$1" output="$2"
+  if [ -f "$file" ]; then
+    cat "$file" >>"$output"
+    printf '\n\n' >>"$output"
+  else
+    echo "Warning: common prompt not found: $file" >&2
+  fi
+}
+
+append_file_if_exists_quiet() {
+  local file="$1" output="$2"
+  if [ -f "$file" ]; then
+    cat "$file" >>"$output"
+    printf '\n\n' >>"$output"
+  fi
+}
+
+COMMON_PROFILE=$(frontmatter_value "common" "$AGENT_FILE")
+if [ -z "$COMMON_PROFILE" ]; then
+  COMMON_PROFILE="core"
+fi
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+PROMPT_FILE="$TMP_DIR/prompt.md"
+
+cat >"$PROMPT_FILE" <<EOF
+<opencode-provider-baseline>
+You are Junior running inside OpenCode as a manual coding agent.
+
+Use OpenCode's native tools to inspect files, search the workspace, edit code, and run verification commands. Read relevant code before changing it.
+
+Respect the active workspace. Work in the current directory and explicit user-provided paths. Do not modify unrelated repositories, generated secrets, or user changes you did not make.
+
+Keep changes scoped to the request and aligned with local patterns. Do not introduce broad refactors, dependencies, or abstractions unless needed to finish safely.
+
+For code changes, run the most relevant typecheck, tests, linters, or targeted commands available. Report any command you could not run and the concrete blocker.
+
+Priority order: explicit user instruction, provider/runtime safety, Junior active agent contract, Junior core rules, then reference context. If rules conflict, follow the higher-priority rule.
+</opencode-provider-baseline>
+
+<junior-active-agent>$AGENT_NAME</junior-active-agent>
+
+EOF
+
+# Match AgentRouter's common profile behavior: core is always first, then the
+# agent-declared common stems in order with duplicate core removed.
+append_file_if_exists "$COMMON_DIR/core.md" "$PROMPT_FILE"
+IFS=',' read -ra COMMON_NAMES <<<"$COMMON_PROFILE"
+for raw_name in "${COMMON_NAMES[@]}"; do
+  name=$(echo "$raw_name" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/\.md$//')
+  [ -n "$name" ] || continue
+  [ "$name" = "core" ] && continue
+  append_file_if_exists "$COMMON_DIR/$name.md" "$PROMPT_FILE"
+done
+
+# Match AgentRouter's org overlay behavior: append matching org common files
+# additively for the selected common profile.
+if [ -d "$ORG_COMMON_DIR" ]; then
+  IFS=',' read -ra ORG_COMMON_NAMES <<<"$COMMON_PROFILE"
+  for raw_name in "${ORG_COMMON_NAMES[@]}"; do
+    name=$(echo "$raw_name" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//;s/\.md$//')
+    [ -n "$name" ] || continue
+    append_file_if_exists_quiet "$ORG_COMMON_DIR/$name.md" "$PROMPT_FILE"
+  done
+fi
+
+strip_frontmatter "$AGENT_FILE" >>"$PROMPT_FILE"
+
+# --- Env defaults (mirror src/config.ts / opencode-with-mcp.sh) ---
+MCP_ENABLED=$(parse_bool "OPENCODE_MCP_ENABLED" "${OPENCODE_MCP_ENABLED:-}" true)
+SLACK_MCP=$(parse_bool "OPENCODE_SLACK_MCP_ENABLED" "${OPENCODE_SLACK_MCP_ENABLED:-}" true)
+PLAYWRIGHT_MCP=$(parse_bool "OPENCODE_PLAYWRIGHT_MCP_ENABLED" "${OPENCODE_PLAYWRIGHT_MCP_ENABLED:-}" true)
+MIXPANEL_MCP=$(parse_bool "OPENCODE_MIXPANEL_MCP_ENABLED" "${OPENCODE_MIXPANEL_MCP_ENABLED:-}" true)
+PERMISSION="${JUNIOR_OPENCODE_PERMISSION:-allow}"
+
+# --- Build config ---
+CONFIG=$(jq -n \
+  --rawfile prompt "$PROMPT_FILE" \
+  --arg permission "$PERMISSION" \
+  --arg desc "Junior manual agent: $AGENT_NAME" \
+  '{
+    "$schema": "https://opencode.ai/config.json",
+    permission: $permission,
+    agent: {
+      build: {
+        description: $desc,
+        mode: "primary",
+        permission: {"*": $permission},
+        prompt: $prompt
+      }
+    }
+  }')
+
+if [ -n "${OPENCODE_MODEL:-}" ]; then
+  CONFIG=$(echo "$CONFIG" | jq --arg model "$OPENCODE_MODEL" '.model = $model')
+fi
+
+if [ "$MCP_ENABLED" = "true" ]; then
+  if [ "$SLACK_MCP" = "true" ]; then
+    CONFIG=$(echo "$CONFIG" | jq --arg url "http://localhost:3456/mcp" \
+      '.mcp["slack-bot"] = {type: "remote", url: $url, enabled: true}')
+  fi
+
+  if [ "$PLAYWRIGHT_MCP" = "true" ]; then
+    CONFIG=$(echo "$CONFIG" | jq \
+      '.mcp.playwright = {type: "local", command: ["npx", "@playwright/mcp", "--headless"], enabled: true}')
+  fi
+
+  if [ "$MIXPANEL_MCP" = "true" ] && [ "$AGENT_NAME" = "feature-metrics" ]; then
+    CONFIG=$(echo "$CONFIG" | jq \
+      '.mcp.mixpanel = {type: "local", command: ["npx", "-y", "mcp-remote", "https://mcp.mixpanel.com/mcp"], enabled: true}')
+  fi
+fi
+
+export OPENCODE_CONFIG_CONTENT="$CONFIG"
+export JUNIOR_AGENT_NAME="$AGENT_NAME"
+unset OPENCODE_CONFIG
+
+exec opencode "$@"

--- a/docs/features/agent-routing.md
+++ b/docs/features/agent-routing.md
@@ -130,6 +130,7 @@ Separate the public Junior repo from org-specific specifics, and let lightweight
 - `composeSystemPrompt`: org overlay's `common/*.md` is appended **additively** after the public/target common — so org-wide invariants (credential paths, merge protocol, infra URLs) reach every agent regardless of which repo's common loaded first.
 - `composeSystemPrompt` also now returns the common preamble alone when no agent definition resolves — covers the default `@junior` path so it picks up the same invariants.
 - Per-agent **context profile** via frontmatter dot-notation flags: `context.identity`, `context.slack`, `context.workspace`, `context.threadHistory`, `context.agentState`. Each gates the corresponding block in `buildPromptPreamble`. Defaults are all-true; missing/invalid flags preserve the heavy preamble (safe-but-heavy).
+- OpenCode MCP config is generated per spawn. The private `feature-metrics` worker gets the Mixpanel MCP server only for its own runs; default Junior and other agents do not receive it.
 - `lead`/`default` agentName branches in `buildRunSession` set `agentType` so they participate in the new compose path (previously short-circuited).
 
 **Test:** Six-scenario load-path matrix (default-no-target, default-target-with-no-common, default-target-with-common, lead variants, worker-with-target) confirms overlay common reaches every agent; public common reaches all agents except those whose target repo has its own common; agent body resolves correctly per the search-chain order.

--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -73,6 +73,11 @@ Status pill updates that agents post mid-run go through `slack_send_message` wit
   `OPENCODE_CONFIG_CONTENT` for all normal runs, including initial lead intake
   from Junior's project root. Explicit `session.cwd` utility runs still skip
   Junior's local MCP wiring.
+- The Mixpanel MCP is intentionally **not** in `.mcp.json` and is not part of
+  default Junior's OpenCode config. It is injected only when the active
+  OpenCode session is `feature-metrics`, using Mixpanel's official hosted MCP
+  through `npx -y mcp-remote https://mcp.mixpanel.com/mcp`. Disable with
+  `OPENCODE_MIXPANEL_MCP_ENABLED=false`.
 
 ## What it replaced
 

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -16,6 +16,7 @@ const ENV_KEYS = [
   "OPENCODE_MCP_ENABLED",
   "OPENCODE_SLACK_MCP_ENABLED",
   "OPENCODE_PLAYWRIGHT_MCP_ENABLED",
+  "OPENCODE_MIXPANEL_MCP_ENABLED",
   "REPOS",
   "SESSION_STALE_TIMEOUT_MS",
   "SESSION_CLEANUP_INTERVAL_MS",
@@ -64,6 +65,7 @@ describe("loadConfig runner providers", () => {
       mcpEnabled: true,
       slackMcpEnabled: true,
       playwrightMcpEnabled: true,
+      mixpanelMcpEnabled: true,
     });
   });
 
@@ -75,6 +77,7 @@ describe("loadConfig runner providers", () => {
     process.env.OPENCODE_MCP_ENABLED = "false";
     process.env.OPENCODE_SLACK_MCP_ENABLED = "0";
     process.env.OPENCODE_PLAYWRIGHT_MCP_ENABLED = "false";
+    process.env.OPENCODE_MIXPANEL_MCP_ENABLED = "0";
 
     const config = loadConfig();
 
@@ -86,6 +89,7 @@ describe("loadConfig runner providers", () => {
       mcpEnabled: false,
       slackMcpEnabled: false,
       playwrightMcpEnabled: false,
+      mixpanelMcpEnabled: false,
     });
   });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -75,6 +75,7 @@ export interface Config {
     mcpEnabled: boolean;
     slackMcpEnabled: boolean;
     playwrightMcpEnabled: boolean;
+    mixpanelMcpEnabled: boolean;
   };
   repos: RepoConfig[];
   session: {
@@ -138,6 +139,10 @@ export function loadConfig(): Config {
       slackMcpEnabled: parseBooleanEnv("OPENCODE_SLACK_MCP_ENABLED", true),
       playwrightMcpEnabled: parseBooleanEnv(
         "OPENCODE_PLAYWRIGHT_MCP_ENABLED",
+        true,
+      ),
+      mixpanelMcpEnabled: parseBooleanEnv(
+        "OPENCODE_MIXPANEL_MCP_ENABLED",
         true,
       ),
     },

--- a/src/runners/index.test.ts
+++ b/src/runners/index.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "bun:test";
+import type { Config } from "../config.ts";
+import { createSession } from "../session/types.ts";
+import { buildOpenCodeMcpConfig } from "./index.ts";
+
+describe("buildOpenCodeMcpConfig", () => {
+  it("only includes Mixpanel MCP for the feature-metrics agent", () => {
+    const mainSession = createSession("thread-1", "C01");
+    const featureMetricsSession = createSession("thread-1", "C01");
+    featureMetricsSession.agentType = "feature-metrics";
+
+    const mainMcp = buildOpenCodeMcpConfig(testConfig(), mainSession);
+    const featureMetricsMcp = buildOpenCodeMcpConfig(
+      testConfig(),
+      featureMetricsSession,
+    );
+
+    expect(mainMcp?.mixpanel).toBeUndefined();
+    expect(featureMetricsMcp?.mixpanel).toEqual({
+      type: "local",
+      command: ["npx", "-y", "mcp-remote", "https://mcp.mixpanel.com/mcp"],
+      enabled: true,
+    });
+  });
+
+  it("respects the Mixpanel MCP feature flag", () => {
+    const session = createSession("thread-1", "C01");
+    session.agentType = "feature-metrics";
+
+    const mcp = buildOpenCodeMcpConfig(
+      testConfig({ mixpanelMcpEnabled: false }),
+      session,
+    );
+
+    expect(mcp?.mixpanel).toBeUndefined();
+  });
+});
+
+function testConfig(
+  opencodeOverrides: Partial<Config["opencode"]> = {},
+): Config {
+  return {
+    slack: {
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      signingSecret: "",
+    },
+    claude: {
+      maxTurns: 25,
+      timeoutMs: 300000,
+      permissionMode: "bypassPermissions",
+      defaultModel: null,
+      defaultDriver: "headless",
+      tmuxIdleTtlMs: 14400000,
+      tmuxSweepIntervalMs: 900000,
+    },
+    runner: { provider: "opencode" },
+    opencode: {
+      model: null,
+      timeoutMs: 300000,
+      permission: "allow",
+      mcpEnabled: true,
+      slackMcpEnabled: true,
+      playwrightMcpEnabled: true,
+      mixpanelMcpEnabled: true,
+      ...opencodeOverrides,
+    },
+    repos: [],
+    session: {
+      staleTimeoutMs: 86400000,
+      cleanupIntervalMs: 900000,
+      store: "memory",
+      sqlitePath: "data/sessions.db",
+      homeWindowMs: 172800000,
+      defaultVerbosity: "normal",
+    },
+    channelDefaults: {},
+    adminSlackUserId: null,
+    http: { enabled: false, port: 0 },
+  };
+}

--- a/src/runners/index.ts
+++ b/src/runners/index.ts
@@ -43,7 +43,7 @@ export function spawnRunner(
       {
         defaultModel: config.opencode.model,
         permission: config.opencode.permission,
-        mcp: buildOpenCodeMcpConfig(config),
+        mcp: buildOpenCodeMcpConfig(config, session),
       },
       targetRepoCwd,
       botToken,
@@ -68,7 +68,10 @@ export function spawnRunner(
   );
 }
 
-function buildOpenCodeMcpConfig(config: Config): OpenCodeMcpConfig | null {
+export function buildOpenCodeMcpConfig(
+  config: Config,
+  session: ThreadSession,
+): OpenCodeMcpConfig | null {
   if (!config.opencode.mcpEnabled) return null;
 
   const mcp: OpenCodeMcpConfig = {};
@@ -86,6 +89,20 @@ function buildOpenCodeMcpConfig(config: Config): OpenCodeMcpConfig | null {
       enabled: true,
     };
   }
+  if (config.opencode.mixpanelMcpEnabled && isFeatureMetricsSession(session)) {
+    mcp.mixpanel = {
+      type: "local",
+      command: ["npx", "-y", "mcp-remote", "https://mcp.mixpanel.com/mcp"],
+      enabled: true,
+    };
+  }
 
   return Object.keys(mcp).length > 0 ? mcp : null;
+}
+
+function isFeatureMetricsSession(session: ThreadSession): boolean {
+  return (
+    session.agentType === "feature-metrics" ||
+    session.activeAgentName === "feature-metrics"
+  );
 }

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -135,6 +135,7 @@ const testConfig: Config = {
     mcpEnabled: true,
     slackMcpEnabled: true,
     playwrightMcpEnabled: true,
+    mixpanelMcpEnabled: true,
   },
   repos: [
     { name: "junior", path: "/tmp/junior", defaultBase: "main" },


### PR DESCRIPTION
## Summary
- Inject Mixpanel's hosted MCP only for `feature-metrics` OpenCode sessions behind `OPENCODE_MIXPANEL_MCP_ENABLED`.
- Add runner config tests and document the scoped MCP behavior.
- Add a manual OpenCode agent launcher that composes Junior agent prompts with MCP config.

## Verification
- `bun run typecheck`
- `bun test src/runners/index.test.ts src/config.test.ts src/session/manager.test.ts`