### PR TITLE
chore: reword dormant-thread side-conversation notice

### DIFF
--- a/docs/features/thread-commands.md
+++ b/docs/features/thread-commands.md
@@ -124,7 +124,7 @@ The problem this solves: a thread that started with Junior often turns into a hu
 - `!aside [text]` — drop the current message before it reaches any agent. React with 👀 so the user knows it landed; do not spawn Claude. Anyone in the thread. Cheap, no state change.
 
 - **Auto-dormant trigger** — when a human posts a message that does NOT @mention Junior AND at least one other human has already posted in the thread, set `session.dormant = true`, post a single notice to the thread:
-  > Looks like a side conversation. I'll stay out — `@` me or `!listen` to bring me back.
+  > Two people are interacting here, so I’ll stop replying. @ me or use !listen to bring me back.
 
   After that, drop every message in the thread except:
     - `!listen` (wake)

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -1916,7 +1916,7 @@ describe("SessionManager", () => {
       expect(after.humanParticipants).toContain("U-A");
       expect(after.humanParticipants).toContain("U-B");
       expect(responses.length).toBe(1);
-      expect(responses[0]).toContain("side conversation");
+      expect(responses[0]).toBe("Two people are interacting here, so I’ll stop replying. @ me or use !listen to bring me back.");
     });
 
     it("does not trigger when there is only one human participant", async () => {

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -217,7 +217,7 @@ export class SessionManager {
         await this.store.set(event.threadId, session);
         this.onCommandResponse?.(
           event,
-          "Looks like a side conversation. I'll stay out — `@` me or `!listen` to bring me back.",
+          "Two people are interacting here, so I’ll stop replying. @ me or use !listen to bring me back.",
         );
         return true;
       }


### PR DESCRIPTION
## What

Rewords the notice Junior posts when it detects a side conversation (two humans talking) and steps out of a thread.

Before:
> Looks like a side conversation. I'll stay out — `@` me or `!listen` to bring me back.

After:
> Two people are interacting here, so I'll stop replying. @ me or use !listen to bring me back.

## Why

Clearer, less ambiguous phrasing about why the bot went quiet.

## Changes

- `src/session/manager.ts` — the posted message string
- `src/session/manager.test.ts` — assertion updated to exact-match the new copy
- `docs/features/thread-commands.md` — doc example updated

Typecheck green; all 75 session-manager tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)