### PR TITLE
Internalize persistent-agent directives from Slack MCP posts

### DIFF
--- a/src/mcp/slack-server.test.ts
+++ b/src/mcp/slack-server.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "bun:test";
-import { searchAgentDefinitions, sendSlackDirectMessage } from "./slack-server.ts";
+import {
+  dispatchAgentDirectivesFromSlackPost,
+  searchAgentDefinitions,
+  sendSlackDirectMessage,
+} from "./slack-server.ts";
 
 describe("MCP agent search", () => {
   it("finds public agent definitions", async () => {
@@ -71,5 +75,52 @@ describe("MCP Slack DM helper", () => {
         },
       ],
     ]);
+  });
+});
+
+describe("MCP Slack agent directive interception", () => {
+  it("ignores normal Slack post text", async () => {
+    await expect(
+      dispatchAgentDirectivesFromSlackPost({
+        text: "normal update",
+        channelId: "C123",
+        threadTs: "111.222",
+        runContext: { agent: "default", channel: "C123", threadId: "111.222" },
+        manager: { handleAgentMessage: async () => undefined },
+      }),
+    ).resolves.toBeNull();
+  });
+
+  it("dispatches pure persistent-agent directives instead of posting them", async () => {
+    const calls: unknown[] = [];
+
+    const result = await dispatchAgentDirectivesFromSlackPost({
+      text: "!review review https://github.com/GrowthX-Club/gx-backend/pull/3199 again",
+      channelId: "C123",
+      threadTs: "111.222",
+      runContext: { agent: "default", channel: "C123", threadId: "111.222" },
+      manager: {
+        handleAgentMessage: async (event, agentName) => {
+          calls.push({ event, agentName });
+        },
+      },
+    });
+
+    expect(JSON.parse(result ?? "{}")).toMatchObject({
+      ok: true,
+      dispatched: ["review"],
+      thread: "111.222",
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      agentName: "review",
+      event: {
+        threadId: "111.222",
+        channel: "C123",
+        text: "review https://github.com/GrowthX-Club/gx-backend/pull/3199 again",
+        isSelfBot: true,
+        botUsername: "Junior",
+      },
+    });
   });
 });

--- a/src/mcp/slack-server.ts
+++ b/src/mcp/slack-server.ts
@@ -26,6 +26,7 @@ import {
   isPersistentAgent,
   loadOverlayIdentities,
 } from "../support/agents.ts";
+import { parsePureAgentDirectiveResponse } from "../support/directives.ts";
 import { parseSlackMcpRunContext, type SlackMcpRunContext } from "./context.ts";
 
 const MCP_PORT = Number(process.env.MCP_PORT ?? "3456");
