### PR TITLE
Wire onboarding agent dispatch context

### DIFF
--- a/.claude/agents/common/core.md
+++ b/.claude/agents/common/core.md
@@ -10,6 +10,17 @@ Before responding, classify the user's message:
 
 If action is required, do the action. Do not only describe how to do it.
 
+## Memory recall first
+
+For every substantive task, call `memory_recall` before answering or acting when the tool is available. Use the user's request as the query, add relevant repo/product tags when obvious, and read the returned snippets as prior operating context. If no relevant memory is returned, proceed normally and do not mention the empty recall unless it matters.
+
+Use memory especially before:
+
+- routing to another agent
+- answering repo setup, env, credential, workflow, or onboarding questions
+- touching production-connected scripts or data
+- repeating a workflow that Junior may have learned from earlier corrections
+
 Common implicit actions:
 
 | User shape | Required action |

--- a/.claude/agents/common/runtime-environment.md
+++ b/.claude/agents/common/runtime-environment.md
@@ -35,7 +35,7 @@ The active dev config and any production-like fallback paths (e.g. `/etc/hosts` 
 
 Pre-loaded — do NOT `ToolSearch` for them:
 
-- **Slack bot** (HTTP MCP, runs in junior's process): `slack_send_message`, `slack_read_thread`, `slack_read_channel`, `slack_search`, `slack_search_users`, `slack_upload_file`. Primary write path for posting to Slack. Pass `username` + `icon_emoji` per `AGENT_IDENTITIES` so attribution is correct.
+- **Slack bot** (HTTP MCP, runs in junior's process): `slack_send_message`, `slack_send_dm`, `slack_read_thread`, `slack_read_channel`, `slack_search`, `slack_search_users`, `slack_upload_file`. Primary write paths for posting to Slack: use `slack_send_message` for channels/threads and `slack_send_dm` for direct messages by Slack user ID. Pass `username` + `icon_emoji` per `AGENT_IDENTITIES` so attribution is correct.
 - **MongoDB (read-only)**: `mcp__mongodb__find`, `mcp__mongodb__aggregate`, `mcp__mongodb__count`, `mcp__mongodb__collection-schema`, `mcp__mongodb__list-collections`, `mcp__mongodb__list-databases`. Use to verify data shape during research / reproduction. NEVER mutate.
 - **Playwright** (browser automation, reproducer's primary tool): `mcp__playwright__browser_navigate`, `browser_click`, `browser_type`, `browser_snapshot`, `browser_take_screenshot`, `browser_console_messages`, `browser_network_requests`, `browser_evaluate`, `browser_wait_for`, `browser_navigate_back`, `browser_fill_form`, `browser_close`.
 

--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -44,6 +44,7 @@ Junior main process
 | Tool | Slack API | Purpose |
 |---|---|---|
 | `slack_send_message` | `chat.postMessage` | Send/reply in channels and threads as the bot |
+| `slack_send_dm` | `conversations.open` + `chat.postMessage` | Open a DM by Slack user ID and send as the bot |
 | `slack_read_channel` | `conversations.history` | Read recent channel messages |
 | `slack_read_thread` | `conversations.replies` | Read thread replies |
 | `slack_search` | `search.messages` | Search across channels (requires `search:read` scope) |

--- a/src/mcp/slack-server.test.ts
+++ b/src/mcp/slack-server.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { searchAgentDefinitions } from "./slack-server.ts";
+import { searchAgentDefinitions, sendSlackDirectMessage } from "./slack-server.ts";
 
 describe("MCP agent search", () => {
   it("finds public agent definitions", async () => {
@@ -29,5 +29,47 @@ describe("MCP agent search", () => {
         path: "agents-org/db-executioner.md",
       }),
     );
+  });
+});
+
+describe("MCP Slack DM helper", () => {
+  it("opens a DM channel before posting to a user", async () => {
+    const calls: unknown[] = [];
+    const client = {
+      conversations: {
+        open: async (args: unknown) => {
+          calls.push(["open", args]);
+          return { channel: { id: "D123" } };
+        },
+      },
+      chat: {
+        postMessage: async (args: unknown) => {
+          calls.push(["postMessage", args]);
+          return { ts: "123.456" };
+        },
+      },
+    };
+
+    await expect(
+      sendSlackDirectMessage(client, {
+        userId: "U123",
+        text: "secret",
+        username: "Onboarding Guide",
+        iconEmoji: ":compass:",
+      }),
+    ).resolves.toEqual({ channelId: "D123", ts: "123.456" });
+
+    expect(calls).toEqual([
+      ["open", { users: "U123", return_im: true }],
+      [
+        "postMessage",
+        {
+          channel: "D123",
+          text: "secret",
+          username: "Onboarding Guide",
+          icon_emoji: ":compass:",
+        },
+      ],
+    ]);
   });
 });

--- a/src/mcp/slack-server.ts
+++ b/src/mcp/slack-server.ts
@@ -69,6 +69,50 @@ function registerTools(server: McpServer, runContext: SlackMcpRunContext | null 
   );
 
   server.registerTool(
+    "slack_send_dm",
+    {
+      description: "Send a direct message to a Slack user ID as Junior (the bot). Opens the DM channel first.",
+      inputSchema: {
+        user_id: z.string().describe("Slack user ID to DM, e.g. U03PNSJ33S5"),
+        text: z.string().describe("Message text (supports Slack mrkdwn formatting)"),
+        username: z.string().optional().describe("Optional display name for this bot message"),
+        icon_emoji: z.string().optional().describe("Optional emoji icon for this bot message"),
+      },
+    },
+    async ({ user_id, text, username, icon_emoji }) => {
+      try {
+        const result = await sendSlackDirectMessage(slack, {
+          userId: user_id,
+          text,
+          username,
+          iconEmoji: icon_emoji,
+        });
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: `DM sent (channel: ${result.channelId}, ts: ${result.ts})`,
+            },
+          ],
+        };
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        if (msg.includes("missing_scope") || msg.includes("not_allowed")) {
+          return {
+            content: [
+              {
+                type: "text" as const,
+                text: "Error: Bot token lacks permission to open or post DMs. Required Slack scopes include im:write and chat:write.",
+              },
+            ],
+          };
+        }
+        throw err;
+      }
+    },
+  );
+
+  server.registerTool(
     "slack_read_channel",
     {
       description: "Read recent messages from a Slack channel (newest first).",
@@ -556,6 +600,48 @@ function registerTools(server: McpServer, runContext: SlackMcpRunContext | null 
       });
     },
   );
