### PR TITLE
Clean up spawned process trees on shutdown

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,7 @@ The server owns the lifecycle. When a Slack message arrives in a thread, the bot
 | What agent definitions exist and how are they structured? | [docs/features/agent-definitions.md](docs/features/agent-definitions.md) |
 | How do thread commands (!build, !reset, !status) work? | [docs/features/thread-commands.md](docs/features/thread-commands.md) |
 | How does process lifecycle and error handling work? | [docs/features/process-lifecycle.md](docs/features/process-lifecycle.md) |
+| How are spawned child process trees cleaned up on shutdown? | [docs/features/process-tree-cleanup.md](docs/features/process-tree-cleanup.md) |
 | How does the bot Slack MCP server work? | [docs/features/mcp-server.md](docs/features/mcp-server.md) |
 | Headless vs tmux driver, why two paths exist, how tmux runs the TUI? | [docs/features/interactive-driver.md](docs/features/interactive-driver.md) |
 | How do persistent agents (lead, reproducer, thinker, …) work? | [docs/features/persistent-agents.md](docs/features/persistent-agents.md) |

--- a/docs/features/process-lifecycle.md
+++ b/docs/features/process-lifecycle.md
@@ -3,6 +3,8 @@
 > **Two process classes live under junior's lifecycle ownership.**
 > 1. **Claude CLI subprocesses** — short-lived, one per Slack message turn. Owned by `src/claude/spawner.ts` + the timeout/shutdown helpers in `src/lifecycle/`. Original scope of this doc.
 > 2. **Dev servers** — long-lived `pnpm dev` / `npm run dev` processes for bug-pipeline validation. Owned by `DevServerManager` (`src/lifecycle/dev-server.ts`) and serialized by `DevServerQueue` (`src/lifecycle/dev-server-queue.ts`). See [bug-pipeline-worktrees.md](bug-pipeline-worktrees.md) for the full design and the Dev-server section below for the runtime invariants.
+>
+> Process-tree cleanup and resumability are specified in [process-tree-cleanup.md](process-tree-cleanup.md).
 
 ## Problem
 
@@ -17,6 +19,7 @@ Claude Code CLI processes can hang, crash, or produce errors. The bot needs to h
 
 - Timeout guard on every spawned process (configurable, default 5 min)
 - Graceful shutdown: SIGINT first, SIGKILL after grace period
+- Process-tree cleanup: spawned CLIs run in their own process group, and cleanup signals the group so wrapper commands cannot leave grandchildren behind
 - Error categorization: timeout, crash, rate limit, auth failure, unknown
 - User-facing error messages in Slack (not raw stderr)
 - Session state recovery: if process dies mid-turn, session stays resumable
@@ -132,6 +135,7 @@ When the bot itself shuts down (SIGINT, SIGTERM, restart), handle running proces
 - **Branch-keyed reuse.** `ensure(repoName, branch)` reuses the running process if its branch matches; otherwise kills, `git fetch && git reset --hard origin/<branch>` (reset, not checkout — checkout rejects branches checked out elsewhere), respawns, polls `<readyUrl>` until 200 (90s timeout).
 - **Idle TTL** = 20 min default. `setInterval` sweeper kills servers whose `lastUsedAt` is past the TTL. Tunable via `DevServerManagerOptions` for tests.
 - **Junior shutdown.** `setupGracefulShutdown` calls `devServerManager.killAll()` in parallel with session teardown. SIGINT first, 5s grace, SIGKILL fallback.
+- **Process group ownership.** Dev servers are spawned as detached process groups. `kill()` tears down the whole group, not only the direct wrapper PID.
 - **Startup orphan check.** `bootstrap()` probes each configured `devPort` via TCP connect. If something else holds it, junior logs loudly and skips spawning that repo's server (does NOT kill the unknown listener — that would be unsafe; see "human's bare-repo dev server" in the design doc).
 - **Worktree ignores written to `.git/info/exclude`.** `bootstrap()` writes `.lock*\n.queue*\n` into the dev-server worktree's per-clone `info/exclude` (resolved via `git rev-parse --git-dir`), not `.gitignore`. `info/exclude` is per-worktree and untracked, so the write is idempotent and invisible to `git status`; writing `.gitignore` would clobber the upstream-tracked file.
 - **Self-heal legacy `.gitignore` overwrite.** A previous bootstrap wrote those ignore lines into `.gitignore` directly. `bootstrap()` detects the exact-match fingerprint (`.lock*\n.queue*\n`), unlinks the file, and runs `git checkout -- .gitignore` to restore from HEAD. Exact-match only — non-matching `.gitignore` files are left alone.