@@ -55,6 +56,18 @@ function registerTools(server: McpServer, runContext: SlackMcpRunContext | null 
       },
     },
     async ({ text, channel_id, thread_ts, reply_broadcast, username, icon_emoji, icon_url, image_url }) => {
+      const internalDispatch = await dispatchAgentDirectivesFromSlackPost({
+        text,
+        channelId: channel_id,
+        threadTs: thread_ts,
+        runContext,
+      });
+      if (internalDispatch) {
+        return {
+          content: [{ type: "text" as const, text: internalDispatch }],
+        };
+      }
+
       const resolvedIconUrl = icon_url ?? image_url;
       const identity = {
         ...(username ? { username } : {}),
@@ -647,6 +660,63 @@ export async function sendSlackDirectMessage(
   });
 
   return { channelId, ts: result.ts };
+}
+
+export async function dispatchAgentDirectivesFromSlackPost(args: {
+  text: string;
+  channelId: string;
+  threadTs?: string;
+  runContext: SlackMcpRunContext | null;
+  manager?: Pick<SessionManager, "handleAgentMessage">;
+}): Promise<string | null> {
+  const directives = parsePureAgentDirectiveResponse(args.text);
+  if (directives.length === 0) return null;
+
+  const manager = args.manager ?? sessionManager;
+  if (!manager) {
+    return "Error: session manager not available; refused to post persistent-agent directive as Slack text.";
+  }
+  if (!args.threadTs) {
+    return "Error: persistent-agent directives must target a Slack thread; refused to post directive as Slack text.";
+  }
+  if (!args.runContext) {
+    return "Error: MCP run context missing; refused to post persistent-agent directive as Slack text.";
+  }
+  if (args.runContext.threadId !== args.threadTs || args.runContext.channel !== args.channelId) {
+    return "Error: dispatch target does not match authenticated MCP run context; refused to post directive as Slack text.";
+  }
+
+  const caller = args.runContext.agent;
+  const allowedAgents = new Set(dispatchableAgentsFor(caller));
+  const disallowed = directives.find((directive) => !allowedAgents.has(directive.agentName));
+  if (disallowed) {
+    return `Error: ${caller} is not allowed to dispatch ${disallowed.agentName}; refused to post directive as Slack text.`;
+  }
+
+  const sourceIdentity = AGENT_IDENTITIES[caller];
+  const now = Date.now();
+  for (const [index, directive] of directives.entries()) {
+    await manager.handleAgentMessage(
+      {
+        threadId: args.threadTs,
+        channel: args.channelId,
+        user: "mcp-internal",
+        text: directive.prompt,
+        ts: args.threadTs,
+        command: null,
+        isSelfBot: true,
+        botUsername: sourceIdentity?.username,
+        dedupeKey: `${args.threadTs}:mcp-slack-send:${caller}:${directive.agentName}:${index}:${now}`,
+      },
+      directive.agentName,
+    );
+  }
+
+  return JSON.stringify({
+    ok: true,
+    dispatched: directives.map((directive) => directive.agentName),
+    thread: args.threadTs,
+  });
 }
 
 async function withMemoryStore<T>(fn: (memory: ReturnType<typeof createMemoryStore>) => Promise<T>): Promise<T> {

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -579,9 +579,13 @@ describe("SessionManager", () => {
     expect(responses).toEqual(["Here is the answer"]);
   });
 
-  it("suppresses final response that duplicates a Slack MCP post", async () => {
+  it("internalizes duplicated Slack MCP persistent-agent directive posts", async () => {
     const responses: string[] = [];
     manager.onResponse = (_session, response) => responses.push(response);
+
+    const reviewHandle = createMockHandle();
+    const handles = [currentHandle, reviewHandle];
+    mockSpawnFn = mock(() => handles.shift() ?? createMockHandle()) as ReturnType<typeof mock<SpawnRunnerFn>>;
 
     await manager.handleMessage(makeEvent({ text: "dispatch review" }));
     currentHandle._complete("!review check PR 123", undefined, [
@@ -594,11 +598,13 @@ describe("SessionManager", () => {
       },
     ]);
 
-    await new Promise((r) => setTimeout(r, 10));
+    await waitFor(() => mockSpawnFn.mock.calls.length === 2);
 
     const session = await store.get("thread-1");
-    expect(session!.status).toBe("idle");
     expect(responses).toEqual([]);
+    expect(mockSpawnFn.mock.calls[1][1]).toContain("check PR 123");
+    expect(session!.status).toBe("idle");
+    expect(session!.agentSessions.review.status).toBe("busy");
   });
 
   it("continues lead instead of posting leaked observability worker output", async () => {

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -1577,23 +1577,20 @@ export class SessionManager {
       }
     }
 
-    if (result.response && isDuplicateSlackToolResponse(result.response, result.events)) {
-      _log.info(
-        "response",
-        `thread=${fresh.threadId} agent=${agentName} suppressed reason=duplicate-slack-tool-post`,
+    if (result.response) {
+      internalDispatchDirectives = this.allowedInternalDirectivesForResponse(
+        agentName,
+        result.response,
       );
-    } else if (result.response) {
-      const parsedDirectives = parsePureAgentDirectiveResponse(result.response);
-      const allowedAgents = new Set(dispatchableAgentsFor(agentName));
-      internalDispatchDirectives = parsedDirectives.every((directive) =>
-        allowedAgents.has(directive.agentName)
-      )
-        ? parsedDirectives
-        : [];
       if (internalDispatchDirectives.length > 0) {
         _log.info(
           "dispatch",
           `thread=${fresh.threadId} agent=${agentName} internalized directives=${internalDispatchDirectives.map((d) => d.agentName).join(",")}`,
+        );
+      } else if (isDuplicateSlackToolResponse(result.response, result.events)) {
+        _log.info(
+          "response",
+          `thread=${fresh.threadId} agent=${agentName} suppressed reason=duplicate-slack-tool-post`,
         );
       } else {
         this.onResponse?.(
@@ -1659,6 +1656,21 @@ export class SessionManager {
         internalDispatchDirectives,
       );
     }
+  }
+
+  private allowedInternalDirectivesForResponse(
+    sourceAgentName: string,
+    response: string,
+  ): AgentDirective[] {
+    const parsedDirectives = parsePureAgentDirectiveResponse(response);
+    if (parsedDirectives.length === 0) return [];
+
+    const allowedAgents = new Set(dispatchableAgentsFor(sourceAgentName));
+    return parsedDirectives.every((directive) =>
+      allowedAgents.has(directive.agentName)
+    )
+      ? parsedDirectives
+      : [];
   }
 
   private async dispatchInternalAgentDirectives(


### PR DESCRIPTION
## Summary
- intercept pure persistent-agent directives passed through slack_send_message and dispatch them internally instead of posting directive text to Slack
- internalize allowed directive responses before duplicate Slack MCP post suppression
- add coverage for MCP Slack directive interception and duplicated Slack MCP directive posts

## Verification
- bun run typecheck
- bun test
- bun run typecheck
- bun test