### PR TITLE
docs: align documentation with multi-provider architecture and add tool prerequisites

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,13 @@
 
 ## Project Overview
 
-junior is a Slack bot that acts as the control plane for Claude Code sessions. It's the successor to the OpenClaw-based agent system (PranavBakre/openclaw-agents) — same role (Junior the orchestrator), rebuilt on Claude Code as a subprocess instead of OpenClaw.
+junior is a Slack bot that acts as the control plane for coding agent sessions. While it follows Claude Code conventions for manual use, it uses **OpenCode** as the default runner for automated Slack turns. It's the successor to the OpenClaw-based agent system (PranavBakre/openclaw-agents).
 
-The server owns the lifecycle. When a Slack message arrives in a thread, the bot either spawns a new Claude Code CLI process or routes the message to an existing session. Each thread gets its own isolated session and optional target-repo worktree; runner processes use Junior's project MCP config for worktree-backed target-repo runs.
+The server owns the lifecycle. When a Slack message arrives in a thread, the bot spawns a short-lived runner subprocess (OpenCode or Claude Code). Each thread gets its own isolated session and optional target-repo worktree; runner processes use Junior's project MCP config for worktree-backed target-repo runs.
 
-**Stack:** Node.js / Bun, TypeScript, Slack Event API, Claude Code CLI (Max subscription auth)
+**Stack:** Node.js / Bun, TypeScript, Slack Event API, OpenCode (default) / Claude Code CLI.
 
-**Key architectural choice:** CLI subprocess (`claude -p`), not SDK. The CLI authenticates via Max subscription — no API keys, no usage-based billing. Each Slack message spawns a short-lived process; `--resume` picks up conversation context from the last completed turn.
+**Key architectural choice:** CLI subprocess, not SDK. Each Slack message spawns a short-lived process; `--resume` (or `--session`) picks up conversation context from the last completed turn.
 
 ## Where to Look
 
@@ -53,19 +53,29 @@ Slack Bot Server (Node.js / Bun)
     +-- On message:
     |     1. Look up thread_id
     |     2. If busy -> buffer message (react with eyes)
-    |     3. If idle -> spawn claude -p with --resume, --worktree, --output-format stream-json
+    |     3. If idle -> spawn runner with --resume, --worktree, --output-format stream-json
     |     4. On exit -> post response to Slack, drain buffer
     |
-    +-- Claude Code CLI Process (short-lived, one per message turn)
-          claude -p "<prompt>" --resume <session_id> --worktree "slack-<threadId>"
-            --output-format stream-json --mcp-config .mcp.json --max-turns 25
+    +-- Runner CLI Process (short-lived, one per message turn)
+          <runner-cli> run "<prompt>" --session <id> --dir "slack-<threadId>"
+            --format json --mcp-config .opencode.json
 ```
+
+## Prerequisites
+
+Ensure the following are installed and authenticated on your host:
+- **OpenCode** (Default runner)
+- **Claude Code CLI** (Alternate runner)
+- **Vercel CLI** (Required for `vercel-status` agent)
+- **New Relic CLI** (Required for `nr-research` agent)
+- **Sentry CLI** (Required for `sentry-fetch` agent)
+- **tmux** (Required for experimental interactive mode)
 
 ## Critical Rules
 
-1. **CLI subprocess, not SDK.** Spawn `claude -p` as a child process. Authenticate via Max subscription. Never use `@anthropic-ai/claude-code` as a library — that requires API keys.
-2. **One process per message turn.** Each Slack message spawns a short-lived `claude -p` process. The process exits after responding. No long-lived processes between messages.
-3. **`--resume` for continuity.** Use `--resume <sessionId>` to pick up conversation context. Session IDs are extracted from the first `stream-json` event on stdout.
+1. **CLI subprocess, not SDK.** Spawn `opencode` or `claude -p` as a child process. Never use `@anthropic-ai/claude-code` as a library — that requires API keys.
+2. **One process per message turn.** Each Slack message spawns a short-lived runner process. The process exits after responding. No long-lived processes between messages (except in experimental TMUX mode).
+3. **Native resume for continuity.** Use `--session` (OpenCode) or `--resume` (Claude) to pick up conversation context. Session IDs are extracted from the first stream event on stdout.
 4. **Buffer, don't interrupt.** If Claude is mid-execution and new messages arrive, buffer them. Never kill a running process — it risks corrupted session state. Drain the buffer as a combined prompt after the current turn exits.
 5. **Worktrees for target repos only.** Junior's workspace is shared across all threads (learnings accumulate). Worktrees are created in TARGET repos (example-backend, example-frontend) when threads need code isolation. Threads that only read or discuss don't need worktrees.
 6. **Stream events for status.** Parse `--output-format stream-json` events (tool_use, text, result) and post incremental Slack updates. The final `result` event is the response to post.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,13 @@
 
 ## Project Overview
 
-junior is a Slack bot that acts as the control plane for coding agent sessions. While it follows Claude Code conventions for manual use, it uses **OpenCode** as the default runner for automated Slack turns. It's the successor to the OpenClaw-based agent system (PranavBakre/openclaw-agents).
+junior is a Slack bot that acts as the control plane for coding agent sessions. OpenCode is the default runner provider for automated Slack turns; Claude Code remains available through the Claude adapter and tmux driver. It's the successor to the OpenClaw-based agent system (PranavBakre/openclaw-agents).
 
-The server owns the lifecycle. When a Slack message arrives in a thread, the bot spawns a short-lived runner subprocess (OpenCode or Claude Code). Each thread gets its own isolated session and optional target-repo worktree; runner processes use Junior's project MCP config for worktree-backed target-repo runs.
+The server owns the lifecycle. When a Slack message arrives in a thread, the bot spawns a runner turn through the selected provider. Headless OpenCode/Claude turns are short-lived subprocesses; Claude tmux mode keeps an interactive process alive behind a per-thread driver flag. Each thread gets its own isolated session and optional target-repo worktree.
 
 **Stack:** Node.js / Bun, TypeScript, Slack Event API, OpenCode (default) / Claude Code CLI.
 
-**Key architectural choice:** CLI subprocess, not SDK. Each Slack message spawns a short-lived process; `--resume` (or `--session`) picks up conversation context from the last completed turn.
+**Key architectural choice:** CLI subprocess, not SDK. Headless turns spawn one provider CLI process per Slack turn; provider-native resume (`--session` for OpenCode, `--resume` for Claude) carries conversation context.
 
 ## Where to Look
 
@@ -53,41 +53,41 @@ Slack Bot Server (Node.js / Bun)
     +-- On message:
     |     1. Look up thread_id
     |     2. If busy -> buffer message (react with eyes)
-    |     3. If idle -> spawn runner with --resume, --worktree, --output-format stream-json
+    |     3. If idle -> spawn selected runner provider
     |     4. On exit -> post response to Slack, drain buffer
     |
     +-- Runner CLI Process (short-lived, one per message turn)
-          <runner-cli> run "<prompt>" --session <id> --dir "slack-<threadId>"
-            --format json --mcp-config .opencode.json
+          opencode run --format json --dir "<worktree>" --session <id> --agent build "<prompt>"
+          claude -p "<prompt>" --output-format stream-json --resume <id> --mcp-config .mcp.json
 ```
 
 ## Prerequisites
 