--- a/docs/features/process-tree-cleanup.md
+++ b/docs/features/process-tree-cleanup.md
@@ -1,0 +1,66 @@
+# Process Tree Cleanup
+
+## Invariant
+
+When Junior terminates, every process it spawned must terminate too, and any
+captured provider session id must remain persisted so the next turn can resume.
+
+This applies to:
+- headless runner CLIs (`claude`, `opencode`, `codex app-server`)
+- workflow runner turns
+- managed dev servers
+- wrapper commands that spawn grandchildren, such as shell scripts that launch
+  `bun test`, `npm run dev`, or framework dev servers
+
+Force-killing Junior with `SIGKILL` cannot run cleanup code. The invariant is
+for normal termination paths: `SIGINT`, `SIGTERM`, `!cancel`, `!stop`, timeout,
+driver switch, reset, and managed dev-server teardown.
+
+## Design
+
+Junior starts external CLIs with `detached: true`, which places the process in
+its own process group. Cleanup signals the negative PID (`process.kill(-pid)`)
+so the whole group receives the signal, not only the wrapper process.
+
+The shared helper is `src/lifecycle/process-tree.ts`:
+- `signalProcessTree(pid, signal)` sends one signal to the process group, with a
+  direct-PID fallback for non-detached or test handles.
+- `terminateProcessTree(pid, opts)` sends a graceful signal, waits, then sends
+  `SIGKILL` if anything in the group is still alive.
+- `isProcessTreeAlive(pid)` checks the process group first, then the direct PID.
+
+Spawner-owned `kill()` methods are synchronous handles, so they call
+`signalProcessTree`. Awaited teardown paths, like dev-server shutdown, call
+`terminateProcessTree`.
+
+## Resumability
+
+Provider session ids are persisted as soon as an `init` event arrives, not only
+when the runner completes. This matters because shutdown can interrupt a turn
+after init but before normal completion.
+
+On shutdown:
+- `SessionManager.terminateActiveRuns()` removes handle ownership first, then
+  sends `SIGINT`. Late runner completions are ignored by the existing stale
+  handle guard, so they cannot overwrite the shutdown-preserved row.
+- Top-level busy/draining sessions are marked `idle`, `pid = null`, and retain
+  `sessionId` / `leadSessionId`.
+- Busy persistent agent sessions are marked `idle`, `pid = null`, and retain
+  their per-agent `sessionId`.
+- `WorkflowExecutor.terminateActiveRuns()` interrupts active workflow handles;
+  workflow run rows keep `providerSessionId` captured from init.
+
+The next Slack message resumes through the provider-native mechanism
+(`--resume` for Claude, `--session` for OpenCode) when the provider supports it.
+
+## Verification
+
+Regression coverage includes:
+- a real detached wrapper process that starts a `sleep` child; cleanup kills the
+  child, proving process-group signaling covers descendants
+- shutdown preserving a top-level session id captured before completion
+- shutdown terminating a busy persistent agent when the top-level session is idle
+- workflow shutdown terminating active workflow runner handles while preserving
+  `providerSessionId`
+- dev-server kill and killAll paths using process-tree termination
+

--- a/src/claude/spawner.ts
+++ b/src/claude/spawner.ts
@@ -6,6 +6,7 @@ import type { RunnerEvent, SpawnHandle, SpawnResult } from "../runners/types.ts"
 import { buildRunnerRuntime } from "../runners/runtime.ts";
 import { buildClaudeArgs } from "./args.ts";
 import { createStreamParser } from "./parser.ts";
+import { signalProcessTree } from "../lifecycle/process-tree.ts";
 
 // Junior's .mcp.json — pass to spawned processes so they find the slack-bot server
 const PROJECT_MCP_CONFIG = resolve(import.meta.dirname ?? ".", "../../.mcp.json");
@@ -33,6 +34,7 @@ export function spawnClaude(
     stderr: "pipe",
     stdin: "ignore",
     env: runtime.env,
+    detached: true,
   });
 
   const listeners: Array<(event: RunnerEvent) => void> = [];
@@ -122,7 +124,7 @@ export function spawnClaude(
       listeners.push(cb);
     },
     kill: (signal) => {
-      signal ? proc.kill(signal) : proc.kill();
+      signalProcessTree(proc.pid, signal ?? "SIGTERM");
     },
     pid: proc.pid,
   };

--- a/src/codex-app-server/spawner.ts
+++ b/src/codex-app-server/spawner.ts
@@ -9,6 +9,7 @@ import {
 } from "./config.ts";
 import { createCodexAppServerEventMapper } from "./parser.ts";
 import { mapCodexRunPolicy } from "./policy.ts";
