### PR TITLE
feat: add !clear command to archive and delete Junior thread messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ Slash-style commands are parsed in [`src/slack/commands.ts`](src/slack/commands.
 
 !cancel                    -- cancel the in-flight turn
 !reset                     -- drop session + worktree state for this thread
+!clear                     -- archive thread and delete Junior bot messages (admin)
 !status                    -- show this thread's session state
 !repo <name>               -- pin this thread to a target repo
 !branch <name>             -- pin this thread to a base ref

--- a/docs/code_index/thread-commands.md
+++ b/docs/code_index/thread-commands.md
@@ -6,7 +6,7 @@
 
 | Symbol | File | Purpose |
 |---|---|---|
-| `KNOWN_COMMANDS` (private set) | `slack/commands.ts` | `build, frontend, architect, cancel, reset, status, repo, branch, agent, quiet, verbose, normal, help, adhoc, bugs, mute, unmute, aside, listen` |
+| `KNOWN_COMMANDS` (private set) | `slack/commands.ts` | `build, frontend, architect, cancel, reset, clear, status, repo, branch, agent, quiet, verbose, normal, help, adhoc, bugs, mute, unmute, aside, listen` |
 | `parseCommand(text)` | `slack/commands.ts` | Splits `!build fix auth` → `{ command: "build", text: "fix auth" }`. Returns `{ command: null, text }` for unknown or non-`!` input. |
 | `SessionManager.handleCommand(session, event)` | `session/manager.ts` | Dispatches by `event.command`; returns true if the command consumed the message (no Claude spawn), false if it should fall through |
 | `SessionManager.gateAttention(event)` | `session/manager.ts` | Runs before any routing in `index.ts`. Consumes `!aside` and `!listen`, drops everything while `session.dormant`, and fires the one-shot auto-dormant trigger when a second human posts without `@`-mentioning Junior. Returns `true` when the message is consumed. Auto-trigger channels (`channelDefaults[channel]`) are exempt. |
@@ -23,6 +23,7 @@
 | `!agent <junior\|lead>` | Sets thread-level `defaultAgent` override (used by `AgentDispatcher`) | No |
 | `!cancel` | Kills all handles for the thread, clears pending, marks idle | No |
 | `!reset <agent\|all>` | **Admin-gated**. `all` → `resetSession`. `<agent>` → `resetAgent` (`lead`/`default` clear top-level; others clear `agentSessions[name]`) | No |
+| `!clear` | **Admin-gated**. Archives full thread to `data/thread-archives/`, deletes Junior bot messages only, clears status-pill cache | No |
 | `!status` | Posts thread/agent/repo/worktree/pending/last-activity summary | No |
 | `!quiet` / `!normal` / `!verbose` | Sets `session.verbosity` | No |
 | `!help` | Posts command reference | No |

--- a/docs/features/thread-clear-command.md
+++ b/docs/features/thread-clear-command.md
@@ -1,0 +1,324 @@
+# Thread Clear Command (`!clear`)
+
+Date: 2026-05-28
+
+Proposal for a new thread command that archives a Slack thread to markdown on disk, then deletes every message posted by Junior (including agent personas) from that thread.
+
+## Problem
+
+Long Junior threads accumulate dozens of status pills, multi-chunk responses, and agent handoffs. The conversation is useful history, but the Slack UI becomes noisy. Users want to tidy the thread without losing context and without resetting the coding session (`!reset` is the wrong tool — it kills runners and wipes session state).
+
+**Who has this problem:** Anyone running multi-turn bug-pipeline or build threads where Junior, Lead, Reproducer, Thinker, and Reviewer have posted many messages.
+
+**What happens today:** No way to bulk-remove bot messages. Users scroll past stale status updates or manually delete messages one at a time (Slack UI only; Junior has no command).
+
+**Painful part:** Deletion without backup is irreversible. Slack's own message retention policies vary by workspace; Junior should not assume Slack search or exports will preserve the thread.
+
+**"Finally" moment:** `!clear` in a cluttered thread → Junior posts one confirmation with the archive path → the thread shows only human messages plus that confirmation. Session state, worktree, and `--resume` / `--session` continuity are untouched.
+
+## Recommendation
+
+Add **`!clear`** as an **admin-gated**, **non-destructive-to-session** housekeeping command:
+
+1. Fetch the full thread (paginated).
+2. Write a markdown archive file locally.
+3. Delete every message whose author is this Junior bot installation (`selfBotId` / `botUserId`).
+4. Post a short confirmation with archive path and delete count.
+5. Clear in-memory status-pill tracking for that thread.
+
+Do **not** reset session state, kill runners, or remove worktrees. That remains `!reset` / `!cancel` territory.
+
+## Behavior Spec
+
+### Invocation
+
+```
+!clear
+```
+
+No arguments in v1. Unknown trailing text is ignored (consistent with `!quiet` / `!status`).
+
+### Permissions
+
+**Admin-gated**, same model as `!reset`, `!mute`, `!unmute`, and `!driver`:
+
+- Env bootstrap: `ADMIN_SLACK_USER_ID`
+- SQLite extras: `admins` table in `data/sessions.db`
+- Open mode when both tiers are empty (local dev)
+- Non-admin: silent `❌` reaction on the trigger message, no thread reply (same as `denyIfNotAdmin`)
+
+Rationale: bulk deletion is irreversible in Slack even with a local archive; treat it like other destructive admin operations.
+
+### What gets archived
+
+**All messages in the thread** — humans, Junior, foreign bots, file-share annotations — in chronological order. This preserves full conversational context even though only Junior messages are deleted.
+
+Reuse the same enrichment as `buildPromptPreamble` / `fetchThreadHistory`:
+
+- Resolve `@mentions` to display names via `resolveSlackMentions`
+- Resolve user IDs via `resolveUserName`
+- Annotate shared files as `[shared file: name]`
+- Label roles clearly (see Archive format below)
+
+Include metadata header: channel name/id, thread ts, archive timestamp, triggering user, message counts.
+
+### What gets deleted
+
+Messages authored by **this Junior installation**:
+
+| Signal | Rule |
+|---|---|
+| Primary | `message.bot_id === selfBotId` |
+| Fallback | `message.user === botUserId` when `bot_id` absent |
+
+This covers:
+
+- Default Junior posts
+- Agent persona posts (`username` / `icon_emoji` overrides — still same bot token)
+- Status pills posted or updated by `SlackResponder`
+- Multi-chunk responses (each chunk is its own message ts)
+- MCP `slack_send_message` posts from spawned runners
+
+**Not deleted:**
+
+- Human messages (including the `!clear` trigger)
+- Foreign bots (Friday, CI webhooks, etc.)
+- The confirmation message Junior posts after `!clear` completes
+
+### Busy-thread policy
+
+**Block while any runner handle is active** for this thread (same guard pattern as `!provider`):
+
+```
+Cannot clear while a runner is active. Use `!cancel` or wait for the turn to finish.
+```
+
+Reason: a mid-turn runner may still be posting chunks/status updates; deleting concurrently produces races and partial clears. Users can `!cancel` first if they need an immediate clear.
+
+Alternative considered and rejected for v1: auto-cancel then clear. Too surprising — `!clear` should not kill in-flight work.
+
+### Confirmation reply
+
+Single Slack message (not deleted):
+
+```
+Cleared *N* Junior message(s) from this thread.
+Archive: `data/thread-archives/<file>.md`
+```
+
+If `N === 0`:
+
+```
+No Junior messages to clear. Archive saved to `data/thread-archives/<file>.md` anyway.
+```
+
+(Still write the archive — cheap insurance, and users may want a snapshot before a future clear.)
+
+### Session impact
+
+| State | Effect |
+|---|---|
+| `sessionId` / agent session IDs | Unchanged |
+| Worktree | Unchanged |
+| `pendingMessages` | Unchanged |
+| `dormant` / `muted` / verbosity | Unchanged |
+| `SlackResponder.statusMessages` | Clear all keys matching `${threadTs}:*` |
+| `SlackResponder.pendingStatusPosts` | Best-effort cancel/await for same keys |
+
+Thread history injected into future runner prompts will shrink naturally (Slack no longer returns deleted messages in `conversations.replies`). Operators should know that **runner resume context may lose Slack-side history** after a clear; native provider session IDs still carry model-side context.
+
+## Archive Format
+
+**Directory:** `data/thread-archives/` (new; configurable via env — see Config)
+
+**Filename:** `{channelSlug-or-id}_{threadTs}_{iso-date}_{short-id}.md`
+
+Example: `tech-support_1716890123.456789_2026-05-28_a1b2c3.md`
+
+**Body:**
+
+```markdown
+# Thread archive
+
+| Field | Value |
+|---|---|
+| Channel | #tech-support (C01234567) |
+| Thread | 1716890123.456789 |
+| Archived at | 2026-05-28T14:32:01.234Z |
+| Triggered by | Pranav (<@U01234567>) |
+| Messages total | 47 |
+| Junior messages deleted | 31 |
+
+---
+
+## Messages
+
+**User(Pranav <@U01234567>)** · 2026-05-28 14:01:02 UTC · `1716890123.456789`
+> @Junior the login button is broken on staging
+
+**Junior (Lead)** · 2026-05-28 14:01:15 UTC · `1716890124.123456`
+> On it — spawning reproducer.
+
+**Reproducer** · 2026-05-28 14:02:40 UTC · `1716890160.789012`
+> Reproduced on staging. Steps: …
+
+**User(Alice <@U07654321>)** · 2026-05-28 14:05:00 UTC · `1716890300.111111`
+> !aside stepping out for lunch
+
+…
+```
+
+Formatting notes:
+
+- Use blockquotes for message bodies; escape or fence if bodies contain markdown-breaking content.
+- Include `ts` on every row so a future `!restore` (v2) could theoretically re-post — out of scope for v1.
+- For deleted messages, optional HTML comment `<!-- deleted by !clear -->` is unnecessary in v1 since the archive is written before deletion.
+
+## Implementation Plan
+
+### New module: `src/slack/thread-archive.ts`
+
+Pure-ish helpers (testable without Bolt):
+
+| Function | Purpose |
+|---|---|
+| `fetchFullThreadReplies(client, channel, threadTs)` | Paginate `conversations.replies` until exhausted |
+| `formatThreadArchiveMarkdown(meta, messages)` | Build archive string |
+| `isJuniorMessage(msg, selfBotId, botUserId)` | Deletion filter |
+| `writeThreadArchive(baseDir, filename, content)` | `mkdir -p` + atomic write |
+
+Pagination: loop with `cursor` while `response_metadata.next_cursor` is set. Slack returns up to ~200 messages per call for `conversations.replies`; typical bug threads fit in 1–2 pages.
+
+Deletion: sequential `chat.delete({ channel, ts })` with best-effort error handling (log and continue). Already used in `SlackResponder.deleteStatus`. Rate-limit: small delay or batch if threads exceed ~50 bot messages (unlikely v1 concern).
+
+### Touch existing files
+
+| File | Change |
+|---|---|
+| `src/slack/commands.ts` | Add `"clear"` to `KNOWN_COMMANDS` |
+| `src/session/manager.ts` | `case "clear":` in `handleCommand`; wire archive + delete; inject `selfBotId` on manager (see below) |
+| `src/slack/responder.ts` | Add `clearStatusForThread(threadTs)` to drop all status keys for a thread |
+| `src/index.ts` | Pass `selfBotId` to `SessionManager` (alongside existing `botUserId`) |
+| `src/session/manager.test.ts` | Unit tests with mocked Slack client |
+| `src/slack/commands.test.ts` | Parse test for `!clear` |
+| `docs/features/thread-commands.md` | Add to Full Vision + admin list |
+| `docs/code_index/thread-commands.md` | Command table row |
+| `README.md` | One-line in command list |
+
+### SessionManager dependencies
+
+Today `SessionManager` has `botUserId` and `slackApp`. It needs **`selfBotId`** for reliable bot-message detection (matches `events.ts` and the MCP server's `Bot(${bot_id})` labeling).
+
+```typescript
+// index.ts (after auth.test)
+sessionManager.botUserId = auth.user_id;
+sessionManager.selfBotId = auth.bot_id;
+```
+
+The `clear` handler uses `this.slackApp.client` for API calls (same pattern as other manager code that touches Slack indirectly via callbacks — or accept `slackClient` if preferred for testability).
+
+### Config
+
+```typescript
+// config.ts
+threadArchives: {
+  dir: optional("THREAD_ARCHIVE_DIR", "data/thread-archives"),
+}
+```
+
+Add to `.gitignore` if not already ignoring `data/` (session DB and memory DB already live there).
+
+### Slack scopes
+
+No new scopes required. `chat:write` covers deleting messages posted by the bot. `channels:history` / `groups:history` already required for `conversations.replies`.
+
+Verify in staging: bot cannot delete human messages (Slack returns `cant_delete_message`) — filter must be strict.
+
+## Command Flow
+
+```
+User: !clear
+  │
+  ├── parseCommand() → { command: "clear", text: "" }
+  │
+  └── SessionManager.handleCommand
+        ├── denyIfNotAdmin → ❌ if denied
+        ├── busy guard → reply if any handle active
+        ├── fetchFullThreadReplies(channel, threadId)
+        ├── writeThreadArchive(data/thread-archives/…)
+        ├── filter isJuniorMessage → chat.delete each
+        ├── responder.clearStatusForThread(threadId)
+        └── onCommandResponse(confirmation with path + count)
+```
+
+`handleCommand` returns `true` (consumed; no runner spawn).
+
+## Edge Cases
+
+| Case | Handling |
+|---|---|
+| Thread with only the parent message | Archive parent; `N = 0` if parent is human |
+| `!clear` in a thread Junior was never in | Still archives; `N = 0` |
+| Partial delete failure (Slack API error) | Continue deleting others; confirmation reports `N` succeeded; log failures |
+| Status pill in-flight during clear | Blocked by busy guard; if idle, `clearStatusForThread` cleans map |
+| Private channel / DM | Same code path; channel name resolution may fall back to ID |
+| Message edited after archive | Archive captures pre-delete snapshot; acceptable |
+| Foreign bot messages in thread | Archived, not deleted |
+| Very large thread (500+ messages) | Pagination handles fetch; deletion may take several seconds — consider `:hourglass:` reaction at start, remove on completion |
+
+## Testing
+
+**Unit (`thread-archive.test.ts`):**
+
+- `isJuniorMessage` true/false matrix (`bot_id`, `user`, foreign bot)
+- Markdown formatter output stable for fixture messages
+- Pagination merges cursors correctly (mock client)
+
+**Integration (`manager.test.ts`):**
+
+- Admin `!clear` → archive write called, delete called for bot messages only, confirmation posted
+- Non-admin → `❌`, no archive, no deletes
+- Busy thread → blocked message, no deletes
+- `N = 0` path still writes archive
+
+**Manual:**
+
+1. Start thread, get Junior + Lead + Reproducer to post several messages.
+2. `!clear` as admin → confirm human messages remain, bot messages gone, file exists on disk.
+3. Send another message → runner still resumes via session ID.
+4. Non-admin `!clear` → silent reject.
+
+## Open Questions
+
+1. **Include human messages in archive only, or offer `!clear --junior-only` archive?** Recommendation: always archive full thread in v1; simpler and more useful for audit.
+
+2. **Upload archive to Slack as a file attachment?** Nice for operators without shell access to the Junior host. Defer to v2 (`files.upload` + link in confirmation).
+
+3. **Retention / rotation** for `data/thread-archives/`? No automatic cleanup in v1; document disk growth. v2: cron or max-age env.
+
+4. **Should `!clear` also delete the auto-dormant notice?** Yes, if it was posted by Junior (`bot_id` match).
+
+5. **Thread-owner elevation** (v2 backlog): allow non-admins who own the thread to clear their own threads? Not in v1.
+
+## Cut List (v2+)
+
+- `!clear --dry-run` — show counts without deleting
+- Upload archive to thread as `.md` file
+- `!restore` from archive (re-post bot messages — likely low value)
+- Auto-clear on `!reset all` (opt-in flag)
+- HTTP dashboard link to browse archives
+
+## Summary
+
+| Item | Decision |
+|---|---|
+| Command | `!clear` |
+| Admin only | Yes |
+| Archives | Full thread → `data/thread-archives/*.md` |
+| Deletes | Junior installation messages only |
+| Session / worktree | Untouched |
+| Busy threads | Block with message |
+| New Slack scopes | None |
+| Primary new code | `src/slack/thread-archive.ts` + `handleCommand` case |
+
+Estimated effort: **~2–3 hours** (implementation + tests + docs index updates).

--- a/docs/features/thread-commands.md
+++ b/docs/features/thread-commands.md
@@ -12,6 +12,7 @@ Users need to control thread behavior beyond just sending messages. Reset a brok
 ## Full Vision
 
 - `!reset <agent|all>` — Clear one agent's slice of the session, or the whole thread. Bare `!reset` is rejected with usage help so admins don't accidentally nuke an active reproducer/thinker turn. (admin only)
+- `!clear` — Archive the full thread to markdown on disk, then delete all Junior bot messages from the thread. Session state is untouched. (admin only)
 - `!status` — Show session state (agent type, worktree, busy/idle, last activity, pending messages count)
 - `!build [prompt]` — Set agent to build, create worktree if needed, run prompt
 - `!frontend [prompt]` — Set agent to frontend, create worktree, run prompt
@@ -28,7 +29,7 @@ Users need to control thread behavior beyond just sending messages. Reset a brok
 
 ## Admin-only commands
 
-`!mute`, `!unmute`, and `!reset` are admin-gated. Two tiers:
+`!mute`, `!unmute`, `!reset`, and `!clear` are admin-gated. Two tiers:
 
 1. **Env bootstrap** — `ADMIN_SLACK_USER_ID` names one Slack user ID. This is the bootstrap admin; the system stays bootable on a fresh DB.
 2. **SQLite extras** — the `admins` table in the session DB (`data/sessions.db`) lists additional admins. Added by **direct SQL only** (no Slack command, no CLI script — intentional minimal UX):

--- a/src/codex-app-server/config.test.ts
+++ b/src/codex-app-server/config.test.ts
@@ -113,6 +113,7 @@ function makeConfig(): Config {
       maxIdleInterrupts: 1,
     },
     memory: { sqlitePath: "data/memory.db" },
+    threadArchives: { dir: "data/thread-archives" },
     channelDefaults: {},
     adminSlackUserId: null,
     http: { enabled: false, port: 0 },

--- a/src/codex-app-server/spawner.test.ts
+++ b/src/codex-app-server/spawner.test.ts
@@ -266,6 +266,7 @@ const testConfig: Config = {
     maxIdleInterrupts: 3,
   },
   memory: { sqlitePath: "data/memory.db" },
+  threadArchives: { dir: "data/thread-archives" },
   channelDefaults: {},
   adminSlackUserId: null,
   http: { enabled: false, port: 0 },

--- a/src/config.ts
+++ b/src/config.ts
@@ -116,6 +116,9 @@ export interface Config {
   memory: {
     sqlitePath: string;
   };
+  threadArchives: {
+    dir: string;
+  };
   channelDefaults: Record<string, { agentType: string }>;
   /**
    * Single Slack user ID allowed to run elevated commands (`!mute`, `!unmute`,
@@ -222,6 +225,9 @@ export function loadConfig(): Config {
     },
     memory: {
       sqlitePath: optional("MEMORY_DB_PATH", "data/memory.db"),
+    },
+    threadArchives: {
+      dir: optional("THREAD_ARCHIVE_DIR", "data/thread-archives"),
     },
     channelDefaults: parseChannelDefaults(
       optional(

--- a/src/index.ts
+++ b/src/index.ts
@@ -169,6 +169,10 @@ sessionManager.onCommandResponse = (event, response) => {
   responder.postResponse(event.channel, event.threadId, response);
 };
 
+sessionManager.onClearThreadStatus = (threadTs) => {
+  responder.clearStatusForThread(threadTs);
+};
+
 sessionManager.onReaction = (event, emoji) => {
   responder.addReaction(event.channel, event.ts, emoji);
 };
@@ -283,6 +287,7 @@ setInterval(() => {
     }
     if (auth.bot_id) {
       selfBotId = auth.bot_id;
+      sessionManager.selfBotId = auth.bot_id;
       log.info("boot", `Bot ID: ${auth.bot_id}`);
     }
   } catch (err) {

--- a/src/opencode/sdk-provider.test.ts
+++ b/src/opencode/sdk-provider.test.ts
@@ -159,6 +159,7 @@ const testConfig: Config = {
     maxIdleInterrupts: 3,
   },
   memory: { sqlitePath: "data/memory.db" },
+  threadArchives: { dir: "data/thread-archives" },
   channelDefaults: {},
   adminSlackUserId: null,
   http: { enabled: false, port: 0 },

--- a/src/runners/index.test.ts
+++ b/src/runners/index.test.ts
@@ -126,6 +126,7 @@ function testConfig(
       maxIdleInterrupts: 3,
     },
     memory: { sqlitePath: "data/memory.db" },
+    threadArchives: { dir: "data/thread-archives" },
     channelDefaults: {},
     adminSlackUserId: null,
     http: { enabled: false, port: 0 },

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -175,6 +175,9 @@ const testConfig: Config = {
   memory: {
     sqlitePath: "data/memory.db",
   },
+  threadArchives: {
+    dir: "data/thread-archives",
+  },
   channelDefaults: {},
   adminSlackUserId: null,
   http: { enabled: false, port: 0 },
@@ -878,6 +881,126 @@ describe("SessionManager", () => {
         expect(onReaction.mock.calls[0][1]).toBe("x");
         expect((await store.get("thread-1"))!.muted).toBe(false);
       });
+    });
+  });
+
+  describe("!clear", () => {
+    const adminConfig: Config = { ...testConfig, adminSlackUserId: "U-ADMIN" };
+    let archiveDir: string;
+
+    beforeEach(() => {
+      archiveDir = mkdtempSync(join(tmpdir(), "junior-clear-"));
+    });
+
+    function makeSlackApp(deleted: string[]) {
+      return {
+        client: {
+          conversations: {
+            replies: async () => ({
+              messages: [
+                { ts: "100.0", user: "U_HUMAN", text: "human msg" },
+                { ts: "101.0", bot_id: "B_SELF", user: "U_BOT", text: "bot msg" },
+              ],
+              response_metadata: {},
+            }),
+            info: async () => ({ channel: { name: "tech" } }),
+          },
+          users: {
+            info: async ({ user }: { user: string }) => ({
+              user: { profile: { display_name: user === "U-ADMIN" ? "Admin" : "Human" } },
+            }),
+          },
+          chat: {
+            delete: async ({ ts }: { ts: string }) => {
+              deleted.push(ts);
+            },
+          },
+        },
+      } as unknown as App;
+    }
+
+    it("archives thread and deletes Junior messages for admin", async () => {
+      const deleted: string[] = [];
+      const clearConfig: Config = {
+        ...adminConfig,
+        threadArchives: { dir: archiveDir },
+      };
+      const adminManager = new SessionManager(store, clearConfig);
+      adminManager.slackApp = makeSlackApp(deleted);
+      adminManager.selfBotId = "B_SELF";
+      adminManager.botUserId = "U_BOT";
+
+      const onCmd = mock((_e: SlackMessageEvent, _r: string) => {});
+      const onClear = mock((_threadTs: string) => {});
+      adminManager.onCommandResponse = onCmd;
+      adminManager.onClearThreadStatus = onClear;
+
+      await adminManager.handleMessage(makeEvent({ user: "U-ADMIN", text: "go" }));
+      await adminManager.handleMessage(
+        makeEvent({ user: "U-ADMIN", command: "clear", text: "", ts: "ts-clear" }),
+      );
+
+      expect(deleted).toEqual(["101.0"]);
+      expect(onClear).toHaveBeenCalledWith("thread-1");
+      expect(onCmd.mock.calls[0][1]).toContain("Cleared *1* Junior message");
+      expect(onCmd.mock.calls[0][1]).toContain(archiveDir);
+      expect(await store.get("thread-1")).toBeDefined();
+    });
+
+    it("rejects non-admin with silent x", async () => {
+      const deleted: string[] = [];
+      const clearConfig: Config = {
+        ...adminConfig,
+        threadArchives: { dir: archiveDir },
+      };
+      const adminManager = new SessionManager(store, clearConfig);
+      adminManager.slackApp = makeSlackApp(deleted);
+      adminManager.selfBotId = "B_SELF";
+
+      const onReaction = mock((_e: SlackMessageEvent, _emoji: string) => {});
+      const onCmd = mock((_e: SlackMessageEvent, _r: string) => {});
+      adminManager.onReaction = onReaction;
+      adminManager.onCommandResponse = onCmd;
+
+      await adminManager.handleMessage(makeEvent({ user: "U-ADMIN", text: "go" }));
+      await adminManager.handleMessage(
+        makeEvent({ user: "U-OTHER", command: "clear", text: "", ts: "ts-clear" }),
+      );
+
+      expect(onReaction).toHaveBeenCalledTimes(1);
+      expect(onReaction.mock.calls[0][1]).toBe("x");
+      expect(onCmd).not.toHaveBeenCalled();
+      expect(deleted).toEqual([]);
+    });
+
+    it("blocks clear while runner is active", async () => {
+      const deleted: string[] = [];
+      const clearConfig: Config = {
+        ...adminConfig,
+        threadArchives: { dir: archiveDir },
+      };
+      const adminManager = new SessionManager(store, clearConfig);
+      adminManager.slackApp = makeSlackApp(deleted);
+      adminManager.selfBotId = "B_SELF";
+
+      const onCmd = mock((_e: SlackMessageEvent, _r: string) => {});
+      adminManager.onCommandResponse = onCmd;
+
+      await adminManager.handleMessage(makeEvent({ user: "U-ADMIN", text: "go" }));
+      const handle = createMockHandle();
+      mockSpawnFn.mockReturnValueOnce(handle);
+      void adminManager.handleMessage(
+        makeEvent({ user: "U-ADMIN", text: "run", ts: "ts-run" }),
+      );
+      await Bun.sleep(20);
+      expect((await store.get("thread-1"))!.status).toBe("busy");
+
+      await adminManager.handleMessage(
+        makeEvent({ user: "U-ADMIN", command: "clear", text: "", ts: "ts-clear" }),
+      );
+
+      expect(deleted).toEqual([]);
+      expect(onCmd.mock.calls.at(-1)?.[1]).toContain("Cannot clear while a runner is active");
     });
   });
 

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -892,7 +892,7 @@ describe("SessionManager", () => {
       archiveDir = mkdtempSync(join(tmpdir(), "junior-clear-"));
     });
 
-    function makeSlackApp(deleted: string[]) {
+    function makeSlackApp(deleted: string[], failDeletes = new Set<string>()) {
       return {
         client: {
           conversations: {
@@ -912,6 +912,7 @@ describe("SessionManager", () => {
           },
           chat: {
             delete: async ({ ts }: { ts: string }) => {
+              if (failDeletes.has(ts)) throw new Error("cant_delete_message");
               deleted.push(ts);
             },
           },
@@ -945,6 +946,31 @@ describe("SessionManager", () => {
       expect(onCmd.mock.calls[0][1]).toContain("Cleared *1* Junior message");
       expect(onCmd.mock.calls[0][1]).toContain(archiveDir);
       expect(await store.get("thread-1")).toBeDefined();
+    });
+
+    it("reports delete failures instead of saying nothing was cleared", async () => {
+      const deleted: string[] = [];
+      const clearConfig: Config = {
+        ...adminConfig,
+        threadArchives: { dir: archiveDir },
+      };
+      const adminManager = new SessionManager(store, clearConfig);
+      adminManager.slackApp = makeSlackApp(deleted, new Set(["101.0"]));
+      adminManager.selfBotId = "B_SELF";
+      adminManager.botUserId = "U_BOT";
+
+      const onCmd = mock((_e: SlackMessageEvent, _r: string) => {});
+      adminManager.onCommandResponse = onCmd;
+
+      await adminManager.handleMessage(makeEvent({ user: "U-ADMIN", text: "go" }));
+      await adminManager.handleMessage(
+        makeEvent({ user: "U-ADMIN", command: "clear", text: "", ts: "ts-clear" }),
+      );
+
+      expect(deleted).toEqual([]);
+      expect(onCmd.mock.calls[0][1]).toContain("failed to delete *1* Junior message");
+      expect(onCmd.mock.calls[0][1]).toContain("Deleted *0* messages");
+      expect(onCmd.mock.calls[0][1]).not.toContain("No Junior messages to clear");
     });
 
     it("rejects non-admin with silent x", async () => {

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -41,6 +41,7 @@ import { DEFAULT_CONTEXT_PROFILE, type AgentContextProfile } from "../agents/loa
 import { downloadSlackFiles } from "../slack/files.ts";
 import { log as _log } from "../logger.ts";
 import type { MemoryIngestor } from "../memory/ingestion.ts";
+import { clearThreadJuniorMessages } from "../slack/thread-archive.ts";
 
 export class SessionManager {
   private store: SessionStore;
@@ -53,6 +54,7 @@ export class SessionManager {
 
   slackApp?: App;
   botUserId?: string;
+  selfBotId?: string;
   agentRouter?: AgentRouter;
   worktreeManager?: WorktreeManager;
   onResponse?: (session: ThreadSession, response: string) => void;
@@ -61,6 +63,7 @@ export class SessionManager {
   onError?: (session: ThreadSession, error: string | null) => void;
   onCommandResponse?: (event: SlackMessageEvent, response: string) => void;
   onReaction?: (event: SlackMessageEvent, emoji: string) => void;
+  onClearThreadStatus?: (threadTs: string) => void;
 
   constructor(
     store: SessionStore,
@@ -465,6 +468,61 @@ export class SessionManager {
         return true;
       }
 
+      case "clear": {
+        if (await this.denyIfNotAdmin(event)) return true;
+
+        for (const key of this.handles.keys()) {
+          if (key.startsWith(`${session.threadId}:`)) {
+            this.onCommandResponse?.(
+              event,
+              "Cannot clear while a runner is active. Use `!cancel` or wait for the turn to finish.",
+            );
+            return true;
+          }
+        }
+
+        if (!this.slackApp) {
+          this.onCommandResponse?.(event, "Slack client not available.");
+          return true;
+        }
+
+        try {
+          const result = await clearThreadJuniorMessages({
+            client: this.slackApp.client,
+            channelId: event.channel,
+            threadTs: session.threadId,
+            selfBotId: this.selfBotId,
+            botUserId: this.botUserId,
+            archiveDir: this.config.threadArchives.dir,
+            triggeredByUserId: event.user,
+          });
+          this.onClearThreadStatus?.(session.threadId);
+
+          const archiveLabel = result.archivePath;
+          if (result.deletedCount === 0) {
+            this.onCommandResponse?.(
+              event,
+              `No Junior messages to clear. Archive saved to \`${archiveLabel}\` anyway.`,
+            );
+          } else {
+            this.onCommandResponse?.(
+              event,
+              `Cleared *${result.deletedCount}* Junior message${result.deletedCount === 1 ? "" : "s"} from this thread.\nArchive: \`${archiveLabel}\``,
+            );
+          }
+        } catch (err) {
+          _log.error(
+            "thread-archive",
+            `clear.fail thread=${session.threadId} err=${err instanceof Error ? err.message : String(err)}`,
+          );
+          this.onCommandResponse?.(
+            event,
+            "Failed to clear thread messages. Check logs for details.",
+          );
+        }
+        return true;
+      }
+
       case "status": {
         const ago = session.lastActivity
           ? `${Math.round((Date.now() - session.lastActivity) / 1000)}s ago`
@@ -498,6 +556,7 @@ export class SessionManager {
           "`!provider <claude|opencode|opencode-sdk|codex-app-server>` — Set runner provider for this thread",
           "`!cancel` — Kill running process, keep session",
           "`!reset <agent|all>` — Reset one agent's state, or the whole thread (admin only)",
+          "`!clear` — Archive thread to markdown and delete Junior messages (admin only)",
           "`!status` — Show session status",
           "`!quiet` — Minimal output",
           "`!normal` — Normal output",

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -499,7 +499,14 @@ export class SessionManager {
           this.onClearThreadStatus?.(session.threadId);
 
           const archiveLabel = result.archivePath;
-          if (result.deletedCount === 0) {
+          if (result.deleteFailedCount > 0) {
+            const failed = result.deleteFailedCount;
+            const deleted = result.deletedCount;
+            this.onCommandResponse?.(
+              event,
+              `Archived thread to \`${archiveLabel}\`, but failed to delete *${failed}* Junior message${failed === 1 ? "" : "s"}. Deleted *${deleted}* message${deleted === 1 ? "" : "s"}. Check logs for details.`,
+            );
+          } else if (result.deletedCount === 0) {
             this.onCommandResponse?.(
               event,
               `No Junior messages to clear. Archive saved to \`${archiveLabel}\` anyway.`,

--- a/src/slack/commands.test.ts
+++ b/src/slack/commands.test.ts
@@ -82,6 +82,7 @@ describe("parseCommand", () => {
       "frontend",
       "architect",
       "reset",
+      "clear",
       "status",
       "repo",
       "branch",

--- a/src/slack/commands.ts
+++ b/src/slack/commands.ts
@@ -9,6 +9,7 @@ export const KNOWN_COMMANDS = new Set([
   "frontend",
   "architect",
   "cancel",
+  "clear",
   "reset",
   "status",
   "repo",

--- a/src/slack/responder.ts
+++ b/src/slack/responder.ts
@@ -286,4 +286,19 @@ export class SlackResponder {
   private statusKey(threadTs: string, agentName: string): string {
     return `${threadTs}:${agentName}`;
   }
+
+  /**
+   * Drop in-memory status tracking for a thread after `!clear` removes bot
+   * messages from Slack.
+   */
+  clearStatusForThread(threadTs: string): void {
+    const prefix = `${threadTs}:`;
+    for (const key of [...this.pendingStatusPosts.keys()]) {
+      if (key.startsWith(prefix)) this.pendingStatusPosts.delete(key);
+    }
+    for (const key of [...this.statusMessages.keys()]) {
+      if (key.startsWith(prefix)) this.statusMessages.delete(key);
+    }
+    log.info("responder", `status.clear.thread thread=${threadTs}`);
+  }
 }

--- a/src/slack/thread-archive.test.ts
+++ b/src/slack/thread-archive.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "bun:test";
+import {
+  fetchFullThreadReplies,
+  formatThreadArchiveMarkdown,
+  isJuniorMessage,
+  type ArchivedMessage,
+  type ThreadArchiveMeta,
+} from "./thread-archive.ts";
+
+describe("isJuniorMessage", () => {
+  it("matches self bot_id", () => {
+    expect(isJuniorMessage({ bot_id: "B_SELF" }, "B_SELF", "U_BOT")).toBe(true);
+  });
+
+  it("matches bot user id when bot_id absent", () => {
+    expect(isJuniorMessage({ user: "U_BOT" }, "B_SELF", "U_BOT")).toBe(true);
+  });
+
+  it("rejects foreign bots", () => {
+    expect(isJuniorMessage({ bot_id: "B_OTHER" }, "B_SELF", "U_BOT")).toBe(false);
+  });
+
+  it("rejects human users", () => {
+    expect(isJuniorMessage({ user: "U_HUMAN" }, "B_SELF", "U_BOT")).toBe(false);
+  });
+});
+
+describe("formatThreadArchiveMarkdown", () => {
+  it("renders metadata and quoted messages", () => {
+    const meta: ThreadArchiveMeta = {
+      channelName: "tech-support",
+      channelId: "C123",
+      threadTs: "1716890123.456789",
+      archivedAt: "2026-05-28T14:32:01.234Z",
+      triggeredByUserId: "U_ADMIN",
+      triggeredByUserName: "Admin",
+      totalMessages: 2,
+      juniorMessageCount: 1,
+    };
+    const messages: ArchivedMessage[] = [
+      {
+        ts: "1716890123.456789",
+        roleLabel: "User(Alice <@U1>)",
+        text: "hello",
+        isJunior: false,
+        timestampUtc: "2026-05-28 14:01:02 UTC",
+      },
+      {
+        ts: "1716890124.123456",
+        roleLabel: "Junior",
+        text: "on it",
+        isJunior: true,
+        timestampUtc: "2026-05-28 14:01:15 UTC",
+      },
+    ];
+
+    const md = formatThreadArchiveMarkdown(meta, messages);
+    expect(md).toContain("# Thread archive");
+    expect(md).toContain("| Channel | #tech-support (C123) |");
+    expect(md).toContain("**User(Alice <@U1>)**");
+    expect(md).toContain("> hello");
+    expect(md).toContain("**Junior**");
+    expect(md).toContain("> on it");
+  });
+});
+
+describe("fetchFullThreadReplies", () => {
+  it("paginates until cursor is exhausted", async () => {
+    const calls: Array<Record<string, unknown>> = [];
+    const client = {
+      conversations: {
+        replies: async (args: Record<string, unknown>) => {
+          calls.push(args);
+          if (!args.cursor) {
+            return {
+              messages: [{ ts: "1.0", user: "U1", text: "first" }],
+              response_metadata: { next_cursor: "cursor-2" },
+            };
+          }
+          return {
+            messages: [{ ts: "2.0", user: "U2", text: "second" }],
+            response_metadata: {},
+          };
+        },
+      },
+    };
+
+    const messages = await fetchFullThreadReplies(
+      client as never,
+      "C123",
+      "1.0",
+    );
+
+    expect(calls).toHaveLength(2);
+    expect(messages).toHaveLength(2);
+    expect(messages[0]?.ts).toBe("1.0");
+    expect(messages[1]?.ts).toBe("2.0");
+  });
+});

--- a/src/slack/thread-archive.test.ts
+++ b/src/slack/thread-archive.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+  deleteJuniorMessages,
   fetchFullThreadReplies,
   formatThreadArchiveMarkdown,
   isJuniorMessage,
@@ -95,5 +96,31 @@ describe("fetchFullThreadReplies", () => {
     expect(messages).toHaveLength(2);
     expect(messages[0]?.ts).toBe("1.0");
     expect(messages[1]?.ts).toBe("2.0");
+  });
+});
+
+describe("deleteJuniorMessages", () => {
+  it("reports delete failures separately from successful deletes", async () => {
+    const client = {
+      chat: {
+        delete: async ({ ts }: { ts: string }) => {
+          if (ts === "101.0") throw new Error("cant_delete_message");
+        },
+      },
+    };
+
+    const result = await deleteJuniorMessages(
+      client as never,
+      "C123",
+      [
+        { ts: "100.0", bot_id: "B_SELF" },
+        { ts: "101.0", bot_id: "B_SELF" },
+        { ts: "102.0", user: "U_HUMAN" },
+      ],
+      "B_SELF",
+      "U_BOT",
+    );
+
+    expect(result).toEqual({ deletedCount: 1, failedCount: 1 });
   });
 });

