### PR TITLE
fix: sanitize Slack error responses

### DIFF
--- a/docs/code_index/stream-to-slack.md
+++ b/docs/code_index/stream-to-slack.md
@@ -23,6 +23,7 @@ Formats normalized runner stream events as Slack status messages, posts final re
 | `extractAssistantText(event)` | Concatenates all `text` content blocks from an assistant event |
 | `prepareSlackResponse(text)` | Sentinel handler: returns null for empty/`NO_SLACK_MESSAGE`/trailing-only-sentinel; strips trailing sentinel from real content |
 | `isDuplicateSlackToolResponse(text, events)` | Detects exact final-response duplicates of text already sent through `slack_send_message`/`mcp__...__slack_send_message` in the same turn so Junior suppresses the second post |
+| `sanitizeErrorForSlack(error)` | Converts runner/tool errors into Slack-safe text: strips ANSI, suppresses prompt/context leak markers, and withholds very long raw stderr |
 | `splitResponse(text, maxLength = 4000)` | Chunks long responses; prefers paragraph (`\n\n`) → line → code-block boundaries; avoids splitting inside fenced code blocks |
 | `NO_SLACK_MESSAGE` | Sentinel constant — agents return this to skip Slack post |
 
@@ -80,6 +81,10 @@ If an agent calls `slack_send_message` and then returns the same text as its fin
 ### Response splitting
 
 `splitResponse` (default 4000 chars) tries paragraph → line → code-fence boundaries. Inside a code block (odd ``` count in slice), it searches for the closing fence and splits after it (within 1.5x maxLength). Falls back to hard split.
+
+### Error response sanitization
+
+`index.ts` logs the raw runner error server-side, then posts only `sanitizeErrorForSlack(error)` to Slack. This prevents provider/tool wrappers from echoing injected prompt/context blocks back into a thread when a bad tool argument appears in stderr (for example `File not found: <identity>...`).
 
 ### Stream parser shape validation
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,12 @@
 import { loadConfig } from "./config.ts";
 import { createSlackApp } from "./slack/app.ts";
 import { registerEventHandlers } from "./slack/events.ts";
-import { formatRunnerToolStatuses, extractRunnerMessageText, prepareSlackResponse } from "./slack/formatting.ts";
+import {
+  extractRunnerMessageText,
+  formatRunnerToolStatuses,
+  prepareSlackResponse,
+  sanitizeErrorForSlack,
+} from "./slack/formatting.ts";
 import { SlackResponder } from "./slack/responder.ts";
 import { SessionManager } from "./session/manager.ts";
 import { createSessionStore } from "./session/store/factory.ts";
@@ -129,11 +134,12 @@ sessionManager.onReaction = (event, emoji) => {
 sessionManager.onError = (session, error) => {
   const agentName = session.activeAgentName ?? "lead";
   log.error("error", `thread=${session.threadId} agent=${agentName} ${error ?? "Unknown error"}`);
+  const safeError = sanitizeErrorForSlack(error);
   responder.deleteStatus(session.channel, session.threadId, agentName);
   responder.postResponse(
     session.channel,
     session.threadId,
-    `Error: ${error ?? "Unknown error"}`,
+    `Error: ${safeError}`,
     session.slackIdentity,
   );
 };

--- a/src/slack/formatting.test.ts
+++ b/src/slack/formatting.test.ts
@@ -254,6 +254,15 @@ describe("sanitizeErrorForSlack", () => {
     );
   });
 
+  it("withholds short errors that include any prompt wrapper tag", () => {
+    expect(sanitizeErrorForSlack("bad input: <workspace>repo paths</workspace>")).toBe(
+      "runner failed. Raw error withheld because it contained injected prompt/context; check server logs.",
+    );
+    expect(sanitizeErrorForSlack("bad input: <junior-core>rules</junior-core>")).toBe(
+      "runner failed. Raw error withheld because it contained injected prompt/context; check server logs.",
+    );
+  });
+
   it("withholds very long errors instead of posting raw stderr", () => {
     expect(sanitizeErrorForSlack("x".repeat(501))).toBe(
       "runner failed. Raw error was too long to post safely; check server logs.",

--- a/src/slack/formatting.test.ts
+++ b/src/slack/formatting.test.ts
@@ -4,6 +4,7 @@ import {
   formatRunnerToolStatuses,
   formatToolStatuses,
   isDuplicateSlackToolResponse,
+  sanitizeErrorForSlack,
   splitResponse,
 } from "./formatting.ts";
 import type { StreamEventAssistant } from "../claude/types.ts";
@@ -231,6 +232,38 @@ describe("isDuplicateSlackToolResponse", () => {
     ];
 
     expect(isDuplicateSlackToolResponse("additional context", events)).toBe(false);
+  });
+});
+
+describe("sanitizeErrorForSlack", () => {
+  it("keeps short normal errors", () => {
+    expect(sanitizeErrorForSlack("Claude crashed")).toBe("Claude crashed");
+  });
+
+  it("strips ANSI sequences from safe errors", () => {
+    expect(sanitizeErrorForSlack("\u001b[91m\u001b[1mError:\u001b[0m nope")).toBe(
+      "Error: nope",
+    );
+  });
+
+  it("withholds tool errors that include injected prompt/context", () => {
+    const leaked = `\u001b[91mError:\u001b[0m File not found: <identity>\n# SOUL.md — Junior\nYour Slack user ID is U0ABKQ4V065`;
+
+    expect(sanitizeErrorForSlack(leaked)).toBe(
+      "runner failed. Raw error withheld because it contained injected prompt/context; check server logs.",
+    );
+  });
+
+  it("withholds very long errors instead of posting raw stderr", () => {
+    expect(sanitizeErrorForSlack("x".repeat(501))).toBe(
+      "runner failed. Raw error was too long to post safely; check server logs.",
+    );
+  });
+
+  it("uses a generic message for blank errors", () => {
+    expect(sanitizeErrorForSlack("  ")).toBe(
+      "runner failed. Check server logs for details.",
+    );
   });
 });
 