+import { signalProcessTree } from "../lifecycle/process-tree.ts";
 
 interface JsonRpcResponse {
   id: number;
@@ -65,6 +66,7 @@ export function spawnCodexAppServer(
     stderr: "pipe",
     stdin: "pipe",
     env,
+    detached: true,
   });
 
   const listeners: Array<(event: RunnerEvent) => void> = [];
@@ -207,7 +209,7 @@ export function spawnCodexAppServer(
 
       await waitForDone(events, proc.exited);
       processKilled = true;
-      proc.kill("SIGTERM");
+      signalProcessTree(proc.pid, "SIGTERM");
       await stdoutDone;
       const exitCode = await proc.exited;
       const stderr = await stderrText;
@@ -221,7 +223,7 @@ export function spawnCodexAppServer(
         error: mapperError ?? (exitCode === 0 || exitCode === 143 ? null : stderr || `Process exited with code ${exitCode}`),
       };
     } catch (err) {
-      if (!processKilled) proc.kill("SIGTERM");
+      if (!processKilled) signalProcessTree(proc.pid, "SIGTERM");
       const stderr = await stderrText;
       return {
         provider,
@@ -251,12 +253,12 @@ export function spawnCodexAppServer(
           threadId: activeThreadId,
           turnId: activeTurnId,
         }).catch(() => {
-          proc.kill("SIGTERM");
+          signalProcessTree(proc.pid, "SIGTERM");
         });
         return;
       }
       processKilled = true;
