### PR TITLE
Guard agent dispatch in support and review flows

### DIFF
--- a/.claude/agents/default.md
+++ b/.claude/agents/default.md
@@ -23,7 +23,7 @@ Classify the message before acting:
 |---|---|
 | direct explanation or opinion | Answer concisely. |
 | code or docs work | Inspect current state, edit the requested scope, verify. |
-| PR link plus review ask | Review on GitHub first, then summarize if useful. |
+| PR link plus review ask | Emit `!review <verbatim ask>` and stop. Do not review inline. |
 | bug report in a support channel | Use the lead/bug pipeline. |
 | bug report outside support | Ask whether the user wants the full pipeline or a quick read. |
 | structured customer/contact details without instruction | Ask one clarifying question unless an org overlay defines a safe default. |

--- a/.claude/agents/lead.md
+++ b/.claude/agents/lead.md
@@ -119,6 +119,7 @@ The temptation to do work yourself is strongest when the fix looks small. That's
 ## Soft caveats
 
 - **Observability sub-agents (`nr-research`, `sentry-fetch`, `vercel-status`)** ARE expected to be dispatched via Task by you — they're stateless data fetchers, not persistent participants. The categorical rule above is about persistent agents (reproducer, thinker, review).
+- Never end your Slack message with raw `DONE:` output from `nr-research`, `sentry-fetch`, or `vercel-status`. Those are internal Task results. Consume them, read the files, classify the bug, and advance to `!reproducer`, `!thinker`, or a blocker.
 - **Reading bug-folder files** under `support/bugs/<product>/<bug-id>/` IS your job — that's where you synthesize. Just don't read product source.
 - **Reading the config files named in the runtime-environment notes above (routing map, admin credentials) and your own past Slack posts** IS your job.
 

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -9,6 +9,9 @@ import type { SlackMessageEvent } from "../slack/events.ts";
 import type { Config } from "../config.ts";
 import { createSession } from "./types.ts";
 import type { App } from "@slack/bolt";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 // --- Mock setup ---
 
