### PR TITLE
docs: dreaming-writes-rules + DSL execution boundary + dedup/recall clarifications

### DIFF
--- a/docs/features/associative-memory.md
+++ b/docs/features/associative-memory.md
@@ -237,6 +237,19 @@ An explicit user/operator/agent correction to a fact, route, tag, outcome, edge,
 
 Raw capture can be broad, but active recall should be selective. The hot set should prefer recent, important, unresolved, frequently reused, or manually curated memories. Low-value events should remain searchable for audit but should not eagerly enter the main agent context.
 
+## Identity and Deduplication
+
+The schema tracks `use_count`, but the ingestion path must say *how* repeated information collapses — otherwise the same fact arriving five times becomes five nodes, inflating recall noise and fragmenting the signal `use_count` is meant to carry. This is distinct from supersession: **dedup handles the *same* fact seen again; supersession handles a fact that *changed*.**
+
+Rules of thumb:
+
+- **Source records are always append-only.** Every raw Slack message / runner output is its own `memory_source_record`. Never dedup the audit layer — provenance depends on it.
+- **Derived nodes dedup against an identity key.** When extraction produces a derived event/fact/lesson, compute a normalized identity key (e.g. normalized claim text, or `(entity, predicate, normalized_value)` for facts). If a live node already matches the key, do not create a new node — instead bump `use_count`, refresh `last_used_at`, and append the new `source_record_id` to its provenance.
+- **Near-duplicates are a consolidation job, not a hot-path job.** Exact/normalized-key matches can merge cheaply at ingest. Fuzzy "these two say the same thing" merges belong in the offline dreaming pass, which can also strengthen the edge between them rather than collapse them if they are merely related.
+- **A changed value triggers supersession, not dedup.** If the identity key matches on entity but the value differs (phone number changed), mark the old node `invalid_at` and link `supersedes` — keep both for temporal audit.
+
+Without this, `frequency` in the ranking model is measuring "how many duplicate rows we failed to merge," not "how often this actually recurred."
+
 ## Recommended V1
 
 Build the first version as a boring, inspectable memory event log before making recall clever.
@@ -250,6 +263,8 @@ Build the first version as a boring, inspectable memory event log before making 
 7. Feed top-k sourced snippets into Junior only through a tool/provider boundary, not by mutating session prompts globally.
 
 V1 success means Junior can answer "what prior sourced facts might matter here?" with a short, inspectable result. It does not need autonomous learning, embeddings, graph infrastructure, or unsupervised lesson promotion.
+
+> **Expectation to set up front: v1 will not feel "associative" yet.** Until the consolidation/dreaming pass has produced a real edge set, recall is effectively FTS + tag/entity lookup. The spreading-activation behavior — surfacing a memory you didn't search for because it is linked to one you did — only emerges once edges exist. Bet the early experience on *sourced, inspectable* recall, not on associative leaps, and let the graph earn its keep over time.
 
 ## Recommended V2
 

--- a/docs/features/memory-informed-agent-selection.md
+++ b/docs/features/memory-informed-agent-selection.md
@@ -314,6 +314,45 @@ If the routing rule set outgrows TypeScript, the migration path is:
 
 For MVP, TypeScript rules are enough and match the codebase.
 
