### PR TITLE
Add internal agent dispatch MCP tool

### DIFF
--- a/src/claude/spawner.ts
+++ b/src/claude/spawner.ts
@@ -129,7 +129,7 @@ export function spawnClaude(
   };
 }
 
-function writeClaudeMcpConfig(session: ThreadSession): string {
+export function writeClaudeMcpConfig(session: ThreadSession): string {
   mkdirSync(MCP_CONFIG_DIR, { recursive: true });
   const agent = session.activeAgentName ?? "default";
   const path = join(MCP_CONFIG_DIR, `${session.threadId}-${agent}.json`);

--- a/src/claude/spawner.ts
+++ b/src/claude/spawner.ts
@@ -1,4 +1,5 @@
-import { resolve } from "node:path";
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join, resolve } from "node:path";
 import type { Config } from "../config.ts";
 import type { AgentIdentity, ThreadSession } from "../session/types.ts";
 import type { ContentBlockToolUse, StreamEvent } from "./types.ts";
@@ -6,9 +7,9 @@ import type { RunnerEvent, SpawnHandle, SpawnResult } from "../runners/types.ts"
 import { buildRunnerRuntime } from "../runners/runtime.ts";
 import { buildClaudeArgs } from "./args.ts";
 import { createStreamParser } from "./parser.ts";
+import { buildSlackMcpUrl } from "../mcp/context.ts";
 
-// Junior's .mcp.json — pass to spawned processes so they find the slack-bot server
-const PROJECT_MCP_CONFIG = resolve(import.meta.dirname ?? ".", "../../.mcp.json");
+const MCP_CONFIG_DIR = resolve(import.meta.dirname ?? ".", "../../data/mcp-configs");
 
 export function spawnClaude(
   session: ThreadSession,
@@ -24,7 +25,7 @@ export function spawnClaude(
     botToken,
     agentIdentity,
   });
-  const mcpConfigPath = runtime.needsProjectMcp ? PROJECT_MCP_CONFIG : undefined;
+  const mcpConfigPath = writeClaudeMcpConfig(session);
   const args = buildClaudeArgs(session, prompt, config, mcpConfigPath);
 
   const proc = Bun.spawn(["claude", ...args], {
@@ -126,6 +127,34 @@ export function spawnClaude(
     },
     pid: proc.pid,
   };
+}
+
+function writeClaudeMcpConfig(session: ThreadSession): string {
+  mkdirSync(MCP_CONFIG_DIR, { recursive: true });
+  const agent = session.activeAgentName ?? "default";
+  const path = join(MCP_CONFIG_DIR, `${session.threadId}-${agent}.json`);
+  const config = {
+    mcpServers: {
+      playwright: {
+        command: "npx",
+        args: ["@playwright/mcp", "--headless"],
+      },
+      "slack-bot": {
+        type: "http",
+        url: buildSlackMcpUrl(session),
+      },
+      mongodb: {
+        type: "stdio",
+        command: "npx",
+        args: ["-y", "mongodb-mcp-server@latest", "--readOnly"],
+        env: {
+          MDB_MCP_CONNECTION_STRING: "${MDB_MCP_CONNECTION_STRING}",
+        },
+      },
+    },
+  };
+  writeFileSync(path, JSON.stringify(config, null, 2));
+  return path;
 }
 
 export function mapClaudeEvent(event: StreamEvent): RunnerEvent[] {

--- a/src/claude/spawner.ts
+++ b/src/claude/spawner.ts
@@ -25,7 +25,9 @@ export function spawnClaude(
     botToken,
     agentIdentity,
   });
-  const mcpConfigPath = writeClaudeMcpConfig(session);
+  const mcpConfigPath = runtime.needsProjectMcp
+    ? writeClaudeMcpConfig(session)
+    : undefined;
   const args = buildClaudeArgs(session, prompt, config, mcpConfigPath);
 
   const proc = Bun.spawn(["claude", ...args], {

--- a/src/claude/tmux-driver.test.ts
+++ b/src/claude/tmux-driver.test.ts
@@ -185,6 +185,30 @@ describe("TmuxDriver with stubbed exec", () => {
     );
   });
 
+  it("does not pass generated MCP config for utility cwd runs", async () => {
+    const { driver, calls } = setup();
+    const cwd = mkdtempSync(join(tmpdir(), "junior-utility-cwd-"));
+    const session = makeSession({
+      cwd,
+      worktreePath: mkdtempSync(join(tmpdir(), "junior-worktree-")),
+      activeAgentName: "lead",
+    });
+
+    const handle = driver.send({
+      session,
+      prompt: "hello",
+      config: claudeConfig(),
+      threadId: session.threadId,
+      agentName: "lead",
+    });
+    await new Promise((r) => setTimeout(r, 50));
+    handle.kill();
+
+    const startCall = calls.find((c) => c.args[0] === "new-session");
+    expect(startCall).toBeDefined();
+    expect(startCall!.args).not.toContain("--mcp-config");
+  });
+
   it("close() invokes kill-session for that (thread, agent)", async () => {
     const { driver, calls } = setup();
     const cwd = mkdtempSync(join(tmpdir(), "junior-cwd-"));

--- a/src/claude/tmux-driver.test.ts
+++ b/src/claude/tmux-driver.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "bun:test";
 import { tmuxSessionNameFor, TmuxDriver } from "./tmux-driver.ts";
-import { mkdtempSync, writeFileSync, mkdirSync, existsSync } from "node:fs";
+import { mkdtempSync, writeFileSync, mkdirSync, existsSync, readFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { ThreadSession } from "../session/types.ts";
@@ -153,6 +153,36 @@ describe("TmuxDriver with stubbed exec", () => {
 
     // Same session — no second new-session call.
     expect(calls.filter((c) => c.args[0] === "new-session").length).toBe(1);
+  });
+
+  it("starts Claude tmux with a per-run contextual MCP config", async () => {
+    const { driver, calls } = setup();
+    const cwd = mkdtempSync(join(tmpdir(), "junior-cwd-"));
+    const session = makeSession({
+      worktreePath: cwd,
+      activeAgentName: "lead",
+    });
+
+    const handle = driver.send({
+      session,
+      prompt: "hello",
+      config: claudeConfig(),
+      threadId: session.threadId,
+      agentName: "lead",
+    });
+    await new Promise((r) => setTimeout(r, 50));
+    handle.kill();
+
+    const startCall = calls.find((c) => c.args[0] === "new-session");
+    expect(startCall).toBeDefined();
+    const mcpArgIndex = startCall!.args.indexOf("--mcp-config");
+    expect(mcpArgIndex).toBeGreaterThan(0);
+
+    const mcpConfigPath = startCall!.args[mcpArgIndex + 1];
+    const mcpConfig = JSON.parse(readFileSync(mcpConfigPath, "utf8"));
+    expect(mcpConfig.mcpServers["slack-bot"].url).toContain(
+      "agent=lead&channel=C01&thread=T-thread1",
+    );
   });
 
   it("close() invokes kill-session for that (thread, agent)", async () => {

--- a/src/claude/tmux-driver.ts
+++ b/src/claude/tmux-driver.ts
@@ -9,6 +9,7 @@ import type { RunnerEvent, SpawnHandle, SpawnResult } from "../runners/types.ts"
 import { buildClaudeArgs } from "./args.ts";
 import { mapClaudeEvent, writeClaudeMcpConfig } from "./spawner.ts";
 import { adaptTranscriptLine } from "./transcript-adapter.ts";
+import { buildRunnerRuntime } from "../runners/runtime.ts";
 
 /**
  * Test seam — let unit tests inject a fake tmux invoker and override the
@@ -306,16 +307,14 @@ export class TmuxDriver implements ClaudeDriver {
       this.sessions.delete(key);
     }
 
-    const cwd = input.session.cwd
-      ?? input.session.worktreePath
-      ?? input.targetRepoCwd
-      ?? process.cwd();
+    const runtime = buildRunnerRuntime(input);
+    const cwd = runtime.cwd;
     mkdirSync(cwd, { recursive: true });
 
     const sessionName = computeSessionName(input.threadId, input.agentName);
     const startedAt = Date.now();
 
-    const claudeArgs = buildInteractiveClaudeArgs(input);
+    const claudeArgs = buildInteractiveClaudeArgs(input, runtime.needsProjectMcp);
     await this.execImpl(this.tmuxBin, [
       "new-session",
       "-d",
@@ -578,14 +577,14 @@ function encodeCwd(cwd: string): string {
   return cwd.replace(/\//g, "-");
 }
 
-function buildInteractiveClaudeArgs(input: DriverSendInput): string[] {
+function buildInteractiveClaudeArgs(input: DriverSendInput, needsProjectMcp: boolean): string[] {
   // Lean on the existing arg builder but strip the `-p <prompt>` and
   // `--output-format` flags — those are headless-only.
   const all = buildClaudeArgs(
     input.session,
     /*prompt*/ "",
     input.config,
-    writeClaudeMcpConfig(input.session),
+    needsProjectMcp ? writeClaudeMcpConfig(input.session) : undefined,
   );
   const out: string[] = [];
   for (let i = 0; i < all.length; i++) {

--- a/src/claude/tmux-driver.ts
+++ b/src/claude/tmux-driver.ts
@@ -7,7 +7,7 @@ import type { ClaudeDriver, DriverMode, DriverSendInput } from "./driver.ts";
 import type { StreamEvent } from "./types.ts";
 import type { RunnerEvent, SpawnHandle, SpawnResult } from "../runners/types.ts";
 import { buildClaudeArgs } from "./args.ts";
-import { mapClaudeEvent } from "./spawner.ts";
+import { mapClaudeEvent, writeClaudeMcpConfig } from "./spawner.ts";
 import { adaptTranscriptLine } from "./transcript-adapter.ts";
 
 /**
@@ -581,7 +581,12 @@ function encodeCwd(cwd: string): string {
 function buildInteractiveClaudeArgs(input: DriverSendInput): string[] {
   // Lean on the existing arg builder but strip the `-p <prompt>` and
   // `--output-format` flags — those are headless-only.
-  const all = buildClaudeArgs(input.session, /*prompt*/ "", input.config);
+  const all = buildClaudeArgs(
+    input.session,
+    /*prompt*/ "",
+    input.config,
+    writeClaudeMcpConfig(input.session),
+  );
   const out: string[] = [];
   for (let i = 0; i < all.length; i++) {
     const arg = all[i];

--- a/src/codex-app-server/config.test.ts
+++ b/src/codex-app-server/config.test.ts
@@ -11,7 +11,7 @@ describe("buildCodexMcpConfig", () => {
     expect(mcp).toMatchObject({
       "slack-bot": {
         transport: "http",
-        url: "http://localhost:3456/mcp",
+        url: expect.stringContaining("http://localhost:3456/mcp?agent=default&channel=c&thread=t"),
       },
       playwright: {
         command: "npx",

--- a/src/codex-app-server/config.ts
+++ b/src/codex-app-server/config.ts
@@ -3,6 +3,7 @@ import { dirname, resolve } from "node:path";
 import type { Config } from "../config.ts";
 import type { ThreadSession } from "../session/types.ts";
 import type { CodexApprovalPolicy, CodexSandbox } from "./policy.ts";
+import { buildSlackMcpUrl } from "../mcp/context.ts";
 
 export interface CodexMcpServerConfig {
   transport?: "http";
@@ -28,7 +29,7 @@ export function buildCodexMcpConfig(
   if (config.codex.slackMcpEnabled && wants("slack-bot")) {
     mcp["slack-bot"] = {
       transport: "http",
-      url: "http://localhost:3456/mcp",
+      url: buildSlackMcpUrl(session),
     };
   }
   if (config.codex.playwrightMcpEnabled && wants("playwright")) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -56,7 +56,7 @@ const agentRouter = new AgentRouter(
 const worktreeManager = new WorktreeManager(config.repos);
 const devServerManager = new DevServerManager(config.repos, worktreeManager);
 const devServerQueue = new DevServerQueue(devServerManager, config.repos);
-startMcpServer(config.slack.botToken, store, worktreeManager);
+startMcpServer(config.slack.botToken, store, worktreeManager, sessionManager);
 sessionManager.agentRouter = agentRouter;
 sessionManager.worktreeManager = worktreeManager;
 sessionManager.slackApp = app;

--- a/src/mcp/context.test.ts
+++ b/src/mcp/context.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "bun:test";
+import { createSession } from "../session/types.ts";
+import { buildSlackMcpUrl, parseSlackMcpRunContext } from "./context.ts";
+
+describe("Slack MCP run context", () => {
+  it("encodes trusted run context in the MCP URL", () => {
+    const session = createSession("thread-1", "C01");
+    session.activeAgentName = "default";
+
+    const parsed = new URL(buildSlackMcpUrl(session));
+
+    expect(parsed.searchParams.get("agent")).toBe("default");
+    expect(parsed.searchParams.get("channel")).toBe("C01");
+    expect(parsed.searchParams.get("thread")).toBe("thread-1");
+  });
+
+  it("parses trusted run context from a request URL", () => {
+    expect(parseSlackMcpRunContext("/mcp?agent=review&channel=C01&thread=thread-1")).toEqual({
+      agent: "review",
+      channel: "C01",
+      threadId: "thread-1",
+    });
+  });
+
+  it("fails closed when context is incomplete", () => {
+    expect(parseSlackMcpRunContext("/mcp?agent=review&channel=C01")).toBeNull();
+  });
+});

--- a/src/mcp/context.ts
+++ b/src/mcp/context.ts
@@ -1,0 +1,37 @@
+import type { ThreadSession } from "../session/types.ts";
+
+const MCP_PORT = Number(process.env.MCP_PORT ?? "3456");
+const DEFAULT_SLACK_MCP_URL = `http://localhost:${MCP_PORT}/mcp`;
+
+export interface SlackMcpRunContext {
+  agent: string;
+  channel: string;
+  threadId: string;
+}
+
+export function slackMcpAgentForSession(session: ThreadSession): string {
+  return session.activeAgentName ?? session.topLevelTmuxAgent ?? topLevelAgentForSession(session);
+}
+
+export function buildSlackMcpUrl(session: ThreadSession): string {
+  const url = new URL(process.env.SLACK_MCP_URL ?? DEFAULT_SLACK_MCP_URL);
+  url.searchParams.set("agent", slackMcpAgentForSession(session));
+  url.searchParams.set("channel", session.channel);
+  url.searchParams.set("thread", session.threadId);
+  return url.toString();
+}
+
+export function parseSlackMcpRunContext(requestUrl: string | undefined): SlackMcpRunContext | null {
+  if (!requestUrl) return null;
+  const url = new URL(requestUrl, DEFAULT_SLACK_MCP_URL);
+  const agent = url.searchParams.get("agent")?.trim();
+  const channel = url.searchParams.get("channel")?.trim();
+  const threadId = url.searchParams.get("thread")?.trim();
+  if (!agent || !channel || !threadId) return null;
+  return { agent, channel, threadId };
+}
+
+function topLevelAgentForSession(session: ThreadSession): "lead" | "default" {
+  if (session.defaultAgent === "lead" || session.agentType === "lead") return "lead";
+  return "default";
+}

--- a/src/mcp/slack-server.test.ts
+++ b/src/mcp/slack-server.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { searchAgentDefinitions } from "./slack-server.ts";
+import { createSession } from "../session/types.ts";
+import { resolveMcpCallerAgent, searchAgentDefinitions } from "./slack-server.ts";
 
 describe("MCP agent search", () => {
   it("finds public agent definitions", async () => {
@@ -29,5 +30,45 @@ describe("MCP agent search", () => {
         path: "agents-org/db-executioner.md",
       }),
     );
+  });
+});
+
+describe("MCP agent dispatch caller resolution", () => {
+  it("authenticates the busy top-level caller from session state", () => {
+    const session = createSession("thread-1", "C123", "normal", "claude", "headless");
+    session.status = "busy";
+    session.activeAgentName = "default";
+
+    expect(resolveMcpCallerAgent(session)).toEqual({ ok: true, agent: "default" });
+  });
+
+  it("authenticates the busy persistent-agent caller from session state", () => {
+    const session = createSession("thread-1", "C123", "normal", "claude", "headless");
+    session.agentSessions.review = {
+      agentName: "review",
+      sessionId: null,
+      status: "busy",
+      pendingMessages: [],
+      lastActivity: Date.now(),
+      pid: null,
+    };
+
+    expect(resolveMcpCallerAgent(session)).toEqual({ ok: true, agent: "review" });
+  });
+
+  it("fails closed when caller identity is ambiguous", () => {
+    const session = createSession("thread-1", "C123", "normal", "claude", "headless");
+    session.status = "busy";
+    session.activeAgentName = "default";
+    session.agentSessions.review = {
+      agentName: "review",
+      sessionId: null,
+      status: "busy",
+      pendingMessages: [],
+      lastActivity: Date.now(),
+      pid: null,
+    };
+
+    expect(resolveMcpCallerAgent(session)).toMatchObject({ ok: false });
   });
 });

--- a/src/mcp/slack-server.test.ts
+++ b/src/mcp/slack-server.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { createSession } from "../session/types.ts";
-import { resolveMcpCallerAgent, searchAgentDefinitions } from "./slack-server.ts";
+import { searchAgentDefinitions } from "./slack-server.ts";
 
 describe("MCP agent search", () => {
   it("finds public agent definitions", async () => {
@@ -30,45 +29,5 @@ describe("MCP agent search", () => {
         path: "agents-org/db-executioner.md",
       }),
     );
-  });
-});
-
-describe("MCP agent dispatch caller resolution", () => {
-  it("authenticates the busy top-level caller from session state", () => {
-    const session = createSession("thread-1", "C123", "normal", "claude", "headless");
-    session.status = "busy";
-    session.activeAgentName = "default";
-
-    expect(resolveMcpCallerAgent(session)).toEqual({ ok: true, agent: "default" });
-  });
-
-  it("authenticates the busy persistent-agent caller from session state", () => {
-    const session = createSession("thread-1", "C123", "normal", "claude", "headless");
-    session.agentSessions.review = {
-      agentName: "review",
-      sessionId: null,
-      status: "busy",
-      pendingMessages: [],
-      lastActivity: Date.now(),
-      pid: null,
-    };
-
-    expect(resolveMcpCallerAgent(session)).toEqual({ ok: true, agent: "review" });
-  });
-
-  it("fails closed when caller identity is ambiguous", () => {
-    const session = createSession("thread-1", "C123", "normal", "claude", "headless");
-    session.status = "busy";
-    session.activeAgentName = "default";
-    session.agentSessions.review = {
-      agentName: "review",
-      sessionId: null,
-      status: "busy",
-      pendingMessages: [],
-      lastActivity: Date.now(),
-      pid: null,
-    };
-
-    expect(resolveMcpCallerAgent(session)).toMatchObject({ ok: false });
   });
 });

--- a/src/mcp/slack-server.ts
+++ b/src/mcp/slack-server.ts
@@ -26,7 +26,7 @@ import {
   isPersistentAgent,
   loadOverlayIdentities,
 } from "../support/agents.ts";
-import type { ThreadSession } from "../session/types.ts";
+import { parseSlackMcpRunContext, type SlackMcpRunContext } from "./context.ts";
 
 const MCP_PORT = Number(process.env.MCP_PORT ?? "3456");
 const FALLBACK_AGENTS_DIR = ".claude/agents";
@@ -38,7 +38,7 @@ let sessionStore: SessionStore | undefined;
 let worktreeManager: WorktreeManager | undefined;
 let sessionManager: SessionManager | undefined;
 
-function registerTools(server: McpServer) {
+function registerTools(server: McpServer, runContext: SlackMcpRunContext | null = null) {
   server.registerTool(
     "slack_send_message",
     {
@@ -341,10 +341,6 @@ function registerTools(server: McpServer) {
       if (!sessionManager) {
         return { content: [{ type: "text" as const, text: "Error: session manager not available" }] };
       }
-      if (!sessionStore) {
-        return { content: [{ type: "text" as const, text: "Error: session store not available" }] };
-      }
-
       const targetAgent = agent_name.trim();
       if (!isPersistentAgent(targetAgent)) {
         return {
@@ -357,13 +353,21 @@ function registerTools(server: McpServer) {
         };
       }
 
-      const session = await sessionStore.get(thread_ts);
-      const callerResult = resolveMcpCallerAgent(session);
-      if (!callerResult.ok) {
-        return { content: [{ type: "text" as const, text: `Error: ${callerResult.error}` }] };
+      if (!runContext) {
+        return { content: [{ type: "text" as const, text: "Error: MCP run context missing; cannot authenticate caller" }] };
+      }
+      if (runContext.threadId !== thread_ts || runContext.channel !== channel_id) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: "Error: dispatch target does not match authenticated MCP run context",
+            },
+          ],
+        };
       }
 
-      const caller = callerResult.agent;
+      const caller = runContext.agent;
       const allowed = dispatchableAgentsFor(caller);
       if (!allowed.includes(targetAgent)) {
         return {
@@ -563,40 +567,6 @@ async function withMemoryStore<T>(fn: (memory: ReturnType<typeof createMemorySto
   }
 }
 
-export type McpCallerResolution =
-  | { ok: true; agent: string }
-  | { ok: false; error: string };
-
-export function resolveMcpCallerAgent(
-  session: ThreadSession | undefined,
-): McpCallerResolution {
-  if (!session) {
-    return { ok: false, error: "no session found for thread; cannot authenticate caller" };
-  }
-
-  const candidates: string[] = [];
-  if (session.status === "busy") {
-    candidates.push(session.activeAgentName ?? session.topLevelTmuxAgent ?? topLevelAgentForSession(session));
-  }
-  for (const agentSession of Object.values(session.agentSessions ?? {})) {
-    if (agentSession.status === "busy") candidates.push(agentSession.agentName);
-  }
-
-  const unique = [...new Set(candidates.filter(Boolean))];
-  if (unique.length !== 1) {
-    return {
-      ok: false,
-      error: `could not authenticate exactly one active caller for thread ${session.threadId}; active callers: ${unique.join(", ") || "(none)"}`,
-    };
-  }
-  return { ok: true, agent: unique[0] };
-}
-
-function topLevelAgentForSession(session: ThreadSession): "lead" | "default" {
-  if (session.defaultAgent === "lead" || session.agentType === "lead") return "lead";
-  return "default";
-}
-
 interface SearchAgentDefinitionsOptions {
   query?: string;
   includePublic: boolean;
@@ -690,7 +660,7 @@ export function startMcpServer(
     // Each request gets its own transport (stateless mode).
     // Tools are registered fresh but share the same WebClient.
     const mcpServer = new McpServer({ name: "slack-bot", version: "0.1.0" });
-    registerTools(mcpServer);
+    registerTools(mcpServer, parseSlackMcpRunContext(req.url));
 
     const transport = new StreamableHTTPServerTransport({
       sessionIdGenerator: undefined, // stateless

--- a/src/mcp/slack-server.ts
+++ b/src/mcp/slack-server.ts
@@ -18,10 +18,12 @@ import { loadAgentDefinition } from "../agents/loader.ts";
 import { log } from "../logger.ts";
 import { createMemoryStore } from "../memory/factory.ts";
 import type { SessionStore } from "../session/store/interface.ts";
+import type { SessionManager } from "../session/manager.ts";
 import type { WorktreeManager } from "../worktree/manager.ts";
 import {
   AGENT_IDENTITIES,
   dispatchableAgentsFor,
+  isPersistentAgent,
   loadOverlayIdentities,
 } from "../support/agents.ts";
 
@@ -33,6 +35,7 @@ const MEMORY_DB_PATH = process.env.MEMORY_DB_PATH ?? "data/memory.db";
 let slack: WebClient;
 let sessionStore: SessionStore | undefined;
 let worktreeManager: WorktreeManager | undefined;
+let sessionManager: SessionManager | undefined;
 
 function registerTools(server: McpServer) {
   server.registerTool(
@@ -320,6 +323,78 @@ function registerTools(server: McpServer) {
   );
 
   server.registerTool(
+    "agent_dispatch",
+    {
+      description:
+        "Internally dispatch a prompt to a registered Junior persistent agent in a Slack thread without posting a Slack !<agent> directive.",
+      inputSchema: {
+        agent_name: z.string().describe("Target persistent agent name, e.g. review, thinker, reproducer"),
+        prompt: z.string().describe("Prompt to send to the agent"),
+        channel_id: z.string().describe("Slack channel ID for the thread context"),
+        thread_ts: z.string().describe("Slack thread timestamp / session key"),
+        source_agent: z.string().optional().describe("Calling agent name for dispatch-allow enforcement (default: default)"),
+        user_id: z.string().optional().describe("User id to record on the synthetic internal event (default: mcp-internal)"),
+        trigger_ts: z.string().optional().describe("Slack message timestamp that caused the dispatch. Defaults to thread_ts."),
+      },
+    },
+    async ({ agent_name, prompt, channel_id, thread_ts, source_agent, user_id, trigger_ts }) => {
+      if (!sessionManager) {
+        return { content: [{ type: "text" as const, text: "Error: session manager not available" }] };
+      }
+
+      const targetAgent = agent_name.trim();
+      if (!isPersistentAgent(targetAgent)) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Error: unknown agent "${targetAgent}". Use agent_search to find registered agents.`,
+            },
+          ],
+        };
+      }
+
+      const caller = source_agent?.trim() || "default";
+      const allowed = dispatchableAgentsFor(caller);
+      if (!allowed.includes(targetAgent)) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `Error: ${caller} is not allowed to dispatch ${targetAgent}. Allowed: ${allowed.join(", ") || "(none)"}.`,
+            },
+          ],
+        };
+      }
+
+      const now = Date.now();
+      await sessionManager.handleAgentMessage(
+        {
+          threadId: thread_ts,
+          channel: channel_id,
+          user: user_id ?? "mcp-internal",
+          text: prompt,
+          ts: trigger_ts ?? thread_ts,
+          command: null,
+          isSelfBot: true,
+          botUsername: AGENT_IDENTITIES[caller]?.username,
+          dedupeKey: `${thread_ts}:mcp:${targetAgent}:${now}`,
+        },
+        targetAgent,
+      );
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({ ok: true, agent: targetAgent, thread: thread_ts }),
+          },
+        ],
+      };
+    },
+  );
+
+  server.registerTool(
     "agent_search",
     {
       description:
@@ -561,10 +636,12 @@ export function startMcpServer(
   botToken: string,
   store?: SessionStore,
   wtManager?: WorktreeManager,
+  manager?: SessionManager,
 ): void {
   slack = new WebClient(botToken);
   sessionStore = store;
   worktreeManager = wtManager;
+  sessionManager = manager;
 
   const httpServer = createServer(async (req, res) => {
     // Each request gets its own transport (stateless mode).

--- a/src/mcp/slack-server.ts
+++ b/src/mcp/slack-server.ts
@@ -26,6 +26,7 @@ import {
   isPersistentAgent,
   loadOverlayIdentities,
 } from "../support/agents.ts";
+import type { ThreadSession } from "../session/types.ts";
 
 const MCP_PORT = Number(process.env.MCP_PORT ?? "3456");
 const FALLBACK_AGENTS_DIR = ".claude/agents";
@@ -332,14 +333,16 @@ function registerTools(server: McpServer) {
         prompt: z.string().describe("Prompt to send to the agent"),
         channel_id: z.string().describe("Slack channel ID for the thread context"),
         thread_ts: z.string().describe("Slack thread timestamp / session key"),
-        source_agent: z.string().optional().describe("Calling agent name for dispatch-allow enforcement (default: default)"),
         user_id: z.string().optional().describe("User id to record on the synthetic internal event (default: mcp-internal)"),
         trigger_ts: z.string().optional().describe("Slack message timestamp that caused the dispatch. Defaults to thread_ts."),
       },
     },
-    async ({ agent_name, prompt, channel_id, thread_ts, source_agent, user_id, trigger_ts }) => {
+    async ({ agent_name, prompt, channel_id, thread_ts, user_id, trigger_ts }) => {
       if (!sessionManager) {
         return { content: [{ type: "text" as const, text: "Error: session manager not available" }] };
+      }
+      if (!sessionStore) {
+        return { content: [{ type: "text" as const, text: "Error: session store not available" }] };
       }
 
       const targetAgent = agent_name.trim();
@@ -354,7 +357,13 @@ function registerTools(server: McpServer) {
         };
       }
 
-      const caller = source_agent?.trim() || "default";
+      const session = await sessionStore.get(thread_ts);
+      const callerResult = resolveMcpCallerAgent(session);
+      if (!callerResult.ok) {
+        return { content: [{ type: "text" as const, text: `Error: ${callerResult.error}` }] };
+      }
+
+      const caller = callerResult.agent;
       const allowed = dispatchableAgentsFor(caller);
       if (!allowed.includes(targetAgent)) {
         return {
@@ -552,6 +561,40 @@ async function withMemoryStore<T>(fn: (memory: ReturnType<typeof createMemorySto
   } finally {
     memory.close();
   }
+}
+
+export type McpCallerResolution =
+  | { ok: true; agent: string }
+  | { ok: false; error: string };
+
+export function resolveMcpCallerAgent(
+  session: ThreadSession | undefined,
+): McpCallerResolution {
+  if (!session) {
+    return { ok: false, error: "no session found for thread; cannot authenticate caller" };
+  }
+
+  const candidates: string[] = [];
+  if (session.status === "busy") {
+    candidates.push(session.activeAgentName ?? session.topLevelTmuxAgent ?? topLevelAgentForSession(session));
+  }
+  for (const agentSession of Object.values(session.agentSessions ?? {})) {
+    if (agentSession.status === "busy") candidates.push(agentSession.agentName);
+  }
+
+  const unique = [...new Set(candidates.filter(Boolean))];
+  if (unique.length !== 1) {
+    return {
+      ok: false,
+      error: `could not authenticate exactly one active caller for thread ${session.threadId}; active callers: ${unique.join(", ") || "(none)"}`,
+    };
+  }
+  return { ok: true, agent: unique[0] };
+}
+
+function topLevelAgentForSession(session: ThreadSession): "lead" | "default" {
+  if (session.defaultAgent === "lead" || session.agentType === "lead") return "lead";
+  return "default";
 }
 
 interface SearchAgentDefinitionsOptions {

--- a/src/runners/index.ts
+++ b/src/runners/index.ts
@@ -6,6 +6,7 @@ import { spawnOpenCodeSdk } from "../opencode/sdk-provider.ts";
 import { spawnCodexAppServer } from "../codex-app-server/spawner.ts";
 import type { OpenCodeMcpConfig } from "../opencode/config.ts";
 import type { SpawnHandle } from "./types.ts";
+import { buildSlackMcpUrl } from "../mcp/context.ts";
 
 export function sessionProvider(
   session: ThreadSession,
@@ -108,7 +109,7 @@ export function buildOpenCodeMcpConfig(
   if (config.opencode.slackMcpEnabled) {
     mcp["slack-bot"] = {
       type: "remote",
-      url: "http://localhost:3456/mcp",
+      url: buildSlackMcpUrl(session),
       enabled: true,
     };
   }

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -288,6 +288,8 @@ export class SessionManager {
     }
 
     session.status = "busy";
+    session.activeAgentName = agentName;
+    session.slackIdentity = identityForAgent(agentName);
     session.lastActivity = Date.now();
     await this.store.set(session.threadId, session);
 


### PR DESCRIPTION
## Summary
- add `agent_dispatch` to the Slack MCP server for direct persistent-agent dispatch without Slack directive posts
- pass `SessionManager` into the MCP server so the tool can call `handleAgentMessage`
- enforce existing dispatch allow-list before spawning the target agent

## Verification
- `bun test src/mcp/slack-server.test.ts`
- `bun run typecheck`