### PR TITLE
Route prose through default agent

### DIFF
--- a/docs/code_index/associative-memory.md
+++ b/docs/code_index/associative-memory.md
@@ -13,7 +13,7 @@
 - `src/memory/ingestion.test.ts` — Tests for live Slack message capture, routing decision capture, and runner result capture.
 - `src/mcp/slack-server.ts` — Exposes `memory_recall` and `memory_consolidate` MCP tools for normal Junior runner sessions.
 - `src/session/manager.ts` — Wires `MemoryIngestor` into live Slack hot path: captures incoming messages, routing decisions, and runner completions via `captureSlackMemory` / `captureRunnerMemory`.
-- `src/support/router.ts` — `AgentDispatcher.memorySuggestedAgent`: recalls routing-memory facts to suggest a persistent agent (e.g., `!build`, `!frontend`) for human messages without explicit directives.
+- `src/support/router.ts` — `AgentDispatcher` records routing decisions through `SessionManager`, but ordinary prose without explicit directives falls through to default/lead routing; memory no longer selects worker agents.
 - `src/workflows/executor.ts` — Runs memory consolidation natively via `MemoryStore` when a workflow is named `memory-consolidation`, bypassing the runner spawn.
 - `src/http/routes/memory.ts` — Dashboard HTTP routes for `GET /api/memory/recall` and `POST /api/memory/consolidate`.
 - `workflows/memory-consolidation.workflow.md` — Operator-triggered workflow shell for the offline V2 consolidation/dreaming pass.
@@ -41,10 +41,10 @@ consolidate()
 CLI / MCP / HTTP / workflow
   -> recall and consolidation are available to workflows/runners without direct DB edits
   -> workflow executor runs memory-consolidation natively through MemoryStore