+### The DSL is the contract between extraction and execution — not between model and host
+
+The single most important rule for keeping this safe: **the LLM never authors a query, and never emits DSL/Prolog text. It emits validated structured facts; the host compiles those into DSL terms and runs a fixed, host-authored goal.**
+
+```text
+LLM emits (data, schema-validated tool args):
+  { "mentions": ["css"], "hasPrUrl": true, "channel": "c123" }
+
+host compiles → asserts (DSL terms, internal):
+  mentions(ctx, css).  has_pr_url(ctx).  channel(ctx, c123).
+
+host runs FIXED goal:
+  ?- select_agent(ctx, Agent, Repo, Why).
+
+returns:
+  { agent: "frontend", repo: "gx-admin-client", proof: [...] }
+```
+
+This works because **LLM tool-calling is already structured JSON validated against a tool's input schema** — so the fact-assertion tool's schema *is* your bounded fact vocabulary (enumerated predicates, fixed arities, typed values). Having the model emit Prolog/DSL text would mean stuffing a string blob into a tool argument and throwing away that validation for free.
+
+Two interfaces that must never be collapsed:
+
+1. **Fact-assertion** — where natural language enters. Structured, schema-validated, bounded predicate set. Deterministic extraction for what parses cheaply; a constrained LLM call only for the rest.
+2. **Query** — fixed, host-authored goals exposed as named tools (`select_agent`, etc.). The model picks a tool and supplies typed params; it never composes the query body.
+
+Why JSON-then-compile, not raw DSL from the model:
+
+- **Validation before it becomes code.** Reject `"css; route(ctx, admin)"` at the schema, instead of sanitizing DSL syntax — that parse step is the injection surface you are trying to avoid.
+- **Bounded vocabulary for free.** No schema field for `frobnicate(...)`, so the model cannot invent it.
+- **Swappable executor.** The same validated facts run through a TypeScript evaluator *or* a Prolog engine. Emitting DSL text hard-couples the model to one executor.
+
+**Executor choice — earn the runtime.** Flat classification/routing (`tag(E, frontend) :- mentions(E, css)`, `route(Ctx, review) :- has_pr_url(Ctx)`) runs fine in a small TypeScript evaluator with zero new dependencies. Reach for an in-process Prolog engine such as `tau-prolog` (pure-JS npm package — no second runtime, no Python/SWI install) only when rules genuinely need recursion / backward-chaining or you want real proof trees for multi-hop "why" reasoning over edges. The "second runtime" objection only ever applied to the ILP *learners* (Popper/Metagol), not to an in-process query engine.
+
+Honest caveat: you *can* let the model emit DSL term strings directly **if** you use grammar-constrained decoding to force valid syntax and the allowed predicate set. Absent that hard grammar, free-text DSL from an LLM produces syntax slips and hallucinated predicates — so JSON-schema-then-compile is the safer default.
+
+### Decisions vs recall — two engines, two return types
+
+Routing/classification (this doc) is a **decision**: structured facts in → fixed goal → a verdict + proof trace, consumed by *code*. Episodic recall (see [Associative Memory MVP](associative-memory.md)) is **retrieval**: structured `recall(terms, filters)` in → FTS seeds + bounded traversal + scoring → ranked text snippets + provenance, consumed by the *LLM* to read. The same graph serves both; only the return type differs. Do not push narrative recall through the symbolic query engine — reading the actual text is the entire point of recall.
+
 ## Learning Loop
 
 Routing should write outcomes back into memory.
@@ -362,6 +401,7 @@ Repeated routing outcomes should first be stored as source events. The consolida
 
 - Do not let memory dispatch agents directly.
 - Do not let an LLM generate arbitrary executable routing rules on the hot path.