--- a/src/slack/thread-archive.ts
+++ b/src/slack/thread-archive.ts
@@ -1,0 +1,296 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { randomBytes } from "node:crypto";
+import type { WebClient } from "@slack/web-api";
+import {
+  resolveChannelName,
+  resolveSlackMentions,
+  resolveUserName,
+} from "./thread-context.ts";
+import { log } from "../logger.ts";
+
+export interface SlackReplyMessage {
+  ts?: string;
+  user?: string;
+  bot_id?: string;
+  username?: string;
+  text?: string;
+  files?: unknown;
+}
+
+export interface ArchivedMessage {
+  ts: string;
+  roleLabel: string;
+  text: string;
+  isJunior: boolean;
+  timestampUtc: string;
+}
+
+export interface ThreadArchiveMeta {
+  channelName: string;
+  channelId: string;
+  threadTs: string;
+  archivedAt: string;
+  triggeredByUserId: string;
+  triggeredByUserName: string;
+  totalMessages: number;
+  juniorMessageCount: number;
+}
+
+export interface ClearThreadOptions {
+  client: WebClient;
+  channelId: string;
+  threadTs: string;
+  selfBotId?: string;
+  botUserId?: string;
+  archiveDir: string;
+  triggeredByUserId: string;
+}
+
+export interface ClearThreadResult {
+  archivePath: string;
+  deletedCount: number;
+  totalMessages: number;
+  juniorMessageCount: number;
+}
+
+export function isJuniorMessage(
+  msg: SlackReplyMessage,
+  selfBotId?: string,
+  botUserId?: string,
+): boolean {
+  if (selfBotId && msg.bot_id === selfBotId) return true;
+  if (botUserId && msg.user === botUserId) return true;
+  return false;
+}
+
+export async function fetchFullThreadReplies(
+  client: WebClient,
+  channel: string,
+  threadTs: string,
+): Promise<SlackReplyMessage[]> {
+  const messages: SlackReplyMessage[] = [];
+  let cursor: string | undefined;
+
+  do {
+    const result = await client.conversations.replies({
+      channel,
+      ts: threadTs,
+      inclusive: true,
+      limit: 200,
+      ...(cursor ? { cursor } : {}),
+    });
+
+    if (result.messages?.length) {
+      messages.push(...(result.messages as SlackReplyMessage[]));
+    }
+
+    cursor = result.response_metadata?.next_cursor || undefined;
+  } while (cursor);
+
+  return messages;
+}
+
+function extractFileNames(files: unknown): string[] {
+  if (!Array.isArray(files)) return [];
+  return files
+    .filter((f): f is { name: string } =>
+      typeof f === "object" && f !== null && typeof (f as { name?: unknown }).name === "string",
+    )
+    .map((f) => f.name);
+}
+
+function formatTsUtc(ts: string): string {
+  const seconds = Number.parseFloat(ts);
+  if (!Number.isFinite(seconds)) return ts;
+  return new Date(seconds * 1000).toISOString().replace("T", " ").replace(/\.\d{3}Z$/, " UTC");
+}
+
+async function roleLabelForMessage(
+  client: WebClient,
+  msg: SlackReplyMessage,
+  selfBotId?: string,
+  botUserId?: string,
+): Promise<string> {
+  if (isJuniorMessage(msg, selfBotId, botUserId)) {
+    if (msg.username) return msg.username;
+    return "Junior";
+  }
+  if (msg.bot_id) return `Bot(${msg.bot_id})`;
+  const userId = msg.user ?? "unknown";
+  if (userId === "unknown") return "User(unknown)";
+  const userName = await resolveUserName(client, userId);
+  return `User(${userName} <@${userId}>)`;
+}
+
+export async function enrichMessagesForArchive(
+  client: WebClient,
+  messages: SlackReplyMessage[],
+  selfBotId?: string,
+  botUserId?: string,
+): Promise<ArchivedMessage[]> {
+  return Promise.all(
+    messages
+      .filter((m) => m.ts)
+      .map(async (m) => {
+        const ts = m.ts!;
+        let text = (await resolveSlackMentions(client, m.text ?? "")).trim();
+        const fileNames = extractFileNames(m.files);
+        if (fileNames.length > 0) {
+          const fileNotes = fileNames.map((f) => `[shared file: ${f}]`).join(" ");
+          text = text ? `${text} ${fileNotes}` : fileNotes;
+        }
+
+        return {
+          ts,
+          roleLabel: await roleLabelForMessage(client, m, selfBotId, botUserId),
+          text,
+          isJunior: isJuniorMessage(m, selfBotId, botUserId),
+          timestampUtc: formatTsUtc(ts),
+        };
+      }),
+  );
+}
+
+function quoteBody(text: string): string {
+  if (!text) return "> _(empty)_";
+  return text.split("\n").map((line) => `> ${line}`).join("\n");
+}
+
+export function formatThreadArchiveMarkdown(
+  meta: ThreadArchiveMeta,
+  messages: ArchivedMessage[],
+): string {
+  const channelDisplay = meta.channelName.startsWith("#")
+    ? meta.channelName
+    : `#${meta.channelName}`;
+
+  const header = [
+    "# Thread archive",
+    "",
+    "| Field | Value |",
+    "|---|---|",
+    `| Channel | ${channelDisplay} (${meta.channelId}) |`,
+    `| Thread | ${meta.threadTs} |`,
+    `| Archived at | ${meta.archivedAt} |`,
+    `| Triggered by | ${meta.triggeredByUserName} (<@${meta.triggeredByUserId}>) |`,
+    `| Messages total | ${meta.totalMessages} |`,
+    `| Junior messages deleted | ${meta.juniorMessageCount} |`,
+    "",
+    "---",
+    "",
+    "## Messages",
+    "",
+  ];
+
+  const body = messages.flatMap((m) => [
+    `**${m.roleLabel}** · ${m.timestampUtc} · \`${m.ts}\``,
+    quoteBody(m.text),
+    "",
+  ]);
+
+  return [...header, ...body].join("\n").trimEnd() + "\n";
+}
+
+export function threadArchiveFilename(
+  channelSlug: string,
+  threadTs: string,
+  archivedAt: Date,
+): string {
+  const safeChannel = channelSlug.replace(/[^a-zA-Z0-9_-]+/g, "-").replace(/^-+|-+$/g, "") || "channel";
+  const safeThread = threadTs.replace(/\./g, "_");
+  const date = archivedAt.toISOString().slice(0, 10);
+  const shortId = randomBytes(3).toString("hex");
+  return `${safeChannel}_${safeThread}_${date}_${shortId}.md`;
+}
+
+export async function writeThreadArchive(
+  baseDir: string,
+  filename: string,
+  content: string,
+): Promise<string> {
+  const archivePath = join(baseDir, filename);
+  await mkdir(dirname(archivePath), { recursive: true });
+  await writeFile(archivePath, content, "utf8");
+  return archivePath;
+}
+
+export async function deleteJuniorMessages(
+  client: WebClient,
+  channelId: string,
+  messages: SlackReplyMessage[],
+  selfBotId?: string,
+  botUserId?: string,
+): Promise<number> {
+  let deletedCount = 0;
+
+  for (const msg of messages) {
+    if (!msg.ts || !isJuniorMessage(msg, selfBotId, botUserId)) continue;
+    try {
+      await client.chat.delete({ channel: channelId, ts: msg.ts });
+      deletedCount++;
+    } catch (err) {
+      log.warn(
+        "thread-archive",
+        `delete.fail channel=${channelId} ts=${msg.ts} err=${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  return deletedCount;
+}
+
+export async function clearThreadJuniorMessages(
+  options: ClearThreadOptions,
+): Promise<ClearThreadResult> {
+  const {
+    client,
+    channelId,
+    threadTs,
+    selfBotId,
+    botUserId,
+    archiveDir,
+    triggeredByUserId,
+  } = options;
+
+  const rawMessages = await fetchFullThreadReplies(client, channelId, threadTs);
+  const archivedMessages = await enrichMessagesForArchive(
+    client,
+    rawMessages,
+    selfBotId,
+    botUserId,
+  );
+  const juniorMessageCount = archivedMessages.filter((m) => m.isJunior).length;
+  const archivedAt = new Date();
+  const channelName = await resolveChannelName(client, channelId);
+  const triggeredByUserName = await resolveUserName(client, triggeredByUserId);
+
+  const meta: ThreadArchiveMeta = {
+    channelName,
+    channelId,
+    threadTs,
+    archivedAt: archivedAt.toISOString(),
+    triggeredByUserId,
+    triggeredByUserName,
+    totalMessages: archivedMessages.length,
+    juniorMessageCount,
+  };
+
+  const markdown = formatThreadArchiveMarkdown(meta, archivedMessages);
+  const filename = threadArchiveFilename(channelName, threadTs, archivedAt);
+  const archivePath = await writeThreadArchive(archiveDir, filename, markdown);
+  const deletedCount = await deleteJuniorMessages(
+    client,
+    channelId,
+    rawMessages,
+    selfBotId,
+    botUserId,
+  );
+
+  return {
+    archivePath,
+    deletedCount,
+    totalMessages: archivedMessages.length,
+    juniorMessageCount,
+  };
+}

--- a/src/slack/thread-archive.ts
+++ b/src/slack/thread-archive.ts
@@ -50,8 +50,14 @@ export interface ClearThreadOptions {
 export interface ClearThreadResult {
   archivePath: string;
   deletedCount: number;
+  deleteFailedCount: number;
   totalMessages: number;
   juniorMessageCount: number;
+}
+
+export interface DeleteJuniorMessagesResult {
+  deletedCount: number;
+  failedCount: number;
 }
 
 export function isJuniorMessage(
@@ -221,8 +227,9 @@ export async function deleteJuniorMessages(
   messages: SlackReplyMessage[],
   selfBotId?: string,
   botUserId?: string,
-): Promise<number> {
+): Promise<DeleteJuniorMessagesResult> {
   let deletedCount = 0;
+  let failedCount = 0;
 
   for (const msg of messages) {
     if (!msg.ts || !isJuniorMessage(msg, selfBotId, botUserId)) continue;
@@ -230,6 +237,7 @@ export async function deleteJuniorMessages(
       await client.chat.delete({ channel: channelId, ts: msg.ts });
       deletedCount++;
     } catch (err) {
+      failedCount++;
       log.warn(
         "thread-archive",
         `delete.fail channel=${channelId} ts=${msg.ts} err=${err instanceof Error ? err.message : String(err)}`,
@@ -237,7 +245,7 @@ export async function deleteJuniorMessages(
     }
   }
 
-  return deletedCount;
+  return { deletedCount, failedCount };
 }
 
 export async function clearThreadJuniorMessages(
@@ -279,7 +287,7 @@ export async function clearThreadJuniorMessages(
   const markdown = formatThreadArchiveMarkdown(meta, archivedMessages);
   const filename = threadArchiveFilename(channelName, threadTs, archivedAt);
   const archivePath = await writeThreadArchive(archiveDir, filename, markdown);
-  const deletedCount = await deleteJuniorMessages(
+  const deleteResult = await deleteJuniorMessages(
     client,
     channelId,
     rawMessages,
@@ -289,7 +297,8 @@ export async function clearThreadJuniorMessages(
 
   return {
     archivePath,
-    deletedCount,
+    deletedCount: deleteResult.deletedCount,
+    deleteFailedCount: deleteResult.failedCount,
     totalMessages: archivedMessages.length,
     juniorMessageCount,
   };

--- a/src/slack/thread-context.ts
+++ b/src/slack/thread-context.ts
@@ -1,4 +1,5 @@
 import type { App } from "@slack/bolt";
+import type { WebClient } from "@slack/web-api";
 import type { RepoConfig } from "../config.ts";
 import { loadPersona } from "../persona.ts";
 import { NO_SLACK_MESSAGE } from "./formatting.ts";
@@ -19,12 +20,16 @@ interface ThreadMessage {
 const channelNameCache = new Map<string, string>();
 const userNameCache = new Map<string, string>();
 
-async function resolveChannelName(app: App, channelId: string): Promise<string> {
+export async function resolveChannelName(
+  clientOrApp: App | WebClient,
+  channelId: string,
+): Promise<string> {
   const cached = channelNameCache.get(channelId);
   if (cached) return cached;
 
   try {
-    const info = await app.client.conversations.info({ channel: channelId });
+    const client = "client" in clientOrApp ? clientOrApp.client : clientOrApp;
+    const info = await client.conversations.info({ channel: channelId });
     const name = info.channel?.name ?? channelId;
     channelNameCache.set(channelId, name);
     return name;
@@ -33,12 +38,16 @@ async function resolveChannelName(app: App, channelId: string): Promise<string> 
   }
 }
 
-async function resolveUserName(app: App, userId: string): Promise<string> {
+export async function resolveUserName(
+  clientOrApp: App | WebClient,
+  userId: string,
+): Promise<string> {
   const cached = userNameCache.get(userId);
   if (cached) return cached;
 
   try {
-    const info = await app.client.users.info({ user: userId });
+    const client = "client" in clientOrApp ? clientOrApp.client : clientOrApp;
+    const info = await client.users.info({ user: userId });
     const user = info.user as
       | {
           name?: string;
@@ -60,7 +69,7 @@ async function resolveUserName(app: App, userId: string): Promise<string> {
 }
 
 export async function resolveSlackMentions(
-  app: App,
+  clientOrApp: App | WebClient,
   text: string,
 ): Promise<string> {
   const mentionPattern = /<@([A-Z0-9]+)>/g;
@@ -73,7 +82,7 @@ export async function resolveSlackMentions(
   const uniqueIds = [...new Set(matches.map((m) => m[1]))];
   const nameMap = new Map(
     await Promise.all(
-      uniqueIds.map(async (id) => [id, await resolveUserName(app, id)] as const),
+      uniqueIds.map(async (id) => [id, await resolveUserName(clientOrApp, id)] as const),
     ),
   );
 

--- a/src/workflows/executor.test.ts
+++ b/src/workflows/executor.test.ts
@@ -455,6 +455,7 @@ function testConfig(): Config {
       maxIdleInterrupts: 3,
     },
     memory: { sqlitePath: "data/memory.db" },
+    threadArchives: { dir: "data/thread-archives" },
     channelDefaults: {},
     adminSlackUserId: null,
     http: { enabled: false, port: 0 },


### PR DESCRIPTION
## Summary
- Adds admin-gated `!clear` thread command that archives the full Slack thread to markdown (`data/thread-archives/`, overridable via `THREAD_ARCHIVE_DIR`) before deleting Junior bot messages
- Leaves session state, worktrees, and provider resume IDs untouched — distinct from `!reset`
- Blocks while a runner is active; clears in-memory status-pill tracking after deletion

## Test plan
- [x] `bun run typecheck`
- [x] `bun test src/slack/thread-archive.test.ts src/slack/commands.test.ts src/session/manager.test.ts`
- [ ] Manual: run `!clear` in a busy thread with multiple Junior/agent posts; confirm humans remain, archive file written, confirmation posted
- [ ] Manual: non-admin `!clear` gets silent ❌ with no archive/delete
- [ ] Manual: `!clear` while runner active is blocked with guidance to `!cancel` first


Made with [Cursor](https://cursor.com)