-memory-suggested routing
-  -> AgentDispatcher calls MemoryStore.recall(routing_memory) for unmatched messages
-  -> top-k routing-memory haystack checked for persistent-agent name mentions
-  -> if matched, dispatches to that agent (e.g., review, build, frontend)
+router decisions
+  -> AgentDispatcher handles explicit !agent / !devserver directives and hard-coded PR-link review requests
+  -> ordinary prose falls through to default Junior or lead based on channel/session defaults
+  -> SessionManager captures the selected route as memory after dispatch; memory does not choose the route
 ```
 
 ## Current scope

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,6 @@ const supportRouter = new AgentDispatcher(sessionManager, supportChannels, {
   sessionStore: store,
   slackClient: app.client,
   repos: config.repos,
-  memoryStore,
 });
 const workflowRegistry = new WorkflowRegistry({
   repos: config.repos,

--- a/src/support/router.test.ts
+++ b/src/support/router.test.ts
@@ -394,20 +394,13 @@ describe("AgentDispatcher", () => {
       handleLeadMessage: mock(async (_event: SlackMessageEvent) => {}),
       handleAgentMessage: mock(async (_event: SlackMessageEvent, _agent: string) => {}),
     };
-    const memoryStore = {
-      recall: mock(async () => {
-        throw new Error("routing memory should not be consulted");
-      }),
-    };
     const router = new AgentDispatcher(
       managerMock as unknown as SessionManager,
       new Set(),
-      { memoryStore: memoryStore as never },
     );
 
     await router.handleMessage(makeEvent({ channel: "C_GENERAL", text: "please look at this PR" }));
 
-    expect(memoryStore.recall).not.toHaveBeenCalled();
     expect(managerMock.handleMessage).toHaveBeenCalledTimes(1);
     expect(managerMock.handleAgentMessage).not.toHaveBeenCalled();
   });
@@ -418,20 +411,13 @@ describe("AgentDispatcher", () => {
       handleLeadMessage: mock(async (_event: SlackMessageEvent) => {}),
       handleAgentMessage: mock(async (_event: SlackMessageEvent, _agent: string) => {}),
     };
-    const memoryStore = {
-      recall: mock(async () => {
-        throw new Error("routing memory should not be consulted");
-      }),
-    };
     const router = new AgentDispatcher(
       managerMock as unknown as SessionManager,
       new Set(),
-      { memoryStore: memoryStore as never },
     );
 
     await router.handleMessage(makeEvent({ channel: "CTECH", text: "<@U0ABKQ4V065>" }));
 
-    expect(memoryStore.recall).not.toHaveBeenCalled();
     expect(managerMock.handleMessage).toHaveBeenCalledTimes(1);
     expect(managerMock.handleAgentMessage).not.toHaveBeenCalled();
   });

--- a/src/support/router.test.ts
+++ b/src/support/router.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, mock } from "bun:test";
 import type { SlackMessageEvent } from "../slack/events.ts";
 import type { SessionManager } from "../session/manager.ts";
 import { parseAgentDirectives, parseDevserverDirective, AgentDispatcher } from "./router.ts";
-import type { MemoryStore } from "../memory/store.ts";
 
 function makeEvent(overrides: Partial<SlackMessageEvent> = {}): SlackMessageEvent {
   return {
@@ -366,39 +365,75 @@ describe("AgentDispatcher", () => {
     );
   });
 
-  it("uses routing memory body even when the memory has a title", async () => {
+  it("routes member onboarding-shaped prose to default", async () => {
+    const managerMock = {
+      handleMessage: mock(async (_event: SlackMessageEvent) => {}),
+      handleLeadMessage: mock(async (_event: SlackMessageEvent) => {}),
+      handleAgentMessage: mock(async (_event: SlackMessageEvent, _agent: string) => {}),
+    };
+    const router = new AgentDispatcher(
+      managerMock as unknown as SessionManager,
+      new Set(["CBUGS"]),
+    );
+
+    await router.handleMessage(
+      makeEvent({
+        channel: "CTECH",
+        text: "<@U_BOT> onboard this member please _id: 6a1fa532c8ac89ad1eee54a6",
+      }),
+    );
+
+    expect(managerMock.handleMessage).toHaveBeenCalledTimes(1);
+    expect(managerMock.handleLeadMessage).not.toHaveBeenCalled();
+    expect(managerMock.handleAgentMessage).not.toHaveBeenCalled();
+  });
+
+  it("routes ordinary prose to default instead of memory-selected workers", async () => {
     const managerMock = {
       handleMessage: mock(async (_event: SlackMessageEvent) => {}),
       handleLeadMessage: mock(async (_event: SlackMessageEvent) => {}),
       handleAgentMessage: mock(async (_event: SlackMessageEvent, _agent: string) => {}),
     };
     const memoryStore = {
-      recall: mock(async () => [
-        {
-          id: "routing-1",
-          kind: "routing_memory",
-          title: "Learned routing memory",
-          body: "Send pull request review requests to review.",
-          outcome: null,
-          score: 1,
-          reasons: [],
-          sourceIds: [],
-        },
-      ]),
-    } as unknown as MemoryStore;
+      recall: mock(async () => {
+        throw new Error("routing memory should not be consulted");
+      }),
+    };
     const router = new AgentDispatcher(
       managerMock as unknown as SessionManager,
       new Set(),
-      { memoryStore },
+      { memoryStore: memoryStore as never },
     );
 
     await router.handleMessage(makeEvent({ channel: "C_GENERAL", text: "please look at this PR" }));
 
-    expect(managerMock.handleAgentMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ dedupeKey: "123.456:review:memory" }),
-      "review",
+    expect(memoryStore.recall).not.toHaveBeenCalled();
+    expect(managerMock.handleMessage).toHaveBeenCalledTimes(1);
+    expect(managerMock.handleAgentMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not use routing memory for mention-only pings", async () => {
+    const managerMock = {
+      handleMessage: mock(async (_event: SlackMessageEvent) => {}),
+      handleLeadMessage: mock(async (_event: SlackMessageEvent) => {}),
+      handleAgentMessage: mock(async (_event: SlackMessageEvent, _agent: string) => {}),
+    };
+    const memoryStore = {
+      recall: mock(async () => {
+        throw new Error("routing memory should not be consulted");
+      }),
+    };
+    const router = new AgentDispatcher(
+      managerMock as unknown as SessionManager,
+      new Set(),
+      { memoryStore: memoryStore as never },
     );
-    expect(managerMock.handleMessage).not.toHaveBeenCalled();
+
+    await router.handleMessage(makeEvent({ channel: "CTECH", text: "<@U0ABKQ4V065>" }));
+
+    expect(memoryStore.recall).not.toHaveBeenCalled();
+    expect(managerMock.handleMessage).toHaveBeenCalledTimes(1);
+    expect(managerMock.handleAgentMessage).not.toHaveBeenCalled();
   });
 
   it("drops self-bot posts with unknown username (no usable identity)", async () => {

--- a/src/support/router.ts
+++ b/src/support/router.ts
@@ -4,7 +4,6 @@ import type { SessionManager } from "../session/manager.ts";
 import type { SessionStore } from "../session/store/interface.ts";
 import type { DevServerQueue } from "../lifecycle/dev-server-queue.ts";
 import type { RepoConfig } from "../config.ts";
-import type { MemoryStore } from "../memory/store.ts";
 import {
   agentForUsername,
   isOrchestratorAgent,
@@ -115,7 +114,6 @@ export class AgentDispatcher {
       sessionStore?: SessionStore;
       slackClient?: WebClient;
       repos?: RepoConfig[];
-      memoryStore?: MemoryStore;
     } = {},
   ) {
     this.manager = manager;

--- a/src/support/router.ts
+++ b/src/support/router.ts
@@ -106,7 +106,6 @@ export class AgentDispatcher {
   private sessionStore: SessionStore | null;
   private slackClient: WebClient | null;
   private repos: RepoConfig[];
-  private memoryStore: MemoryStore | null;
 
   constructor(
     manager: SessionManager,
@@ -125,7 +124,6 @@ export class AgentDispatcher {
     this.sessionStore = opts.sessionStore ?? null;
     this.slackClient = opts.slackClient ?? null;
     this.repos = opts.repos ?? [];
-    this.memoryStore = opts.memoryStore ?? null;
   }
 
   isSupportChannel(channel: string): boolean {
@@ -192,15 +190,6 @@ export class AgentDispatcher {
           ...event,
           dedupeKey: event.dedupeKey ?? `${event.ts}:review:auto`,
         }, "review");
-        return;
-      }
-
-      const memoryAgent = await this.memorySuggestedAgent(event);
-      if (memoryAgent && targetAgent !== "lead") {
-        await this.manager.handleAgentMessage({
-          ...event,
-          dedupeKey: event.dedupeKey ?? `${event.ts}:${memoryAgent}:memory`,
-        }, memoryAgent);
         return;
       }
 
@@ -480,30 +469,6 @@ export class AgentDispatcher {
     }
   }
 
-  private memorySuggestedAgent = (() => {
-    const AGENTS = ["frontend", "review", "build", "architect", "pm", "reproducer", "thinker"] as const;
-    return async function (this: AgentDispatcher, event: SlackMessageEvent): Promise<string | null> {
-      if (!this.memoryStore || event.command || event.isSelfBot) return null;
-      try {
-        const memories = await this.memoryStore.recall({
-          query: event.text,
-          kinds: ["routing_memory"],
-          tags: ["routing_memory", "routing_decision", "learned_correction"],
-          limit: 5,
-          depth: 1,
-        });
-        for (const memory of memories) {
-          const h = `${memory.title ?? ""} ${memory.body}`.toLowerCase();
-          for (const agent of AGENTS) {
-            if (h.includes(agent) && isPersistentAgent(agent)) return agent;
-          }
-        }
-      } catch (err) {
-        log.warn("memory", `routing recall failed thread=${event.threadId}: ${err instanceof Error ? err.message : String(err)}`);
-      }
-      return null;
-    };
-  })();
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- remove memory-based worker auto-routing for ordinary prose
- keep explicit !agent directives and the hard PR-link review route intact
- add regressions for onboarding-shaped prose, ordinary prose, and mention-only pings falling through to default

## Verification
- bun test src/support/router.test.ts
- bun run typecheck