### PR TITLE
Download non-image Slack file attachments

### DIFF
--- a/docs/features/slack-event-handler.md
+++ b/docs/features/slack-event-handler.md
@@ -36,7 +36,7 @@ The bot needs to receive Slack messages and route them to the right session. A m
 - `src/slack/commands.ts` — `parseCommand(text)` extracts a leading `!<word>` from `KNOWN_COMMANDS`. `!<persistent-agent>` directives (e.g. `!lead`, `!reproducer`, `!thinker`, `!review`) are **not** in this set — they pass through with the prefix intact for the agent dispatcher.
 - `src/slack/responder.ts` — `SlackResponder` wraps `chat.postMessage`, `chat.update`, `chat.delete`, and `reactions.add`. Handles response splitting (via `formatting.ts`), agent identity (`username` + `icon_emoji` on posts), and per-agent status pills keyed by `${threadTs}:${agentName}` with a 1s debounce.
 - `src/slack/home.ts` — `registerHomeTab` listens for `app_home_opened` and `home_session_details` button actions. `publishHomeTab` calls `store.getRecent(windowMs)`, resolves Slack permalinks, and renders blocks: stats summary (active/idle/draining/errors/muted/total), Active Sessions, Recent Sessions (last 10 idle), Recent Errors (last 5). Each session block stays compact (status, lead agent, provider, repo, last activity, mute flag, pending count, agent count) and includes a `View details` button. Detail modals show worktree path, resume command, per-agent resume/status rows, and last error, split into Slack-safe section blocks. Last-error text is passed through the same prompt-leak sanitizer used for runner error replies before it appears in Home or modals.
-- `src/slack/files.ts` — `downloadSlackFiles(files, threadId, botToken)` fetches image attachments (`image/png|jpeg|gif|webp`) to `/tmp/junior-files/<threadId>/` so Claude can read them. Non-image files are skipped.
+- `src/slack/files.ts` — `downloadSlackFiles(files, threadId, botToken)` fetches Slack attachments to `/tmp/junior-files/<threadId>/` so the runner can read them from disk.
 
 ### Drop rules in `events.ts`
 
@@ -95,7 +95,7 @@ Drop rules, `threadId` extraction, structured event passed to session manager. N
 
 - DMs (`channel_type === "im"`) bypass the mention requirement.
 - Message edits/deletes have no `text` and fall through `no-text`.
-- File uploads: image attachments are downloaded by `files.ts` and the local paths are passed to Claude as context. Non-image files are skipped today.
+- File uploads: attachments are downloaded by `files.ts` and the local paths are passed to the runner as context.
 - No outgoing rate-limit beyond the 1s status-pill debounce.
 
 ## Shortcuts

--- a/docs/features/thread-context.md
+++ b/docs/features/thread-context.md
@@ -14,7 +14,7 @@ When Junior spawns a `claude -p` process, that process has zero knowledge of the
 1. **`<identity>`** — Junior's persona (see [agent-definitions](agent-definitions.md)) + the bot's Slack user ID so Claude can recognize its own messages.
 2. **`<slack-context>`** — channel name + ID, thread_ts, instruction not to search Slack, how to tag users via `<@USERID>`, the `NO_SLACK_MESSAGE` sentinel, and the no-double-post rule when `slack_send_message` was used.
 3. **`<workspace>`** — see Workspace Block below.
-4. **`<thread-context>`** — prior messages from `conversations.replies` (limit 100, excluding the current message), labeled `User(Name <@U…>)` or `Junior (you)`, with `[shared image: name]` annotations.
+4. **`<thread-context>`** — prior messages from `conversations.replies` (limit 100, excluding the current message), labeled `User(Name <@U…>)` or `Junior (you)`, with `[shared file: name]` annotations.
 5. **`<persistent-agent-state>`** — injected by the manager (not preamble itself) when the agent has `context.agentState`; lists per-thread agent sessions and pending counts.
 6. **`<dispatch-allow>`** — appended to the system prompt by the manager (`buildDispatchAllowBlock`) so every agent sees the authoritative list of `!<agent>` directives it may emit. See [agent-routing](agent-routing.md).
 
@@ -43,8 +43,8 @@ User and channel names are cached in module-level Maps.
 
 ## File Handling
 
-- **Images on the message** — downloaded to `/tmp/junior-files/<threadId>/` via `files.ts`, then appended to the prompt as Read-tool paths. Image MIME only (png/jpeg/gif/webp).
-- **Historical images** — surfaced as `[shared image: name.png]` annotations in `<thread-context>` (no download).
+- **Files on the message** — downloaded to `/tmp/junior-files/<threadId>/` via `files.ts`, then appended to the prompt as local paths.
+- **Historical files** — surfaced as `[shared file: name]` annotations in `<thread-context>` (no download).
 - **Outbound files** — the spawner exports `SLACK_CHANNEL`, `SLACK_THREAD_TS`, `SLACK_BOT_TOKEN`; `bin/slack-upload.sh` and Playwright MCP screenshots use them with zero per-thread config.
 
 ## Key Files