--- a/src/slack/formatting.ts
+++ b/src/slack/formatting.ts
@@ -54,6 +54,46 @@ export function extractRunnerMessageText(event: RunnerEvent): string | null {
 
 export const NO_SLACK_MESSAGE = "NO_SLACK_MESSAGE";
 
+const MAX_SLACK_ERROR_LENGTH = 500;
+const PROMPT_LEAK_MARKERS = [
+  /<\/?(?:identity|slack-context|thread-context|system|developer|user|assistant)\b/i,
+  /#\s*(?:IDENTITY|SOUL)\.md\b/i,
+  /Do NOT use Slack search/i,
+  /CRITICAL\s+[—-]\s+no double-posting/i,
+  /Your Slack user ID is\b/i,
+  /File not found:\s*</i,
+];
+
+/**
+ * Convert a runner/tool error into a Slack-safe message.
+ *
+ * Raw provider stderr can include the full prompt when a tool wrapper echoes a
+ * bad argument (e.g. `File not found: <identity>...`). Keep the full error in
+ * server logs, but never mirror prompt/context blocks back into Slack.
+ */
+export function sanitizeErrorForSlack(error: string | null | undefined): string {
+  const cleaned = stripAnsi(error ?? "").trim();
+  if (!cleaned) return "runner failed. Check server logs for details.";
+
+  if (containsPromptLeak(cleaned)) {
+    return "runner failed. Raw error withheld because it contained injected prompt/context; check server logs.";
+  }
+
+  if (cleaned.length > MAX_SLACK_ERROR_LENGTH) {
+    return "runner failed. Raw error was too long to post safely; check server logs.";
+  }
+
+  return cleaned;
+}
+
+function stripAnsi(text: string): string {
+  return text.replace(/\u001b\[[0-9;]*m/g, "");
+}
+
+function containsPromptLeak(text: string): boolean {
+  return PROMPT_LEAK_MARKERS.some((marker) => marker.test(text));
+}
+
 /**
  * Decide whether to post `text` to Slack and what to post.
  * Returns null to suppress entirely; otherwise the cleaned text to post.

--- a/src/slack/formatting.ts
+++ b/src/slack/formatting.ts
@@ -56,7 +56,7 @@ export const NO_SLACK_MESSAGE = "NO_SLACK_MESSAGE";
 
 const MAX_SLACK_ERROR_LENGTH = 500;
 const PROMPT_LEAK_MARKERS = [
-  /<\/?(?:identity|slack-context|thread-context|system|developer|user|assistant)\b/i,
+  /<\/?[a-z][a-z0-9-]*(?:\s[^>]*)?>/i,
   /#\s*(?:IDENTITY|SOUL)\.md\b/i,
   /Do NOT use Slack search/i,
   /CRITICAL\s+[—-]\s+no double-posting/i,


### PR DESCRIPTION
## Summary
- Sanitize runner error messages before posting them to Slack.
- Withhold prompt/context-like stderr and overlong errors while keeping raw details in server logs.
- Add regression coverage for the leaked prompt failure mode.

## Verification
- bun test src/slack/formatting.test.ts
- bun run typecheck
- bun test