@@ -476,6 +479,67 @@ describe("SessionManager", () => {
     const session = await store.get("thread-1");
     expect(session!.status).toBe("idle");
     expect(responses).toEqual([]);
+  });
+
+  it("continues lead instead of posting leaked observability worker output", async () => {
+    const bugRoot = mkdtempSync(join(tmpdir(), "junior-bugs-"));
+    const previousBugRoot = process.env.JUNIOR_BUG_ROOT;
+    process.env.JUNIOR_BUG_ROOT = bugRoot;
+    try {
+      const bugDir = join(bugRoot, "growthx", "6a167cfb");
+      mkdirSync(bugDir, { recursive: true });
+      writeFileSync(
+        join(bugDir, "state.json"),
+        JSON.stringify({
+          bugId: "6a167cfb",
+          product: "growthx",
+          status: "researching",
+          slackChannel: "C-BUGS",
+          slackThread: "thread-1",
+        }),
+      );
+
+      const supportConfig = cloneConfig({
+        channelDefaults: { "C-BUGS": { agentType: "lead" } },
+      });
+      const handle1 = createMockHandle();
+      const handle2 = createMockHandle();
+      let spawnCount = 0;
+      mockSpawnFn = mock(() => (spawnCount++ === 0 ? handle1 : handle2));
+      manager = new SessionManager(
+        store,
+        supportConfig,
+        ((...args: Parameters<SpawnRunnerFn>) => mockSpawnFn(...args)) as SpawnRunnerFn,
+      );
+
+      const responses: string[] = [];
+      manager.onResponse = (_session, response) => responses.push(response);
+
+      await manager.handleLeadMessage(
+        makeEvent({ channel: "C-BUGS", text: "bug report" }),
+      );
+      handle1._complete(
+        "DONE: New Relic findings written to `/Users/psbakre/Projects/junior/support/bugs/growthx/6a167cfb/research.md`.",
+      );
+
+      await waitFor(() => mockSpawnFn.mock.calls.length === 2);
+      expect(responses).toEqual([]);
+      expect(mockSpawnFn.mock.calls[1][1]).toContain("Your previous lead turn ended before advancing");
+      expect(mockSpawnFn.mock.calls[1][1]).toContain("Previous invalid response");
+
+      handle2._complete("!reproducer reproduce as affected member");
+      await waitFor(async () => (await store.get("thread-1"))?.status === "idle");
+
+      expect(responses).toEqual(["!reproducer reproduce as affected member"]);
+      expect((await store.get("thread-1"))!.pipelineGuardRetryCount).toBe(0);
+    } finally {
+      if (previousBugRoot === undefined) {
+        delete process.env.JUNIOR_BUG_ROOT;
+      } else {
+        process.env.JUNIOR_BUG_ROOT = previousBugRoot;
+      }
+      rmSync(bugRoot, { recursive: true, force: true });
+    }
   });
 
   it("captures sessionId from init event", async () => {

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -28,6 +28,7 @@ import {
 import { createDrivers, type DriverMap } from "../claude/factory.ts";
 import { tmuxSessionNameFor } from "../claude/tmux-driver.ts";
 import { buildDispatchAllowBlock, identityForAgent } from "../support/agents.ts";
+import { validateLeadPipelineResponse } from "../support/pipeline-guard.ts";
 import { withTimeout } from "../lifecycle/timeout.ts";
 import {
   buildPromptPreamble,
@@ -1347,6 +1348,57 @@ export class SessionManager {
         this.buildRunSession(fresh, agentName, agentIdentity),
         result.error,
       );
+    }
+
+    if (!result.error && isTopLevel && result.response) {
+      const supportChannels = new Set(
+        Object.entries(this.config.channelDefaults)
+          .filter(([, def]) => def.agentType === "lead")
+          .map(([channel]) => channel),
+      );
+      const validation = validateLeadPipelineResponse(
+        this.buildRunSession(fresh, agentName, agentIdentity),
+        result.response,
+        supportChannels,
+        fresh.pipelineGuardRetryCount ?? 0,
+      );
+      if (validation.action === "continue") {
+        fresh.pipelineGuardRetryCount = (fresh.pipelineGuardRetryCount ?? 0) + 1;
+        fresh.status = "busy";
+        fresh.pid = null;
+        await this.store.set(fresh.threadId, fresh);
+        _log.warn(
+          "pipeline",
+          `guard.continue thread=${fresh.threadId} bug=${validation.state.bugId ?? "-"} reason=${validation.reason}`,
+        );
+        this.runRunnerWithAgent(
+          fresh,
+          validation.prompt,
+          undefined,
+          undefined,
+          agentName,
+        ).catch(async (err) => {
+          _log.error(
+            "pipeline",
+            `guard.continue.fail thread=${fresh.threadId} err=${err instanceof Error ? err.message : String(err)}`,
+          );
+          const guardFresh = (await this.store.get(fresh.threadId)) ?? fresh;
+          guardFresh.status = "idle";
+          guardFresh.pid = null;
+          await this.store.set(guardFresh.threadId, guardFresh);
+        });
+        return;
+      }
+      if (validation.action === "blocker") {
+        _log.warn(
+          "pipeline",
+          `guard.blocker thread=${fresh.threadId} bug=${validation.state.bugId ?? "-"} reason=${validation.reason}`,
+        );
+        result = { ...result, response: validation.message };
+        fresh.pipelineGuardRetryCount = 0;
+      } else {
+        fresh.pipelineGuardRetryCount = 0;
+      }
     }
 
     if (result.response && isDuplicateSlackToolResponse(result.response, result.events)) {

--- a/src/session/store/sqlite.ts
+++ b/src/session/store/sqlite.ts
@@ -256,6 +256,7 @@ function normalizeSession(session: ThreadSession): ThreadSession {
   session.dormant ??= false;
   session.dormantAnnounced ??= false;
   session.humanParticipants ??= [];
+  session.pipelineGuardRetryCount ??= 0;
   return session;
 }
 

--- a/src/session/types.test.ts
+++ b/src/session/types.test.ts
@@ -127,6 +127,7 @@ describe("createSession", () => {
       "needsThreadCatchup",
       "pendingMessages",
       "pid",
+      "pipelineGuardRetryCount",
       "provider",
       "sessionId",
       "status",

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -160,6 +160,8 @@ export interface ThreadSession {
   topLevelTmuxAgent: string | null;
   /** Number of times this session's current turn has been idle-interrupted and resumed. */
   idleInterruptCount: number;
+  /** Number of automatic lead-pipeline guard continuations attempted for the current turn. */
+  pipelineGuardRetryCount?: number;
 }
 
 export function createSession(
@@ -207,6 +209,7 @@ export function createSession(
     tmuxSessionName: null,
     topLevelTmuxAgent: null,
     idleInterruptCount: 0,
+    pipelineGuardRetryCount: 0,
   };
 }
 

--- a/src/support/pipeline-guard.ts
+++ b/src/support/pipeline-guard.ts
@@ -1,0 +1,136 @@
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import type { ThreadSession } from "../session/types.ts";
+
+export interface BugPipelineState {
+  bugId?: string;
+  product?: string;
+  status?: string;
+  slackChannel?: string;
+  slackThread?: string;
+}
+
+export type LeadPipelineValidation =
+  | { action: "allow"; state?: BugPipelineState }
+  | { action: "continue"; state: BugPipelineState; reason: string; prompt: string }
+  | { action: "blocker"; state: BugPipelineState; reason: string; message: string };
+
+const ADVANCE_REQUIRED_STATUSES = new Set([
+  "intake",
+  "researching",
+  "observability_done",
+]);
+
+const PERSISTENT_ADVANCE_RE = /^!(reproducer|thinker)\b/m;
+const BLOCKER_RE = /\b(blocker|blocked|needs-human|need human|escalat(?:e|ing|ion)|missing|cannot|can't|failed)\b/i;
+const STATEFUL_WORKER_DONE_RE = /^DONE:\s+.*\b(?:New Relic|Sentry|Vercel|findings)\b.*\b(?:research|sentry|vercel)\.md\b/i;
+
+export function validateLeadPipelineResponse(
+  session: ThreadSession,
+  response: string,
+  supportChannels: Set<string>,
+  retryCount: number,
+): LeadPipelineValidation {
+  if (session.activeAgentName !== "lead") return { action: "allow" };
+  if (!supportChannels.has(session.channel)) return { action: "allow" };
+
+  const state = findBugPipelineState(session);
+  if (!state?.status) return { action: "allow" };
+  if (!ADVANCE_REQUIRED_STATUSES.has(state.status)) return { action: "allow", state };
+
+  const trimmed = response.trim();
+  if (PERSISTENT_ADVANCE_RE.test(trimmed)) return { action: "allow", state };
+  if (BLOCKER_RE.test(trimmed) && !STATEFUL_WORKER_DONE_RE.test(trimmed)) {
+    return { action: "allow", state };
+  }
+
+  const reason = STATEFUL_WORKER_DONE_RE.test(trimmed)
+    ? "lead returned stateless observability worker output"
+    : `lead did not advance bug pipeline from status=${state.status}`;
+
+  if (retryCount > 0) {
+    return {
+      action: "blocker",
+      state,
+      reason,
+      message: [
+        `Blocker: lead could not advance bug ${state.bugId ?? "(unknown)"} after observability.`,
+        `Reason: ${reason}.`,
+        "Needs human review before continuing.",
+      ].join("\n"),
+    };
+  }
+
+  return {
+    action: "continue",
+    state,
+    reason,
+    prompt: buildContinuationPrompt(state, trimmed, reason),
+  };
+}
+
+export function looksLikePrReviewRequest(text: string): boolean {
+  const hasPrLink = /https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+/i.test(text);
+  if (!hasPrLink) return false;
+  return /\b(review|reviews|reviewed|please review|take a look|approve|approval)\b/i.test(text);
+}
+
+function buildContinuationPrompt(
+  state: BugPipelineState,
+  leakedResponse: string,
+  reason: string,
+): string {
+  return [
+    "Your previous lead turn ended before advancing the bug pipeline.",
+    `Guard reason: ${reason}.`,
+    `Bug: ${state.product ?? "unknown"}/${state.bugId ?? "unknown"} status=${state.status ?? "unknown"}.`,
+    "",
+    "Do not repeat raw observability worker output.",
+    "Read the bug files under `support/bugs/<product>/<bugId>/`, synthesize observability, classify read-only vs write-path, then emit exactly one of:",
+    "- `!reproducer <bounded reproduction prompt>` for read-only bugs",
+    "- `!thinker <bounded scoping prompt>` for write-path bugs or after reproduction is unsafe",
+    "- a concise blocker/escalation message if required data is missing",
+    "",
+    "Previous invalid response:",
+    leakedResponse.slice(0, 2000),
+  ].join("\n");
+}
+
+function findBugPipelineState(session: ThreadSession): BugPipelineState | null {
+  const root = process.env.JUNIOR_BUG_ROOT ?? "support/bugs";
+  if (!existsSync(root)) return null;
+
+  for (const product of safeReadDir(root)) {
+    const productDir = join(root, product);
+    for (const bugId of safeReadDir(productDir)) {
+      const statePath = join(productDir, bugId, "state.json");
+      if (!existsSync(statePath)) continue;
+      const state = readJsonState(statePath);
+      if (
+        state?.slackThread === session.threadId &&
+        state?.slackChannel === session.channel
+      ) {
+        return state;
+      }
+    }
+  }
+  return null;
+}
+
+function safeReadDir(path: string): string[] {
+  try {
+    return readdirSync(path, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+  } catch {
+    return [];
+  }
+}
+
+function readJsonState(path: string): BugPipelineState | null {
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as BugPipelineState;
+  } catch {
+    return null;
+  }
+}

--- a/src/support/router.test.ts
+++ b/src/support/router.test.ts
@@ -339,6 +339,33 @@ describe("AgentDispatcher", () => {
     expect(call.dedupeKey).toBeUndefined();
   });
 
+  it("auto-dispatches GitHub PR review requests to review in non-support channels", async () => {
+    const managerMock = {
+      handleMessage: mock(async (_event: SlackMessageEvent) => {}),
+      handleLeadMessage: mock(async (_event: SlackMessageEvent) => {}),
+      handleAgentMessage: mock(async (_event: SlackMessageEvent, _agent: string) => {}),
+    };
+    const router = new AgentDispatcher(
+      managerMock as unknown as SessionManager,
+      new Set(["CBUGS"]),
+    );
+
+    await router.handleMessage(
+      makeEvent({
+        channel: "CTECH",
+        text: "https://github.com/GrowthX-Club/gx-backend/pull/3150 please review",
+      }),
+    );
+
+    expect(managerMock.handleMessage).not.toHaveBeenCalled();
+    expect(managerMock.handleLeadMessage).not.toHaveBeenCalled();
+    expect(managerMock.handleAgentMessage).toHaveBeenCalledTimes(1);
+    expect(managerMock.handleAgentMessage).toHaveBeenCalledWith(
+      expect.objectContaining({ dedupeKey: "123.456:review:auto" }),
+      "review",
+    );
+  });
+
   it("uses routing memory body even when the memory has a title", async () => {
     const managerMock = {
       handleMessage: mock(async (_event: SlackMessageEvent) => {}),

--- a/src/support/router.ts
+++ b/src/support/router.ts
@@ -11,6 +11,7 @@ import {
   isPersistentAgent,
   workerMayDispatch,
 } from "./agents.ts";
+import { looksLikePrReviewRequest } from "./pipeline-guard.ts";
 import { log } from "../logger.ts";
 
 export interface AgentDirective {
@@ -205,6 +206,14 @@ export class AgentDispatcher {
         if (session?.defaultAgent) {
           targetAgent = session.defaultAgent;
         }
+      }
+
+      if (targetAgent !== "lead" && looksLikePrReviewRequest(event.text)) {
+        await this.manager.handleAgentMessage({
+          ...event,
+          dedupeKey: event.dedupeKey ?? `${event.ts}:review:auto`,
+        }, "review");
+        return;
       }
 
       const memoryAgent = await this.memorySuggestedAgent(event);


### PR DESCRIPTION
## Summary
- auto-dispatch GitHub PR review requests to the persistent review agent outside support channels
- add a lead pipeline guard that suppresses leaked observability worker output and resumes lead with corrective instructions
- update default/lead prompts and add regression coverage for both routing failures

## Verification
- bun test
- bun run typecheck