### PR TITLE
Fix persistent agent review routing

### DIFF
--- a/.claude/agents/review.md
+++ b/.claude/agents/review.md
@@ -1,17 +1,19 @@
 ---
 name: review
 description: Code reviewer. Use for PR reviews, code quality checks, security audits.
-tools: Read, Grep, Glob, Bash(git *)
-common: core,merge-workflow
-context.threadHistory: false
+tools: Read, Write, Grep, Glob, Bash(git *), Bash(gh *), mcp__slack-bot__slack_send_message, mcp__slack-bot__slack_read_thread, mcp__slack-bot__register_worktree
+common: core,merge-workflow,runtime-environment
+context.threadHistory: true
 context.threadHistoryLimit: 20
 context.workspace: true
-context.agentState: false
+context.agentState: true
 ---
 
 # review -- Code Reviewer
 
 You review code with the thoroughness of a doctor diagnosing a patient. Not every line needs a comment, but every problem needs to be caught before it ships.
+
+You are Junior's persistent `review` agent. Evaluate the PR/code using the repo-local Claude docs and runtime workspace context, not a separate home-directory Claude agent definition. Read the target repo's `CLAUDE.md` and any relevant `docs/features/` / `docs/code_index/` docs before reviewing implementation details.
 
 ## Review workflow
 
@@ -30,6 +32,27 @@ Run six passes on every review. Do not blend them — each pass has a different 
 - Do not suggest purely stylistic changes unless they genuinely harm readability.
 - Read the full diff before forming opinions.
 - Two consecutive clean passes before approving.
+
+## Worktree rules
+
+Use the `<workspace>` block as the source of truth for repo paths. Review inside the routed per-thread worktree for the target repo, not the bare repo.
+
+If the needed target repo is missing from `<workspace>`, call `mcp__slack-bot__register_worktree({ thread_id: "<thread ts>", repo: "<repo name>" })` before reading code or running git commands in that repo. Do not create ad hoc worktrees with shell commands; Junior's MCP tool owns worktree creation and persistence.
+
+Use the worktree to:
+- read the full diff and surrounding code
+- trace imports, callers, services, middleware, schemas, and database access
+- verify whether changed function signatures break callers
+- run focused checks when they are needed to confirm a finding
+
+## Re-review behavior
+
+When re-reviewing a PR:
+
+1. Read existing GitHub review comments and reviews with `gh api` / `gh pr view` before making new comments.
+2. Do not duplicate issues already raised. If a previous blocker/warning is still present, reply/update in that existing thread when possible; otherwise mention that it is still unresolved in the verdict.
+3. Review only newly pushed commits and the code paths needed to verify prior findings. Do not re-review unchanged code from scratch unless the previous review state is unavailable or the diff has been rebased so heavily that the old comments no longer map.
+4. If all previous blocker/warning items are fixed, still run the normal clean-pass approval rule: two consecutive clean passes before `approved`.
 
 ## Output
 

--- a/src/slack/events.test.ts
+++ b/src/slack/events.test.ts
@@ -164,6 +164,117 @@ describe("registerEventHandlers — ✽ filter", () => {
     expect(onMessage.mock.calls[0][0].isSelfBot).toBe(true);
   });
 
