### PR TITLE
Support image URL icons for agents

### DIFF
--- a/docs/code_index/agent-routing.md
+++ b/docs/code_index/agent-routing.md
@@ -80,7 +80,7 @@ Missing flags default to `true`. Invalid values fall back to default (silent typ
 
 ### Agent identity in frontmatter
 
-`username:` + `iconEmoji:` declare the slack identity of overlay/private agents. Loaded by `loadOverlayIdentities` (see `persistent-agents.md`). Both fields required; partial declarations are ignored.
+`username:` + `iconEmoji:` or `imageUrl:` declare the slack identity of overlay/private agents. Loaded by `loadOverlayIdentities` (see `persistent-agents.md`). Username plus one visual field is required; partial declarations are ignored.
 
 ## Dependencies
 

--- a/docs/code_index/claude-spawner.md
+++ b/docs/code_index/claude-spawner.md
@@ -53,6 +53,7 @@ Bun.spawn(["claude", ...args], { cwd, env })
 | `JUNIOR_AGENT_NAME` | `session.activeAgentName ?? "lead"` |
 | `JUNIOR_SLACK_USERNAME` | From `agentIdentity` (when present) |
 | `JUNIOR_SLACK_ICON_EMOJI` | From `agentIdentity` (when present) |
+| `JUNIOR_SLACK_ICON_URL` | From `agentIdentity.imageUrl` (when present and no emoji icon is set) |
 | `SLACK_BOT_TOKEN` | When `botToken` arg passed — enables `bin/slack-upload.sh` |
 
 ### MCP config injection

--- a/docs/code_index/persistent-agents.md
+++ b/docs/code_index/persistent-agents.md
@@ -66,7 +66,7 @@ Handled by `AgentDispatcher`, not by spawning Claude. `acquire` calls `DevServer
 
 ### Overlay identities
 
-Private/org agents register slack identities via frontmatter (`username:` + `iconEmoji:`) in `agents-org/*.md`. Loaded at startup by `loadOverlayIdentities`. Core identities can't be overwritten — overlay can only add new names.
+Private/org agents register slack identities via frontmatter (`username:` + `iconEmoji:` or `imageUrl:`) in `agents-org/*.md`. Loaded at startup by `loadOverlayIdentities`. Core identities can't be overwritten — overlay can only add new names.
 
 ## Dependencies
 

--- a/docs/features/claude-spawner.md
+++ b/docs/features/claude-spawner.md
@@ -27,7 +27,7 @@ Conditional:
 - `cwd` precedence: `session.cwd` (utility commands) -> `session.worktreePath` (per-thread worktree, see [worktree-manager](worktree-manager.md)) -> `targetRepoCwd` -> `process.cwd()`
 - If `session.cwd` is set, it's `mkdirSync`'d first (e.g. `/tmp/junior-utility` for `!adhoc` / `!bugs`). This keeps utility commands away from any project `CLAUDE.md`.
 - `--mcp-config` points at junior's `.mcp.json` (so worktrees can reach the slack-bot MCP server, see [mcp-server](mcp-server.md)). Skipped when `session.cwd` is an override — utility commands rely on cloud integrations, not local MCP.
-- Env passed to child: `JUNIOR_SPAWNED=1`, `SLACK_CHANNEL`, `SLACK_THREAD_TS`, `JUNIOR_AGENT_NAME`, optional `JUNIOR_SLACK_USERNAME` / `JUNIOR_SLACK_ICON_EMOJI` (per-agent identity for [mcp-server](mcp-server.md) postings, see [thread-context](thread-context.md)), and `SLACK_BOT_TOKEN` when provided.
+- Env passed to child: `JUNIOR_SPAWNED=1`, `SLACK_CHANNEL`, `SLACK_THREAD_TS`, `JUNIOR_AGENT_NAME`, optional `JUNIOR_SLACK_USERNAME` plus optional `JUNIOR_SLACK_ICON_EMOJI` or `JUNIOR_SLACK_ICON_URL` (per-agent identity for [mcp-server](mcp-server.md) postings, see [thread-context](thread-context.md)), and `SLACK_BOT_TOKEN` when provided.
 
 Process is `Bun.spawn(["claude", ...args])` with piped stdout/stderr. `kill()` forwards to the child; lifecycle (timeout, zombie cleanup) lives in [process-lifecycle](process-lifecycle.md).
 

--- a/docs/features/codex-runner.md
+++ b/docs/features/codex-runner.md
@@ -18,7 +18,7 @@ We want Junior to be able to run Codex as well, without forking the whole app or
 Junior's Claude-specific behavior lives primarily in `src/claude`:
 
 - `args.ts` builds `claude` flags: `-p`, `--output-format stream-json`, `--verbose`, `--max-turns`, `--resume`, `--append-system-prompt`, `--model`, `--permission-mode`, `--mcp-config`.
-- `spawner.ts` starts `claude`, selects cwd, injects Slack env (`SLACK_BOT_TOKEN`, `SLACK_CHANNEL`, `SLACK_THREAD_TS`) plus Junior env (`JUNIOR_SPAWNED=1`, `JUNIOR_AGENT_NAME`, identity vars `JUNIOR_SLACK_USERNAME` / `JUNIOR_SLACK_ICON_EMOJI`), parses stdout, captures session ID and final response.
+- `spawner.ts` starts `claude`, selects cwd, injects Slack env (`SLACK_BOT_TOKEN`, `SLACK_CHANNEL`, `SLACK_THREAD_TS`) plus Junior env (`JUNIOR_SPAWNED=1`, `JUNIOR_AGENT_NAME`, identity vars `JUNIOR_SLACK_USERNAME` plus `JUNIOR_SLACK_ICON_EMOJI` or `JUNIOR_SLACK_ICON_URL`), parses stdout, captures session ID and final response.
 - `parser.ts` parses Claude JSONL events.
 - `types.ts` defines the event model consumed by session lifecycle and Slack formatting.
 
@@ -134,7 +134,7 @@ Then:
 - Update `SessionManager` to depend on a `spawnRunner()` function rather than `spawnClaude()`.
 - Update Slack formatting to consume normalized `RunnerEventTool` and `RunnerEventMessage`.
 - Keep provider-native raw events inside adapter tests, not in app-level types.
-- The Codex spawner must inject the same env vars the Claude spawner does today: `JUNIOR_SPAWNED`, `JUNIOR_AGENT_NAME`, `JUNIOR_SLACK_USERNAME`, `JUNIOR_SLACK_ICON_EMOJI`, plus the Slack trio. Sub-agents read these to attribute Slack posts; missing them is a silent attribution bug.
+- The Codex spawner must inject the same env vars the Claude spawner does today: `JUNIOR_SPAWNED`, `JUNIOR_AGENT_NAME`, `JUNIOR_SLACK_USERNAME`, `JUNIOR_SLACK_ICON_EMOJI` or `JUNIOR_SLACK_ICON_URL`, plus the Slack trio. Sub-agents read these to attribute Slack posts; missing them is a silent attribution bug.
 
 ## MCP Configuration
 
@@ -303,7 +303,7 @@ Spawn Codex non-interactively.
   - `--sandbox workspace-write` for code worktrees, `--sandbox read-only` for review agents.
   - Supports fresh runs and `exec resume <thread_id> <prompt>`.
   - Sets cwd via spawn cwd plus `-C`.
-  - Injects `JUNIOR_SPAWNED`, `JUNIOR_AGENT_NAME`, `JUNIOR_SLACK_USERNAME`, `JUNIOR_SLACK_ICON_EMOJI`, `SLACK_BOT_TOKEN`, `SLACK_CHANNEL`, `SLACK_THREAD_TS`.
+  - Injects `JUNIOR_SPAWNED`, `JUNIOR_AGENT_NAME`, `JUNIOR_SLACK_USERNAME`, `JUNIOR_SLACK_ICON_EMOJI` or `JUNIOR_SLACK_ICON_URL`, `SLACK_BOT_TOKEN`, `SLACK_CHANNEL`, `SLACK_THREAD_TS`.
   - Honors the `session.cwd` override → no MCP injection (matches Claude carve-out).
   - Captures stderr and non-zero exits like Claude.
 

--- a/docs/features/persistent-agents.md
+++ b/docs/features/persistent-agents.md
@@ -114,7 +114,7 @@ Agent identities for Slack posting (persistent agents only — sub-agents never 
 ```typescript
 const AGENT_IDENTITIES: Record<
   string,
-  { username: string; iconEmoji: string }
+  { username: string; iconEmoji?: string; imageUrl?: string }
 > = {
   // Default Junior — the bot's main face for any-channel @mentions.
   default: { username: "Junior", iconEmoji: ":face_with_cowboy_hat:" },
@@ -126,7 +126,7 @@ const AGENT_IDENTITIES: Record<
   review: { username: "Reviewer", iconEmoji: ":eyes:" },
 };
 // Private / org-specific worker identities are NOT registered here — they
-// declare `username` + `iconEmoji` in their own .md frontmatter and get
+// declare `username` + `iconEmoji` or `imageUrl` in their own .md frontmatter and get
 // merged in at startup by `loadOverlayIdentities` from the org overlay
 // directory. This keeps the public repo free of org-specific agent names.
 ```

--- a/docs/features/runner-providers.md
+++ b/docs/features/runner-providers.md
@@ -122,7 +122,8 @@ adapter re-discovers it independently:
 - **env contract:** every adapter injects the same Junior/Slack env vars:
   `JUNIOR_SPAWNED`, `SLACK_CHANNEL`, `SLACK_THREAD_TS`,
   `JUNIOR_AGENT_NAME`, optional `JUNIOR_SLACK_USERNAME`,
-  optional `JUNIOR_SLACK_ICON_EMOJI`, and optional `SLACK_BOT_TOKEN`.
+  optional `JUNIOR_SLACK_ICON_EMOJI` or `JUNIOR_SLACK_ICON_URL`, and optional
+  `SLACK_BOT_TOKEN`.
 - **identity contract:** missing `JUNIOR_AGENT_NAME` or identity env vars is a
   silent attribution bug for sub-agent Slack posts.
 

--- a/src/agents/loader.test.ts
+++ b/src/agents/loader.test.ts
@@ -84,13 +84,14 @@ body`);
     }
   });
 
-  it("parses optional username + iconEmoji frontmatter fields", async () => {
+  it("parses optional username + iconEmoji/imageUrl frontmatter fields", async () => {
     const tmpPath = path.join(import.meta.dir, "__test_identity_fm.md");
     const content = `---
 name: example-worker
 description: Test
 username: Examplor
 iconEmoji: ":wave:"
+imageUrl: "https://example.com/icon.png"
 ---
 
 body`;
@@ -101,6 +102,7 @@ body`;
       expect(def).not.toBeNull();
       expect(def!.username).toBe("Examplor");
       expect(def!.iconEmoji).toBe(":wave:");
+      expect(def!.imageUrl).toBe("https://example.com/icon.png");
     } finally {
       const fs = await import("node:fs/promises");
       await fs.unlink(tmpPath).catch(() => {});

--- a/src/agents/loader.ts
+++ b/src/agents/loader.ts
@@ -59,12 +59,14 @@ export interface AgentDefinition {
   permissions: AgentPermissions;
   /**
    * Optional slack identity declared in frontmatter. Lets private/overlay
-   * agents register their visual identity (username + emoji) without
-   * touching the public AGENT_IDENTITIES literal. Both fields must be
-   * present to take effect; a partial declaration is ignored.
+   * agents register their visual identity (username + emoji/image URL)
+   * without touching the public AGENT_IDENTITIES literal. Username plus at
+   * least one visual field must be present to take effect; a partial
+   * declaration is ignored.
    */
   username: string | null;
   iconEmoji: string | null;
+  imageUrl: string | null;
 }
 
 export async function loadAgentDefinition(
@@ -88,6 +90,7 @@ export async function loadAgentDefinition(
     permissions: readAgentPermissions(frontmatter),
     username: frontmatter["username"] ?? null,
     iconEmoji: frontmatter["iconEmoji"] ?? null,
+    imageUrl: frontmatter["imageUrl"] ?? frontmatter["iconUrl"] ?? null,
   };
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -230,8 +230,8 @@ setInterval(() => {
 
 (async () => {
   // Load private/overlay agent identities BEFORE accepting events. Each
-  // `agents-org/*.md` files may declare `username` + `iconEmoji` in
-  // frontmatter; those get merged into `AGENT_IDENTITIES` so dispatch,
+  // `agents-org/*.md` files may declare `username` + `iconEmoji`/`imageUrl`
+  // in frontmatter; those get merged into `AGENT_IDENTITIES` so dispatch,
   // `agentForUsername`, and slack posting all see them. Failure is
   // non-fatal — overlay is optional.
   try {

--- a/src/mcp/slack-server.ts
+++ b/src/mcp/slack-server.ts
@@ -50,18 +50,23 @@ function registerTools(server: McpServer, runContext: SlackMcpRunContext | null 
         reply_broadcast: z.boolean().optional().describe("Also post to the channel (for thread replies)"),
         username: z.string().optional().describe("Optional display name for this bot message"),
         icon_emoji: z.string().optional().describe("Optional emoji icon for this bot message"),
+        icon_url: z.string().optional().describe("Optional image URL icon for this bot message"),
+        image_url: z.string().optional().describe("Alias for icon_url"),
       },
     },
-    async ({ text, channel_id, thread_ts, reply_broadcast, username, icon_emoji }) => {
+    async ({ text, channel_id, thread_ts, reply_broadcast, username, icon_emoji, icon_url, image_url }) => {
+      const resolvedIconUrl = icon_url ?? image_url;
       const identity = {
         ...(username ? { username } : {}),
         ...(icon_emoji ? { icon_emoji } : {}),
+        ...(resolvedIconUrl && !icon_emoji ? { icon_url: resolvedIconUrl } : {}),
       };
-      const result = reply_broadcast && thread_ts
-        ? await slack.chat.postMessage({ channel: channel_id, text, thread_ts, reply_broadcast: true, ...identity })
+      const message = reply_broadcast && thread_ts
+        ? { channel: channel_id, text, thread_ts, reply_broadcast: true, ...identity }
         : thread_ts
-          ? await slack.chat.postMessage({ channel: channel_id, text, thread_ts, ...identity })
-          : await slack.chat.postMessage({ channel: channel_id, text, ...identity });
+          ? { channel: channel_id, text, thread_ts, ...identity }
+          : { channel: channel_id, text, ...identity };
+      const result = await slack.chat.postMessage(message as Parameters<typeof slack.chat.postMessage>[0]);
       return {
         content: [{ type: "text" as const, text: `Message sent (ts: ${result.ts})` }],
       };
@@ -77,15 +82,18 @@ function registerTools(server: McpServer, runContext: SlackMcpRunContext | null 
         text: z.string().describe("Message text (supports Slack mrkdwn formatting)"),
         username: z.string().optional().describe("Optional display name for this bot message"),
         icon_emoji: z.string().optional().describe("Optional emoji icon for this bot message"),
+        icon_url: z.string().optional().describe("Optional image URL icon for this bot message"),
+        image_url: z.string().optional().describe("Alias for icon_url"),
       },
     },
-    async ({ user_id, text, username, icon_emoji }) => {
+    async ({ user_id, text, username, icon_emoji, icon_url, image_url }) => {
       try {
         const result = await sendSlackDirectMessage(slack, {
           userId: user_id,
           text,
           username,
           iconEmoji: icon_emoji,
+          imageUrl: icon_url ?? image_url,
         });
         return {
           content: [
@@ -607,12 +615,7 @@ interface SlackDirectMessageClient {
     open: (args: { users: string; return_im: boolean }) => Promise<{ channel?: { id?: string } }>;
   };
   chat: {
-    postMessage: (args: {
-      channel: string;
-      text: string;
-      username?: string;
-      icon_emoji?: string;
-    }) => Promise<{ ts?: string }>;
+    postMessage: (args: any) => Promise<{ ts?: string }>;
   };
 }
 
@@ -623,6 +626,7 @@ export async function sendSlackDirectMessage(
     text: string;
     username?: string;
     iconEmoji?: string;
+    imageUrl?: string;
   },
 ): Promise<{ channelId: string; ts: string | undefined }> {
   const opened = await client.conversations.open({
@@ -639,6 +643,7 @@ export async function sendSlackDirectMessage(
     text: options.text,
     ...(options.username ? { username: options.username } : {}),
     ...(options.iconEmoji ? { icon_emoji: options.iconEmoji } : {}),
+    ...(options.imageUrl && !options.iconEmoji ? { icon_url: options.imageUrl } : {}),
   });
 
   return { channelId, ts: result.ts };
@@ -666,7 +671,7 @@ interface AgentSearchResult {
   origin: "private" | "public";
   description: string | null;
   registeredForDispatch: boolean;
-  slackIdentity: { username: string; iconEmoji?: string } | null;
+  slackIdentity: { username: string; iconEmoji?: string; imageUrl?: string } | null;
 }
 
 export async function searchAgentDefinitions(
@@ -705,6 +710,7 @@ export async function searchAgentDefinitions(
           ? {
               username: identity.username,
               ...(identity.iconEmoji ? { iconEmoji: identity.iconEmoji } : {}),
+              ...(identity.imageUrl ? { imageUrl: identity.imageUrl } : {}),
             }
           : null,
       });

--- a/src/runners/runtime.test.ts
+++ b/src/runners/runtime.test.ts
@@ -82,7 +82,20 @@ describe("runner runtime", () => {
     expect(env.JUNIOR_AGENT_NAME).toBe("reviewer");
     expect(env.JUNIOR_SLACK_USERNAME).toBe("Reviewer");
     expect(env.JUNIOR_SLACK_ICON_EMOJI).toBe(":eyes:");
+    expect(env.JUNIOR_SLACK_ICON_URL).toBeUndefined();
     expect(env.SLACK_BOT_TOKEN).toBe("xoxb-test");
+  });
+
+  it("sets JUNIOR_SLACK_ICON_URL for image URL identities", () => {
+    const env = buildRunnerEnv(
+      makeSession({ activeAgentName: "github-access" }),
+      "xoxb-test",
+      { username: "GitHub Access", imageUrl: "https://example.com/icon.png" },
+    );
+
+    expect(env.JUNIOR_SLACK_USERNAME).toBe("GitHub Access");
+    expect(env.JUNIOR_SLACK_ICON_URL).toBe("https://example.com/icon.png");
+    expect(env.JUNIOR_SLACK_ICON_EMOJI).toBeUndefined();
   });
 
   it("omits JUNIOR_SLACK_ICON_EMOJI when identity has no iconEmoji (default agent)", () => {
@@ -99,8 +112,10 @@ describe("runner runtime", () => {
   it("clears inherited Junior Slack identity env when not explicitly set", () => {
     const previousUsername = process.env.JUNIOR_SLACK_USERNAME;
     const previousIcon = process.env.JUNIOR_SLACK_ICON_EMOJI;
+    const previousIconUrl = process.env.JUNIOR_SLACK_ICON_URL;
     process.env.JUNIOR_SLACK_USERNAME = "Stale Agent";
     process.env.JUNIOR_SLACK_ICON_EMOJI = ":face_with_cowboy_hat:";
+    process.env.JUNIOR_SLACK_ICON_URL = "https://example.com/stale.png";
 
     try {
       const defaultEnv = buildRunnerEnv(
@@ -110,6 +125,7 @@ describe("runner runtime", () => {
       );
       expect(defaultEnv.JUNIOR_SLACK_USERNAME).toBe("Junior");
       expect(defaultEnv.JUNIOR_SLACK_ICON_EMOJI).toBeUndefined();
+      expect(defaultEnv.JUNIOR_SLACK_ICON_URL).toBeUndefined();
 
       const noIdentityEnv = buildRunnerEnv(
         makeSession({ activeAgentName: "lead" }),
@@ -117,6 +133,7 @@ describe("runner runtime", () => {
       );
       expect(noIdentityEnv.JUNIOR_SLACK_USERNAME).toBeUndefined();
       expect(noIdentityEnv.JUNIOR_SLACK_ICON_EMOJI).toBeUndefined();
+      expect(noIdentityEnv.JUNIOR_SLACK_ICON_URL).toBeUndefined();
     } finally {
       if (previousUsername === undefined) {
         delete process.env.JUNIOR_SLACK_USERNAME;
@@ -127,6 +144,11 @@ describe("runner runtime", () => {
         delete process.env.JUNIOR_SLACK_ICON_EMOJI;
       } else {
         process.env.JUNIOR_SLACK_ICON_EMOJI = previousIcon;
+      }
+      if (previousIconUrl === undefined) {
+        delete process.env.JUNIOR_SLACK_ICON_URL;
+      } else {
+        process.env.JUNIOR_SLACK_ICON_URL = previousIconUrl;
       }
     }
   });

--- a/src/runners/runtime.ts
+++ b/src/runners/runtime.ts
@@ -59,12 +59,18 @@ export function buildRunnerEnv(
     env.JUNIOR_SLACK_USERNAME = agentIdentity.username;
     if (agentIdentity.iconEmoji) {
       env.JUNIOR_SLACK_ICON_EMOJI = agentIdentity.iconEmoji;
+      delete env.JUNIOR_SLACK_ICON_URL;
+    } else if (agentIdentity.imageUrl) {
+      env.JUNIOR_SLACK_ICON_URL = agentIdentity.imageUrl;
+      delete env.JUNIOR_SLACK_ICON_EMOJI;
     } else {
       delete env.JUNIOR_SLACK_ICON_EMOJI;
+      delete env.JUNIOR_SLACK_ICON_URL;
     }
   } else {
     delete env.JUNIOR_SLACK_USERNAME;
     delete env.JUNIOR_SLACK_ICON_EMOJI;
+    delete env.JUNIOR_SLACK_ICON_URL;
   }
 
   return env;

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -1843,11 +1843,14 @@ export class SessionManager {
     if (systemPrompt) sections.push(systemPrompt);
     if (identity) {
       const isOrchestrator = agentName === "lead" || agentName === "default";
+      const iconInstruction = identity.iconEmoji
+        ? `When posting through slack_send_message, pass username="${identity.username}" and icon_emoji="${identity.iconEmoji}".`
+        : identity.imageUrl
+          ? `When posting through slack_send_message, pass username="${identity.username}" and icon_url="${identity.imageUrl}".`
+          : `When posting through slack_send_message, pass username="${identity.username}". Do NOT set icon_emoji or icon_url — the bot's default profile picture is correct for your role.`;
       const identityPrompt = [
         `You are the "${agentName}" agent in this Slack thread.`,
-        identity.iconEmoji
-          ? `When posting through slack_send_message, pass username="${identity.username}" and icon_emoji="${identity.iconEmoji}".`
-          : `When posting through slack_send_message, pass username="${identity.username}". Do NOT set icon_emoji — the bot's default profile picture is correct for your role.`,
+        iconInstruction,
         // Orchestrators (lead, default Junior) post as Junior's voice and
         // don't append a "by <agent>" suffix — that's a worker convention so
         // humans can tell workers' posts apart from the orchestrator's.

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -67,6 +67,7 @@ export interface AgentSession {
 export interface AgentIdentity {
   username: string;
   iconEmoji?: string;
+  imageUrl?: string;
 }
 
 export type SessionStatus = "idle" | "busy" | "draining";

--- a/src/slack/responder.test.ts
+++ b/src/slack/responder.test.ts
@@ -24,6 +24,7 @@ function mockApp(stubs?: {
       text: string;
       username?: string;
       icon_emoji?: string;
+      icon_url?: string;
     }>;
     delete: Array<{ channel: string; ts: string }>;
     update: Array<{ channel: string; ts: string; text: string }>;
@@ -460,6 +461,23 @@ describe("SlackResponder", () => {
 
       expect(calls.postMessage).toHaveLength(1);
       expect(calls.postMessage[0].username).toBe("Junior");
+      expect(calls.postMessage[0].icon_emoji).toBeUndefined();
+    });
+
+    it("includes icon_url when identity has imageUrl set", async () => {
+      const { app, calls } = mockApp();
+      const responder = new SlackResponder(app);
+
+      await responder.postResponse(
+        "C123",
+        "1234567890.123456",
+        "Hello!",
+        { username: "GitHub Access", imageUrl: "https://example.com/icon.png" },
+      );
+
+      expect(calls.postMessage).toHaveLength(1);
+      expect(calls.postMessage[0].username).toBe("GitHub Access");
+      expect(calls.postMessage[0].icon_url).toBe("https://example.com/icon.png");
       expect(calls.postMessage[0].icon_emoji).toBeUndefined();
     });
   });

--- a/src/slack/responder.ts
+++ b/src/slack/responder.ts
@@ -49,7 +49,7 @@ export class SlackResponder {
     for (let i = 0; i < chunks.length; i++) {
       const chunk = chunks[i];
       try {
-        const result = await this.app.client.chat.postMessage({
+        const message = {
           channel,
           thread_ts: threadTs,
           text: chunk,
@@ -57,9 +57,15 @@ export class SlackResponder {
             ? {
                 username: identity.username,
                 ...(identity.iconEmoji ? { icon_emoji: identity.iconEmoji } : {}),
+                ...(identity.imageUrl && !identity.iconEmoji
+                  ? { icon_url: identity.imageUrl }
+                  : {}),
               }
             : {}),
-        });
+        };
+        const result = await this.app.client.chat.postMessage(
+          message as Parameters<typeof this.app.client.chat.postMessage>[0],
+        );
         log.info(
           "responder",
           `post.ok thread=${threadTs} chunk=${i + 1}/${chunks.length} ts=${result.ts ?? "?"} preview="${preview(chunk)}"`,

--- a/src/support/agents.test.ts
+++ b/src/support/agents.test.ts
@@ -220,7 +220,31 @@ body
     });
   });
 
-  it("skips .md files that declare only one of username/iconEmoji", async () => {
+  it("registers identities that use imageUrl instead of iconEmoji", async () => {
+    await fs.mkdir(tmpDir, { recursive: true });
+    await Bun.write(
+      path.join(tmpDir, "image-worker.md"),
+      `---
+name: image-worker
+description: Test image worker
+username: ImagePerson
+imageUrl: "https://example.com/icon.png"
+---
+
+body
+`,
+    );
+
+    cleanupKeys.push("image-worker");
+    await loadOverlayIdentities(tmpDir);
+
+    expect(AGENT_IDENTITIES["image-worker"]).toEqual({
+      username: "ImagePerson",
+      imageUrl: "https://example.com/icon.png",
+    });
+  });
+
+  it("skips .md files that declare only one identity field", async () => {
     await fs.mkdir(tmpDir, { recursive: true });
     await Bun.write(
       path.join(tmpDir, "half-identity.md"),

--- a/src/support/agents.ts
+++ b/src/support/agents.ts
@@ -11,9 +11,9 @@ import type { AgentIdentity } from "../session/types.ts";
  * of the contract any fork of junior inherits.
  *
  * Private / org-specific workers (e.g. an org-specific worker) register
- * their identities via `username` + `iconEmoji` frontmatter on their `.md`
- * files, loaded at startup by `loadOverlayIdentities` from the org overlay
- * directory. This keeps the public repo free of org-specific names.
+ * their identities via `username` + `iconEmoji` or `imageUrl` frontmatter on
+ * their `.md` files, loaded at startup by `loadOverlayIdentities` from the org
+ * overlay directory. This keeps the public repo free of org-specific names.
  */
 export const AGENT_IDENTITIES: Record<string, AgentIdentity> = {
   // Default Junior — the bot's main face, responds to @mentions in any channel.
@@ -54,11 +54,11 @@ export function registerAgentIdentity(
 
 /**
  * Scan a directory of agent `.md` files (typically the org overlay at
- * `agents-org/`) and register slack identities for any agent that
- * declares both `username` and `iconEmoji` in its frontmatter. Files
- * without those fields are skipped silently — agents are free to declare
- * just a prompt without a slack identity (e.g. they only run as Task-tool
- * sub-agents and never post to slack).
+ * `agents-org/`) and register slack identities for any agent that declares
+ * `username` plus either `iconEmoji` or `imageUrl` in its frontmatter. Files
+ * without those fields are skipped silently — agents are free to declare just
+ * a prompt without a slack identity (e.g. they only run as Task-tool sub-agents
+ * and never post to slack).
  *
  * Idempotent: re-running won't double-register. Call once at startup before
  * any session spawns; the registry is read at call-time by every consumer
@@ -75,7 +75,7 @@ export async function loadOverlayIdentities(dirPath: string): Promise<void> {
       const def = await loadAgentDefinition(`${dirPath}/${entry}`);
       if (!def) continue;
       const hasUsername = !!def.username;
-      const hasIcon = !!def.iconEmoji;
+      const hasIcon = !!def.iconEmoji || !!def.imageUrl;
       // Genuine "no slack identity declared" — fine. Many overlay files are
       // pure prompt with no slack-posting role (Task-tool sub-agents, etc.).
       if (!hasUsername && !hasIcon) continue;
@@ -85,20 +85,21 @@ export async function loadOverlayIdentities(dirPath: string): Promise<void> {
       if (!hasUsername || !hasIcon) {
         log.warn(
           "agents",
-          `loadOverlayIdentities: ${entry} declares ${hasUsername ? "username" : "iconEmoji"} but not ${hasUsername ? "iconEmoji" : "username"} — both fields are required; skipping`,
+          `loadOverlayIdentities: ${entry} declares ${hasUsername ? "username" : "iconEmoji/imageUrl"} but not ${hasUsername ? "iconEmoji/imageUrl" : "username"} — username plus iconEmoji or imageUrl is required; skipping`,
         );
         continue;
       }
       if (!def.name) {
         log.warn(
           "agents",
-          `loadOverlayIdentities: ${entry} declares username + iconEmoji but no name — skipping; add a 'name:' field in frontmatter`,
+          `loadOverlayIdentities: ${entry} declares username + iconEmoji/imageUrl but no name — skipping; add a 'name:' field in frontmatter`,
         );
         continue;
       }
       registerAgentIdentity(def.name, {
         username: def.username!,
-        iconEmoji: def.iconEmoji!,
+        ...(def.iconEmoji ? { iconEmoji: def.iconEmoji } : {}),
+        ...(def.imageUrl ? { imageUrl: def.imageUrl } : {}),
       });
     }
   } catch (err) {


### PR DESCRIPTION
## What
- Adds `imageUrl`/`iconUrl` support for private agent identities.
- Passes image URL identities through Slack posts as `icon_url` while keeping `iconEmoji` support.
- Bumps `agents-org` submodule to the updated `github-access` agent commit.

## Related
- Private agent PR: https://github.com/GrowthX-Club/junior-private-agents/pull/8
- Original GitHub access agent PR: https://github.com/GrowthX-Club/junior-private-agents/pull/7
- Submodule commit: https://github.com/GrowthX-Club/junior-private-agents/commit/853212269d0f1f26746ec7df5eafba4fbbdcc5c7

## Verification
- `bun test src/agents/loader.test.ts src/support/agents.test.ts src/slack/responder.test.ts src/runners/runtime.test.ts src/mcp/slack-server.test.ts`
- `bun run typecheck`