### PR TITLE
Gate workflow idle resume by provider

### DIFF
--- a/src/workflows/executor.test.ts
+++ b/src/workflows/executor.test.ts
@@ -247,8 +247,10 @@ describe("WorkflowExecutor", () => {
         pid: null,
       };
     };
+    const config = testConfig();
+    config.opencode.continuityEnabled = true;
     const executor = new WorkflowExecutor({
-      config: testConfig(),
+      config,
       store,
       spawn,
       now: () => new Date("2026-05-24T11:00:00.000Z"),
@@ -262,6 +264,108 @@ describe("WorkflowExecutor", () => {
       expect(killSignals).toContain("SIGINT");
       expect(seenSessionIds).toEqual([null, "ses-idle"]);
       expect((await store.getRun(result.run.id))?.providerSessionId).toBe("ses-idle");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not idle-interrupt workflow runners for server-attached providers", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "junior-workflow-server-provider-test-"));
+    const definition = workflowDefinition(dir);
+    definition.runner = {
+      provider: "default",
+      agentName: "default",
+      timeoutMs: 1000,
+      idleTimeoutMs: 10,
+      maxIdleInterrupts: 1,
+    };
+    const store = new InMemoryWorkflowStore();
+    const killSignals: Array<string | undefined> = [];
+    const spawn: SpawnRunnerFn = (): SpawnHandle => {
+      return {
+        provider: "codex-app-server",
+        result: new Promise((resolve) => {
+          setTimeout(() => resolve({
+            provider: "codex-app-server",
+            sessionId: null,
+            response: "Completed after quiet server-attached work.",
+            events: [],
+            exitCode: 0,
+            error: null,
+          }), 30);
+        }),
+        onEvent: () => {},
+        kill: (signal) => {
+          killSignals.push(signal);
+        },
+        pid: null,
+      };
+    };
+    const config = testConfig();
+    config.runner.provider = "codex-app-server";
+    const executor = new WorkflowExecutor({
+      config,
+      store,
+      spawn,
+      now: () => new Date("2026-05-24T11:30:00.000Z"),
+    });
+
+    try {
+      const result = await executor.run({ definition, reason: "manual" });
+
+      expect(result.summary).toBe("Completed after quiet server-attached work.");
+      expect(killSignals).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("does not idle-interrupt opencode workflow runners when continuity is disabled", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "junior-workflow-opencode-no-continuity-test-"));
+    const definition = workflowDefinition(dir);
+    definition.runner = {
+      provider: "default",
+      agentName: "default",
+      timeoutMs: 1000,
+      idleTimeoutMs: 10,
+      maxIdleInterrupts: 1,
+    };
+    const store = new InMemoryWorkflowStore();
+    const killSignals: Array<string | undefined> = [];
+    const spawn: SpawnRunnerFn = (): SpawnHandle => {
+      return {
+        provider: "opencode",
+        result: new Promise((resolve) => {
+          setTimeout(() => resolve({
+            provider: "opencode",
+            sessionId: null,
+            response: "Completed without continuity.",
+            events: [],
+            exitCode: 0,
+            error: null,
+          }), 30);
+        }),
+        onEvent: () => {},
+        kill: (signal) => {
+          killSignals.push(signal);
+        },
+        pid: null,
+      };
+    };
+    const config = testConfig();
+    config.opencode.continuityEnabled = false;
+    const executor = new WorkflowExecutor({
+      config,
+      store,
+      spawn,
+      now: () => new Date("2026-05-24T12:00:00.000Z"),
+    });
+
+    try {
+      const result = await executor.run({ definition, reason: "manual" });
+
+      expect(result.summary).toBe("Completed without continuity.");
+      expect(killSignals).toEqual([]);
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/src/workflows/executor.ts
+++ b/src/workflows/executor.ts
@@ -196,14 +196,19 @@ export class WorkflowExecutor {
     session: ReturnType<typeof createSession>;
     initialPrompt: string;
   }): Promise<string> {
-    const maxIdleInterrupts = options.runner.idleTimeoutMs
+    const idleResumeEnabled = this.idleResumeEnabled(options.provider);
+    const maxIdleInterrupts = options.runner.idleTimeoutMs && idleResumeEnabled
       ? (options.runner.maxIdleInterrupts ?? DEFAULT_MAX_IDLE_INTERRUPTS)
       : 0;
     let idleInterrupts = 0;
     let prompt = options.initialPrompt;
 
     for (;;) {
-      const attempt = await this.runWorkflowRunnerAttempt({ ...options, prompt });
+      const attempt = await this.runWorkflowRunnerAttempt({
+        ...options,
+        prompt,
+        idleResumeEnabled,
+      });
       if (attempt.result.sessionId) {
         options.session.sessionId = attempt.result.sessionId;
       }
@@ -213,7 +218,12 @@ export class WorkflowExecutor {
         return response;
       }
 
-      if (attempt.idleInterrupted && options.session.sessionId && idleInterrupts < maxIdleInterrupts) {
+      if (
+        attempt.idleInterrupted &&
+        idleResumeEnabled &&
+        options.session.sessionId &&
+        idleInterrupts < maxIdleInterrupts
+      ) {
         idleInterrupts += 1;
         log.warn(
           "workflow",
@@ -244,6 +254,7 @@ export class WorkflowExecutor {
     provider: ImplementedRunnerProvider;
     session: ReturnType<typeof createSession>;
     prompt: string;
+    idleResumeEnabled: boolean;
   }): Promise<{ result: Awaited<SpawnHandle["result"]>; idleInterrupted: boolean }> {
     const handle = this.spawn(
       options.session,
@@ -261,7 +272,7 @@ export class WorkflowExecutor {
     };
     const armIdleTimer = () => {
       clearIdleTimer();
-      if (!options.runner.idleTimeoutMs) return;
+      if (!options.idleResumeEnabled || !options.runner.idleTimeoutMs) return;
       idleTimer = setTimeout(() => {
         idleInterrupted = true;
         log.warn(
@@ -302,6 +313,11 @@ export class WorkflowExecutor {
     );
     const result = await bounded.result.finally(clearIdleTimer);
     return { result, idleInterrupted };
+  }
+
+  private idleResumeEnabled(provider: ImplementedRunnerProvider): boolean {
+    if (provider === "opencode") return this.config.opencode.continuityEnabled;
+    return provider !== "opencode-sdk" && provider !== "codex-app-server";
   }
 
   private async emitOutputs(


### PR DESCRIPTION
## Summary
- Gate workflow idle-interrupt/resume using the same provider policy as normal sessions
- Keep workflow idle resume enabled for Claude and OpenCode only when OpenCode continuity is enabled
- Add regression tests for resumable OpenCode, server-attached Codex app-server, and OpenCode without continuity

## Verification
- bun test src/workflows/executor.test.ts
- bun run typecheck

Both verification commands were run twice in the clean PR worktree.