@@ -56,7 +56,7 @@ User and channel names are cached in module-level Maps.
 | `src/agents/loader.ts` | `AgentContextProfile` + `DEFAULT_CONTEXT_PROFILE` |
 | `src/agents/router.ts` | Agent resolution with target-repo → org overlay → fallback search order |
 | `src/support/agents.ts` | `buildDispatchAllowBlock` (injected per agent) |
-| `src/slack/files.ts` | Image download |
+| `src/slack/files.ts` | Slack file download |
 | `src/session/manager.ts` | Calls preamble on first turn, workspace-only on resume, appends agent-state + dispatch-allow |
 | `src/claude/spawner.ts` | Exports Slack env vars |
 | `bin/slack-upload.sh` | Outbound uploads via env vars |

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -330,6 +330,34 @@ describe("SessionManager", () => {
     expect(callArgs[1]).toBe("Build me a feature");
   });
 
+  it("adds downloaded non-image Slack file paths to the prompt", async () => {
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async () => new Response("a,b\n1,2\n", { status: 200 })) as unknown as typeof fetch;
+    try {
+      await manager.handleMessage(
+        makeEvent({
+          text: "review this csv",
+          files: [
+            {
+              url: "https://files.slack.com/files-pri/T/F/download/input.csv",
+              name: "input.csv",
+              mimetype: "text/csv",
+            },
+          ],
+        }),
+      );
+      await waitFor(() => mockSpawnFn.mock.calls.length === 1);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    expect(mockSpawnFn).toHaveBeenCalledTimes(1);
+    const prompt = mockSpawnFn.mock.calls[0][1] as string;
+    expect(prompt).toContain("review this csv");
+    expect(prompt).toContain("The user shared files.");
+    expect(prompt).toContain("/tmp/junior-files/thread-1/input.csv");
+  });
+
   // --- Message buffering ---
 
   it("buffers message when thread is busy", async () => {

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -961,18 +961,28 @@ export class SessionManager {
         }
       }
 
-      // Download image files from Slack and append their paths to the prompt
+      // Download files from Slack and append their paths to the prompt.
+      let filePaths: string[] = [];
       let imagePaths: string[] = [];
       if (files && files.length > 0) {
         try {
-          imagePaths = await downloadSlackFiles(
+          filePaths = await downloadSlackFiles(
             files,
             session.threadId,
             this.config.slack.botToken,
           );
-          if (imagePaths.length > 0) {
-            const pathList = imagePaths.map((p) => `- ${p}`).join("\n");
-            prompt += `\n\nThe user shared images. They are saved at these paths — use the Read tool to view them:\n${pathList}`;
+          if (filePaths.length > 0) {
+            const imageNames = new Set(
+              files
+                .filter((f) => f.mimetype.startsWith("image/"))
+                .map((f) => f.name.split(/[\\/]/).pop() ?? f.name),
+            );
+            imagePaths = filePaths.filter((p) => {
+              const name = p.split(/[\\/]/).pop() ?? p;
+              return imageNames.has(name);
+            });
+            const pathList = filePaths.map((p) => `- ${p}`).join("\n");
+            prompt += `\n\nThe user shared files. They are saved at these paths — read them from disk when needed:\n${pathList}`;
           }
         } catch (err) {
           console.error("[manager] Failed to download Slack files:", err);

--- a/src/slack/files.test.ts
+++ b/src/slack/files.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { downloadSlackFiles } from "./files.ts";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("downloadSlackFiles", () => {
+  it("downloads non-image Slack files too", async () => {
+    const fetchMock = mock(async (_url: string | URL | Request, init?: RequestInit) => {
+      expect(init?.headers).toEqual({ Authorization: "Bearer xoxb-test" });
+      return new Response("name,email\nA,a@example.com\n", { status: 200 });
+    });
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+    const paths = await downloadSlackFiles(
+      [
+        {
+          url: "https://files.slack.com/files-pri/T/F/download/report.csv",
+          name: "report.csv",
+          mimetype: "text/csv",
+        },
+      ],
+      "thread-files-test",
+      "xoxb-test",
+    );
+
+    expect(paths).toEqual(["/tmp/junior-files/thread-files-test/report.csv"]);
+    expect(await readFile(paths[0], "utf8")).toBe("name,email\nA,a@example.com\n");
+  });
+
+  it("uses the basename of Slack file names when writing locally", async () => {
+    globalThis.fetch = mock(async () => new Response("safe", { status: 200 })) as unknown as typeof fetch;
+
+    const paths = await downloadSlackFiles(
+      [
+        {
+          url: "https://files.slack.com/files-pri/T/F/download/report.csv",
+          name: "../report.csv",
+          mimetype: "text/csv",
+        },
+      ],
+      "thread-files-basename-test",
+      "xoxb-test",
+    );
+
+    expect(paths).toEqual(["/tmp/junior-files/thread-files-basename-test/report.csv"]);
+  });
+});

--- a/src/slack/files.ts
+++ b/src/slack/files.ts
@@ -1,12 +1,5 @@
 import { mkdir } from "node:fs/promises";
-import { join } from "node:path";
-
-const IMAGE_TYPES = new Set([
-  "image/png",
-  "image/jpeg",
-  "image/gif",
-  "image/webp",
-]);
+import { basename, join } from "node:path";
 
 export interface SlackFile {
   url: string;
@@ -15,8 +8,7 @@ export interface SlackFile {
 }
 
 /**
- * Download image files from Slack to local disk so Claude can read them.
- * Only downloads image types; non-image files are silently skipped.
+ * Download Slack files to local disk so the runner can read them.
  * Returns array of local file paths for successfully downloaded files.
  */
 export async function downloadSlackFiles(
@@ -24,15 +16,12 @@ export async function downloadSlackFiles(
   threadId: string,
   botToken: string,
 ): Promise<string[]> {
-  const imageFiles = files.filter((f) => IMAGE_TYPES.has(f.mimetype));
-  if (imageFiles.length === 0) return [];
-
   const dir = join("/tmp", "junior-files", threadId);
   await mkdir(dir, { recursive: true });
 
   const paths: string[] = [];
 
-  for (const file of imageFiles) {
+  for (const file of files) {
     try {
       const response = await fetch(file.url, {
         headers: { Authorization: `Bearer ${botToken}` },
@@ -45,7 +34,7 @@ export async function downloadSlackFiles(
         continue;
       }
 
-      const filePath = join(dir, file.name);
+      const filePath = join(dir, basename(file.name));
       const buffer = await response.arrayBuffer();
       await Bun.write(filePath, buffer);
       paths.push(filePath);

--- a/src/slack/thread-context.test.ts
+++ b/src/slack/thread-context.test.ts
@@ -176,4 +176,51 @@ describe("buildPromptPreamble", () => {
     expect(preamble).not.toContain("private aside");
     expect(preamble).not.toContain("User(U5 <@U5>): current message");
   });
+
+  it("labels historical attachments as shared files", async () => {
+    const app = {
+      client: {
+        users: {
+          info: async ({ user }: { user: string }) => ({
+            user: { profile: { display_name: user } },
+          }),
+        },
+        conversations: {
+          replies: async () => ({
+            messages: [
+              { ts: "1", user: "U1", text: "root message" },
+              {
+                ts: "2",
+                user: "U2",
+                text: "see attached",
+                files: [{ name: "assignments.csv" }],
+              },
+              { ts: "3", user: "U3", text: "current message" },
+            ],
+          }),
+        },
+      },
+    } as unknown as App;
+
+    const preamble = await buildPromptPreamble(
+      app,
+      "C1",
+      "1",
+      "3",
+      "UBOT",
+      null,
+      undefined,
+      undefined,
+      {
+        identity: false,
+        slack: false,
+        workspace: false,
+        threadHistory: true,
+        threadHistoryLimit: 100,
+        agentState: false,
+      },
+    );
+
+    expect(preamble).toContain("[shared file: assignments.csv]");
+  });
 });

--- a/src/slack/thread-context.ts
+++ b/src/slack/thread-context.ts
@@ -293,7 +293,7 @@ async function fetchThreadHistory(
         : `User(${m.userName}${m.user !== "unknown" ? ` <@${m.user}>` : ""})`;
       let line = `${role}: ${m.text}`;
       if (m.fileNames.length > 0) {
-        const fileNotes = m.fileNames.map((f) => `[shared image: ${f}]`).join(" ");
+        const fileNotes = m.fileNames.map((f) => `[shared file: ${f}]`).join(" ");
         line += ` ${fileNotes}`;
       }
       return line;


### PR DESCRIPTION
## Summary
- download all Slack attachments with private download URLs, not just image MIME types
- pass downloaded file paths into the runner prompt with generic file wording
- label historical attachments as shared files and add CSV regression coverage

## Test plan
- bun test src/slack/files.test.ts src/slack/thread-context.test.ts src/session/manager.test.ts
- bun run typecheck