### PR TITLE
Fix Codex app-server Claude model aliases

### DIFF
--- a/.claude/agents/reproducer.md
+++ b/.claude/agents/reproducer.md
@@ -2,7 +2,7 @@
 name: reproducer
 description: Walks the UI as the affected user. Two phases — reproduction (top of pipeline) and validation (after the fix lands). Honest about what it sees.
 tools: Read, Write, Bash, Grep, Glob, mcp__playwright__browser_navigate, mcp__playwright__browser_click, mcp__playwright__browser_type, mcp__playwright__browser_snapshot, mcp__playwright__browser_take_screenshot, mcp__playwright__browser_console_messages, mcp__playwright__browser_network_requests, mcp__playwright__browser_evaluate, mcp__playwright__browser_wait_for, mcp__playwright__browser_navigate_back, mcp__playwright__browser_fill_form, mcp__playwright__browser_close
-model: qwen3.6
+model: gpt-5.5
 common: core,runtime-environment
 context.threadHistory: false
 context.threadHistoryLimit: 20

--- a/src/codex-app-server/config.test.ts
+++ b/src/codex-app-server/config.test.ts
@@ -38,7 +38,7 @@ describe("buildCodexConfigToml", () => {
   it("serializes minimal isolated Codex config", () => {
     expect(
       buildCodexConfigToml({
-        model: "gpt-5.1-codex",
+        model: "gpt-5.5",
         approvalPolicy: "never",
         sandbox: "danger-full-access",
         mcp: {
@@ -52,7 +52,7 @@ describe("buildCodexConfigToml", () => {
     ).toContain('[projects."/repo"]\ntrust_level = "trusted"');
     expect(
       buildCodexConfigToml({
-        model: "gpt-5.1-codex",
+        model: "gpt-5.5",
         approvalPolicy: "never",
         sandbox: "danger-full-access",
         mcp: null,

--- a/src/codex-app-server/spawner.test.ts
+++ b/src/codex-app-server/spawner.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { Config } from "../config.ts";
 import { createSession } from "../session/types.ts";
-import { spawnCodexAppServer } from "./spawner.ts";
+import { resolveCodexModel, spawnCodexAppServer } from "./spawner.ts";
 
 const originalCodexBin = process.env.CODEX_BIN;
 
@@ -123,6 +123,24 @@ describe("spawnCodexAppServer", () => {
     } finally {
       fakeCodex.cleanup();
     }
+  });
+});
+
+describe("resolveCodexModel", () => {
+  it("ignores Claude agent aliases and falls back to Codex config", () => {
+    expect(resolveCodexModel("sonnet", "gpt-5.5")).toBe("gpt-5.5");
+    expect(resolveCodexModel("opus", "gpt-5.5")).toBe("gpt-5.5");
+    expect(resolveCodexModel("haiku", "gpt-5.5")).toBe("gpt-5.5");
+  });
+
+  it("omits unsupported Claude model names when no Codex fallback is configured", () => {
+    expect(resolveCodexModel("claude-sonnet-4-5", null)).toBeNull();
+    expect(resolveCodexModel("claude/opus", null)).toBeNull();
+  });
+
+  it("keeps explicit Codex-compatible model overrides", () => {
+    expect(resolveCodexModel("gpt-5.5", "gpt-5.1-codex")).toBe("gpt-5.5");
+    expect(resolveCodexModel(null, "gpt-5.1-codex")).toBe("gpt-5.1-codex");
   });
 });
 

--- a/src/codex-app-server/spawner.ts
+++ b/src/codex-app-server/spawner.ts
@@ -38,7 +38,7 @@ export function spawnCodexAppServer(
     botToken,
     agentIdentity,
   });
-  const model = session.model ?? config.codex.model ?? null;
+  const model = resolveCodexModel(session.model, config.codex.model);
   const policy = mapCodexRunPolicy({
     config: config.codex,
     session,
@@ -260,6 +260,30 @@ export function spawnCodexAppServer(
     },
     pid: proc.pid,
   };
+}
+
+export function resolveCodexModel(
+  sessionModel: string | null,
+  configModel: string | null,
+): string | null {
+  const sessionCodexModel = codexCompatibleModel(sessionModel);
+  if (sessionCodexModel) return sessionCodexModel;
+  return codexCompatibleModel(configModel);
+}
+
+function codexCompatibleModel(model: string | null): string | null {
+  if (!model) return null;
+
+  // Private/public agent definitions historically used Claude shorthand
+  // frontmatter (`sonnet`, `opus`, `haiku`) because agents first ran on the
+  // Claude runner. Passing those aliases through to Codex app-server breaks
+  // ChatGPT-authenticated Codex accounts with "model is not supported".
+  // Treat them as runner-specific hints, not Codex overrides, and let Codex
+  // use the configured/default model instead.
+  if (/^(sonnet|opus|haiku)$/i.test(model)) return null;
+  if (/^claude[-/]/i.test(model)) return null;
+
+  return model;
 }
 
 function baseInstructions(): string {

--- a/src/config.test.ts
+++ b/src/config.test.ts
@@ -164,7 +164,7 @@ describe("loadConfig runner providers", () => {
   it("parses codex-app-server provider and Codex env vars", () => {
     process.env.RUNNER_PROVIDER = "codex-app-server";
     process.env.CODEX_MODE = "app-server";
-    process.env.CODEX_MODEL = "gpt-5.1-codex";
+    process.env.CODEX_MODEL = "gpt-5.5";
     process.env.CODEX_TIMEOUT_MS = "2345";
     process.env.CODEX_SANDBOX = "read-only";
     process.env.CODEX_ASK_FOR_APPROVAL = "on-request";
@@ -183,7 +183,7 @@ describe("loadConfig runner providers", () => {
     expect(config.runner.provider).toBe("codex-app-server");
     expect(config.codex).toEqual({
       mode: "app-server",
-      model: "gpt-5.1-codex",
+      model: "gpt-5.5",
       timeoutMs: 2345,
       sandbox: "read-only",
       askForApproval: "on-request",


### PR DESCRIPTION
## What
- Ignore Claude-only model aliases (`sonnet`, `opus`, `haiku`, `claude-*`) when spawning Codex app-server sessions.
- Fall back to `CODEX_MODEL` or Codex's account default instead of passing an unsupported model through.
- Add coverage for model resolution behavior.

## Why
Oogway/worker agent sessions can carry historical Claude model frontmatter. With Codex app-server + ChatGPT auth, passing `sonnet` causes: `The 'sonnet' model is not supported when using Codex with a ChatGPT account.`

## Test
- `bun test src/codex-app-server/spawner.test.ts src/codex-app-server/config.test.ts`
- `bun run typecheck`