+}
+
+interface SlackDirectMessageClient {
+  conversations: {
+    open: (args: { users: string; return_im: boolean }) => Promise<{ channel?: { id?: string } }>;
+  };
+  chat: {
+    postMessage: (args: {
+      channel: string;
+      text: string;
+      username?: string;
+      icon_emoji?: string;
+    }) => Promise<{ ts?: string }>;
+  };
+}
+
+export async function sendSlackDirectMessage(
+  client: SlackDirectMessageClient,
+  options: {
+    userId: string;
+    text: string;
+    username?: string;
+    iconEmoji?: string;
+  },
+): Promise<{ channelId: string; ts: string | undefined }> {
+  const opened = await client.conversations.open({
+    users: options.userId,
+    return_im: true,
+  });
+  const channelId = opened.channel?.id;
+  if (!channelId) {
+    throw new Error(`Slack did not return a DM channel for user ${options.userId}`);
+  }
+
+  const result = await client.chat.postMessage({
+    channel: channelId,
+    text: options.text,
+    ...(options.username ? { username: options.username } : {}),
+    ...(options.iconEmoji ? { icon_emoji: options.iconEmoji } : {}),
+  });
+
+  return { channelId, ts: result.ts };
 }
 
 async function withMemoryStore<T>(fn: (memory: ReturnType<typeof createMemoryStore>) => Promise<T>): Promise<T> {


### PR DESCRIPTION
## Summary
- require agents to use memory recall for substantive work, especially routing/setup/env/onboarding questions
- add `slack_send_dm`, a Slack MCP helper that opens a DM by user ID before posting
- document the DM tool in runtime/MCP docs
- update the private agents submodule to include onboarding and credential-agent DM prompt fixes

## Verification
- bun test src/support/router.test.ts src/support/agents.test.ts src/agents/loader.test.ts src/agents/router.test.ts
- bun test src/mcp/slack-server.test.ts src/agents/loader.test.ts src/support/agents.test.ts src/agents/router.test.ts
- bun run typecheck
- loaded onboarding/admin-account/onboard-member through Junior agent loader
- Codex app-server smoke: plain onboarding question -> default Junior emitted !onboarding -> dispatcher targeted onboarding

## Related
- Includes GrowthX-Club/junior-private-agents#4
- Depends on GrowthX-Club/junior-private-agents#5 for the submodule pointer update