### PR TITLE
Fix stacked PR review findings

### DIFF
--- a/src/codex-app-server/spawner.test.ts
+++ b/src/codex-app-server/spawner.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Config } from "../config.ts";
+import { createSession } from "../session/types.ts";
+import { spawnCodexAppServer } from "./spawner.ts";
+
+const originalCodexBin = process.env.CODEX_BIN;
+
+afterEach(() => {
+  if (originalCodexBin == null) {
+    delete process.env.CODEX_BIN;
+  } else {
+    process.env.CODEX_BIN = originalCodexBin;
+  }
+});
+
+describe("spawnCodexAppServer", () => {
+  it("fails pending JSON-RPC requests when the process exits before responding", async () => {
+    const fakeCodex = installFakeCodex();
+    process.env.CODEX_BIN = fakeCodex.command;
+
+    try {
+      const session = createSession("thread-1", "C01");
+      session.provider = "codex-app-server";
+      const config = {
+        ...testConfig,
+        codex: {
+          ...testConfig.codex,
+          isolatedHomePath: join(fakeCodex.root, "codex-home"),
+        },
+      };
+
+      const handle = spawnCodexAppServer(session, "hello", config);
+      const result = await Promise.race([
+        handle.result,
+        new Promise<never>((_, reject) => setTimeout(() => reject(new Error("timed out")), 1000)),
+      ]);
+
+      expect(result.exitCode).toBe(42);
+      expect(result.error).toContain("Codex app-server exited before replying to pending requests");
+    } finally {
+      fakeCodex.cleanup();
+    }
+  });
+});
+
+function installFakeCodex(): { root: string; command: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), "junior-codex-app-server-"));
+  const binDir = join(root, "bin");
+  const command = join(binDir, "codex");
+  mkdirSync(binDir, { recursive: true });
+  writeFileSync(command, "#!/bin/sh\necho startup failed >&2\nexit 42\n");
+  chmodSync(command, 0o755);
+  return {
+    root,
+    command,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+const testConfig: Config = {
+  slack: { botToken: "xoxb-test", appToken: "xapp-test", signingSecret: "s" },
+  claude: {
+    maxTurns: 25,
+    timeoutMs: 300000,
+    permissionMode: "bypassPermissions",
+    defaultModel: null,
+    defaultDriver: "headless",
+    tmuxIdleTtlMs: 14_400_000,
+    tmuxSweepIntervalMs: 900_000,
+  },
+  runner: { provider: "codex-app-server" },
+  opencode: {
+    model: null,
+    timeoutMs: 300000,
+    continuityEnabled: false,
+    permission: "allow",
+    mcpEnabled: true,
+    slackMcpEnabled: true,
+    playwrightMcpEnabled: true,
+    mixpanelMcpEnabled: true,
+    mongodbMcpEnabled: true,
+  },
+  codex: {
+    mode: "app-server",
+    model: null,
+    timeoutMs: 300000,
+    sandbox: "workspace-write",
+    askForApproval: "never",
+    searchEnabled: false,
+    appServerContinuityEnabled: false,
+    mcpEnabled: false,
+    slackMcpEnabled: false,
+    playwrightMcpEnabled: false,
+    mixpanelMcpEnabled: false,
+    mongodbMcpEnabled: false,
+    memoryMcpEnabled: false,
+    isolatedHomePath: null,
+  },
+  repos: [],
+  session: {
+    staleTimeoutMs: 86400000,
+    cleanupIntervalMs: 900000,
+    store: "memory",
+    sqlitePath: "data/sessions.db",
+    homeWindowMs: 172800000,
+    defaultVerbosity: "quiet",
+    idleTimeoutMs: 300000,
+    maxIdleInterrupts: 3,
+  },
+  memory: { sqlitePath: "data/memory.db" },
+  channelDefaults: {},
+  adminSlackUserId: null,
+  http: { enabled: false, port: 0 },
+};

--- a/src/codex-app-server/spawner.ts
+++ b/src/codex-app-server/spawner.ts
@@ -57,7 +57,7 @@ export function spawnCodexAppServer(
     ...(codexHome ? { CODEX_HOME: codexHome } : {}),
   };
 
-  const proc = Bun.spawn(["codex", "app-server", "--listen", "stdio://"], {
+  const proc = Bun.spawn([process.env.CODEX_BIN ?? "codex", "app-server", "--listen", "stdio://"], {
     cwd: runtime.cwd,
     stdout: "pipe",
     stderr: "pipe",
@@ -73,6 +73,7 @@ export function spawnCodexAppServer(
   let activeThreadId: string | null = session.sessionId;
   let activeTurnId: string | null = null;
   let processKilled = false;
+  let processExitError: Error | null = null;
 
   const emit = (event: RunnerEvent) => {
     events.push(event);
@@ -88,15 +89,33 @@ export function spawnCodexAppServer(
   const send = (method: string, params: Record<string, unknown>): Promise<unknown> => {
     const id = nextId++;
     const message = { jsonrpc: "2.0", id, method, params };
-    proc.stdin.write(`${JSON.stringify(message)}\n`);
     return new Promise((resolve, reject) => {
       pending.set(id, { method, resolve, reject });
+      if (processExitError) {
+        pending.delete(id);
+        reject(processExitError);
+        return;
+      }
+      try {
+        proc.stdin.write(`${JSON.stringify(message)}\n`);
+      } catch (err) {
+        pending.delete(id);
+        reject(err instanceof Error ? err : new Error(String(err)));
+      }
     });
   };
 
   const respond = (id: number, result: Record<string, unknown>) => {
     proc.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`);
   };
+
+  proc.exited.then((exitCode) => {
+    processExitError = new Error(`Codex app-server exited before replying to pending requests (exit ${exitCode})`);
+    rejectPending(pending, processExitError);
+  }).catch(() => {
+    processExitError = new Error("Codex app-server exited before replying to pending requests");
+    rejectPending(pending, processExitError);
+  });
 
   const stdoutDone = consumeStdout(proc.stdout, (message) => {
     if ("id" in message && typeof message.id === "number" && !("method" in message)) {
@@ -313,6 +332,13 @@ function settleResponse(response: JsonRpcResponse, pending: Map<number, PendingR
   } else {
     entry.resolve(response.result);
   }
+}
+
+function rejectPending(pending: Map<number, PendingRequest>, err: Error): void {
+  for (const entry of pending.values()) {
+    entry.reject(err);
+  }
+  pending.clear();
 }
 
 async function waitForDone(events: RunnerEvent[], exited: Promise<number>): Promise<void> {

--- a/src/memory/sqlite.test.ts
+++ b/src/memory/sqlite.test.ts
@@ -264,6 +264,34 @@ describe("SqliteMemoryStore", () => {
     expect(historical.map((result) => result.id)).toContain("fact-old");
   });
 
+  it("keeps memory_node kind in sync when updating fact kind", async () => {
+    const now = Date.now();
+    await store.upsertFact({
+      id: "fact-kind",
+      kind: "curated_fact",
+      title: "Review route",
+      body: "PR requests should go to review.",
+      createdAt: now,
+    });
+
+    await store.updateFact("fact-kind", { kind: "routing_memory" });
+
+    const db = (store as unknown as { db: Database }).db;
+    const node = db
+      .query<{ kind: string }, [string]>(
+        "SELECT kind FROM memory_node WHERE id = ?",
+      )
+      .get("fact-kind");
+    const doc = db
+      .query<{ kind: string }, [string]>(
+        "SELECT kind FROM memory_search_doc WHERE id = ?",
+      )
+      .get("fact-kind");
+
+    expect(node?.kind).toBe("routing_memory");
+    expect(doc?.kind).toBe("routing_memory");
+  });
+
   it("logs classifications and corrections for ingestion rule learning", async () => {
     const now = Date.now();
     await store.logClassification({

--- a/src/memory/sqlite.ts
+++ b/src/memory/sqlite.ts
@@ -265,13 +265,14 @@ export class SqliteMemoryStore implements MemoryStore {
         .run(update.kind ?? null, update.title ?? null, update.body ?? null, update.confidence ?? null, update.importance ?? null, id);
 
       const current = this.db
-        .query<{ kind: string; title: string | null; body: string }, [string]>(
-          "SELECT kind, title, body FROM memory_fact WHERE id = ?",
+        .query<{ kind: string; title: string | null; body: string; created_at: number }, [string]>(
+          "SELECT kind, title, body, created_at FROM memory_fact WHERE id = ?",
         )
         .get(id);
       if (!current) return;
 
       const nodeKind = current.kind === "curated_fact" ? "fact" : current.kind as SearchableMemoryKind;
+      this.upsertNode(id, nodeKind, current.created_at);
       this.upsertProvenance(id, update.addSourceIds ?? []);
       this.upsertTags(id, nodeKind, update.addTags ?? []);
       this.upsertEntities(id, nodeKind, update.addEntities ?? []);

--- a/src/opencode/sdk-provider.test.ts
+++ b/src/opencode/sdk-provider.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createSession } from "../session/types.ts";
+import { spawnOpenCodeSdk } from "./sdk-provider.ts";
+import type { Config } from "../config.ts";
+
+interface MockSdkController {
+  createOpencode(options?: { directory?: string }): Promise<{
+    client: {
+      session: {
+        create(args?: { directory?: string; agent?: string }): Promise<{ id: string }>;
+        prompt(args: { sessionID: string; message: { role: string; parts: Array<{ type: string; text?: string }> } }): Promise<unknown>;
+        abort(args: { sessionID: string }): Promise<unknown>;
+      };
+      event: {
+        subscribe(args: { directory?: string }): AsyncIterable<{ data: string }>;
+      };
+      config: {
+        update(args: { config: Record<string, unknown> }): Promise<unknown>;
+      };
+    };
+    server: { url: string; close(): void };
+  }>;
+}
+
+type GlobalWithSdkMock = typeof globalThis & {
+  __juniorOpenCodeSdkMock?: MockSdkController;
+};
+
+const originalOpenCodeBin = process.env.OPENCODE_BIN;
+
+afterEach(() => {
+  if (originalOpenCodeBin == null) {
+    delete process.env.OPENCODE_BIN;
+  } else {
+    process.env.OPENCODE_BIN = originalOpenCodeBin;
+  }
+  delete (globalThis as GlobalWithSdkMock).__juniorOpenCodeSdkMock;
+});
+
+describe("spawnOpenCodeSdk", () => {
+  it("resolves on the active session step-finish without waiting for the server event stream to close", async () => {
+    const fakeSdk = installFakeSdk();
+    process.env.OPENCODE_BIN = fakeSdk.opencodeBin;
+
+    (globalThis as GlobalWithSdkMock).__juniorOpenCodeSdkMock = {
+      createOpencode: async () => ({
+        client: {
+          session: {
+            create: async () => ({ id: "ses_active" }),
+            prompt: async () => ({}),
+            abort: async () => ({}),
+          },
+          event: {
+            subscribe: async function* () {
+              yield { data: JSON.stringify({ type: "text", sessionID: "ses_other", text: "wrong" }) };
+              yield { data: JSON.stringify({ type: "step-finish", sessionID: "ses_other" }) };
+              yield { data: JSON.stringify({ type: "text", sessionID: "ses_active", text: "right" }) };
+              yield { data: JSON.stringify({ type: "step-finish", sessionID: "ses_active" }) };
+              await new Promise<never>(() => undefined);
+            },
+          },
+          config: { update: async () => ({}) },
+        },
+        server: { url: "http://localhost:0", close: () => undefined },
+      }),
+    };
+
+    try {
+      const session = createSession("thread-1", "C01");
+      session.provider = "opencode-sdk";
+      const handle = spawnOpenCodeSdk(session, "work", testConfig);
+      const result = await Promise.race([
+        handle.result,
+        new Promise<never>((_, reject) => setTimeout(() => reject(new Error("timed out")), 100)),
+      ]);
+
+      expect(result.sessionId).toBe("ses_active");
+      expect(result.response).toBe("right");
+      expect(result.events.map((event) => event.type)).toEqual(["init", "message", "done"]);
+    } finally {
+      fakeSdk.cleanup();
+    }
+  });
+});
+
+function installFakeSdk(): { opencodeBin: string; cleanup: () => void } {
+  const root = mkdtempSync(join(tmpdir(), "junior-opencode-sdk-"));
+  const binDir = join(root, "bin");
+  const sdkDir = join(root, "node_modules", "@opencode-ai", "sdk");
+  mkdirSync(binDir, { recursive: true });
+  mkdirSync(sdkDir, { recursive: true });
+
+  const opencodeBin = join(binDir, "opencode");
+  writeFileSync(opencodeBin, "#!/bin/sh\nexit 0\n");
+  chmodSync(opencodeBin, 0o755);
+  writeFileSync(join(sdkDir, "package.json"), JSON.stringify({ type: "module", main: "index.js" }));
+  writeFileSync(
+    join(sdkDir, "index.js"),
+    "export async function createOpencode(options) { return globalThis.__juniorOpenCodeSdkMock.createOpencode(options); }\n",
+  );
+
+  return {
+    opencodeBin,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+const testConfig: Config = {
+  slack: { botToken: "xoxb-test", appToken: "xapp-test", signingSecret: "s" },
+  claude: {
+    maxTurns: 25,
+    timeoutMs: 300000,
+    permissionMode: "bypassPermissions",
+    defaultModel: null,
+    defaultDriver: "headless",
+    tmuxIdleTtlMs: 14_400_000,
+    tmuxSweepIntervalMs: 900_000,
+  },
+  runner: { provider: "opencode-sdk" },
+  opencode: {
+    model: null,
+    timeoutMs: 300000,
+    continuityEnabled: false,
+    permission: "allow",
+    mcpEnabled: true,
+    slackMcpEnabled: true,
+    playwrightMcpEnabled: true,
+    mixpanelMcpEnabled: true,
+    mongodbMcpEnabled: true,
+  },
+  codex: {
+    mode: "app-server",
+    model: null,
+    timeoutMs: 300000,
+    sandbox: "workspace-write",
+    askForApproval: "never",
+    searchEnabled: false,
+    appServerContinuityEnabled: false,
+    mcpEnabled: true,
+    slackMcpEnabled: true,
+    playwrightMcpEnabled: true,
+    mixpanelMcpEnabled: true,
+    mongodbMcpEnabled: true,
+    memoryMcpEnabled: true,
+    isolatedHomePath: "data/codex-home",
+  },
+  repos: [],
+  session: {
+    staleTimeoutMs: 86400000,
+    cleanupIntervalMs: 900000,
+    store: "memory",
+    sqlitePath: "data/sessions.db",
+    homeWindowMs: 172800000,
+    defaultVerbosity: "quiet",
+    idleTimeoutMs: 300000,
+    maxIdleInterrupts: 3,
+  },
+  memory: { sqlitePath: "data/memory.db" },
+  channelDefaults: {},
+  adminSlackUserId: null,
+  http: { enabled: false, port: 0 },
+};

--- a/src/opencode/sdk-provider.ts
+++ b/src/opencode/sdk-provider.ts
@@ -152,6 +152,7 @@ export function spawnOpenCodeSdk(
 
   let sdkSessionId: string | null = null;
   let aborted = false;
+  let finishTurn: (() => void) | null = null;
   const eventListeners: Array<(event: RunnerEvent) => void> = [];
 
   const spawnResult = new Promise<SpawnResult>(async (resolve, reject) => {
@@ -195,16 +196,21 @@ export function spawnOpenCodeSdk(
       };
 
       const eventStream = server.client.event.subscribe({ directory: cwd });
+      const turnDone = new Promise<void>((resolve) => {
+        finishTurn = resolve;
+      });
       const eventConsumer = (async () => {
         try {
           for await (const raw of eventStream) {
             if (aborted) break;
             try {
               const part = (typeof raw.data === "string" ? JSON.parse(raw.data) : raw.data) as SdkEventPart;
+              const partSessionId = "sessionID" in part ? (part as { sessionID?: string }).sessionID : undefined;
+              if (partSessionId && partSessionId !== currentSessionId) continue;
 
               // Capture session ID from first part carrying one
               if (!sessionIdCaptured) {
-                const sid = "sessionID" in part ? (part as { sessionID?: string }).sessionID : undefined;
+                const sid = partSessionId;
                 if (sid) {
                   sessionIdCaptured = true;
                   emit({ type: "init", provider, sessionId: sid });
@@ -238,6 +244,8 @@ export function spawnOpenCodeSdk(
                   ? { input: stepPart.tokens.input ?? 0, output: stepPart.tokens.output ?? 0 }
                   : undefined;
                 emit({ type: "done", provider, usage });
+                finishTurn?.();
+                break;
               }
             } catch {
               // Skip unparseable events
@@ -266,7 +274,9 @@ export function spawnOpenCodeSdk(
         return;
       }
 
-      // Wait for event stream to finish
+      // The SDK subscription is server-lived; a Junior turn is complete when
+      // the active SDK session emits step-finish, not when the stream closes.
+      await turnDone;
       await eventConsumer;
 
       const responseText = events
@@ -299,6 +309,7 @@ export function spawnOpenCodeSdk(
           // ok
         }
       }
+      finishTurn?.();
       if (signal === "SIGKILL" && _server) {
         try { _server.close(); } catch { /* ok */ }
         _server = null;

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -197,11 +197,11 @@ function cloneConfig(overrides: Partial<Config> = {}): Config {
 }
 
 async function waitFor(
-  predicate: () => boolean,
+  predicate: () => boolean | Promise<boolean>,
   timeoutMs: number = 100,
 ): Promise<void> {
   const started = Date.now();
-  while (!predicate()) {
+  while (!(await predicate())) {
     if (Date.now() - started > timeoutMs) {
       throw new Error("Timed out waiting for condition");
     }
@@ -209,7 +209,10 @@ async function waitFor(
   }
 }
 
-function createIdleOpencodeHandle(sessionId = "ses_idle_1"): SpawnHandle {
+function createIdleOpencodeHandle(
+  sessionId = "ses_idle_1",
+  pid = 12345,
+): SpawnHandle {
   let resolveResult!: (result: SpawnResult) => void;
   const result = new Promise<SpawnResult>((res) => {
     resolveResult = res;
@@ -231,11 +234,14 @@ function createIdleOpencodeHandle(sessionId = "ses_idle_1"): SpawnHandle {
         error: "interrupted",
       });
     }),
-    pid: 12345,
+    pid,
   };
 }
 
-function createCompletingOpencodeHandle(sessionId = "ses_idle_1"): MockHandle {
+function createCompletingOpencodeHandle(
+  sessionId = "ses_idle_1",
+  pid = 12345,
+): MockHandle {
   const listeners: Array<(event: RunnerEvent) => void> = [];
   let resolveResult!: (result: SpawnResult) => void;
   const result = new Promise<SpawnResult>((res) => {
@@ -247,7 +253,7 @@ function createCompletingOpencodeHandle(sessionId = "ses_idle_1"): MockHandle {
     result,
     onEvent: (cb) => listeners.push(cb),
     kill: mock(() => {}),
-    pid: 12345,
+    pid,
     _complete: (resp?: string, sid?: string, resultEvents?: RunnerEvent[]) => {
       const finalSessionId = sid ?? sessionId;
       for (const l of listeners) {
@@ -495,8 +501,8 @@ describe("SessionManager", () => {
         maxIdleInterrupts: 1,
       },
     });
-    const idleHandle = createIdleOpencodeHandle("ses_resume_1");
-    const retryHandle = createCompletingOpencodeHandle("ses_resume_1");
+    const idleHandle = createIdleOpencodeHandle("ses_resume_1", 12345);
+    const retryHandle = createCompletingOpencodeHandle("ses_resume_1", 67890);
     let spawnCount = 0;
     mockSpawnFn = mock(() => (spawnCount++ === 0 ? idleHandle : retryHandle));
     manager = new SessionManager(
@@ -513,6 +519,7 @@ describe("SessionManager", () => {
     const retryConfig = mockSpawnFn.mock.calls[1][2];
     expect(retrySession.sessionId).toBe("ses_resume_1");
     expect(retryConfig.opencode.continuityEnabled).toBe(true);
+    await waitFor(async () => (await store.get("thread-1"))?.pid === 67890);
 
     retryHandle._complete("resumed", "ses_resume_1");
     await new Promise((r) => setTimeout(r, 10));

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -1078,6 +1078,7 @@ export class SessionManager {
       // SIGINT'd by Junior.
       const idleEnabled = this.idleResumeEnabled(provider);
       let idleInterrupted = false;
+      let activeHandle = handle;
       let idleTimer: ReturnType<typeof setTimeout> | null = null;
       let idleKillTimer: ReturnType<typeof setTimeout> | null = null;
       const clearIdleTimers = () => {
@@ -1092,10 +1093,10 @@ export class SessionManager {
         idleTimer = setTimeout(() => {
           idleInterrupted = true;
           _log.warn("session", `idle-interrupt thread=${session.threadId} agent=${agentName} provider=${provider}`);
-          handle.kill("SIGINT");
+          activeHandle.kill("SIGINT");
           idleKillTimer = setTimeout(() => {
             _log.warn("session", `idle-escalate thread=${session.threadId} agent=${agentName} provider=${provider}`);
-            handle.kill("SIGKILL");
+            activeHandle.kill("SIGKILL");
           }, 10_000);
         }, this.config.session.idleTimeoutMs);
       };
@@ -1115,6 +1116,7 @@ export class SessionManager {
         }
         this.onEvent?.(this.buildRunSession(session, agentName, agentIdentity), event);
       });
+      await this.persistRunProcessDetails(session.threadId, agentName, handle.pid);
 
       const maxIdleInterrupts = this.config.session.maxIdleInterrupts;
       let attemptHandle = handle;
@@ -1198,9 +1200,8 @@ export class SessionManager {
             agentSession.pid = retryHandle.pid;
           }
 
-          // Re-arm idle timer for the retry handle
+          activeHandle = retryHandle;
           idleInterrupted = false;
-          armIdleTimer();
           retryHandle.onEvent((event: RunnerEvent) => {
             armIdleTimer();
             if (event.type === "init") {
@@ -1215,6 +1216,10 @@ export class SessionManager {
             }
             this.onEvent?.(this.buildRunSession(session, agentName, agentIdentity), event);
           });
+          await this.persistRunProcessDetails(session.threadId, agentName, retryHandle.pid);
+
+          // Re-arm idle timer for the retry handle
+          armIdleTimer();
 
           attemptHandle = retryHandle;
           continue;
@@ -1249,6 +1254,28 @@ export class SessionManager {
         session.lastError.message,
       );
     }
+  }
+
+  private async persistRunProcessDetails(
+    threadId: string,
+    agentName: string,
+    pid: number | null,
+  ): Promise<void> {
+    const fresh = await this.store.get(threadId);
+    if (!fresh) return;
+
+    if (agentName === "lead" || agentName === "default") {
+      if (fresh.status === "busy") {
+        fresh.pid = pid;
+      }
+    } else {
+      const agentSession = fresh.agentSessions?.[agentName];
+      if (agentSession?.status === "busy") {
+        agentSession.pid = pid;
+      }
+    }
+
+    await this.store.set(threadId, fresh);
   }
 
   private async onRunComplete(

--- a/src/support/router.test.ts
+++ b/src/support/router.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, mock } from "bun:test";
 import type { SlackMessageEvent } from "../slack/events.ts";
 import type { SessionManager } from "../session/manager.ts";
 import { parseAgentDirectives, parseDevserverDirective, AgentDispatcher } from "./router.ts";
+import type { MemoryStore } from "../memory/store.ts";
 
 function makeEvent(overrides: Partial<SlackMessageEvent> = {}): SlackMessageEvent {
   return {
@@ -336,6 +337,41 @@ describe("AgentDispatcher", () => {
     expect(managerMock.handleAgentMessage).not.toHaveBeenCalled();
     const call = managerMock.handleMessage.mock.calls[0][0];
     expect(call.dedupeKey).toBeUndefined();
+  });
+
+  it("uses routing memory body even when the memory has a title", async () => {
+    const managerMock = {
+      handleMessage: mock(async (_event: SlackMessageEvent) => {}),
+      handleLeadMessage: mock(async (_event: SlackMessageEvent) => {}),
+      handleAgentMessage: mock(async (_event: SlackMessageEvent, _agent: string) => {}),
+    };
+    const memoryStore = {
+      recall: mock(async () => [
+        {
+          id: "routing-1",
+          kind: "routing_memory",
+          title: "Learned routing memory",
+          body: "Send pull request review requests to review.",
+          outcome: null,
+          score: 1,
+          reasons: [],
+          sourceIds: [],
+        },
+      ]),
+    } as unknown as MemoryStore;
+    const router = new AgentDispatcher(
+      managerMock as unknown as SessionManager,
+      new Set(),
+      { memoryStore },
+    );
+
+    await router.handleMessage(makeEvent({ channel: "C_GENERAL", text: "please look at this PR" }));
+
+    expect(managerMock.handleAgentMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ dedupeKey: "123.456:review:memory" }),
+      "review",
+    );
+    expect(managerMock.handleMessage).not.toHaveBeenCalled();
   });
 
   it("drops self-bot posts with unknown username (no usable identity)", async () => {

--- a/src/support/router.ts
+++ b/src/support/router.ts
@@ -505,7 +505,7 @@ export class AgentDispatcher {
           depth: 1,
         });
         for (const memory of memories) {
-          const h = (memory.title ?? "" + " " + memory.body).toLowerCase();
+          const h = `${memory.title ?? ""} ${memory.body}`.toLowerCase();
           for (const agent of AGENTS) {
             if (h.includes(agent) && isPersistentAgent(agent)) return agent;
           }


### PR DESCRIPTION
## Summary
- fix memory routing so titled routing memories search both title and body
- keep memory node kind in sync when fact kind changes
- resolve OpenCode SDK turns on active session step-finish instead of stream close
- reject Codex app-server JSON-RPC requests when the process exits early, including pre-send exit races
- include the idle-resume current-handle/process-detail fix and regression coverage

## Verification
- bun run typecheck
- bun test src/support/router.test.ts src/memory/sqlite.test.ts src/opencode/sdk-provider.test.ts src/codex-app-server/spawner.test.ts src/session/manager.test.ts
- bun test