### PR TITLE
Add direct worklog cron

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,18 @@ SESSION_DEFAULT_VERBOSITY=normal
 # Localhost dashboard. Unset to disable.
 # HTTP_DASHBOARD_PORT=3457
 
+# Daily PR/commit worklog. Posts to Slack and writes docs/worklog/YYYY-MM-DD.md.
+# WORKLOG_CRON_ENABLED=false
+# WORKLOG_SLACK_CHANNEL=C0123456789
+# WORKLOG_SLACK_THREAD_TS=1234567890.123456
+# WORKLOG_DAILY_AT=18:00
+# WORKLOG_LOOKBACK_HOURS=24
+# WORKLOG_DOCS_DIR=docs/worklog
+# WORKLOG_GIT_AUTHOR=you@example.com
+# WORKLOG_GITHUB_USER=your-github-login
+# WORKLOG_USE_AGENT=true
+# WORKLOG_RUN_ON_STARTUP=false
+
 # Slack-bot MCP server (used by spawned Claude sessions to post back to threads).
 MCP_PORT=3456
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,16 @@ All config is loaded from environment variables in [`src/config.ts`](src/config.
 | `SESSION_STORE` | `sqlite` | `sqlite` or `memory` |
 | `SESSION_DB_PATH` | `data/sessions.db` | SQLite file path |
 | `HTTP_DASHBOARD_PORT` | *(unset)* | If set, starts the localhost dashboard |
+| `WORKLOG_CRON_ENABLED` | `false` | Enables the daily PR/commit worklog cron |
+| `WORKLOG_SLACK_CHANNEL` | *(unset)* | Slack channel ID for the worklog post; required when enabled |
+| `WORKLOG_SLACK_THREAD_TS` | *(unset)* | Optional thread timestamp to post the worklog into |
+| `WORKLOG_DAILY_AT` | `18:00` | Local server time for the daily worklog run (`HH:mm`) |
+| `WORKLOG_LOOKBACK_HOURS` | `24` | Commit/PR lookback window |
+| `WORKLOG_DOCS_DIR` | `docs/worklog` | Directory for generated markdown snapshots |
+| `WORKLOG_GIT_AUTHOR` | repo git config | Optional git author filter for commits |
+| `WORKLOG_GITHUB_USER` | gh `@me` | Optional GitHub username for PR filtering |
+| `WORKLOG_USE_AGENT` | `true` | Let the configured runner compress/group the raw activity before posting |
+| `WORKLOG_RUN_ON_STARTUP` | `false` | Run once immediately after boot for verification |
 | `MCP_PORT` | `3456` | Port for the in-process Slack MCP server |
 | `RUNNER_PROVIDER` | `opencode` | Default runner provider: `opencode` or `claude` (codex is planned but not yet implemented) |
 | `CLAUDE_MAX_TURNS` | `25` | Max turns per `claude -p` invocation |

--- a/docs/features/project-setup.md
+++ b/docs/features/project-setup.md
@@ -33,7 +33,16 @@ The bot needs environment configuration (Slack tokens, repo paths, timeouts) and
 9. `app.start()`, resolve bot identity via `auth.test`, register event handlers (every message goes through `supportRouter.handleMessage`).
 10. If `config.http.enabled`, dynamic-import `./http/server.ts` and start the localhost dashboard. Failure is non-fatal — logged so the bot keeps running.
 
-## Private Org Overlay
+## Git Submodule Layout
+
+Submodule paths and remotes are defined only in `.gitmodules`. README and feature docs should not list private repository names, remotes, or org-specific content. They should document only the runtime contract Junior expects from mounted submodules.
+
+Junior currently expects two optional submodule-backed content roots:
+
+| Root | Contract |
+| --- | --- |
+| `identity/` | Persona material. Each persona lives under its own directory and may expose `IDENTITY.md` and `SOUL.md`. Junior treats these as private prompt/context source files; their content is documented inside the submodule, not here. |
+| `agents-org/` | Private/org overlay. May provide agent definitions, shared prompt fragments, and workflow definitions using the same external schema as the public roots. Org-specific details stay inside the submodule. |
 
 The private agent overlay is mounted at `agents-org/`, not under `.claude/`, because it is Junior-owned runtime data rather than a Claude Code native agent directory. Fresh clones initialize it with:
 

--- a/docs/features/v2-backlog.md
+++ b/docs/features/v2-backlog.md
@@ -47,6 +47,22 @@ Features explicitly deferred from MVP. To be scoped when MVP is running.
 - Does `!mute` (no arg) become an alias for `!mute all`, or a usage error like `!reset`? Leaning toward usage error to stay consistent with `!reset`.
 - Should muting an agent kill an in-flight process for that agent, or only suppress *future* turns? Today muting mid-turn discards the buffer (`manager.ts:651`) but lets the running process complete — that behavior probably ports over.
 
+## Hot-reloaded agent definitions
+
+**Problem:** `agents-org` and public agent definitions are loaded at boot. Adding or editing an agent identity, prompt, or dispatch permission requires a bot restart even though agents are operational configuration, not compiled code.
+
+**Scope (to be refined):**
+- Add an `AgentDefinitionRegistry` with the same shape as the dynamic workflow registry: file watch/poll, validation, version hash, and last-known-good behavior.
+- Reload affects future dispatches only. Existing resumed sessions keep the prompt/identity hash they started with until reset or a new session is created.
+- Identity changes require care: Slack self-bot routing depends on username/icon mapping. Keep old identity aliases alive for in-flight messages until no active sessions use them.
+- Dispatch permissions are security-sensitive. Invalid allow-list changes fail closed and keep the previous valid definition.
+- Add admin controls: `!agents`, `!agent show <name>`, `!agent start <name>`, `!agent stop <name>`, `!agent reload <name>` as a diagnostic escape hatch.
+
+**Open questions:**
+- Should public agents and `agents-org` overlays share one registry with precedence, or two registries composed at lookup time?
+- Should changing an agent prompt optionally reset active sessions, or only affect new sessions?
+- Where should active/inactive agent state live: SQLite runtime state, frontmatter `enabled`, or both?
+
 ## Thread-owner-based command access
 
 **Status:** Two-tier admin (env + SQLite `admins` table) shipped — see [thread-commands.md](thread-commands.md#admin-only-commands). Thread-owner branch is still open.

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -28,6 +28,16 @@ const ENV_KEYS = [
   "CHANNEL_DEFAULTS",
   "ADMIN_SLACK_USER_ID",
   "HTTP_DASHBOARD_PORT",
+  "WORKLOG_CRON_ENABLED",
+  "WORKLOG_SLACK_CHANNEL",
+  "WORKLOG_SLACK_THREAD_TS",
+  "WORKLOG_DAILY_AT",
+  "WORKLOG_LOOKBACK_HOURS",
+  "WORKLOG_DOCS_DIR",
+  "WORKLOG_GIT_AUTHOR",
+  "WORKLOG_GITHUB_USER",
+  "WORKLOG_USE_AGENT",
+  "WORKLOG_RUN_ON_STARTUP",
 ] as const;
 
 let savedEnv: Record<string, string | undefined>;
@@ -111,5 +121,60 @@ describe("loadConfig runner providers", () => {
     expect(() => loadConfig()).toThrow(
       "RUNNER_PROVIDER=codex is a planned provider but is not yet implemented. Use opencode or claude.",
     );
+  });
+});
+
+describe("loadConfig worklog cron", () => {
+  it("defaults the worklog cron off", () => {
+    const config = loadConfig();
+
+    expect(config.worklog).toEqual({
+      enabled: false,
+      channel: null,
+      threadTs: null,
+      dailyAt: "18:00",
+      lookbackHours: 24,
+      docsDir: "docs/worklog",
+      gitAuthor: null,
+      githubUser: null,
+      useAgent: true,
+      runOnStartup: false,
+    });
+  });
+
+  it("requires a Slack channel when enabled", () => {
+    process.env.WORKLOG_CRON_ENABLED = "true";
+
+    expect(() => loadConfig()).toThrow(
+      "WORKLOG_SLACK_CHANNEL is required when WORKLOG_CRON_ENABLED=true",
+    );
+  });
+
+  it("parses worklog cron settings", () => {
+    process.env.WORKLOG_CRON_ENABLED = "true";
+    process.env.WORKLOG_SLACK_CHANNEL = "C123";
+    process.env.WORKLOG_SLACK_THREAD_TS = "123.456";
+    process.env.WORKLOG_DAILY_AT = "09:30";
+    process.env.WORKLOG_LOOKBACK_HOURS = "12";
+    process.env.WORKLOG_DOCS_DIR = "docs/status";
+    process.env.WORKLOG_GIT_AUTHOR = "me@example.com";
+    process.env.WORKLOG_GITHUB_USER = "octocat";
+    process.env.WORKLOG_USE_AGENT = "false";
+    process.env.WORKLOG_RUN_ON_STARTUP = "1";
+
+    const config = loadConfig();
+
+    expect(config.worklog).toEqual({
+      enabled: true,
+      channel: "C123",
+      threadTs: "123.456",
+      dailyAt: "09:30",
+      lookbackHours: 12,
+      docsDir: "docs/status",
+      gitAuthor: "me@example.com",
+      githubUser: "octocat",
+      useAgent: false,
+      runOnStartup: true,
+    });
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -99,6 +99,28 @@ export interface Config {
     enabled: boolean;
     port: number;
   };
+  worklog: {
+    /** Daily PR/commit digest. Off unless WORKLOG_CRON_ENABLED=true. */
+    enabled: boolean;
+    /** Slack channel to post the digest into. Required when enabled. */
+    channel: string | null;
+    /** Optional thread timestamp; when unset the digest is posted as a channel message. */
+    threadTs: string | null;
+    /** Local server time in HH:mm, e.g. 18:30. */
+    dailyAt: string;
+    /** Activity lookback window for commits and PR updates. */
+    lookbackHours: number;
+    /** Where markdown snapshots are written. */
+    docsDir: string;
+    /** Optional git log author filter. Defaults to each repo's git user when unset. */
+    gitAuthor: string | null;
+    /** Optional GitHub username for PR filtering. Defaults to gh's authenticated user when unset. */
+    githubUser: string | null;
+    /** Let the configured runner compress/group the collected activity before Slack posting. */
+    useAgent: boolean;
+    /** Run once immediately after boot, useful for local verification. */
+    runOnStartup: boolean;
+  };
 }
 
 function required(name: string): string {
@@ -176,6 +198,7 @@ export function loadConfig(): Config {
     ),
     adminSlackUserId: process.env.ADMIN_SLACK_USER_ID?.trim() || null,
     http: parseHttpDashboard(process.env.HTTP_DASHBOARD_PORT),
+    worklog: parseWorklogConfig(),
   };
 }
 
@@ -235,6 +258,41 @@ function parseBooleanEnv(name: string, fallback: boolean): boolean {
 function parseDriverMode(value: string): DriverMode {
   if (value === "headless" || value === "tmux") return value;
   throw new Error(`Invalid DEFAULT_CLAUDE_DRIVER: ${value} (expected headless|tmux)`);
+}
+
+function parseWorklogConfig(): Config["worklog"] {
+  const enabled = parseBooleanEnv("WORKLOG_CRON_ENABLED", false);
+  const channel = process.env.WORKLOG_SLACK_CHANNEL?.trim() || null;
+  if (enabled && !channel) {
+    throw new Error("WORKLOG_SLACK_CHANNEL is required when WORKLOG_CRON_ENABLED=true");
+  }
+
+  const dailyAt = optional("WORKLOG_DAILY_AT", "18:00");
+  if (!/^\d{2}:\d{2}$/.test(dailyAt)) {
+    throw new Error("Invalid WORKLOG_DAILY_AT: expected HH:mm");
+  }
+  const [hour, minute] = dailyAt.split(":").map(Number);
+  if (hour > 23 || minute > 59) {
+    throw new Error("Invalid WORKLOG_DAILY_AT: expected HH:mm in 24-hour time");
+  }
+
+  const lookbackHours = Number(optional("WORKLOG_LOOKBACK_HOURS", "24"));
+  if (!Number.isFinite(lookbackHours) || lookbackHours <= 0) {
+    throw new Error("Invalid WORKLOG_LOOKBACK_HOURS: expected positive number");
+  }
+
+  return {
+    enabled,
+    channel,
+    threadTs: process.env.WORKLOG_SLACK_THREAD_TS?.trim() || null,
+    dailyAt,
+    lookbackHours,
+    docsDir: optional("WORKLOG_DOCS_DIR", "docs/worklog"),
+    gitAuthor: process.env.WORKLOG_GIT_AUTHOR?.trim() || null,
+    githubUser: process.env.WORKLOG_GITHUB_USER?.trim() || null,
+    useAgent: parseBooleanEnv("WORKLOG_USE_AGENT", true),
+    runOnStartup: parseBooleanEnv("WORKLOG_RUN_ON_STARTUP", false),
+  };
 }
 
 function parseChannelDefaults(

--- a/src/cron/scheduler.test.ts
+++ b/src/cron/scheduler.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "bun:test";
+import { msUntilNextDailyRun } from "./scheduler.ts";
+
+describe("msUntilNextDailyRun", () => {
+  it("schedules later today when the time has not passed", () => {
+    const now = new Date(2026, 4, 21, 10, 0, 0, 0);
+
+    expect(msUntilNextDailyRun(now, "18:00")).toBe(8 * 60 * 60 * 1000);
+  });
+
+  it("schedules tomorrow when the time has passed", () => {
+    const now = new Date(2026, 4, 21, 19, 30, 0, 0);
+
+    expect(msUntilNextDailyRun(now, "18:00")).toBe(22.5 * 60 * 60 * 1000);
+  });
+});

--- a/src/cron/scheduler.ts
+++ b/src/cron/scheduler.ts
@@ -1,0 +1,76 @@
+import { log } from "../logger.ts";
+
+export interface DailyCronOptions {
+  name: string;
+  dailyAt: string;
+  runOnStartup?: boolean;
+  now?: () => Date;
+  setTimeoutFn?: typeof setTimeout;
+  clearTimeoutFn?: typeof clearTimeout;
+  run: () => Promise<void>;
+}
+
+export interface StartedCron {
+  stop: () => void;
+}
+
+export function startDailyCron(options: DailyCronOptions): StartedCron {
+  const now = options.now ?? (() => new Date());
+  const setTimeoutFn = options.setTimeoutFn ?? setTimeout;
+  const clearTimeoutFn = options.clearTimeoutFn ?? clearTimeout;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let running = false;
+  let stopped = false;
+
+  const execute = async () => {
+    if (stopped) return;
+    if (running) {
+      log.warn("cron", `${options.name} skipped; previous run still active`);
+      scheduleNext();
+      return;
+    }
+
+    running = true;
+    try {
+      await options.run();
+    } catch (err) {
+      log.error(
+        "cron",
+        `${options.name} failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    } finally {
+      running = false;
+      scheduleNext();
+    }
+  };
+
+  const scheduleNext = () => {
+    if (stopped) return;
+    const delayMs = msUntilNextDailyRun(now(), options.dailyAt);
+    timer = setTimeoutFn(execute, delayMs);
+    log.info("cron", `${options.name} scheduled in ${Math.round(delayMs / 1000)}s`);
+  };
+
+  if (options.runOnStartup) {
+    void execute();
+  } else {
+    scheduleNext();
+  }
+
+  return {
+    stop: () => {
+      stopped = true;
+      if (timer) clearTimeoutFn(timer);
+    },
+  };
+}
+
+export function msUntilNextDailyRun(now: Date, dailyAt: string): number {
+  const [hour, minute] = dailyAt.split(":").map(Number);
+  const next = new Date(now);
+  next.setHours(hour, minute, 0, 0);
+  if (next.getTime() <= now.getTime()) {
+    next.setDate(next.getDate() + 1);
+  }
+  return next.getTime() - now.getTime();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,8 @@ import { WorktreeManager } from "./worktree/manager.ts";
 import { DevServerManager } from "./lifecycle/dev-server.ts";
 import { DevServerQueue } from "./lifecycle/dev-server-queue.ts";
 import { startMcpServer } from "./mcp/slack-server.ts";
+import { startDailyCron } from "./cron/scheduler.ts";
+import { runWorklogJob } from "./worklog/job.ts";
 import { log } from "./logger.ts";
 import { WorkflowController } from "./workflows/controller.ts";
 import { WorkflowExecutor } from "./workflows/executor.ts";
@@ -292,6 +294,17 @@ setInterval(() => {
     // agent (any channel) or fall through to the single-session manager.
     supportRouter.handleMessage(event);
   }, store, selfBotId, sessionManager.botUserId, autoTriggerChannels);
+
+  if (config.worklog.enabled) {
+    startDailyCron({
+      name: "worklog",
+      dailyAt: config.worklog.dailyAt,
+      runOnStartup: config.worklog.runOnStartup,
+      run: async () => {
+        await runWorklogJob({ config, app });
+      },
+    });
+  }
 
   if (config.http.enabled) {
     // Bun.serve throws synchronously on port conflict (EADDRINUSE) and a few

--- a/src/runners/index.test.ts
+++ b/src/runners/index.test.ts
@@ -109,5 +109,17 @@ function testConfig(
     channelDefaults: {},
     adminSlackUserId: null,
     http: { enabled: false, port: 0 },
+    worklog: {
+      enabled: false,
+      channel: null,
+      threadTs: null,
+      dailyAt: "18:00",
+      lookbackHours: 24,
+      docsDir: "docs/worklog",
+      gitAuthor: null,
+      githubUser: null,
+      useAgent: true,
+      runOnStartup: false,
+    },
   };
 }

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -153,6 +153,18 @@ const testConfig: Config = {
   channelDefaults: {},
   adminSlackUserId: null,
   http: { enabled: false, port: 0 },
+  worklog: {
+    enabled: false,
+    channel: null,
+    threadTs: null,
+    dailyAt: "18:00",
+    lookbackHours: 24,
+    docsDir: "docs/worklog",
+    gitAuthor: null,
+    githubUser: null,
+    useAgent: true,
+    runOnStartup: false,
+  },
 };
 
 function makeEvent(overrides: Partial<SlackMessageEvent> = {}): SlackMessageEvent {

--- a/src/worklog/activity.test.ts
+++ b/src/worklog/activity.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "bun:test";
+import {
+  collectWorklogActivity,
+  parseGithubSlug,
+  type RunCommand,
+} from "./activity.ts";
+
+describe("parseGithubSlug", () => {
+  it("parses ssh and https GitHub remotes", () => {
+    expect(parseGithubSlug("git@github.com:acme/app.git")).toBe("acme/app");
+    expect(parseGithubSlug("https://github.com/acme/app.git")).toBe("acme/app");
+    expect(parseGithubSlug("https://github.com/acme/app")).toBe("acme/app");
+  });
+
+  it("ignores non-GitHub remotes", () => {
+    expect(parseGithubSlug("git@gitlab.com:acme/app.git")).toBeNull();
+  });
+});
+
+describe("collectWorklogActivity", () => {
+  it("collects commits and pull requests per configured repo", async () => {
+    const runCommand: RunCommand = async (command, args) => {
+      const key = `${command} ${args.join(" ")}`;
+      if (key === "git config --get user.email") {
+        return { exitCode: 0, stdout: "me@example.com\n", stderr: "" };
+      }
+      if (key.startsWith("git log ")) {
+        return {
+          exitCode: 0,
+          stdout: "abc123\x1fabc123\x1f2026-05-21T09:00:00+05:30\x1fship event redesign\n",
+          stderr: "",
+        };
+      }
+      if (key === "git remote get-url origin") {
+        return {
+          exitCode: 0,
+          stdout: "git@github.com:growthx/app.git\n",
+          stderr: "",
+        };
+      }
+      if (key === "gh api user --jq .login") {
+        return { exitCode: 0, stdout: "pranav\n", stderr: "" };
+      }
+      if (key.startsWith("gh pr list ")) {
+        return {
+          exitCode: 0,
+          stdout: JSON.stringify([
+            {
+              number: 42,
+              title: "Event registration redesign",
+              state: "MERGED",
+              url: "https://github.com/growthx/app/pull/42",
+              updatedAt: "2026-05-21T09:10:00Z",
+              mergedAt: "2026-05-21T09:15:00Z",
+            },
+          ]),
+          stderr: "",
+        };
+      }
+      return { exitCode: 1, stdout: "", stderr: `unexpected ${key}` };
+    };
+
+    const activity = await collectWorklogActivity({
+      repos: [{ name: "gx-client-next", path: "/repo", defaultBase: "main" }],
+      since: new Date("2026-05-20T18:00:00.000Z"),
+      until: new Date("2026-05-21T18:00:00.000Z"),
+      runCommand,
+    });
+
+    expect(activity.commits).toHaveLength(1);
+    expect(activity.commits[0].subject).toBe("ship event redesign");
+    expect(activity.prs).toHaveLength(1);
+    expect(activity.prs[0].number).toBe(42);
+    expect(activity.errors).toEqual([]);
+  });
+});

--- a/src/worklog/activity.ts
+++ b/src/worklog/activity.ts
@@ -1,0 +1,288 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import type { RepoConfig } from "../config.ts";
+
+export interface WorklogCommit {
+  repo: string;
+  hash: string;
+  shortHash: string;
+  date: string;
+  subject: string;
+}
+
+export interface WorklogPr {
+  repo: string;
+  number: number;
+  title: string;
+  state: string;
+  url: string;
+  updatedAt: string;
+  createdAt?: string;
+  mergedAt?: string | null;
+  headRefName?: string;
+  baseRefName?: string;
+}
+
+export interface WorklogActivity {
+  generatedAt: string;
+  since: string;
+  until: string;
+  repos: string[];
+  commits: WorklogCommit[];
+  prs: WorklogPr[];
+  errors: string[];
+}
+
+export interface CommandResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+}
+
+export type RunCommand = (
+  command: string,
+  args: string[],
+  cwd: string,
+) => Promise<CommandResult>;
+
+export interface CollectWorklogOptions {
+  repos: RepoConfig[];
+  since: Date;
+  until?: Date;
+  gitAuthor?: string | null;
+  githubUser?: string | null;
+  runCommand?: RunCommand;
+}
+
+export async function collectWorklogActivity(
+  options: CollectWorklogOptions,
+): Promise<WorklogActivity> {
+  const until = options.until ?? new Date();
+  const runCommand = options.runCommand ?? runCommandDefault;
+  const activity: WorklogActivity = {
+    generatedAt: until.toISOString(),
+    since: options.since.toISOString(),
+    until: until.toISOString(),
+    repos: options.repos.map((repo) => repo.name),
+    commits: [],
+    prs: [],
+    errors: [],
+  };
+
+  for (const repo of options.repos) {
+    const gitAuthor =
+      options.gitAuthor ?? (await detectGitAuthor(repo.path, runCommand));
+    try {
+      activity.commits.push(
+        ...(await collectCommits(repo, options.since, gitAuthor, runCommand)),
+      );
+    } catch (err) {
+      activity.errors.push(formatRepoError(repo.name, "git log", err));
+    }
+
+    try {
+      activity.prs.push(
+        ...(await collectPullRequests(repo, options.since, options.githubUser, runCommand)),
+      );
+    } catch (err) {
+      activity.errors.push(formatRepoError(repo.name, "gh pr list", err));
+    }
+  }
+
+  return activity;
+}
+
+export async function writeWorklogDoc(
+  activity: WorklogActivity,
+  docsDir: string,
+  slackSummary: string,
+): Promise<string> {
+  await mkdir(docsDir, { recursive: true });
+  const date = activity.until.slice(0, 10);
+  const path = join(docsDir, `${date}.md`);
+  await writeFile(path, renderWorklogMarkdown(activity, slackSummary), "utf8");
+  return path;
+}
+
+export function renderWorklogMarkdown(
+  activity: WorklogActivity,
+  slackSummary: string,
+): string {
+  const lines = [
+    `# Worklog ${activity.until.slice(0, 10)}`,
+    "",
+    `Generated: ${activity.generatedAt}`,
+    `Window: ${activity.since} to ${activity.until}`,
+    "",
+    "## Slack Summary",
+    "",
+    slackSummary.trim() || "_No summary generated._",
+    "",
+    "## Pull Requests",
+    "",
+  ];
+
+  if (activity.prs.length === 0) {
+    lines.push("_No PR activity found._");
+  } else {
+    for (const pr of activity.prs) {
+      lines.push(
+        `- [${pr.repo}#${pr.number}](${pr.url}) ${pr.title} (${pr.state}, updated ${pr.updatedAt})`,
+      );
+    }
+  }
+
+  lines.push("", "## Commits", "");
+  if (activity.commits.length === 0) {
+    lines.push("_No commits found._");
+  } else {
+    for (const commit of activity.commits) {
+      lines.push(
+        `- ${commit.repo} ${commit.shortHash} ${commit.subject} (${commit.date})`,
+      );
+    }
+  }
+
+  if (activity.errors.length > 0) {
+    lines.push("", "## Collection Errors", "");
+    for (const error of activity.errors) {
+      lines.push(`- ${error}`);
+    }
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}
+
+async function collectCommits(
+  repo: RepoConfig,
+  since: Date,
+  gitAuthor: string | null,
+  runCommand: RunCommand,
+): Promise<WorklogCommit[]> {
+  const args = [
+    "log",
+    `--since=${since.toISOString()}`,
+    "--date=iso-strict",
+    "--pretty=format:%H%x1f%h%x1f%ad%x1f%s",
+  ];
+  if (gitAuthor) args.splice(2, 0, `--author=${gitAuthor}`);
+
+  const result = await runCommand("git", args, repo.path);
+  if (result.exitCode !== 0) {
+    throw new Error(result.stderr || `git exited ${result.exitCode}`);
+  }
+  if (!result.stdout.trim()) return [];
+
+  return result.stdout
+    .split("\n")
+    .filter(Boolean)
+    .map((line) => {
+      const [hash, shortHash, date, subject] = line.split("\x1f");
+      return {
+        repo: repo.name,
+        hash,
+        shortHash,
+        date,
+        subject,
+      };
+    });
+}
+
+async function collectPullRequests(
+  repo: RepoConfig,
+  since: Date,
+  githubUser: string | null | undefined,
+  runCommand: RunCommand,
+): Promise<WorklogPr[]> {
+  const remote = await runCommand("git", ["remote", "get-url", "origin"], repo.path);
+  if (remote.exitCode !== 0) {
+    throw new Error(remote.stderr || `git remote exited ${remote.exitCode}`);
+  }
+  const slug = parseGithubSlug(remote.stdout.trim());
+  if (!slug) return [];
+
+  const author = githubUser ?? (await detectGithubUser(repo.path, runCommand));
+  if (!author) return [];
+  const result = await runCommand(
+    "gh",
+    [
+      "pr",
+      "list",
+      "--repo",
+      slug,
+      "--author",
+      author,
+      "--state",
+      "all",
+      "--search",
+      `updated:>=${since.toISOString().slice(0, 10)}`,
+      "--limit",
+      "50",
+      "--json",
+      "number,title,state,url,updatedAt,createdAt,mergedAt,headRefName,baseRefName",
+    ],
+    repo.path,
+  );
+  if (result.exitCode !== 0) {
+    throw new Error(result.stderr || `gh exited ${result.exitCode}`);
+  }
+  if (!result.stdout.trim()) return [];
+
+  const parsed = JSON.parse(result.stdout) as Array<Omit<WorklogPr, "repo">>;
+  return parsed.map((pr) => ({ ...pr, repo: repo.name }));
+}
+
+async function detectGithubUser(
+  cwd: string,
+  runCommand: RunCommand,
+): Promise<string | null> {
+  const result = await runCommand("gh", ["api", "user", "--jq", ".login"], cwd);
+  if (result.exitCode === 0 && result.stdout.trim()) {
+    return result.stdout.trim();
+  }
+  throw new Error(result.stderr || `gh api user exited ${result.exitCode}`);
+}
+
+async function detectGitAuthor(
+  cwd: string,
+  runCommand: RunCommand,
+): Promise<string | null> {
+  for (const key of ["user.email", "user.name"]) {
+    const result = await runCommand("git", ["config", "--get", key], cwd);
+    if (result.exitCode === 0 && result.stdout.trim()) {
+      return result.stdout.trim();
+    }
+  }
+  return null;
+}
+
+export function parseGithubSlug(remoteUrl: string): string | null {
+  const match =
+    remoteUrl.match(/^git@github\.com:([^/]+\/[^/.]+)(?:\.git)?$/) ??
+    remoteUrl.match(/^https:\/\/github\.com\/([^/]+\/[^/.]+)(?:\.git)?$/);
+  return match?.[1] ?? null;
+}
+
+async function runCommandDefault(
+  command: string,
+  args: string[],
+  cwd: string,
+): Promise<CommandResult> {
+  const proc = Bun.spawn([command, ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  return { stdout, stderr, exitCode };
+}
+
+function formatRepoError(repo: string, step: string, err: unknown): string {
+  return `${repo} ${step}: ${err instanceof Error ? err.message : String(err)}`;
+}

--- a/src/worklog/job.test.ts
+++ b/src/worklog/job.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import type { App } from "@slack/bolt";
+import type { Config } from "../config.ts";
+import { runWorklogJob } from "./job.ts";
+import type { RunCommand } from "./activity.ts";
+
+describe("runWorklogJob", () => {
+  it("writes a doc and posts the generated summary to Slack", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "junior-worklog-test-"));
+    const posts: Array<Record<string, unknown>> = [];
+    const app = {
+      client: {
+        chat: {
+          postMessage: async (args: Record<string, unknown>) => {
+            posts.push(args);
+            return { ok: true, ts: "1.2" };
+          },
+        },
+      },
+    } as unknown as App;
+    const config = makeConfig({
+      docsDir: dir,
+      useAgent: true,
+    });
+    const runCommand: RunCommand = async (command, args) => {
+      const key = `${command} ${args.join(" ")}`;
+      if (key === "git config --get user.email") {
+        return { exitCode: 0, stdout: "me@example.com\n", stderr: "" };
+      }
+      if (key.startsWith("git log ")) {
+        return {
+          exitCode: 0,
+          stdout: "abc\x1fabc\x1f2026-05-21T08:00:00Z\x1fwire worklog cron\n",
+          stderr: "",
+        };
+      }
+      if (key === "git remote get-url origin") {
+        return { exitCode: 0, stdout: "https://github.com/acme/app.git\n", stderr: "" };
+      }
+      if (key === "gh api user --jq .login") {
+        return { exitCode: 0, stdout: "pranav\n", stderr: "" };
+      }
+      if (key.startsWith("gh pr list ")) {
+        return { exitCode: 0, stdout: "[]", stderr: "" };
+      }
+      return { exitCode: 1, stdout: "", stderr: `unexpected ${key}` };
+    };
+
+    try {
+      const result = await runWorklogJob({
+        app,
+        config,
+        now: new Date("2026-05-21T12:00:00.000Z"),
+        runCommand,
+        summarizeWithAgent: async () => "*Worklog* :white_check_mark:\n> Cron\n- Added worklog digest",
+      });
+
+      expect(result.posted).toBe(true);
+      expect(posts).toEqual([
+        {
+          channel: "C123",
+          thread_ts: "123.456",
+          text: "*Worklog* :white_check_mark:\n> Cron\n- Added worklog digest",
+        },
+      ]);
+      expect(readFileSync(result.docPath, "utf8")).toContain("Added worklog digest");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+function makeConfig(worklog: Partial<Config["worklog"]>): Config {
+  return {
+    slack: {
+      botToken: "xoxb-test",
+      appToken: "xapp-test",
+      signingSecret: "",
+    },
+    claude: {
+      maxTurns: 25,
+      timeoutMs: 300000,
+      permissionMode: "bypassPermissions",
+      defaultModel: null,
+      defaultDriver: "headless",
+      tmuxIdleTtlMs: 1000,
+      tmuxSweepIntervalMs: 1000,
+    },
+    runner: { provider: "opencode" },
+    opencode: {
+      model: null,
+      timeoutMs: 300000,
+      permission: "allow",
+      mcpEnabled: true,
+      slackMcpEnabled: true,
+      playwrightMcpEnabled: true,
+      mixpanelMcpEnabled: true,
+      mongodbMcpEnabled: true,
+    },
+    repos: [{ name: "app", path: "/repo", defaultBase: "main" }],
+    session: {
+      staleTimeoutMs: 86400000,
+      cleanupIntervalMs: 900000,
+      store: "memory",
+      sqlitePath: "data/sessions.db",
+      homeWindowMs: 172800000,
+      defaultVerbosity: "normal",
+    },
+    channelDefaults: {},
+    adminSlackUserId: null,
+    http: { enabled: false, port: 0 },
+    worklog: {
+      enabled: true,
+      channel: "C123",
+      threadTs: "123.456",
+      dailyAt: "18:00",
+      lookbackHours: 24,
+      docsDir: "docs/worklog",
+      gitAuthor: null,
+      githubUser: null,
+      useAgent: true,
+      runOnStartup: false,
+      ...worklog,
+    },
+  };
+}

--- a/src/worklog/job.ts
+++ b/src/worklog/job.ts
@@ -1,0 +1,91 @@
+import type { App } from "@slack/bolt";
+import type { Config } from "../config.ts";
+import { log } from "../logger.ts";
+import {
+  collectWorklogActivity,
+  writeWorklogDoc,
+  type RunCommand,
+  type WorklogActivity,
+} from "./activity.ts";
+import {
+  formatWorklogSlackSummary,
+  summarizeWorklogWithRunner,
+  type SummarizeWithAgent,
+} from "./summary.ts";
+
+export interface RunWorklogJobOptions {
+  config: Config;
+  app: App;
+  now?: Date;
+  runCommand?: RunCommand;
+  summarizeWithAgent?: SummarizeWithAgent;
+}
+
+export interface WorklogJobResult {
+  activity: WorklogActivity;
+  docPath: string;
+  slackSummary: string;
+  posted: boolean;
+}
+
+export async function runWorklogJob(
+  options: RunWorklogJobOptions,
+): Promise<WorklogJobResult> {
+  const now = options.now ?? new Date();
+  const since = new Date(
+    now.getTime() - options.config.worklog.lookbackHours * 60 * 60 * 1000,
+  );
+  const activity = await collectWorklogActivity({
+    repos: options.config.repos,
+    since,
+    until: now,
+    gitAuthor: options.config.worklog.gitAuthor,
+    githubUser: options.config.worklog.githubUser,
+    runCommand: options.runCommand,
+  });
+
+  const deterministicSummary = formatWorklogSlackSummary(activity);
+  let slackSummary = deterministicSummary;
+
+  if (options.config.worklog.useAgent) {
+    try {
+      const agentSummary = await (options.summarizeWithAgent
+        ? options.summarizeWithAgent(activity)
+        : summarizeWorklogWithRunner(activity, options.config));
+      if (agentSummary) slackSummary = agentSummary;
+    } catch (err) {
+      log.warn(
+        "worklog",
+        `agent summary failed; using deterministic summary: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  const docPath = await writeWorklogDoc(
+    activity,
+    options.config.worklog.docsDir,
+    slackSummary,
+  );
+
+  const posted = await postWorklogToSlack(options.app, options.config, slackSummary);
+  log.info(
+    "worklog",
+    `complete commits=${activity.commits.length} prs=${activity.prs.length} errors=${activity.errors.length} doc=${docPath} posted=${posted}`,
+  );
+
+  return { activity, docPath, slackSummary, posted };
+}
+
+async function postWorklogToSlack(
+  app: App,
+  config: Config,
+  text: string,
+): Promise<boolean> {
+  if (!config.worklog.channel) return false;
+  await app.client.chat.postMessage({
+    channel: config.worklog.channel,
+    text,
+    ...(config.worklog.threadTs ? { thread_ts: config.worklog.threadTs } : {}),
+  });
+  return true;
+}

--- a/src/worklog/summary.test.ts
+++ b/src/worklog/summary.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import { formatWorklogSlackSummary } from "./summary.ts";
+import type { WorklogActivity } from "./activity.ts";
+
+describe("formatWorklogSlackSummary", () => {
+  it("groups PRs and commits by repo in Slack mrkdwn", () => {
+    const activity: WorklogActivity = {
+      generatedAt: "2026-05-21T12:00:00.000Z",
+      since: "2026-05-20T12:00:00.000Z",
+      until: "2026-05-21T12:00:00.000Z",
+      repos: ["event-registration", "member-connect"],
+      prs: [
+        {
+          repo: "event-registration",
+          number: 7,
+          title: "New redesign is live",
+          state: "MERGED",
+          url: "https://example.com/pr/7",
+          updatedAt: "2026-05-21T10:00:00.000Z",
+          mergedAt: "2026-05-21T10:00:00.000Z",
+        },
+      ],
+      commits: [
+        {
+          repo: "member-connect",
+          hash: "abcdef",
+          shortHash: "abc123",
+          date: "2026-05-21T09:00:00+05:30",
+          subject: "continue core flows iteration",
+        },
+      ],
+      errors: [],
+    };
+
+    const summary = formatWorklogSlackSummary(activity);
+
+    expect(summary).toContain("> Event Registration");
+    expect(summary).toContain("- New redesign is live (merged PR #7) :white_check_mark:");
+    expect(summary).toContain("> Member Connect");
+    expect(summary).toContain("continue core flows iteration (abc123)");
+  });
+});

--- a/src/worklog/summary.ts
+++ b/src/worklog/summary.ts
@@ -1,0 +1,161 @@
+import type { Config } from "../config.ts";
+import { runnerTimeoutMs, spawnRunner } from "../runners/index.ts";
+import type { SpawnRunnerFn } from "../runners/types.ts";
+import { withTimeout } from "../lifecycle/timeout.ts";
+import { createSession } from "../session/types.ts";
+import type { WorklogActivity, WorklogCommit, WorklogPr } from "./activity.ts";
+
+export type SummarizeWithAgent = (
+  activity: WorklogActivity,
+) => Promise<string | null>;
+
+export function formatWorklogSlackSummary(activity: WorklogActivity): string {
+  const groups = groupActivity(activity);
+  const lines = ["*Worklog* :white_check_mark:"];
+
+  if (groups.size === 0) {
+    lines.push("> No tracked PR or commit activity");
+  }
+
+  for (const [repo, group] of groups) {
+    lines.push(`> ${repo}`);
+    for (const pr of group.prs.slice(0, 6)) {
+      lines.push(`- ${prSummary(pr)}`);
+    }
+    const commitOnly = group.commits
+      .filter((commit) => !isLikelyCoveredByPr(commit, group.prs))
+      .slice(0, 6);
+    if (commitOnly.length > 0) {
+      lines.push("- Commits");
+      for (const commit of commitOnly) {
+        lines.push(`  - ${cleanSubject(commit.subject)} (${commit.shortHash})`);
+      }
+    }
+  }
+
+  if (activity.errors.length > 0) {
+    lines.push("> Collection notes");
+    for (const error of activity.errors.slice(0, 4)) {
+      lines.push(`- ${error}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export async function summarizeWorklogWithRunner(
+  activity: WorklogActivity,
+  config: Config,
+  spawn: SpawnRunnerFn = spawnRunner,
+): Promise<string | null> {
+  const channel = config.worklog.channel ?? "worklog-cron";
+  const session = createSession(
+    `cron-worklog-${activity.until.slice(0, 10)}`,
+    channel,
+    "quiet",
+    config.runner.provider,
+    config.claude.defaultDriver,
+  );
+  session.cwd = process.cwd();
+  session.agentType = "worklog";
+  session.activeAgentName = "worklog";
+  session.systemPrompt = [
+    "You turn raw GitHub PR and git commit activity into a concise Slack work update.",
+    "Group related work under short project or feature headings.",
+    "Prefer human-readable outcomes over commit-by-commit detail.",
+    "Use Slack mrkdwn only. No preamble, no code block.",
+    "Use this shape:",
+    "*Worklog* :white_check_mark:",
+    "> Project or feature",
+    "- Outcome :white_check_mark:",
+    "  - Supporting detail",
+  ].join("\n");
+
+  const handle = spawn(
+    session,
+    [
+      "Summarize this activity for Slack. Keep it compact and grouped.",
+      "Do not invent work. If there is no activity, say so plainly.",
+      "",
+      JSON.stringify(activity, null, 2),
+    ].join("\n"),
+    config,
+  );
+
+  const boundedHandle = withTimeout(
+    handle,
+    runnerTimeoutMs(config, handle.provider),
+    () => handle.kill(),
+  );
+  const result = await boundedHandle.result;
+  if (result.exitCode !== 0 || result.error) return null;
+  const response = result.response.trim();
+  return response || null;
+}
+
+interface ActivityGroup {
+  prs: WorklogPr[];
+  commits: WorklogCommit[];
+}
+
+function groupActivity(activity: WorklogActivity): Map<string, ActivityGroup> {
+  const groups = new Map<string, ActivityGroup>();
+  for (const repo of activity.repos) {
+    groups.set(labelRepo(repo), { prs: [], commits: [] });
+  }
+  for (const pr of activity.prs) {
+    getGroup(groups, labelRepo(pr.repo)).prs.push(pr);
+  }
+  for (const commit of activity.commits) {
+    getGroup(groups, labelRepo(commit.repo)).commits.push(commit);
+  }
+  for (const [key, value] of [...groups]) {
+    if (value.prs.length === 0 && value.commits.length === 0) {
+      groups.delete(key);
+    }
+  }
+  return groups;
+}
+
+function getGroup(groups: Map<string, ActivityGroup>, key: string): ActivityGroup {
+  let group = groups.get(key);
+  if (!group) {
+    group = { prs: [], commits: [] };
+    groups.set(key, group);
+  }
+  return group;
+}
+
+function prSummary(pr: WorklogPr): string {
+  const state = pr.mergedAt
+    ? "merged"
+    : pr.state.toLowerCase() === "open"
+      ? "open"
+      : pr.state.toLowerCase();
+  const suffix = pr.mergedAt ? " :white_check_mark:" : "";
+  return `${cleanSubject(pr.title)} (${state} PR #${pr.number})${suffix}`;
+}
+
+function isLikelyCoveredByPr(commit: WorklogCommit, prs: WorklogPr[]): boolean {
+  const subject = cleanSubject(commit.subject).toLowerCase();
+  return prs.some((pr) => {
+    const title = cleanSubject(pr.title).toLowerCase();
+    return title.includes(subject) || subject.includes(title);
+  });
+}
+
+function cleanSubject(subject: string): string {
+  return subject
+    .replace(/^merge pull request #\d+ from \S+\s*/i, "")
+    .replace(/^\w+\([^)]+\):\s*/, "")
+    .replace(/^\w+:\s*/, "")
+    .trim();
+}
+
+function labelRepo(repo: string): string {
+  return repo
+    .split(/[-_]/)
+    .filter(Boolean)
+    .map((part) => part.slice(0, 1).toUpperCase() + part.slice(1))
+    .join(" ");
+}


### PR DESCRIPTION
## Summary
- Adds an env-gated daily worklog cron that collects configured repo commits and GitHub PRs.
- Writes a markdown worklog snapshot and posts a grouped Slack summary.
- Adds deterministic fallback summary formatting plus optional runner-based summarization.
- Documents worklog env vars and submodule layout guidance.

## Verification
- `bun run typecheck`
- `bun test src/cron src/worklog src/config.test.ts`
- `bun run build`
- `bun test`

## Notes
- Rebased onto `personal/main` after PR #45 was merged.
- The older local `docs/features/dynamic-workflows.md` draft was resolved in favor of the newer merged PR #45 doc.