-Ensure the following are installed and authenticated on your host:
-- **OpenCode** (Default runner)
-- **Claude Code CLI** (Alternate runner)
-- **Vercel CLI** (Required for `vercel-status` agent)
-- **New Relic CLI** (Required for `nr-research` agent)
-- **Sentry CLI** (Required for `sentry-fetch` agent)
-- **tmux** (Required for experimental interactive mode)
+Install and authenticate the tools required by the provider and agents you enable:
+- **OpenCode** (default runner provider)
+- **Claude Code CLI** (Claude provider and tmux driver)
+- **Vercel CLI** (required by `vercel-status`)
+- **New Relic CLI** (required by `nr-research`)
+- **Sentry CLI** (required by `sentry-fetch`)
+- **tmux 3.4+** (required only for `DEFAULT_CLAUDE_DRIVER=tmux`)
 
 ## Critical Rules
 
 1. **CLI subprocess, not SDK.** Spawn `opencode` or `claude -p` as a child process. Never use `@anthropic-ai/claude-code` as a library — that requires API keys.
 2. **One process per message turn.** Each Slack message spawns a short-lived runner process. The process exits after responding. No long-lived processes between messages (except in experimental TMUX mode).
 3. **Native resume for continuity.** Use `--session` (OpenCode) or `--resume` (Claude) to pick up conversation context. Session IDs are extracted from the first stream event on stdout.
-4. **Buffer, don't interrupt.** If Claude is mid-execution and new messages arrive, buffer them. Never kill a running process — it risks corrupted session state. Drain the buffer as a combined prompt after the current turn exits.
+4. **Buffer, don't interrupt.** If a runner is mid-execution and new messages arrive, buffer them. Do not kill the running turn except through the explicit stop/driver interrupt path. Drain the buffer as a combined prompt after the current turn exits.
 5. **Worktrees for target repos only.** Junior's workspace is shared across all threads (learnings accumulate). Worktrees are created in TARGET repos (example-backend, example-frontend) when threads need code isolation. Threads that only read or discuss don't need worktrees.
-6. **Stream events for status.** Parse `--output-format stream-json` events (tool_use, text, result) and post incremental Slack updates. The final `result` event is the response to post.
+6. **Stream events for status.** Parse provider-native JSON streams (`opencode run --format json`, Claude `--output-format stream-json`) into normalized runner events and post incremental Slack updates.
 7. **Session state is authoritative.** The session map (thread_id -> session) is the single source of truth for whether a thread is idle/busy, what its session ID is, and what messages are pending.
-8. **Cleanup stale threads.** Worktrees and sessions for inactive threads (24h default) must be cleaned up. Check for uncommitted changes before force-removing a worktree.
-9. **Runner MCP contract.** Worktree-backed target-repo runs use Junior's project `.mcp.json` via `--mcp-config` so spawned runners can reach local tools such as the Slack MCP server. Runs with an explicit `session.cwd` skip Junior's project MCP wiring because utility commands need their own cloud integrations. Keep this aligned with [docs/features/runner-providers.md](docs/features/runner-providers.md).
+8. **Cleanup stale sessions.** The cleanup job deletes stale idle/draining session rows (24h default). Worktree removal is separate and must dirty-check before destructive cleanup.
+9. **Runner MCP contract.** Worktree-backed target-repo runs get Junior's local MCP wiring. Claude receives the project `.mcp.json` via `--mcp-config`; OpenCode receives generated MCP config through `OPENCODE_CONFIG_CONTENT`. Runs with an explicit `session.cwd` skip Junior's project MCP wiring because utility commands need their own cloud integrations. Keep this aligned with [docs/features/runner-providers.md](docs/features/runner-providers.md).
 10. **No `--input-format stream-json` in production.** The bidirectional streaming flag exists but is undocumented and unstable. Use `--resume` for multi-turn until the protocol is specified.
 11. **SQLite for persistence.** Sessions persist in a SQLite file via `bun:sqlite` (`data/sessions.db` by default, `SESSION_DB_PATH` to override). Single-writer, no extra service, survives restarts. `SESSION_STORE=memory` switches to the in-memory store for tests/dev. The home tab shows only sessions active in the last `HOME_WINDOW_MS` (2 days default); cleanup and health still scan all rows. Pending messages are persisted but treated as stale on restart — the Claude process they were queued behind is dead.
 12. **Always handle zombie processes.** Set a timeout guard (5 min default). Kill with SIGINT on timeout. Handle process errors. Clear the timeout on exit.
 13. **Design for swappability.** When adding infrastructure that could have multiple implementations (persistence, message queue, notification), use a provider/factory pattern. Each provider gets its own file, a factory selects the right one.
 14. **Pure functions over framework ceremony.** If a library's core value is bypassed, replace it with the simplest implementation. A 20-line function beats a dependency you're working around.
-15. **Test against real infrastructure, mock at boundaries.** Mock Slack API and Claude CLI at system boundaries. Don't mock internal session management or message routing.
+15. **Test against real infrastructure, mock at boundaries.** Mock Slack API and runner CLIs at system boundaries. Don't mock internal session management or message routing.
 
 ## Engineering Principles
 
@@ -117,8 +117,14 @@ junior/
         factory.ts        -- createSessionStore(config)
         memory.ts         -- InMemorySessionStore (tests, dev)
         sqlite.ts         -- SqliteSessionStore (production)
+    runners/
+      index.ts            -- select OpenCode/Claude provider
+      runtime.ts          -- shared cwd/env/MCP runtime contract
+    opencode/
+      spawner.ts          -- spawn opencode run, parse JSON events
     claude/
-      spawner.ts          -- spawn claude -p, manage child process
+      spawner.ts          -- spawn claude -p for headless mode
+      tmux-driver.ts      -- interactive Claude driver behind tmux
       args.ts             -- build CLI args from session state
       parser.ts           -- stream-json line parser
       types.ts            -- stream-json event types
@@ -190,7 +196,7 @@ bun run build                   # Build for production
 bun run typecheck               # Type checking without emit
 
 # Slack bot management
-bun run cleanup                 # Clean stale worktrees and sessions
+bun run cleanup                 # Delete stale idle/draining session rows
 
 # Upload files/screenshots to the current Slack thread
 bin/slack-upload.sh <file-path> [comment]  # Uses SLACK_BOT_TOKEN, SLACK_CHANNEL, SLACK_THREAD_TS env vars (auto-set)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,17 @@ Successor to the OpenClaw-based agent system at [PranavBakre/openclaw-agents](ht
 
 For deep architecture and the canonical "critical rules" list, see [CLAUDE.md](./CLAUDE.md). This README is the on-ramp.
 