+  it("self-bot directive is let through as a top-level post in mention-required channels", async () => {
+    const { app, handlers } = makeMockApp();
+    const onMessage = mock((_e: SlackMessageEvent) => {});
+    registerEventHandlers(app, onMessage, undefined, "B_SELF", "U_BOT");
+
+    await handlers.get("message")!({
+      event: {
+        type: "message",
+        text: "!review take a look at PR 21",
+        channel: "C_OTHER",
+        channel_type: "channel",
+        ts: "1700000000.000013",
+        bot_id: "B_SELF",
+      },
+    });
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onMessage.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        threadId: "1700000000.000013",
+        text: "!review take a look at PR 21",
+        isSelfBot: true,
+      }),
+    );
+  });
+
+  it("self-bot directive is let through in a new thread even when no session exists", async () => {
+    const { app, handlers } = makeMockApp();
+    const onMessage = mock((_e: SlackMessageEvent) => {});
+    const store = {
+      get: mock(async () => undefined),
+    } as unknown as Parameters<typeof registerEventHandlers>[2];
+    registerEventHandlers(app, onMessage, store, "B_SELF", "U_BOT");
+
+    await handlers.get("message")!({
+      event: {
+        type: "message",
+        text: "!review take a look at PR 21",
+        channel: "C_OTHER",
+        channel_type: "channel",
+        ts: "1700000000.000014",
+        thread_ts: "1700000000.000000",
+        bot_id: "B_SELF",
+      },
+    });
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onMessage.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        threadId: "1700000000.000000",
+        text: "!review take a look at PR 21",
+        isSelfBot: true,
+      }),
+    );
+  });
+
+  it("human !<persistent-agent> directive is let through without mentioning Junior", async () => {
+    const { app, handlers } = makeMockApp();
+    const onMessage = mock((_e: SlackMessageEvent) => {});
+    registerEventHandlers(app, onMessage, undefined, "B_SELF", "U_BOT");
+
+    await handlers.get("message")!({
+      event: {
+        type: "message",
+        text: "!review take a look at PR 21",
+        channel: "C_OTHER",
+        channel_type: "channel",
+        ts: "1700000000.000015",
+        user: "U_HUMAN",
+      },
+    });
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onMessage.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        threadId: "1700000000.000015",
+        text: "!review take a look at PR 21",
+        command: null,
+      }),
+    );
+  });
+
+  it("human !<persistent-agent> directive is let through in a new thread without an existing session", async () => {
+    const { app, handlers } = makeMockApp();
+    const onMessage = mock((_e: SlackMessageEvent) => {});
+    const store = {
+      get: mock(async () => undefined),
+    } as unknown as Parameters<typeof registerEventHandlers>[2];
+    registerEventHandlers(app, onMessage, store, "B_SELF", "U_BOT");
+
+    await handlers.get("message")!({
+      event: {
+        type: "message",
+        text: "!review take a look at PR 21",
+        channel: "C_OTHER",
+        channel_type: "channel",
+        ts: "1700000000.000016",
+        thread_ts: "1700000000.000000",
+        user: "U_HUMAN",
+      },
+    });
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onMessage.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        threadId: "1700000000.000000",
+        text: "!review take a look at PR 21",
+      }),
+    );
+  });
+
   it("self-bot message with a non-agent !word is still dropped", async () => {
     const { app, handlers } = makeMockApp();
     const onMessage = mock((_e: SlackMessageEvent) => {});
@@ -183,7 +294,7 @@ describe("registerEventHandlers — ✽ filter", () => {
     expect(onMessage).not.toHaveBeenCalled();
   });
 
-  it("app_mention handler passes through a normal mention", async () => {
+  it("app_mention handler preserves and resolves the normal mention later", async () => {
     const { app, handlers } = makeMockApp();
     const onMessage = mock((_e: SlackMessageEvent) => {});
     registerEventHandlers(app, onMessage, undefined, undefined, "U_BOT");
@@ -199,6 +310,53 @@ describe("registerEventHandlers — ✽ filter", () => {
     });
 
     expect(onMessage).toHaveBeenCalledTimes(1);
-    expect(onMessage.mock.calls[0][0].text).toBe("hello");
+    expect(onMessage.mock.calls[0][0].text).toBe("<@U_BOT> hello");
+    expect(onMessage.mock.calls[0][0].mentionsJunior).toBe(true);
+  });
+
+  it("app_mention handler preserves Junior when other users are mentioned too", async () => {
+    const { app, handlers } = makeMockApp();
+    const onMessage = mock((_e: SlackMessageEvent) => {});
+    registerEventHandlers(app, onMessage, undefined, undefined, "U_BOT");
+
+    await handlers.get("app_mention")!({
+      event: {
+        type: "app_mention",
+        text: "<@U_BOT> <@U_A> <@U_B> can you check this?",
+        channel: "C123",
+        ts: "1700000000.000017",
+        user: "U_HUMAN",
+      },
+    });
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onMessage.mock.calls[0][0].text).toBe(
+      "<@U_BOT> <@U_A> <@U_B> can you check this?",
+    );
+  });
+
+  it("app_mention handler still routes directives after Junior mention", async () => {
+    const { app, handlers } = makeMockApp();
+    const onMessage = mock((_e: SlackMessageEvent) => {});
+    registerEventHandlers(app, onMessage, undefined, undefined, "U_BOT");
+
+    await handlers.get("app_mention")!({
+      event: {
+        type: "app_mention",
+        text: "<@U_BOT> !review take a look at PR 21",
+        channel: "C123",
+        ts: "1700000000.000018",
+        user: "U_HUMAN",
+      },
+    });
+
+    expect(onMessage).toHaveBeenCalledTimes(1);
+    expect(onMessage.mock.calls[0][0]).toEqual(
+      expect.objectContaining({
+        text: "!review take a look at PR 21",
+        command: null,
+        mentionsJunior: true,
+      }),
+    );
   });
 });

--- a/src/slack/events.ts
+++ b/src/slack/events.ts
@@ -90,8 +90,9 @@ export function registerEventHandlers(
       selfBotId &&
       (event as { bot_id: string }).bot_id === selfBotId;
     const isAutoTrigger = !!autoTriggerChannels?.has(event.channel);
-    const selfBotText = "text" in event ? event.text : undefined;
-    const hasDirective = isSelfBot && containsDispatchDirective(selfBotText);
+    const eventText = "text" in event ? event.text : undefined;
+    const commandText = eventText ? stripOwnMention(eventText, selfUserId) : undefined;
+    const hasDirective = containsDispatchDirective(commandText ?? eventText);
 
     // Only support auto-trigger channels route our own bot messages; other
     // channels keep the legacy self-filter to avoid ordinary response loops.
@@ -104,7 +105,7 @@ export function registerEventHandlers(
       return;
     }
 
-    const text = "text" in event ? event.text : undefined;
+    const text = eventText;
     if (!text) {
       logDrop("no-text", evMeta);
       return;
@@ -132,13 +133,16 @@ export function registerEventHandlers(
     const isThread = "thread_ts" in event && !!event.thread_ts;
     const isDM = event.channel_type === "im";
 
-    if (!isThread && !isDM && !isAutoTrigger) {
-      // Top-level channel message without mention — app_mention handler covers @mentions.
+    if (!isThread && !isDM && !isAutoTrigger && !hasDirective) {
+      // Top-level channel message without mention — app_mention handler covers
+      // @mentions. `!<agent>` directives are explicit dispatch requests, so
+      // don't drop them just because the channel normally requires tagging
+      // Junior first.
       logDrop("top-level-no-mention", evMeta);
       return;
     }
 
-    if (isThread && !isAutoTrigger && store) {
+    if (isThread && !isAutoTrigger && store && !hasDirective) {
       // Only respond in threads where the bot has an active session
       const threadTs = "thread_ts" in event ? event.thread_ts! : event.ts;
       const session = await store.get(threadTs);
@@ -152,8 +156,9 @@ export function registerEventHandlers(
       "thread_ts" in event && event.thread_ts ? event.thread_ts : event.ts;
 
     const mentionsJunior = detectSelfMention(text, selfUserId);
-    const cleanText = stripOwnMention(text, selfUserId);
-    const parsed = parseCommand(cleanText);
+    const routingText = commandText ?? text;
+    const parsed = parseCommand(routingText);
+    const deliveredText = deliveredEventText(text, routingText, parsed);
 
     // Extract file attachments if present
     const files = extractFiles(event);
@@ -167,7 +172,7 @@ export function registerEventHandlers(
       threadId,
       channel: event.channel,
       user,
-      text: parsed.text,
+      text: deliveredText,
       ts: event.ts,
       command: parsed.command,
       files: files.length > 0 ? files : undefined,
@@ -199,8 +204,9 @@ export function registerEventHandlers(
     // the attention gate's wake-on-mention path works uniformly across both
     // event sources.
     const mentionsJunior = true;
-    const cleanText = stripOwnMention(event.text, selfUserId);
-    const parsed = parseCommand(cleanText);
+    const routingText = stripOwnMention(event.text, selfUserId);
+    const parsed = parseCommand(routingText);
+    const deliveredText = deliveredEventText(event.text, routingText, parsed);
 
     // Extract file attachments if present
     const files = extractFiles(event);
@@ -220,7 +226,7 @@ export function registerEventHandlers(
       threadId,
       channel: event.channel,
       user: event.user,
-      text: parsed.text,
+      text: deliveredText,
       ts: event.ts,
       command: parsed.command,
       files: files.length > 0 ? files : undefined,
@@ -243,6 +249,16 @@ function stripOwnMention(text: string, selfUserId?: string): string {
       .trim();
   }
   return text.replace(/^<@[A-Z0-9_]+>\s*/g, "").trim();
+}
+
+function deliveredEventText(
+  originalText: string,
+  routingText: string,
+  parsed: { command: string | null; text: string },
+): string {
+  if (parsed.command) return parsed.text;
+  if (containsDispatchDirective(routingText)) return routingText;
+  return originalText;
 }
 
 function escapeRegExp(value: string): string {


### PR DESCRIPTION
## Summary
- let bare `!<persistent-agent>` directives through Slack event gates without requiring an @Junior mention
- preserve @Junior mentions in normal app-mention prompts while still routing `<@Junior> !review ...` correctly
- update the review agent spec for persistent-agent tools, context, worktrees, and re-review behavior

## Tests
- `bun test src/slack/events.test.ts src/slack/commands.test.ts src/support/router.test.ts`