+- Do not let the LLM author queries or emit DSL/Prolog text. It asserts validated structured facts; the host runs fixed goals. (See [The DSL is the contract between extraction and execution](#the-dsl-is-the-contract-between-extraction-and-execution--not-between-model-and-host).)
 - Do not add Prolog/graph/vector infrastructure for MVP.
 - Do not override explicit user commands with learned preferences.
 - Do not run expensive memory extraction in the dispatch hot path.

--- a/docs/features/memory-ingestion-rule-learning.md
+++ b/docs/features/memory-ingestion-rule-learning.md
@@ -11,6 +11,8 @@ Associative memory only works if messy Slack conversations become clean, consist
 
 ## Position
 
+> **Superseded by [Primary Approach: Dreaming Writes the Rules](#primary-approach-dreaming-writes-the-rules) below.** The ILP-as-learner framing in this section is retained as a fallback reference only.
+
 Metagol and Popper should not be part of the live routing or recall path initially. They fit better as **offline rule learners for the memory ingestion layer**.
 
 Use them to suggest rules for:
@@ -45,6 +47,29 @@ human or high-confidence gate reviews
 accepted rules become normal ingestion rules
 ```
 
+## Primary Approach: Dreaming Writes the Rules
+
+**Design-review update: the V2 "dreaming" consolidation engine should author candidate ingestion rules directly. Popper/Metagol are demoted to a research spike, not the planned path.** The ILP sections that follow are retained as the *only-if-needed* fallback.
+
+The realization: the V2 consolidation/"dreaming" pass is *already* an offline LLM run over recent source records and corrections. Rather than exporting labeled examples to a separate ILP learner, let dreaming emit candidate rules into the bounded predicate DSL as one more promotion type, alongside `promote_lesson` / `promote_fact`.
+
+This collapses the old "ILP V3" into V2 and removes its three biggest costs:
+
+- **No labeled-data gate.** The dreaming LLM proposes a rule from observed patterns + corrections already in context. It does not need a curated positive/negative example set accumulated over months before it can produce anything.
+- **No second runtime.** No Popper/Metagol, no Python/SWI toolchain, no compile-from-learned-Prolog step. The rule author lives in the offline job that already runs.
+- **The cost justification flips positive.** You pay one dream-time LLM call to mint a rule that then runs deterministically and replaces N future per-event extraction calls. ILP never had a clean story for that; this does.
+
+**Crucially, the safety pipeline does not change — only the *author* of the candidate rule changes** (the dreaming LLM instead of Popper). Every candidate still: starts as `draft`, carries the examples it covers and the examples it would misfire on, is scored for precision/recall on held-out history, passes human review or a strict auto-threshold, and compiles into the TypeScript rule set or a constrained symbolic evaluator. See [Runtime Safety](#runtime-safety) — it applies unchanged.
+
+Two risks survive and must be guarded:
+
+1. **Confabulation instead of overfitting.** ILP overfits to label noise; an LLM *invents* a plausible-but-wrong rule from a coincidence (e.g. sees "dashboard" + "500" twice and writes `tag(Event, backend) :- mentions(Event, dashboard)` when the real cause was a frontend bug). Same blast radius, different mechanism — and the same `draft → held-out eval → gate` pipeline contains it.
+2. **Model monoculture / grading its own homework.** If the *same* model both extracts events and writes the rules that classify events, its biases self-reinforce and it cannot catch its own systematic errors. ILP's hidden value was being a *different kind* of learner. Mitigation: the held-out evaluation must score against **human-confirmed corrections** as ground truth, never against LLM judgments. Keep one independent signal in the loop.
+
+Constrain the dreaming output to the bounded predicate DSL (`mentions`, `tag`, `event_type`, `edge`, …) — never arbitrary executable TypeScript or free-form Prolog on the hot path.
+
+**Popper/Metagol remain documented below as a fallback only.** Resurrect ILP if, and only if, a measured need for recursive or meta-rule synthesis appears that the dreaming LLM cannot produce reliably — which at Junior's scale is unlikely.
+
 ## Recommended V1
 
 Do not build Popper, Metagol, or any other ILP loop in v1. Build the data needed to make that work later.
@@ -63,8 +88,8 @@ V1 success means Junior can answer "why did this memory get this tag/type/edge?"
 
 After V1 has enough accepted and rejected classifications:
 
-1. Start with Popper for narrow classification rules such as tags, event types, and routing fact extraction.
-2. Treat Metagol as optional research for recursive/meta-rule cases, not the default.
+1. Have the dreaming/consolidation engine emit candidate rules into the bounded predicate DSL as a promotion type (see [Primary Approach](#primary-approach-dreaming-writes-the-rules)). This is the default path.
+2. Treat Popper/Metagol as a fallback research spike, only if recursive/meta-rule synthesis is measurably needed and the dreaming LLM can't produce it reliably.
 3. Generate candidate rules offline with explicit positive examples, negative examples, and held-out metrics.
 4. Review learned rules manually or pass them through a strict promotion gate before they affect live ingestion.
 5. Compile accepted rules into TypeScript or a constrained symbolic evaluator with bounded predicates, not arbitrary hot-path Prolog.
@@ -314,15 +339,16 @@ Do not let an LLM or ILP tool write arbitrary hot-path code or arbitrary Prolog 
 2. Store classifications with provenance.
 3. Store corrections and outcome signals.
 4. Add scheduled LLM extraction/consolidation for fields deterministic rules cannot safely infer.
-5. Add an offline rule-learning job once there is enough labeled history.
-6. Start with Popper for simple tag/event-type rules.
+5. Extend the dreaming/consolidation pass to emit candidate DSL rules as a promotion type (default path).
+6. Only if recursive/meta-rule synthesis proves necessary, add an offline ILP job (Popper) as a fallback.
 7. Review generated rules manually.
 8. Promote accepted rules into the ingestion pipeline.
 9. Measure whether LLM extraction calls decrease and classification consistency improves.
 
 ## Non-Goals
 
-- Do not use Popper/Metagol in the live Slack response path.
+- Do not use Popper/Metagol in the live Slack response path. (They are now a fallback spike, not the default — see [Primary Approach](#primary-approach-dreaming-writes-the-rules).)
+- Do not let the dreaming LLM emit arbitrary code or free-form Prolog; constrain it to the bounded predicate DSL, and gate every candidate rule before it goes live.
 - Do not use learned rules as the only classifier.
 - Do not learn from untrusted labels without review.
 - Do not replace recall scoring or SQLite traversal with ILP.


### PR DESCRIPTION
Doc updates from the design-review discussion with Anmol's Friday. Targets the `docs/memory-v1-v2-recommendations` branch so merging this folds the commit into #50. (Couldn't push directly — `anmolm-growthx` has no write access to this repo.)

### Changes

**`memory-ingestion-rule-learning.md` — biggest change**
- New **Primary Approach: Dreaming Writes the Rules** section. The V2 consolidation/"dreaming" pass authors candidate ingestion rules into the bounded predicate DSL directly (as a promotion type alongside `promote_lesson`/`promote_fact`). Popper/Metagol are demoted to a fallback research spike.
- Collapses the old "ILP V3" into V2: kills the labeled-data gate, the second runtime, and flips the cost justification positive (one dream-time call mints a rule that replaces N future extraction calls).
- The `draft → held-out eval → gate → compile` safety pipeline is **unchanged** — only the rule *author* changes. Two surviving risks flagged: confabulation (LLM invents a plausible-but-wrong rule) and model-monoculture (same model extracts + classifies → grades its own homework; mitigate by scoring against human-confirmed corrections).
- Updated Recommended V2, Recommended Sequence, and Non-Goals accordingly.

**`memory-informed-agent-selection.md`**
- New subsection: **the DSL is the contract between extraction and execution, not between model and host.** The LLM never authors a query or emits DSL text — it emits validated structured facts (tool-call args = the bounded vocabulary), the host compiles those into DSL terms and runs a fixed goal. Two interfaces that must never collapse: fact-assertion vs query.
- `tau-prolog` (pure-JS, in-process) noted as the executor to reach for only when rules need recursion/backward-chaining or proof trees; a TS evaluator covers flat routing. The "second runtime" cost only ever applied to the ILP learners.
- Decisions vs recall: two return types over one graph.
- Added a matching Non-Goal.

**`associative-memory.md`**
- New **Identity and Deduplication** section: dedup (same fact again) vs supersession (fact changed); source records stay append-only; derived nodes merge on an identity key and bump `use_count` instead of spawning duplicates — otherwise `frequency` just measures un-merged rows.
- Set the expectation that **v1 won't feel associative** until the consolidation pass produces edges; until then recall is FTS + tags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