+## Prerequisites
+
+Junior orchestrates external coding agents and observability tools. Ensure the following are installed and authenticated on your host:
+
+- **[OpenCode](https://opencode.ai)** (Default runner)
+- **[Claude Code CLI](https://anthropic.com)** (Alternate runner)
+- **[Vercel CLI](https://vercel.com/docs/cli)** (Required for `vercel-status` agent)
+- **[New Relic CLI](https://github.com/newrelic/newrelic-cli)** (Required for `nr-research` agent)
+- **[Sentry CLI](https://docs.sentry.io/product/cli/)** (Required for `sentry-fetch` agent)
+- **tmux** (Required for experimental interactive mode)
+
 ---
 
 ## What it does
@@ -177,7 +188,17 @@ Slash-style commands are parsed in [`src/slack/commands.ts`](src/slack/commands.
 !devserver <branch> [repo] -- acquire dev-server slot
 !devserver status          -- queue depth
 !devserver kill <repo>     -- drop slot
+
+!driver <headless|tmux>    -- switch driver (tmux is EXPERIMENTAL)
 ```
+
+### Experimental: TMUX Mode
+
+Junior supports an experimental "Interactive Driver" that runs Claude Code inside a persistent `tmux` session. This allows using your Claude Max subscription instead of API credits, but it is **not yet fully developed or tested**.
+
+To try it:
+- Set `DEFAULT_CLAUDE_DRIVER=tmux` in your `.env`.
+- Ensure `tmux` version ≥ 3.4 is installed.
 
 ---
 
@@ -243,8 +264,10 @@ For per-feature deep dives, see the [`docs/`](docs/) tree — `docs/architecture
 ## Running tests + typecheck
 
 ```sh
+bun run dev         # start bot server with hot reload
 bun run typecheck   # tsc --noEmit
 bun test            # bun:test
+bun run build       # build for production
 bun run cleanup     # remove stale worktrees + sessions
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ For deep architecture and the canonical "critical rules" list, see [CLAUDE.md](.
 
 Junior orchestrates external coding agents and observability tools. Ensure the following are installed and authenticated on your host:
 
-- **[OpenCode](https://opencode.ai)** (Default runner)
-- **[Claude Code CLI](https://anthropic.com)** (Alternate runner)
-- **[Vercel CLI](https://vercel.com/docs/cli)** (Required for `vercel-status` agent)
-- **[New Relic CLI](https://github.com/newrelic/newrelic-cli)** (Required for `nr-research` agent)
-- **[Sentry CLI](https://docs.sentry.io/product/cli/)** (Required for `sentry-fetch` agent)
-- **tmux** (Required for experimental interactive mode)
+- **[OpenCode](https://opencode.ai)** (default runner provider)
+- **[Claude Code CLI](https://anthropic.com)** (Claude provider and tmux driver)
+- **[Vercel CLI](https://vercel.com/docs/cli)** (required by `vercel-status`)
+- **[New Relic CLI](https://github.com/newrelic/newrelic-cli)** (required by `nr-research`)
+- **[Sentry CLI](https://docs.sentry.io/product/cli/)** (required by `sentry-fetch`)
+- **tmux 3.4+** (required only for `DEFAULT_CLAUDE_DRIVER=tmux`)
 
 ---
 
@@ -45,7 +45,7 @@ Each agent stores its own row in the `agent_sessions` SQLite table so threading 
 
 ### Slack MCP server
 
-While Claude is running, it can post to and read from Slack autonomously through an in-process HTTP MCP server ([`src/mcp/slack-server.ts`](src/mcp/slack-server.ts)). Tools exposed:
+While a runner is active, it can post to and read from Slack autonomously through an in-process HTTP MCP server ([`src/mcp/slack-server.ts`](src/mcp/slack-server.ts)). Tools exposed:
 
 - `slack_send_message`, `slack_read_channel`, `slack_read_thread`
 - `slack_search`, `slack_search_users`
@@ -88,7 +88,7 @@ HTTP_DASHBOARD_PORT=8787 bun run dev
 # open http://127.0.0.1:8787
 ```
 
-Binds `127.0.0.1` only — there is no auth. Do not put it behind a reverse proxy without adding one.
+Binds `127.0.0.1` only. Junior is intentionally insecure as a networked product: there is no dashboard auth, and it assumes a trusted local operator. Do not put it behind a reverse proxy without adding auth and a real security review.
 
 | Path | Description |
 | --- | --- |
@@ -194,7 +194,7 @@ Slash-style commands are parsed in [`src/slack/commands.ts`](src/slack/commands.
 
 ### Experimental: TMUX Mode
 
-Junior supports an experimental "Interactive Driver" that runs Claude Code inside a persistent `tmux` session. This allows using your Claude Max subscription instead of API credits, but it is **not yet fully developed or tested**.
+Junior supports an experimental "Interactive Driver" that runs Claude Code inside a persistent `tmux` session. The implementation is present behind a flag and still needs production soak before becoming the default.
 
 To try it:
 - Set `DEFAULT_CLAUDE_DRIVER=tmux` in your `.env`.
@@ -246,7 +246,9 @@ src/
   config.ts             env loading, RepoConfig
   slack/                Bolt app, event handlers, formatting, home tab
   session/              ThreadSession, SessionManager, SQLite + memory stores
-  claude/               spawner, args, stream-json parser
+  runners/              provider selection, shared runtime contract
+  opencode/             OpenCode args, config, parser, spawner
+  claude/               Claude headless spawner, tmux driver, parsers
   worktree/             per-(repo, thread) worktree manager
   agents/               agent loader (.md frontmatter)
   support/              AgentDispatcher, persistent-agent identities
@@ -268,7 +270,7 @@ bun run dev         # start bot server with hot reload
 bun run typecheck   # tsc --noEmit
 bun test            # bun:test
 bun run build       # build for production
-bun run cleanup     # remove stale worktrees + sessions
+bun run cleanup     # delete stale idle/draining session rows
 ```
 
 ---

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-System architecture for junior — the Slack bot that orchestrates Claude Code sessions.
+System architecture for junior — the Slack bot that orchestrates coding-agent sessions.
 
 ## Tech Stack
 
@@ -9,9 +9,9 @@ System architecture for junior — the Slack bot that orchestrates Claude Code s
 | Runtime | Bun | Built-in TS, .env, faster child_process spawning. Fallback to Node+tsx if Bun has issues. |
 | Slack SDK | @slack/bolt (Socket Mode) | Official SDK. Socket Mode = no public URL needed, works from a laptop. |
 | Language | TypeScript (strict, ESM) | Type safety across the session state machine and stream parser. |
-| Persistence (MVP) | In-memory Map | Good enough for single-process bot. |
-| Persistence (prod) | Redis | Survives restarts. TTL-based session cleanup. Provider/factory pattern. |
-| CLI | Claude Code (`claude -p`) | Max subscription auth. Short-lived processes. Stream-json output. |
+| Persistence | SQLite (`bun:sqlite`) | Survives restarts without an external service; memory store remains available for tests/dev. |
+| Runner providers | OpenCode by default, Claude as fallback | Provider adapters normalize CLI args, events, resume semantics, cwd, env, and MCP wiring. |
+| Driver modes | Headless by default, Claude tmux opt-in | Headless uses one subprocess per turn; tmux keeps an interactive Claude session alive behind a flag. |
 
 ## System Diagram
 
@@ -40,17 +40,17 @@ Slack (Socket Mode)
        │               │               │
        ▼               ▼               ▼
 ┌────────────┐  ┌────────────┐  ┌────────────┐
-│   Agent    │  │  Worktree  │  │   Claude   │
-│   Router   │  │  Manager   │  │  Spawner   │
+│   Agent    │  │  Worktree  │  │  Runner    │
+│   Router   │  │  Manager   │  │ Providers   │
 │            │  │            │  │            │
 │ Load .md   │  │ git work-  │  │ spawn      │
-│ from target│  │ tree in    │  │ claude -p  │
-│ repo's     │  │ TARGET     │  │ parse      │
-│ .claude/   │  │ repos      │  │ stream-json│
+│ from target│  │ tree in    │  │ opencode /│
+│ repo's     │  │ TARGET     │  │ claude     │
+│ .claude/   │  │ repos      │  │ parse JSON │
 │ agents/    │  │ (not here) │  │            │
 └─────┬──────┘  └─────┬──────┘  └──────┬─────┘
       │               │                │
-      │   systemPrompt│   cwd          │  stdout events
+      │   systemPrompt│   cwd          │  runner events
       └───────────────┴────────────────┘
                       │
                       ▼
@@ -75,7 +75,7 @@ Target repos (example-backend, example-frontend) are the **data plane** — isol
 This means:
 - Learnings accumulate across all threads (shared control plane)
 - Two threads editing example-backend don't collide (isolated data plane)
-- `--resume` provides per-thread conversation continuity without filesystem isolation
+- Provider-native resume IDs provide per-thread conversation continuity without filesystem isolation
 - Target repos' own `.claude/agents/` definitions are used in-place — not duplicated here
 
 ### 2. Session manager as the central hub
@@ -85,43 +85,44 @@ Every feature touches `ThreadSession`. It's the shared entity, like `jobs` in in
 | Field | Set by | Read by |
 |---|---|---|
 | `status` | Session Manager | All (guards behavior) |
-| `sessionId` | Claude Spawner (from stream-json init event) | Claude Spawner (for --resume) |
-| `worktreePath` | Worktree Manager | Claude Spawner (for cwd) |
+| `sessionId` | Runner provider (from provider event stream) | Runner provider (for native resume) |
+| `worktreePath` | Worktree Manager | Runner provider (for cwd) |
 | `agentType` | Thread Commands / Agent Router | Agent Router (to load definition) |
-| `systemPrompt` | Agent Router | Claude Spawner (for --append-system-prompt) |
+| `systemPrompt` | Agent Router | Runner provider (Claude append-system-prompt or generated OpenCode config) |
 | `pendingMessages` | Session Manager (buffer) | Session Manager (drain) |
 | `verbosity` | Thread Commands | Stream-to-Slack |
 | `targetRepo` | Thread Commands | Worktree Manager, Agent Router |
 
 **Implication:** `ThreadSession` is the integration contract. Changes to its shape affect every module. Keep it stable early.
 
-### 3. Spawner is a dumb executor
+### 3. Runner providers are dumb executors
 
-The spawner accepts pre-composed inputs (system prompt string, cwd path, tool config) and returns structured output (session ID, response text, events). It doesn't know about agents, worktrees, or Slack. This separation means:
+The runner boundary accepts pre-composed inputs (system prompt string, cwd path, tool config) and returns structured output (session ID, response text, normalized events). It doesn't know about Slack routing policy. This separation means:
 
-- Agent router composes the prompt → spawner passes it through
-- Worktree manager resolves the path → spawner uses it as cwd
-- Stream-to-slack subscribes to events → spawner emits them
+- Agent router composes the prompt → provider adapter passes it through
+- Worktree manager resolves the path → shared runtime uses it as cwd
+- Stream-to-slack subscribes to normalized events → provider adapter emits them
 
-Testing the spawner doesn't require Slack, git, or agent definitions.
+Testing provider adapters doesn't require Slack, git, or agent definitions.
 
 ### 4. `cwd` as the configuration mechanism
 
-Instead of passing the target repo's conventions, agent definitions, and CLAUDE.md via flags, set `cwd` to the target repo (or its worktree). Claude Code automatically reads:
+Instead of passing the target repo's conventions and agent definitions via bespoke Slack state, set `cwd` to the target repo (or its worktree). Provider adapters then use that cwd consistently. Claude Code automatically reads:
 - The target repo's `CLAUDE.md`
 - The target repo's `.claude/agents/` definitions
 - The target repo's `.claude/settings.json`
 
-The bot only needs to add:
+The bot also adds provider-specific wiring:
 - `--append-system-prompt` (for the selected agent definition, if overriding)
-- `--mcp-config` (for per-thread tool scoping)
-- `--resume` (for conversation continuity)
+- `--mcp-config` for Claude worktree-backed local tools
+- generated `OPENCODE_CONFIG_CONTENT` for OpenCode prompt, permissions, support subagents, and MCP config
+- native resume flags (`--resume` for Claude, `--session` for OpenCode)
 
-This is inversion of control — the target repo configures Claude, not the bot.
+This is inversion of control — the target repo configures the runner context, not the bot hardcoding every repo convention.
 
-### 5. Stream-json as the system boundary
+### 5. Provider event streams as the system boundary
 
-Everything inside the Claude Code process is opaque. The bot can't inspect Claude's internal state, tool calls in progress, or partial file edits. The only interface is the stream-json stdout:
+Everything inside the runner process is opaque. The bot can't inspect the model's internal state, tool calls in progress, or partial file edits. The interface is provider-native events normalized into `RunnerEvent`. Claude headless emits stream-json:
 
 ```jsonl
 {"type":"system","subtype":"init","session_id":"abc-123"}
@@ -130,7 +131,9 @@ Everything inside the Claude Code process is opaque. The bot can't inspect Claud
 {"type":"result","subtype":"success","text":"Here's what I found:..."}
 ```
 
-**Implication:** The stream parser is the most critical piece to get right. If it drops an event or misparses a line, the bot loses track of what Claude did. Test it thoroughly with real stream-json output samples.
+OpenCode emits JSONL from `opencode run --format json`, and Claude tmux mode tails transcript JSONL. Each adapter maps those shapes into `init`, `message`, `tool`, and `done`.
+
+**Implication:** Provider parsers are critical. If an adapter drops an event or misparses a line, the bot loses track of what the runner did. Test adapters with captured provider output.
 
 ### 6. Provider/factory pattern at every system boundary
 
@@ -138,9 +141,9 @@ Four boundaries need swappable implementations:
 
 | Boundary | Interface | Implementations |
 |---|---|---|
-| Session persistence | `SessionStore` | `InMemorySessionStore`, `RedisSessionStore` |
+| Session persistence | `SessionStore` | `InMemorySessionStore`, `SqliteSessionStore` |
 | Slack posting | `SlackClient` | Real Bolt client, mock for tests |
-| Claude spawning | `ClaudeSpawner` | Real child_process, mock for tests |
+| Runner spawning | `spawnRunner` / driver interfaces | OpenCode adapter, Claude headless adapter, Claude tmux driver |
 | Worktree operations | `WorktreeManager` | Real git commands, mock for tests |
 
 Factory selects the implementation at startup based on config. Consumer code only sees the interface.
@@ -160,19 +163,17 @@ This is simple enough for a pure `validateTransition()` function — no XState n
 
 ### 8. Event-driven internal flow (EventEmitter, not queue)
 
-The spawner emits events as it parses stream-json. Stream-to-Slack subscribes to these events. This is in-process pub/sub — an EventEmitter, not RabbitMQ.
+The runner handle emits normalized events as it parses provider output. Stream-to-Slack subscribes to these events. This is in-process pub/sub, not RabbitMQ.
 
 ```typescript
-// spawner emits
-spawner.on("tool_use", (event) => { ... });
-spawner.on("result", (event) => { ... });
+// runner emits
+handle.onEvent((event) => { ... });
 
 // stream-to-slack subscribes
-spawner.on("tool_use", (event) => updateSlackStatus(event));
-spawner.on("result", (event) => postFinalResponse(event));
+handle.onEvent((event) => updateSlackStatus(event));
 ```
 
-No external message queue needed. If the bot scales to multiple processes, consider Redis pub/sub — but that's post-MVP.
+No external message queue needed. If the bot scales to multiple processes, add a real pub/sub boundary then.
 
 ## Data Flow
 
@@ -184,26 +185,26 @@ Slack message ("!build fix auth")
   → Session Manager: no existing session → create with agentType="build"
   → Worktree Manager: create worktree in example-backend
   → Agent Router: load example-backend/.claude/agents/build.md → compose systemPrompt
-  → Claude Spawner: spawn claude -p "fix auth" --resume --append-system-prompt "..." 
+  → Runner Provider: spawn opencode/claude with the composed prompt and native resume flags
       cwd=example-backend.junior-worktrees/slack-<threadId>
-  → Stream Parser: parse stdout events
+  → Provider Parser: parse stdout/transcript events
       → init event: extract sessionId, store in session
-      → tool_use events: emit to Stream-to-Slack → edit status message
-      → result event: emit to Stream-to-Slack → post final response
+      → tool events: emit to Stream-to-Slack → edit status message
+      → done/final response: emit to Stream-to-Slack → post final response
   → Session Manager: set status=idle, check pendingMessages
   → Done
 ```
 
-### Happy path: message while Claude is busy
+### Happy path: message while a runner is busy
 
 ```
 Slack message ("also fix the tests")
   → Event Handler: extract threadId
   → Session Manager: session exists, status=busy → buffer message, react with 👀
-  → [Claude finishes previous turn]
+  → [Runner finishes previous turn]
   → Session Manager: status → draining, combine buffered messages
       "[alice]: also fix the tests"
-  → Claude Spawner: spawn claude -p "<combined>" --resume <sessionId>
+  → Runner Provider: spawn next turn with native resume id
   → [same flow as above]
 ```
 
@@ -224,14 +225,17 @@ slack/app ──── slack/events ──── slack/commands       │
           │          │    │    │          │           │
           └──────────┤    │    ├──────────┘           │
                      │    │    │                       │
-                 claude/spawner ◄──────────────────────┘
+                 runners/index ◄──────────────────────┘
                      │    │
-              claude/parser
+          ┌──────────┘    └──────────┐
+     opencode/*                  claude/*
+          │                           │
+          └────────── runner events ──┘
                      │
               stream-to-slack
 ```
 
-**Direction of dependencies:** config is depended on by all. Slack modules produce events. Session manager is the hub. Spawner, router, and worktree manager are peers that the session manager coordinates. Stream-to-slack subscribes to spawner events.
+**Direction of dependencies:** config is depended on by all. Slack modules produce events. Session manager is the hub. Runner providers, router, and worktree manager are peers that the session manager coordinates. Stream-to-slack subscribes to runner events.
 
 **No circular dependencies.** If module A depends on B, B must not depend on A. The session manager coordinates the other modules but doesn't import from stream-to-slack — it emits events that stream-to-slack subscribes to.
 
@@ -239,7 +243,7 @@ slack/app ──── slack/events ──── slack/commands       │
 
 ### Error handling
 
-Errors at system boundaries (Slack API, Claude CLI, git commands) are caught and converted to user-facing Slack messages. Internal errors (state machine violations, parse failures) are logged but don't crash the bot.
+Errors at system boundaries (Slack API, runner CLI, git commands) are caught and converted to user-facing Slack messages. Internal errors (state machine violations, parse failures) are logged but don't crash the bot.
 
 ### Logging
 
@@ -249,14 +253,14 @@ Console.log for MVP. Structured logging (pino) for production. Every log line in
 
 | Layer | Test approach |
 |---|---|
-| Stream parser | Unit tests with captured stream-json samples |
+| Provider parsers | Unit tests with captured Claude/OpenCode/tmux transcript samples |
 | Session state machine | Unit tests — pure function, no I/O |
 | Agent loader | Unit tests — read real .md files from fixtures |
-| Spawner | Integration tests — mock child_process or use real Claude with simple prompts |
+| Runner adapters | Integration tests — mock child_process or use real CLI smoke tests |
 | Slack handler | Integration tests — mock Bolt client |
 | End-to-end | Manual — send Slack messages, verify responses |
 
-Mock at the four system boundaries (Slack, Claude, git, Redis). Everything internal is tested with real code.
+Mock at the four system boundaries (Slack, runner CLI, git, persistence). Everything internal is tested with real code.
 
 ## Patterns from Reference Projects
 

--- a/docs/code_index/agent-definitions.md
+++ b/docs/code_index/agent-definitions.md
@@ -1,0 +1,21 @@
+# Code Index: Agent Definitions
+
+This module handles loading and parsing of agent definitions from markdown files with YAML frontmatter.
+
+## Directory Structure
+
+- [.claude/agents/](file:///Users/psbakre/Projects/junior/.claude/agents/): Public agent definitions.
+- [agents-org/](file:///Users/psbakre/Projects/junior/agents-org/): Private/overlay agent definitions (git submodule).
+- [support/agents/](file:///Users/psbakre/Projects/junior/support/agents/): Stateless support sub-agent prompts.
+
+## Key Files
+
+- [loader.ts](file:///Users/psbakre/Projects/junior/src/agents/loader.ts): Handles reading `.md` files and parsing frontmatter identities.
+- [router.ts](file:///Users/psbakre/Projects/junior/src/agents/router.ts): High-level routing logic to pick an agent definition based on thread state.
+
+## Data Flow
+
+1. `AgentDispatcher` (in `support/router.ts`) identifies the requested agent.
+2. `AgentRouter` calls the `loader` to fetch the definition from the target repo's `.claude/agents/` or Junior's own registries.
+3. The frontmatter (username, emoji) is used for Slack attribution.
+4. The markdown body is passed as the system prompt to the runner provider.

--- a/docs/code_index/agent-definitions.md
+++ b/docs/code_index/agent-definitions.md
@@ -1,21 +1,31 @@
 # Code Index: Agent Definitions
 
-This module handles loading and parsing of agent definitions from markdown files with YAML frontmatter.
+This module handles loading, parsing, and routing of agent definitions from markdown files with YAML frontmatter.
 
-## Directory Structure
+## Definition Locations
 
-- [.claude/agents/](file:///Users/psbakre/Projects/junior/.claude/agents/): Public agent definitions.
-- [agents-org/](file:///Users/psbakre/Projects/junior/agents-org/): Private/overlay agent definitions (git submodule).
-- [support/agents/](file:///Users/psbakre/Projects/junior/support/agents/): Stateless support sub-agent prompts.
+| Path | Purpose |
+|---|---|
+| `.claude/agents/` | Public fallback agents and shared common prompt files. |
+| `agents-org/` | Private overlay agents and common prompt files, mounted as a git submodule. |
+| `<target-repo>/.claude/agents/` | Repo-local agent definitions, used first when `session.targetRepo` is set. |
+| `support/agents/` | Stateless OpenCode support subagents such as `nr-research`, `sentry-fetch`, and `vercel-status`. |
 
-## Key Files
+## Code Index
 
-- [loader.ts](file:///Users/psbakre/Projects/junior/src/agents/loader.ts): Handles reading `.md` files and parsing frontmatter identities.
-- [router.ts](file:///Users/psbakre/Projects/junior/src/agents/router.ts): High-level routing logic to pick an agent definition based on thread state.
+| Symbol | File | Purpose |
+|---|---|---|
+| `loadAgentDefinition(filePath)` | `src/agents/loader.ts` | Reads an agent markdown file, parses flat frontmatter, strips quotes, and returns the body prompt. |
+| `parseAgentFrontmatter(...)` | `src/agents/loader.ts` | Parses `name`, `description`, `tools`, `model`, `common`, `username`, `iconEmoji`, and `context.*` flags. |
+| `AgentRouter.resolveAgent(session)` | `src/agents/router.ts` | Resolves target repo -> org overlay -> public fallback, first match wins. |
+| `AgentRouter.composeSystemPrompt(session)` | `src/agents/router.ts` | Prepends selected common prompt files and appends the resolved agent body. |
+| `loadOverlayIdentities(...)` | `src/support/agents.ts` | Loads Slack identity frontmatter for overlay/private persistent agents. |
+| `loadOpenCodeSupportSubagents()` | `src/opencode/support-agents.ts` | Loads stateless support prompts into generated OpenCode config. |
 
 ## Data Flow
 
-1. `AgentDispatcher` (in `support/router.ts`) identifies the requested agent.
-2. `AgentRouter` calls the `loader` to fetch the definition from the target repo's `.claude/agents/` or Junior's own registries.
-3. The frontmatter (username, emoji) is used for Slack attribution.
-4. The markdown body is passed as the system prompt to the runner provider.
+1. `AgentDispatcher` (`src/support/router.ts`) identifies a persistent-agent directive when one is present.
+2. `SessionManager` sets the active agent and asks `AgentRouter` for the composed prompt.
+3. `AgentRouter` resolves the agent from the target repo, private overlay, or public fallback.
+4. Common prompt files selected by `common:` are loaded from the repo/public layer, with org overlay common files appended when configured.
+5. The composed prompt and Slack identity are passed to the selected runner provider.

--- a/docs/code_index/bug-pipeline-worktrees.md
+++ b/docs/code_index/bug-pipeline-worktrees.md
@@ -1,0 +1,20 @@
+# Code Index: Bug Pipeline Worktrees
+
+This module manages the lifecycle of git worktrees created in target repositories to provide code isolation for Slack threads.
+
+## Key Files
+
+- [manager.ts](file:///Users/psbakre/Projects/junior/src/worktree/manager.ts): Core logic for `git worktree add`, `remove`, and `prune`.
+- [types.ts](file:///Users/psbakre/Projects/junior/src/worktree/types.ts): `RepoConfig` and worktree state interfaces.
+
+## Worktree Layout
+
+Worktrees are created at:
+`<repo-path>.junior-worktrees/slack-<threadId>`
+
+This keeps them sibling to the original repository but clearly separated.
+
+## Lifecycle
+
+1. **Acquire**: When a thread first touches a repo, `WorktreeManager` creates the worktree and runs the optional `worktreeSetupCommand`.
+2. **Cleanup**: Stale worktrees (inactive for 24h) are pruned by the `cleanup` script to save disk space.

--- a/docs/code_index/bug-pipeline-worktrees.md
+++ b/docs/code_index/bug-pipeline-worktrees.md
@@ -1,20 +1,28 @@
 # Code Index: Bug Pipeline Worktrees
 
-This module manages the lifecycle of git worktrees created in target repositories to provide code isolation for Slack threads.
+This index ties the bug-pipeline worktree behavior to the worktree manager, session state, Slack MCP registration, and dev-server queue.
 
-## Key Files
+## Code Index
 
-- [manager.ts](file:///Users/psbakre/Projects/junior/src/worktree/manager.ts): Core logic for `git worktree add`, `remove`, and `prune`.
-- [types.ts](file:///Users/psbakre/Projects/junior/src/worktree/types.ts): `RepoConfig` and worktree state interfaces.
+| Symbol | File | Purpose |
+|---|---|---|
+| `WorktreeManager.createWorktree(...)` | `src/worktree/manager.ts` | Creates per-thread target-repo worktrees inline or via `worktreeSetupCommand`. |
+| `WorktreeManager.getWorktreePath(...)` | `src/worktree/manager.ts` | Resolves `<repo.path>.junior-worktrees/slack-<threadId>`, outside the repo. |
+| `ThreadSession.worktreePaths` | `src/session/types.ts` | Stores per-repo worktree paths for multi-repo bug threads. |
+| `buildWorkspaceBlock(...)` | `src/slack/thread-context.ts` | Injects single- or multi-repo workspace safety rules into runner prompts. |
+| `register_worktree` | `src/mcp/slack-server.ts` | Lets a runner claim/create a repo worktree for the current Slack thread. |
+| `DevServerQueue.acquire(...)` | `src/lifecycle/dev-server-queue.ts` | Serializes shared dev-server slots across threads. |
 
 ## Worktree Layout
 
 Worktrees are created at:
 `<repo-path>.junior-worktrees/slack-<threadId>`
 
-This keeps them sibling to the original repository but clearly separated.
+This keeps them sibling to the original repository. They are deliberately not placed under `.claude/`, because target-repo setup scripts may copy `.claude/` recursively.
 
 ## Lifecycle
 
-1. **Acquire**: When a thread first touches a repo, `WorktreeManager` creates the worktree and runs the optional `worktreeSetupCommand`.
-2. **Cleanup**: Stale worktrees (inactive for 24h) are pruned by the `cleanup` script to save disk space.
+1. **Acquire**: When a target-repo thread or `register_worktree` first needs a repo, `WorktreeManager` creates the worktree and runs the optional `worktreeSetupCommand`.
+2. **Use**: `SessionManager` runs the provider from the worktree cwd; multi-repo bug threads carry all paths in `session.worktreePaths`.
+3. **Dev-server slot**: `!devserver` uses the shared queue/manager rather than letting every thread own a fixed port independently.
+4. **Cleanup**: `cleanupStaleSessions` deletes stale session rows only. Worktree deletion is a separate operation and must check `isWorktreeDirty()` before `removeWorktree()`.

--- a/docs/code_index/http-dashboard.md
+++ b/docs/code_index/http-dashboard.md
@@ -1,6 +1,6 @@
 # Code Index: HTTP Dashboard
 
-Localhost-only HTTP server for operator inspection (sessions, dev-servers, logs, docs). Off by default; enabled via `HTTP_DASHBOARD_PORT`. Binds 127.0.0.1, no auth.
+Localhost-only HTTP server for operator inspection (sessions, dev-servers, logs, docs). Off by default; enabled via `HTTP_DASHBOARD_PORT`. Binds 127.0.0.1 and intentionally has no auth; do not expose it beyond a trusted local operator environment.
 
 ## Code Index
 

--- a/docs/code_index/interactive-driver.md
+++ b/docs/code_index/interactive-driver.md
@@ -1,14 +1,20 @@
 # Code Index: Interactive Driver (EXPERIMENTAL)
 
 > [!WARNING]
-> This module is **EXPERIMENTAL** and not yet fully developed or tested.
+> This module is experimental and opt-in. The implementation exists behind `DEFAULT_CLAUDE_DRIVER=tmux`, but the default remains headless while it soaks.
 
-This module provides the "Interactive" execution path, driving Claude Code inside a persistent `tmux` session to utilize the Max subscription instead of API credits.
+This module provides the interactive Claude execution path, driving Claude Code inside a persistent `tmux` session instead of spawning `claude -p` for every turn.
 
-## Key Files
+## Code Index
 
-- [runtime.ts](file:///Users/psbakre/Projects/junior/src/runners/runtime.ts): Orchestrates the choice between headless and interactive drivers.
-- [src/claude/tmux-driver.ts](file:///Users/psbakre/Projects/junior/src/claude/tmux-driver.ts) (Internal): Implementation of the tmux driver.
+| Symbol | File | Purpose |
+|---|---|---|
+| `createDriver(mode, config)` | `src/claude/factory.ts` | Selects `HeadlessDriver` or `TmuxDriver`. |
+| `HeadlessDriver` | `src/claude/headless-driver.ts` | Wraps the existing `claude -p` spawner path. |
+| `TmuxDriver` | `src/claude/tmux-driver.ts` | Starts/reuses tmux sessions, pastes prompts, tails transcripts, and supports interrupts. |
+| `adaptTranscriptLine(...)` | `src/claude/transcript-adapter.ts` | Converts Claude transcript JSONL lines into stream events. |
+| `reconcileTmuxSessions(...)` | `src/lifecycle/tmux-reconcile.ts` | Reattaches or downgrades tmux sessions on bot boot. |
+| `evictIdleTmuxSessions(...)` | `src/lifecycle/tmux-evict.ts` | Kills idle tmux sessions while preserving resume IDs. |
 
 ## Mechanism
 

--- a/docs/code_index/interactive-driver.md
+++ b/docs/code_index/interactive-driver.md
@@ -1,0 +1,18 @@
+# Code Index: Interactive Driver (EXPERIMENTAL)
+
+> [!WARNING]
+> This module is **EXPERIMENTAL** and not yet fully developed or tested.
+
+This module provides the "Interactive" execution path, driving Claude Code inside a persistent `tmux` session to utilize the Max subscription instead of API credits.
+
+## Key Files
+
+- [runtime.ts](file:///Users/psbakre/Projects/junior/src/runners/runtime.ts): Orchestrates the choice between headless and interactive drivers.
+- [src/claude/tmux-driver.ts](file:///Users/psbakre/Projects/junior/src/claude/tmux-driver.ts) (Internal): Implementation of the tmux driver.
+
+## Mechanism
+
+1. **Session Start**: `tmux new-session -d` starts Claude Code TUI.
+2. **Input**: Prompts are injected via `tmux load-buffer` + `paste-buffer -p`.
+3. **Observation**: The driver tails the Claude transcript file (`~/.claude/projects/.../*.jsonl`) to extract events.
+4. **Completion**: A `system.turn_duration` event in the transcript signals the end of the turn.

--- a/docs/features/bug-pipeline-worktrees.md
+++ b/docs/features/bug-pipeline-worktrees.md
@@ -220,7 +220,7 @@ Extend `lifecycle/cleanup.ts`:
 - Replacing `repo-routing.yaml` with anything else.
 - Changing how `thinker` opens PRs.
 - Multi-repo dev-server orchestration beyond the FE+BE pair.
-- Auto-cleanup of the per-thread worktrees on bug-thread completion (already covered by the existing worktree cleanup feature).
+- Auto-cleanup of the per-thread worktrees on bug-thread completion. Today `cleanupStaleSessions` deletes stale session rows only; worktree deletion must be a separate dirty-checked operation.
 
 ## Build order
 

--- a/docs/features/http-dashboard.md
+++ b/docs/features/http-dashboard.md
@@ -23,9 +23,11 @@ src/http/
 
 Bun-native: no router framework, no auth, no CORS. Static `public/index.html` is served at `/` from the same origin as the API, so cross-origin access has no reason to exist.
 
+Junior is intentionally insecure as a networked product. The dashboard assumes a trusted local operator and host-level access control; exposing it beyond loopback requires adding authentication, authorization, and a real security review.
+
 ## Security posture
 
-- **Loopback-only.** Binds `127.0.0.1` — never reachable off-host without an explicit SSH tunnel. This is the entire threat model; there is no auth layer behind it.
+- **Loopback-only.** Binds `127.0.0.1` — never reachable off-host without an explicit SSH tunnel. This is the entire threat model; there is intentionally no auth layer behind it.
 - **Same-origin.** Dashboard HTML is served by the same Bun process. No CORS headers — adding `Access-Control-Allow-Origin: *` would only let arbitrary websites the operator visits read this server's data.
 - **Path-traversal rejection at the input layer.** `/api/logs?date=` accepts only `YYYY-MM-DD` (strict regex); `/api/memory/<path>` rejects `..` and absolute paths and verifies the resolved path stays inside `docs/`. Reject early, don't sanitize after concatenation.
 - **Projection on `/api/sessions`.** Filesystem paths (`worktreePath`, `cwd`), PIDs (`pid`), prompt-engineering details (`systemPrompt`), and `slackIdentity` are stripped before serialization. `pendingMessages` is reduced to a length count — message bodies never leave the box.

--- a/docs/features/runner-providers.md
+++ b/docs/features/runner-providers.md
@@ -8,7 +8,8 @@ adapters own each CLI's flags, native event stream, prompt mechanics, MCP config
 and resume semantics.
 
 ## Status
-The provider abstraction and OpenCode/Claude adapters are fully implemented and in production as of 2026-05-18. OpenCode is the default provider.
+
+The provider abstraction and OpenCode/Claude adapters are implemented. OpenCode is the default provider (`RUNNER_PROVIDER=opencode`); Claude remains the fallback provider.
 
 OpenCode is currently a better replacement candidate than Codex for Junior's
 specific needs because it has:
@@ -120,7 +121,7 @@ that project MCP wiring for explicit `session.cwd` utility runs.
 
 ## Current Claude Mapping
 
-Claude remains the default adapter during the migration.
+Claude remains an implemented fallback adapter.
 
 | Junior need | Claude today |
 |---|---|

--- a/docs/features/runner-providers.md
+++ b/docs/features/runner-providers.md
@@ -7,10 +7,8 @@ provider boundary: Junior owns Slack/session/worktree behavior, and provider
 adapters own each CLI's flags, native event stream, prompt mechanics, MCP config,
 and resume semantics.
 
-## Recommendation
-
-Build the provider abstraction first, then add OpenCode as the first non-Claude
-provider.
+## Status
+The provider abstraction and OpenCode/Claude adapters are fully implemented and in production as of 2026-05-18. OpenCode is the default provider.
 
 OpenCode is currently a better replacement candidate than Codex for Junior's
 specific needs because it has:

--- a/docs/features/v2-backlog.md
+++ b/docs/features/v2-backlog.md
@@ -2,22 +2,9 @@
 
 Features explicitly deferred from MVP. To be scoped when MVP is running.
 
-## Admin Dashboard
+## Admin Dashboard (DONE)
 
-**Problem:** No visibility into what's happening across threads. How many sessions are active? Which threads are stuck? What agent types are being used? Which repos? Without a dashboard, debugging requires reading server logs.
-
-**Scope (to be refined):**
-- Live session graph: threads as nodes, edges showing dependencies (drain chains, worktree sharing)
-- Per-session detail: agent type, status (idle/busy/draining), last activity, pending message count, worktree path, session ID
-- Activity timeline: message received → Claude spawned → events streamed → response posted, with timestamps
-- Error log: failed spawns, timeouts, orphaned sessions — filterable
-- Who's using what: Slack user → threads → agent types → repos
-- Metrics: response latency p50/p99, timeout rate, buffer frequency, agent type distribution
-
-**Open questions:**
-- Web UI or Slack-native (home tab)? Web gives more flexibility. Slack home tab is zero-deploy.
-- Real-time or polling? EventSource/WebSocket from the bot server, or periodic API calls?
-- Auth? If web UI, who can see the dashboard? Pranav only, or whole team?
+**Status:** Completed as the [HTTP Dashboard](./http-dashboard.md). Surfaces live sessions, dev-server queue, logs, and docs.
 
 ## Batch User Resolution in Thread Context
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -21,7 +21,7 @@ Junior uses the native permission models of its runners:
 - **Claude Code**: Uses `--permission-mode bypassPermissions` for trusted developer use, or can be configured for restricted modes.
 
 ## 4. MCP Server Security
-The in-process Slack MCP server only exposes tools to the locally spawned runner processes. It requires a shared `MCP_PORT` that is not exposed externally.
+The in-process Slack MCP server is intended for locally spawned runner processes and requires a shared `MCP_PORT`. It does not currently bind explicitly to loopback, so treat it as local-network exposed unless the host firewall or deployment environment restricts the port.
 
 ## 5. Environment Variables
 Sensitive tokens (`SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`) should be stored in a `.env` file that is never committed (included in `.gitignore`).

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,12 +1,14 @@
 # Security Posture
 
-Junior is designed as a developer tool running on a local workstation or a trusted private server.
+Junior is intentionally insecure as a networked product. It is a trusted-operator developer tool meant to run on a local workstation or a private server controlled by the operator, with access limited by host/network boundaries rather than by application-layer auth.
+
+Do not expose Junior, its dashboard, or its MCP server to untrusted networks without adding authentication, authorization, request-origin checks, and a real deployment security review.
 
 ## 1. Loopback-only Dashboard
 The [HTTP Dashboard](./features/http-dashboard.md) binds only to `127.0.0.1` by default.
 - **No Remote Access**: It is not reachable from the internet without an explicit SSH tunnel.
-- **No Auth**: Because it is loopback-only, it does not include an authentication layer.
-- **CSRF Protection**: The API is restricted to the same origin; external sites cannot trigger Junior actions via the dashboard.
+- **No Auth by Design**: Because Junior assumes a trusted local operator, the dashboard does not include an authentication layer.
+- **No CORS Opt-in**: The dashboard does not emit CORS headers, so arbitrary websites cannot read API responses from a browser. The current dashboard is read-only; it does not validate `Origin` or `Sec-Fetch-Site` as a CSRF defense.
 
 ## 2. Worktree Isolation
 Target repositories are never edited in their original paths.
@@ -15,7 +17,7 @@ Target repositories are never edited in their original paths.
 
 ## 3. Provider-level Permissions
 Junior uses the native permission models of its runners:
-- **OpenCode**: Junior generates a restricted `opencode.json` config per spawn, explicitly allowing or denying tools (e.g., `bash` is often restricted for support agents).
+- **OpenCode**: Junior generates config per spawn through `OPENCODE_CONFIG_CONTENT`, including permissions, MCP entries, and constrained support subagents.
 - **Claude Code**: Uses `--permission-mode bypassPermissions` for trusted developer use, or can be configured for restricted modes.
 
 ## 4. MCP Server Security

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,25 @@
+# Security Posture
+
+Junior is designed as a developer tool running on a local workstation or a trusted private server.
+
+## 1. Loopback-only Dashboard
+The [HTTP Dashboard](./features/http-dashboard.md) binds only to `127.0.0.1` by default.
+- **No Remote Access**: It is not reachable from the internet without an explicit SSH tunnel.
+- **No Auth**: Because it is loopback-only, it does not include an authentication layer.
+- **CSRF Protection**: The API is restricted to the same origin; external sites cannot trigger Junior actions via the dashboard.
+
+## 2. Worktree Isolation
+Target repositories are never edited in their original paths.
+- **Data Plane Isolation**: Junior creates isolated git worktrees for each Slack thread.
+- **No Shared State**: Edits in one thread cannot affect the main branch or other threads until explicitly pushed by the runner.
+
+## 3. Provider-level Permissions
+Junior uses the native permission models of its runners:
+- **OpenCode**: Junior generates a restricted `opencode.json` config per spawn, explicitly allowing or denying tools (e.g., `bash` is often restricted for support agents).
+- **Claude Code**: Uses `--permission-mode bypassPermissions` for trusted developer use, or can be configured for restricted modes.
+
+## 4. MCP Server Security
+The in-process Slack MCP server only exposes tools to the locally spawned runner processes. It requires a shared `MCP_PORT` that is not exposed externally.
+
+## 5. Environment Variables
+Sensitive tokens (`SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`) should be stored in a `.env` file that is never committed (included in `.gitignore`).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,27 @@
+# Troubleshooting Guide
+
+## 1. Runner Not Found
+**Symptoms:** "Command not found: opencode" or "claude" in logs.
+- **Fix:** Ensure the required CLIs are installed and available in your `$PATH`.
+- **Note:** Junior spawns these as subprocesses; if you can't run them in your terminal, Junior can't either.
+
+## 2. TMUX Version Too Old
+**Symptoms:** Interactive mode fails to paste prompts or errors on `-p`.
+- **Requirement:** `tmux` version 3.4 or higher is required for the bracketed paste (`-p`) flag.
+- **Check:** `tmux -V`
+- **Fix:** Upgrade tmux via `brew upgrade tmux` (macOS) or your Linux package manager.
+
+## 3. Slack Rate Limits
+**Symptoms:** "ratelimited" errors in logs; messages delayed or skipped.
+- **Cause:** Large threads with many participants or rapid-fire commands can hit Slack's Tier 2 limits.
+- **Fix:** The bot will automatically retry with exponential backoff, but you can reduce noise by muting inactive threads (`!mute`).
+
+## 4. SQLite Database Locked
+**Symptoms:** "database is locked" errors during session persistence.
+- **Cause:** Concurrent writers or a hung process holding a lock.
+- **Fix:** Check for orphan `bun` processes. `bun run cleanup` can help clear stale state.
+
+## 5. Dev Server Fails to Start
+**Symptoms:** `!devserver` status shows `error` or times out.
+- **Check:** Ensure the `devCommand` and `devPort` in your `REPOS` config are correct.
+- **Logs:** Check `logs/<date>.log` for the specific stdout/stderr from the dev-server spawn.

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "bun --watch src/index.ts",
     "start": "bun src/index.ts",
     "typecheck": "tsc --noEmit",
-    "test": "bun test"
+    "test": "bun test",
+    "build": "bun build ./src/index.ts --outdir ./dist --target bun",
+    "cleanup": "bun run src/lifecycle/cleanup.ts"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",

--- a/src/lifecycle/cleanup.test.ts
+++ b/src/lifecycle/cleanup.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect } from "bun:test";
-import { cleanupStaleSessions } from "./cleanup.ts";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { cleanupStaleSessions, runCleanupFromEnv } from "./cleanup.ts";
 import { InMemorySessionStore } from "../session/store/memory.ts";
+import { SqliteSessionStore } from "../session/store/sqlite.ts";
 import { createSession } from "../session/types.ts";
 
 describe("cleanupStaleSessions", () => {
@@ -97,5 +101,40 @@ describe("cleanupStaleSessions", () => {
     const cleaned = await cleanupStaleSessions(store, 50_000);
     expect(cleaned).toEqual([]);
     expect(await store.get("thread-1")).toBeDefined();
+  });
+
+  it("CLI entrypoint cleans persisted sqlite sessions", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "junior-cleanup-test-"));
+    const dbPath = join(dir, "sessions.db");
+    const store = new SqliteSessionStore(dbPath);
+
+    try {
+      const staleIdle = createSession("stale-idle", "channel-1");
+      staleIdle.lastActivity = Date.now() - 100_000;
+      staleIdle.status = "idle";
+      await store.set("stale-idle", staleIdle);
+      store.close();
+
+      const logs: unknown[] = [];
+      const cleaned = await runCleanupFromEnv(
+        {
+          SESSION_STORE: "sqlite",
+          SESSION_DB_PATH: dbPath,
+          SESSION_STALE_TIMEOUT_MS: "50000",
+        },
+        { log: (message?: unknown) => logs.push(message) },
+      );
+
+      const verificationStore = new SqliteSessionStore(dbPath);
+      try {
+        expect(cleaned).toEqual(["stale-idle"]);
+        expect(await verificationStore.get("stale-idle")).toBeUndefined();
+        expect(logs).toContain("Removed 1 stale session(s).");
+      } finally {
+        verificationStore.close();
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 });

--- a/src/lifecycle/cleanup.ts
+++ b/src/lifecycle/cleanup.ts
@@ -1,4 +1,7 @@
+import { resolve } from "node:path";
 import type { SessionStore } from "../session/store/interface.ts";
+import { InMemorySessionStore } from "../session/store/memory.ts";
+import { SqliteSessionStore } from "../session/store/sqlite.ts";
 
 export async function cleanupStaleSessions(
   store: SessionStore,
@@ -18,4 +21,67 @@ export async function cleanupStaleSessions(
   }
 
   return cleaned;
+}
+
+interface CleanupEnv extends Record<string, string | undefined> {
+  SESSION_STORE?: string;
+  SESSION_DB_PATH?: string;
+  SESSION_STALE_TIMEOUT_MS?: string;
+}
+
+interface CleanupLogger {
+  log(message?: unknown, ...optionalParams: unknown[]): void;
+}
+
+type ClosableSessionStore = SessionStore & { close?: () => void };
+
+export async function runCleanupFromEnv(
+  env: CleanupEnv = process.env,
+  logger: CleanupLogger = console,
+): Promise<string[]> {
+  const store = createCleanupStore(env);
+  try {
+    const staleTimeoutMs = parsePositiveIntegerEnv(
+      env.SESSION_STALE_TIMEOUT_MS,
+      86_400_000,
+      "SESSION_STALE_TIMEOUT_MS",
+    );
+    const cleaned = await cleanupStaleSessions(store, staleTimeoutMs);
+    logger.log(`Removed ${cleaned.length} stale session(s).`);
+    if (cleaned.length > 0) {
+      logger.log(cleaned.join("\n"));
+    }
+    return cleaned;
+  } finally {
+    store.close?.();
+  }
+}
+
+function createCleanupStore(env: CleanupEnv): ClosableSessionStore {
+  const storeKind = env.SESSION_STORE ?? "sqlite";
+  if (storeKind === "memory") return new InMemorySessionStore();
+  if (storeKind === "sqlite") {
+    return new SqliteSessionStore(resolve(env.SESSION_DB_PATH ?? "data/sessions.db"));
+  }
+  throw new Error(`Invalid SESSION_STORE: ${storeKind} (expected memory|sqlite)`);
+}
+
+function parsePositiveIntegerEnv(
+  raw: string | undefined,
+  fallback: number,
+  name: string,
+): number {
+  if (raw == null || raw === "") return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value <= 0) {
+    throw new Error(`Invalid ${name}: ${JSON.stringify(raw)} (expected positive integer)`);
+  }
+  return value;
+}
+
+if (import.meta.main) {
+  runCleanupFromEnv().catch((err) => {
+    console.error(err instanceof Error ? err.message : err);
+    process.exitCode = 1;
+  });
 }


### PR DESCRIPTION
This PR synchronizes the project documentation with the current implementation state. It acknowledges OpenCode as the default runner, preserves CLAUDE.md for manual use, documents external tool requirements (Vercel, Sentry, NewRelic), and fixes technical drift in package.json.