### PR TITLE
fix: keep OpenCode prompt before file args

### DIFF
--- a/docs/code_index/runner-providers.md
+++ b/docs/code_index/runner-providers.md
@@ -21,7 +21,7 @@ and MCP wiring.
 | Symbol | File | Purpose |
 |---|---|---|
 | `spawnOpenCode(...)` | `spawner.ts` | Runs `opencode run --format json`, generates `OPENCODE_CONFIG_CONTENT`, parses events. |
-| `buildOpenCodeArgs(...)` | `args.ts` | Builds fresh/resume CLI args using `--session`, `--dir`, `--agent build`, and attachments. |
+| `buildOpenCodeArgs(...)` | `args.ts` | Builds fresh/resume CLI args using `--session`, `--dir`, `--agent build`, and attachments; keeps the prompt before `--file` flags so OpenCode does not parse prompt text as file paths. |
 | `buildOpenCodeConfig(...)` | `config.ts` | Generates model, permissions, primary `agent.build`, MCP entries, and subagent entries. |
 | `loadOpenCodeSupportSubagents()` | `support-agents.ts` | Exposes standalone stateless support prompts as generated OpenCode subagents. |
 | `buildOpenCodeAgentPrompt(...)` | `prompt.ts` | Wraps Junior core + active-agent prompt in the OpenCode provider baseline. |

--- a/src/opencode/args.test.ts
+++ b/src/opencode/args.test.ts
@@ -35,7 +35,7 @@ describe("buildOpenCodeArgs", () => {
     expect(args.at(-1)).toBe("continue");
   });
 
-  it("adds model and file attachments before the prompt", () => {
+  it("adds model before prompt and file attachments after prompt", () => {
     expect(
       buildOpenCodeArgs({
         cwd: "/repo/worktree",
@@ -54,11 +54,23 @@ describe("buildOpenCodeArgs", () => {
       "reviewer",
       "--model",
       "openai/gpt-5.1",
+      "inspect files",
       "--file",
       "/tmp/a.png",
       "--file",
       "/tmp/b.txt",
-      "inspect files",
     ]);
+  });
+
+  it("keeps prompt before files so OpenCode does not parse prompt as a file", () => {
+    const prompt = "<identity>\nsecret prompt context\n</identity>";
+    const args = buildOpenCodeArgs({
+      cwd: "/repo/worktree",
+      agentName: "junior",
+      files: ["/tmp/image.png"],
+      prompt,
+    });
+
+    expect(args.indexOf(prompt)).toBeLessThan(args.indexOf("--file"));
   });
 });

--- a/src/opencode/args.ts
+++ b/src/opencode/args.ts
@@ -26,11 +26,15 @@ export function buildOpenCodeArgs(options: BuildOpenCodeArgsOptions): string[] {
     args.push("--model", options.model);
   }
 
+  // OpenCode's --file is an array option. If it appears before the message,
+  // yargs can greedily consume the prompt as another file path and echo the
+  // full prompt in a "File not found" error. Keep the positional prompt before
+  // file flags so attached images don't make prompt text parse as filenames.
+  args.push(options.prompt);
+
   for (const file of options.files ?? []) {
     args.push("--file", file);
   }
-
-  args.push(options.prompt);
 
   return args;
 }


### PR DESCRIPTION
## Summary
- Move OpenCode file attachment flags after the positional prompt so `--file` does not consume injected prompt text as a filename.
- Add a regression test for the prompt-as-file parsing failure and update the runner provider code index.

## Verification
- bun test src/opencode/args.test.ts
- bun run typecheck
- bun test