### PR TITLE
Filter non-semantic memory lesson tags

### DIFF
--- a/src/memory/sqlite.test.ts
+++ b/src/memory/sqlite.test.ts
@@ -330,7 +330,7 @@ describe("SqliteMemoryStore", () => {
     expect(correction?.correct_value).toBe("frontend");
   });
 
-  it("consolidates by archiving cold events, promoting routing memories, proposing draft rules, promoting lessons, and pruning edges", async () => {
+  it("consolidates by archiving cold events, promoting routing memories, proposing draft rules, semantic lessons, and pruning edges", async () => {
     const now = Date.now();
     const old = now - 60 * 24 * 60 * 60 * 1000;
     await store.appendSourceRecord({ id: "source-old", kind: "slack_message", body: "ok", createdAt: old });
@@ -343,7 +343,7 @@ describe("SqliteMemoryStore", () => {
       createdAt: old,
     });
 
-    // Lesson promotion: multiple high-importance events with the same tag
+    // Semantic repeated tags can promote; operational/import tags should not.
     const recent = now - 1000;
     await store.appendSourceRecord({ id: "src-a", kind: "slack_message", body: "auth middleware broken", createdAt: recent });
     await store.upsertEvent({
@@ -351,7 +351,7 @@ describe("SqliteMemoryStore", () => {
       sourceRecordId: "src-a",
       threadId: "T2",
       body: "auth middleware broken on /api/v2",
-      tags: ["auth", "bug"],
+      tags: ["auth", "bug", "agent:default", "runner_tool_error", "gx_learnings"],
       importance: 0.8,
       createdAt: recent,
     });
@@ -361,7 +361,7 @@ describe("SqliteMemoryStore", () => {
       sourceRecordId: "src-b",
       threadId: "T2",
       body: "JWT token expired after 5 min",
-      tags: ["auth", "error"],
+      tags: ["auth", "error", "agent:default", "runner_tool_error", "gx_learnings"],
       importance: 0.9,
       createdAt: recent,
     });
@@ -371,7 +371,7 @@ describe("SqliteMemoryStore", () => {
       sourceRecordId: "src-c",
       threadId: "T2",
       body: "fixed auth middleware with token refresh",
-      tags: ["auth"],
+      tags: ["auth", "agent:default", "runner_tool_error", "gx_learnings"],
       importance: 0.75,
       createdAt: recent,
     });
@@ -428,8 +428,12 @@ describe("SqliteMemoryStore", () => {
     expect(result.proposedRuleIds).toContain("rule_tag_frontend");
     expect(result.decisions.map((decision) => decision.action)).toContain("propose_rule");
 
-    // Lesson promotion (3+ high-importance events with same tag)
+    // Semantic tag promotion remains, but bad input tags are ignored.
     expect(result.decisions.map((decision) => decision.action)).toContain("promote_lesson");
+    expect(result.promotedMemoryIds).toContain(`lesson_tag:auth_${now}`);
+    expect(result.promotedMemoryIds).not.toContain(`lesson_tag:agent:default_${now}`);
+    expect(result.promotedMemoryIds).not.toContain(`lesson_tag:runner_tool_error_${now}`);
+    expect(result.promotedMemoryIds).not.toContain(`lesson_tag:gx_learnings_${now}`);
 
     // Edge pruning (weak old edge removed)
     expect(result.decisions.map((decision) => decision.action)).toContain("prune_edges");

--- a/src/memory/sqlite.ts
+++ b/src/memory/sqlite.ts
@@ -691,7 +691,7 @@ export class SqliteMemoryStore implements MemoryStore {
       archivedEventIds.push(row.id);
     }
 
-    // --- Lesson promotion: promote repeated high-importance event patterns ---
+    // --- Lesson promotion: promote repeated high-importance semantic event patterns ---
     const lessonRows = this.db
       .query<{ tag: string; count: number; event_ids: string }, [number, number, number]>(
         `SELECT mt.tag_id AS tag, COUNT(*) AS count,
@@ -705,6 +705,8 @@ export class SqliteMemoryStore implements MemoryStore {
       .all(0.7, now - 14 * 24 * 60 * 60 * 1000, repeatedThreshold);
 
     for (const row of lessonRows) {
+      if (!isPromotableLessonTag(row.tag)) continue;
+
       const eventIds = row.event_ids.split(",");
       const lessonId = `lesson_${slug(row.tag)}_${now}`;
       await this.upsertLesson({
@@ -1251,6 +1253,25 @@ function normalizeName(value: string): string {
 function slug(value: string): string {
   return normalizeName(value).replace(/[^a-z0-9_:-]/g, "_").slice(0, 80) || "unknown";
 }
+
+function isPromotableLessonTag(tagId: string): boolean {
+  const tag = tagId.startsWith("tag:") ? tagId.slice(4) : tagId;
+  if (tag.startsWith("agent:") || tag.startsWith("command:")) return false;
+  if (tag.includes("worktree") || tag.includes("worktrees")) return false;
+  if (tag.includes("import")) return false;
+
+  return !NON_LESSON_TAGS.has(tag);
+}
+
+const NON_LESSON_TAGS = new Set([
+  "error",
+  "growthx",
+  "gx_learnings",
+  "learnings",
+  "runner_output",
+  "runner_tool_error",
+  "slack_message",
+]);
 
 function unique<T>(values: T[]): T[] {
   return [...new Set(values.filter(Boolean))];

--- a/workflows/memory-consolidation.workflow.md
+++ b/workflows/memory-consolidation.workflow.md
@@ -43,9 +43,19 @@ Expected work:
 
 1. Inspect recent memory source records, derived events, ingestion classifications, and corrections.
 2. Promote repeated corrections into routing memories only when the evidence is explicit.
-3. Promote repeated high-importance patterns into lessons/facts only when source records support them.
+3. Promote repeated high-importance patterns into lessons/facts only when source records support a reusable behavioral rule, user preference, domain fact, or operating procedure.
 4. Archive low-importance stale events out of active recall without deleting source records.
 5. Propose draft bounded-DSL ingestion rules from repeated corrections; do not mark them accepted without review.
 6. Record a compact summary of decisions: promoted memories, archived event ids, draft rule ids, and any blockers.
+
+Quality bar:
+
+- Tag-based promotion is allowed only for semantic tags that describe reusable work patterns, domains, products, features, user preferences, or procedures.
+- Tags may help find candidate evidence, but a promoted lesson must be backed by source bodies that explain why the pattern matters.
+- Reject or flag promotions from operational/indexing tags, including `agent:*`, `runner_tool_error`, `runner_output`, `slack_message`, `error`, `command:*`, `growthx`, `gx_learnings`, `learnings`, worktree/repo labels, import labels, or similarly broad metadata tags.
+- GrowthX/imported-learning tags are retrieval labels, not lessons. If they reveal useful guidance, extract the actual guidance from the event bodies and preserve provenance.
+- Before accepting any promotion, check whether an equivalent lesson/fact/summary already exists. Prefer stable IDs, update, merge, or report a duplicate instead of creating timestamped near-duplicates.
+- Treat clusters of tool errors, runner failures, agent activity, or Slack message counts as health/telemetry findings, not associative-memory lessons.
+- If the deterministic/native pass promotes low-value tag summaries caused by bad input labels, explicitly call them out in the final report and recommend cleanup rather than validating them as good memories.
 
 Do not run this on every Slack message. This is an offline/operator-triggered pass, not the hot capture path.


### PR DESCRIPTION
## Summary
- keep semantic tag-based lesson promotion, but filter operational/import labels before creating lessons
- document the consolidation quality bar for semantic tags versus retrieval/telemetry labels
- cover that auth still promotes while agent/tool-error/gx_learnings tags do not

## Tests
- bun test src/memory/sqlite.test.ts
- bun run typecheck