-      proc.kill(signal ?? "SIGTERM");
+      signalProcessTree(proc.pid, signal ?? "SIGTERM");
     },
     pid: proc.pid,
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -192,8 +192,8 @@ sessionManager.onError = (session, error) => {
 
 registerHomeTab(app, store, config.session.homeWindowMs, workflowStore);
 
-setupGracefulShutdown(sessionManager, store, devServerManager, () => {
-  workflowScheduler.stop();
+setupGracefulShutdown(sessionManager, devServerManager, async () => {
+  await workflowScheduler.shutdown();
   workflowRegistry.stopWatching();
   workflowStore.close?.();
   memoryStore.close();

--- a/src/lifecycle/dev-server.ts
+++ b/src/lifecycle/dev-server.ts
@@ -17,6 +17,7 @@ import { log } from "../logger.ts";
 import type { RepoConfig } from "../config.ts";
 import { WorktreeManager } from "../worktree/manager.ts";
 import { isPidAlive, isPortHeld } from "./process-utils.ts";
+import { isProcessTreeAlive, terminateProcessTree } from "./process-tree.ts";
 
 export interface DevServerState {
   pid: number | null;
@@ -167,6 +168,7 @@ export class DevServerManager {
       cwd: worktreePath,
       stdout: "pipe",
       stderr: "pipe",
+      detached: true,
       // Don't inherit stdin — we don't want the process to block on stdin.
     });
 
@@ -196,37 +198,18 @@ export class DevServerManager {
     // Clear state immediately so concurrent calls are idempotent.
     this.state.delete(repoName);
 
-    if (!isPidAlive(pid)) {
+    if (!isProcessTreeAlive(pid)) {
       log.info("dev-server", `kill repo=${repoName} pid=${pid} already dead`);
       await this.waitForPortRelease(repoName);
       return;
     }
 
-    log.info("dev-server", `kill repo=${repoName} pid=${pid} SIGINT`);
-    try {
-      process.kill(pid, "SIGINT");
-    } catch {
-      // Process may have just exited — that's fine.
-      return;
-    }
-
-    // Wait up to SIGINT_GRACE_MS for the process to exit gracefully.
-    const deadline = Date.now() + SIGINT_GRACE_MS;
-    while (Date.now() < deadline) {
-      await sleep(200);
-      if (!isPidAlive(pid)) {
-        log.info("dev-server", `kill repo=${repoName} pid=${pid} exited after SIGINT`);
-        await this.waitForPortRelease(repoName);
-        return;
-      }
-    }
-
-    // Escalate to SIGKILL.
-    log.warn("dev-server", `kill repo=${repoName} pid=${pid} escalating to SIGKILL`);
-    try {
-      process.kill(pid, "SIGKILL");
-    } catch {
-      // Already dead.
+    log.info("dev-server", `kill repo=${repoName} pid=${pid} SIGINT tree`);
+    await terminateProcessTree(pid, { signal: "SIGINT", forceAfterMs: SIGINT_GRACE_MS });
+    if (isProcessTreeAlive(pid)) {
+      log.warn("dev-server", `kill repo=${repoName} pid=${pid} tree still alive after SIGKILL`);
+    } else {
+      log.info("dev-server", `kill repo=${repoName} pid=${pid} tree exited`);
     }
     await this.waitForPortRelease(repoName);
   }

--- a/src/lifecycle/process-tree.test.ts
+++ b/src/lifecycle/process-tree.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "bun:test";
+import { terminateProcessTree } from "./process-tree.ts";
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 5_000,
+): Promise<void> {
+  const started = Date.now();
+  while (!predicate()) {
+    if (Date.now() - started > timeoutMs) {
+      throw new Error("Timed out waiting for condition");
+    }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
+describe("process tree cleanup", () => {
+  it("kills descendants when the managed process is a wrapper", async () => {
+    const proc = Bun.spawn(
+      ["sh", "-c", "sleep 60 & echo $!; wait"],
+      {
+        stdout: "pipe",
+        stderr: "pipe",
+        stdin: "ignore",
+        detached: true,
+      },
+    );
+    const reader = proc.stdout.getReader();
+    const { value } = await reader.read();
+    const childPid = Number(new TextDecoder().decode(value).trim());
+
+    try {
+      expect(childPid).toBeGreaterThan(0);
+      expect(isPidAlive(childPid)).toBe(true);
+
+      await terminateProcessTree(proc.pid, {
+        signal: "SIGTERM",
+        forceAfterMs: 500,
+        waitAfterForceMs: 500,
+      });
+      await waitFor(() => !isPidAlive(childPid));
+
+      expect(isPidAlive(childPid)).toBe(false);
+    } finally {
+      try {
+        process.kill(childPid, "SIGKILL");
+      } catch {
+        // Already gone.
+      }
+      try {
+        process.kill(proc.pid, "SIGKILL");
+      } catch {
+        // Already gone.
+      }
+    }
+  });
+});

--- a/src/lifecycle/process-tree.ts
+++ b/src/lifecycle/process-tree.ts
@@ -1,0 +1,82 @@
+import type { RunnerKillSignal } from "../runners/types.ts";
+
+export interface TerminateProcessTreeOptions {
+  signal?: RunnerKillSignal;
+  forceAfterMs?: number;
+  waitAfterForceMs?: number;
+}
+
+const DEFAULT_FORCE_AFTER_MS = 5_000;
+const DEFAULT_WAIT_AFTER_FORCE_MS = 1_000;
+
+/**
+ * Kill a managed child process and its descendants.
+ *
+ * Junior spawns long-running external CLIs in their own process group
+ * (`detached: true`). Signalling `-pid` targets that whole group, so wrapper
+ * shells cannot leave `bun test`, dev servers, or provider subprocesses behind.
+ * The positive-PID fallback keeps tests and any non-detached legacy handles
+ * killable.
+ */
+export function signalProcessTree(
+  pid: number | null | undefined,
+  signal: RunnerKillSignal = "SIGINT",
+): void {
+  if (!pid) return;
+  try {
+    process.kill(-pid, signal);
+    return;
+  } catch {
+    // Fall back below.
+  }
+  try {
+    process.kill(pid, signal);
+  } catch {
+    // Already gone.
+  }
+}
+
+export async function terminateProcessTree(
+  pid: number | null | undefined,
+  options: TerminateProcessTreeOptions = {},
+): Promise<void> {
+  if (!pid) return;
+  const signal = options.signal ?? "SIGINT";
+  const forceAfterMs = options.forceAfterMs ?? DEFAULT_FORCE_AFTER_MS;
+  const waitAfterForceMs = options.waitAfterForceMs ?? DEFAULT_WAIT_AFTER_FORCE_MS;
+
+  signalProcessTree(pid, signal);
+  if (await waitForExit(pid, forceAfterMs)) return;
+
+  signalProcessTree(pid, "SIGKILL");
+  await waitForExit(pid, waitAfterForceMs);
+}
+
+export function isProcessTreeAlive(pid: number | null | undefined): boolean {
+  if (!pid) return false;
+  try {
+    process.kill(-pid, 0);
+    return true;
+  } catch {
+    // Fall back below.
+  }
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isProcessTreeAlive(pid)) return true;
+    await sleep(100);
+  }
+  return !isProcessTreeAlive(pid);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/src/lifecycle/shutdown.ts
+++ b/src/lifecycle/shutdown.ts
@@ -1,10 +1,8 @@
 import type { SessionManager } from "../session/manager.ts";
-import type { SessionStore } from "../session/store/interface.ts";
 import type { DevServerManager } from "./dev-server.ts";
 
 export function setupGracefulShutdown(
   manager: SessionManager,
-  store: SessionStore,
   devServerManager?: DevServerManager,
   extraShutdown?: () => void | Promise<void>,
 ): void {
@@ -17,14 +15,8 @@ export function setupGracefulShutdown(
     }, 30_000);
 
     try {
-      const sessions = await store.getAll();
       const kills: Promise<void>[] = [];
-
-      for (const [threadId, session] of sessions) {
-        if (session.status === "busy") {
-          kills.push(manager.resetSession(threadId));
-        }
-      }
+      kills.push(manager.terminateActiveRuns("shutdown"));
 
       // Kill all managed dev servers in parallel with session teardown.
       if (devServerManager) {

--- a/src/opencode/spawner.ts
+++ b/src/opencode/spawner.ts
@@ -15,6 +15,7 @@ import {
 } from "./parser.ts";
 import { buildOpenCodeAgentPrompt, OPENCODE_PROVIDER_AGENT } from "./prompt.ts";
 import { loadOpenCodeSupportSubagents } from "./support-agents.ts";
+import { signalProcessTree } from "../lifecycle/process-tree.ts";
 
 export interface OpenCodeEnvContext {
   session: ThreadSession;
@@ -109,6 +110,7 @@ export function spawnOpenCode(
     stderr: "pipe",
     stdin: "ignore",
     env,
+    detached: true,
   });
 
   const listeners: Array<(event: RunnerEvent) => void> = [];
@@ -159,7 +161,7 @@ export function spawnOpenCode(
       listeners.push(cb);
     },
     kill: (signal) => {
-      signal ? proc.kill(signal) : proc.kill();
+      signalProcessTree(proc.pid, signal ?? "SIGTERM");
     },
     pid: proc.pid,
   };

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -594,7 +594,7 @@ describe("SessionManager", () => {
     await manager.terminateActiveRuns("shutdown");
 
     const session = (await store.get("thread-1"))!;
-    expect(killSignals).toContain("SIGINT");
+    expect(killSignals).toEqual(["SIGINT"]);
     expect(session.sessionId).toBe("claude-live-1");
     expect(session.leadSessionId).toBe("claude-live-1");
     expect(session.status).toBe("idle");
@@ -647,7 +647,7 @@ describe("SessionManager", () => {
     expect(session.agentSessions.echo.sessionId).toBe("echo-live-1");
     expect(session.agentSessions.echo.status).toBe("idle");
     expect(session.agentSessions.echo.pid).toBeNull();
-    expect(killSignals).toContain("SIGINT");
+    expect(killSignals).toEqual(["SIGINT"]);
   });
 
   it("does not idle-interrupt opencode when continuity is disabled", async () => {

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -555,6 +555,101 @@ describe("SessionManager", () => {
     expect(session!.sessionId).toBe("claude-session-42");
   });
 
+  it("persists sessionId before completion so shutdown can resume the turn", async () => {
+    const killSignals: Array<string | undefined> = [];
+    const listeners: Array<(event: RunnerEvent) => void> = [];
+    let resolveResult!: (result: SpawnResult) => void;
+    const result = new Promise<SpawnResult>((resolve) => {
+      resolveResult = resolve;
+    });
+    mockSpawnFn = mock(() => ({
+      provider: "claude",
+      result,
+      onEvent: (cb) => listeners.push(cb),
+      kill: (signal) => {
+        killSignals.push(signal);
+        resolveResult({
+          provider: "claude",
+          sessionId: "claude-live-1",
+          response: "",
+          events: [],
+          exitCode: 130,
+          error: "shutdown",
+        });
+      },
+      pid: 43210,
+    }));
+    manager = new SessionManager(
+      store,
+      testConfig,
+      ((...args: Parameters<SpawnRunnerFn>) => mockSpawnFn(...args)) as SpawnRunnerFn,
+    );
+
+    await manager.handleMessage(makeEvent());
+    for (const listener of listeners) {
+      listener({ type: "init", provider: "claude", sessionId: "claude-live-1" });
+    }
+    await waitFor(async () => (await store.get("thread-1"))?.sessionId === "claude-live-1");
+
+    await manager.terminateActiveRuns("shutdown");
+
+    const session = (await store.get("thread-1"))!;
+    expect(killSignals).toContain("SIGINT");
+    expect(session.sessionId).toBe("claude-live-1");
+    expect(session.leadSessionId).toBe("claude-live-1");
+    expect(session.status).toBe("idle");
+    expect(session.pid).toBeNull();
+    expect(session.lastError?.type).toBe("shutdown");
+  });
+
+  it("shutdown terminates busy persistent agents even when top-level session is idle", async () => {
+    const killSignals: Array<string | undefined> = [];
+    const listeners: Array<(event: RunnerEvent) => void> = [];
+    let resolveResult!: (result: SpawnResult) => void;
+    const result = new Promise<SpawnResult>((resolve) => {
+      resolveResult = resolve;
+    });
+    mockSpawnFn = mock(() => ({
+      provider: "opencode",
+      result,
+      onEvent: (cb) => listeners.push(cb),
+      kill: (signal) => {
+        killSignals.push(signal);
+        resolveResult({
+          provider: "opencode",
+          sessionId: "echo-live-1",
+          response: "",
+          events: [],
+          exitCode: 130,
+          error: "shutdown",
+        });
+      },
+      pid: 54321,
+    }));
+    manager = new SessionManager(
+      store,
+      cloneConfig({ runner: { provider: "opencode" } }),
+      ((...args: Parameters<SpawnRunnerFn>) => mockSpawnFn(...args)) as SpawnRunnerFn,
+    );
+
+    await manager.handleAgentMessage(makeEvent({ text: "hello echo" }), "echo");
+    for (const listener of listeners) {
+      listener({ type: "init", provider: "opencode", sessionId: "echo-live-1" });
+    }
+    await waitFor(async () =>
+      (await store.get("thread-1"))?.agentSessions.echo.sessionId === "echo-live-1"
+    );
+
+    await manager.terminateActiveRuns("shutdown");
+
+    const session = (await store.get("thread-1"))!;
+    expect(session.status).toBe("idle");
+    expect(session.agentSessions.echo.sessionId).toBe("echo-live-1");
+    expect(session.agentSessions.echo.status).toBe("idle");
+    expect(session.agentSessions.echo.pid).toBeNull();
+    expect(killSignals).toContain("SIGINT");
+  });
+
   it("does not idle-interrupt opencode when continuity is disabled", async () => {
     const config = cloneConfig({
       runner: { provider: "opencode" },
@@ -1632,6 +1727,47 @@ describe("SessionManager", () => {
         makeEvent({ user: "U-A", text: "hello", ts: "ts-drop" }),
       );
       expect(drop).toBe(true);
+    });
+
+    it("drops messages silently while muted and does not auto-dormant", async () => {
+      await manager.handleMessage(makeEvent({ user: "U-A" }));
+      currentHandle._complete("done");
+      await new Promise((r) => setTimeout(r, 5));
+
+      const seeded = (await store.get("thread-1"))!;
+      seeded.muted = true;
+      await store.set("thread-1", seeded);
+
+      const responses: string[] = [];
+      manager.onCommandResponse = (_e, r) => responses.push(r);
+
+      const drop = await manager.gateAttention(
+        makeEvent({ user: "U-B", text: "side chat", ts: "ts-muted" }),
+      );
+
+      expect(drop).toBe(true);
+      expect(responses).toEqual([]);
+      const after = (await store.get("thread-1"))!;
+      expect(after.muted).toBe(true);
+      expect(after.dormant).toBe(false);
+      expect(after.dormantAnnounced).toBe(false);
+      expect(after.humanParticipants).toEqual(["U-A"]);
+    });
+
+    it("lets !unmute through while muted", async () => {
+      await manager.handleMessage(makeEvent({ user: "U-A" }));
+      currentHandle._complete("done");
+      await new Promise((r) => setTimeout(r, 5));
+
+      const seeded = (await store.get("thread-1"))!;
+      seeded.muted = true;
+      await store.set("thread-1", seeded);
+
+      const drop = await manager.gateAttention(
+        makeEvent({ user: "U-A", command: "unmute", text: "", ts: "ts-unmute" }),
+      );
+
+      expect(drop).toBe(false);
     });
 
     it("triggers dormancy when a second human posts without @mention", async () => {

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -341,17 +341,24 @@ export class SessionManager {
    */
   async terminateActiveRuns(reason = "shutdown"): Promise<void> {
     const handles = [...this.handles.entries()];
+    const unsettledHandles = new Set(handles.map(([, handle]) => handle));
     for (const [key, handle] of handles) {
       this.handles.delete(key);
       handle.kill("SIGINT");
     }
 
     await Promise.race([
-      Promise.allSettled(handles.map(([, handle]) => handle.result)),
+      Promise.allSettled(
+        handles.map(([, handle]) =>
+          handle.result.finally(() => {
+            unsettledHandles.delete(handle);
+          })
+        ),
+      ),
       new Promise((resolve) => setTimeout(resolve, 10_000)),
     ]);
 
-    for (const [, handle] of handles) {
+    for (const handle of unsettledHandles) {
       handle.kill("SIGKILL");
     }
 

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -117,6 +117,7 @@ export class SessionManager {
    * - `!aside` — drop with 👀.
    * - `!listen` — clear dormant (if set) and drop with 👂.
    * - Wake on @mention — clear dormant and fall through to routing.
+   * - Drop everything while muted, except `!unmute`.
    * - Drop everything while dormant.
    * - One-shot auto-dormant trigger when a second human posts without
    *   mentioning Junior. Announcement only fires once per thread (sticky
@@ -151,6 +152,13 @@ export class SessionManager {
     const isAutoTrigger = !!this.config.channelDefaults[event.channel];
 
     const session = await this.store.get(event.threadId);
+
+    // Muted means no thread replies or runner dispatch until an admin sends
+    // !unmute. Check this before auto-dormant so muted threads cannot still
+    // emit the side-conversation notice.
+    if (session?.muted && event.command !== "unmute") {
+      return true;
+    }
 
     // !listen: wake from dormant if needed. Anyone in the thread.
     if (event.command === "listen") {
@@ -324,6 +332,52 @@ export class SessionManager {
       }
     }
     await this.store.delete(threadId);
+  }
+
+  /**
+   * Shutdown path: interrupt live handles but keep the session rows and native
+   * provider session ids. The next Slack turn can resume with --resume/--session
+   * instead of starting from a blank conversation.
+   */
+  async terminateActiveRuns(reason = "shutdown"): Promise<void> {
+    const handles = [...this.handles.entries()];
+    for (const [key, handle] of handles) {
+      this.handles.delete(key);
+      handle.kill("SIGINT");
+    }
+
+    await Promise.race([
+      Promise.allSettled(handles.map(([, handle]) => handle.result)),
+      new Promise((resolve) => setTimeout(resolve, 10_000)),
+    ]);
+
+    for (const [, handle] of handles) {
+      handle.kill("SIGKILL");
+    }
+
+    const sessions = await this.store.getAll();
+    for (const [threadId, session] of sessions) {
+      let mutated = false;
+      if (session.status === "busy" || session.status === "draining" || session.pid !== null) {
+        session.status = "idle";
+        session.pid = null;
+        session.lastError = {
+          type: reason,
+          message: "Junior terminated an in-flight runner; send a new message to resume.",
+          timestamp: Date.now(),
+        };
+        mutated = true;
+      }
+      for (const agentSession of Object.values(session.agentSessions ?? {})) {
+        if (agentSession.status !== "busy" && agentSession.pid === null) continue;
+        agentSession.status = "idle";
+        agentSession.pid = null;
+        mutated = true;
+      }
+      if (mutated) {
+        await this.store.set(threadId, session);
+      }
+    }
   }
 
   /**
@@ -1190,6 +1244,12 @@ export class SessionManager {
             agentSession.sessionId = event.sessionId;
             agentSession.provider = event.provider;
           }
+          void this.persistRunSessionId(
+            session.threadId,
+            agentName,
+            event.provider,
+            event.sessionId,
+          );
         }
         this.onEvent?.(this.buildRunSession(session, agentName, agentIdentity), event);
       });
@@ -1290,6 +1350,12 @@ export class SessionManager {
                 agentSession.sessionId = event.sessionId;
                 agentSession.provider = event.provider;
               }
+              void this.persistRunSessionId(
+                session.threadId,
+                agentName,
+                event.provider,
+                event.sessionId,
+              );
             }
             this.onEvent?.(this.buildRunSession(session, agentName, agentIdentity), event);
           });
@@ -1349,6 +1415,32 @@ export class SessionManager {
       const agentSession = fresh.agentSessions?.[agentName];
       if (agentSession?.status === "busy") {
         agentSession.pid = pid;
+      }
+    }
+
+    await this.store.set(threadId, fresh);
+  }
+
+  private async persistRunSessionId(
+    threadId: string,
+    agentName: string,
+    provider: RunnerProvider,
+    sessionId: string,
+  ): Promise<void> {
+    const fresh = await this.store.get(threadId);
+    if (!fresh) return;
+
+    if (agentName === "lead" || agentName === "default") {
+      if (fresh.status === "busy" || fresh.status === "draining") {
+        fresh.sessionId = sessionId;
+        fresh.leadSessionId = sessionId;
+        fresh.provider = provider;
+      }
+    } else {
+      const agentSession = fresh.agentSessions?.[agentName];
+      if (agentSession?.status === "busy") {
+        agentSession.sessionId = sessionId;
+        agentSession.provider = provider;
       }
     }
 

--- a/src/workflows/executor.test.ts
+++ b/src/workflows/executor.test.ts
@@ -370,6 +370,58 @@ describe("WorkflowExecutor", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it("terminates active workflow runner handles on shutdown", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "junior-workflow-shutdown-test-"));
+    const definition = workflowDefinition(dir);
+    const store = new InMemoryWorkflowStore();
+    const killSignals: Array<string | undefined> = [];
+    let resolveResult!: (result: Awaited<SpawnHandle["result"]>) => void;
+    const spawn: SpawnRunnerFn = (): SpawnHandle => ({
+      provider: "opencode",
+      result: new Promise((resolve) => {
+        resolveResult = resolve;
+      }),
+      onEvent: (cb) => setTimeout(() => cb({
+        type: "init",
+        provider: "opencode",
+        sessionId: "ses-shutdown",
+      }), 0),
+      kill: (signal) => {
+        killSignals.push(signal);
+        resolveResult({
+          provider: "opencode",
+          sessionId: "ses-shutdown",
+          response: "",
+          events: [],
+          exitCode: 130,
+          error: "shutdown",
+        });
+      },
+      pid: 98765,
+    });
+    const executor = new WorkflowExecutor({
+      config: testConfig(),
+      store,
+      spawn,
+      now: () => new Date("2026-05-24T12:00:00.000Z"),
+    });
+
+    try {
+      const runPromise = executor.run({ definition, reason: "manual" }).catch((err) => err);
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      await executor.terminateActiveRuns();
+      const outcome = await runPromise;
+
+      expect(killSignals).toContain("SIGINT");
+      expect(outcome).toBeInstanceOf(Error);
+      const runs = await store.listRuns(definition.name, 1);
+      expect(runs[0]?.providerSessionId).toBe("ses-shutdown");
+      expect(runs[0]?.status).toBe("failed");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 function workflowDefinition(root: string): WorkflowDefinition {

--- a/src/workflows/executor.ts
+++ b/src/workflows/executor.ts
@@ -50,6 +50,7 @@ export class WorkflowExecutor {
   private spawn: SpawnRunnerFn;
   private now: () => Date;
   private memoryStore?: MemoryStore;
+  private activeHandles = new Set<SpawnHandle>();
 
   constructor(options: WorkflowExecutorOptions) {
     this.config = options.config;
@@ -147,6 +148,22 @@ export class WorkflowExecutor {
       await this.store.updateRun(run);
       await this.updateStateAfterRun(request.definition, run);
       throw err;
+    }
+  }
+
+  async terminateActiveRuns(): Promise<void> {
+    const handles = [...this.activeHandles];
+    for (const handle of handles) {
+      handle.kill("SIGINT");
+    }
+    await Promise.race([
+      Promise.allSettled(handles.map((handle) => handle.result)),
+      new Promise((resolve) => setTimeout(resolve, 10_000)),
+    ]);
+    for (const handle of handles) {
+      if (!this.activeHandles.has(handle)) continue;
+      handle.kill("SIGKILL");
+      this.activeHandles.delete(handle);
     }
   }
 
@@ -261,6 +278,7 @@ export class WorkflowExecutor {
       options.prompt,
       this.config,
     );
+    this.activeHandles.add(handle);
     let idleInterrupted = false;
     let idleTimer: ReturnType<typeof setTimeout> | null = null;
     let idleKillTimer: ReturnType<typeof setTimeout> | null = null;
@@ -311,7 +329,10 @@ export class WorkflowExecutor {
       options.runner.timeoutMs ?? this.timeoutFor(options.provider),
       () => handle.kill(),
     );
-    const result = await bounded.result.finally(clearIdleTimer);
+    const result = await bounded.result.finally(() => {
+      clearIdleTimer();
+      this.activeHandles.delete(handle);
+    });
     return { result, idleInterrupted };
   }
 

--- a/src/workflows/scheduler.ts
+++ b/src/workflows/scheduler.ts
@@ -123,6 +123,11 @@ export class WorkflowScheduler {
     this.timers.clear();
   }
 
+  async shutdown(): Promise<void> {
+    this.stop();
+    await this.executor.terminateActiveRuns();
+  }
+
   private async schedule(definition: WorkflowDefinition): Promise<void> {
     this.cancel(definition.name);
     const state = await this.ensureState(definition);


### PR DESCRIPTION
## Summary
- add process-group cleanup helpers and use them for runner/dev-server process trees
- preserve provider session IDs early and reset busy sessions/agents to idle on shutdown for resumption
- stop workflow runners on scheduler shutdown and document the cleanup contract

## Verification
- bun run typecheck
- bun test
- pgrep -xlaf bun (clean)