### PR TITLE
Proxy MongoDB MCP through Junior

### DIFF
--- a/.claude/agents/default.md
+++ b/.claude/agents/default.md
@@ -2,6 +2,7 @@
 name: default
 description: Default Junior orchestrator for broad Slack asks.
 tools: Task, Read, Write, Edit, Bash, Grep, Glob, mcp__slack-bot__slack_send_message, mcp__slack-bot__slack_read_thread, mcp__slack-bot__slack_read_channel, mcp__slack-bot__slack_search, mcp__slack-bot__slack_search_users, mcp__slack-bot__slack_upload_file, mcp__slack-bot__agent_dispatch
+permissions.mcp: mongodb
 common: core,orchestrator-dispatch
 context.threadHistory: true
 context.threadHistoryLimit: 20

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,20 +1,8 @@
 {
   "mcpServers": {
-    "playwright": {
-      "command": "npx",
-      "args": ["@playwright/mcp", "--headless"]
-    },
     "slack-bot": {
       "type": "http",
       "url": "http://localhost:3456/mcp"
-    },
-    "mongodb": {
-      "type": "stdio",
-      "command": "npx",
-      "args": ["-y", "mongodb-mcp-server@latest", "--readOnly"],
-      "env": {
-        "MDB_MCP_CONNECTION_STRING": "${MDB_MCP_CONNECTION_STRING}"
-      }
     }
   }
 }

--- a/bin/junior-mcp-stdio-wrapper.js
+++ b/bin/junior-mcp-stdio-wrapper.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+
+const separator = process.argv.indexOf("--");
+const command = separator === -1 ? [] : process.argv.slice(separator + 1);
+
+if (command.length === 0) {
+  console.error("Usage: junior-mcp-stdio-wrapper.js -- <command> [args...]");
+  process.exit(64);
+}
+
+const { spawn } = await import("node:child_process");
+
+let exiting = false;
+const child = spawn(command[0], command.slice(1), {
+  stdio: ["pipe", "pipe", "pipe"],
+  env: {
+    ...process.env,
+    JUNIOR_MCP_WRAPPED: "1",
+  },
+  detached: true,
+});
+
+process.stdin.pipe(child.stdin);
+child.stdout.pipe(process.stdout);
+child.stderr.pipe(process.stderr);
+
+function signalChild(signal = "SIGTERM") {
+  if (!child.pid) return;
+  try {
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // Already gone.
+    }
+  }
+}
+
+function shutdown(signal = "SIGTERM") {
+  if (exiting) return;
+  exiting = true;
+  signalChild(signal);
+  setTimeout(() => signalChild("SIGKILL"), 2_000).unref();
+}
+
+process.stdin.on("end", () => {
+  child.stdin.end();
+  shutdown("SIGTERM");
+});
+process.stdin.on("close", () => shutdown("SIGTERM"));
+process.on("SIGINT", () => shutdown("SIGINT"));
+process.on("SIGTERM", () => shutdown("SIGTERM"));
+process.on("SIGHUP", () => shutdown("SIGTERM"));
+
+child.on("exit", (code, signal) => {
+  exiting = true;
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 0);
+});
+
+child.on("error", (err) => {
+  console.error(`[junior-mcp-wrapper] ${err.message}`);
+  process.exit(127);
+});

--- a/docs/code_index/mcp-server.md
+++ b/docs/code_index/mcp-server.md
@@ -10,6 +10,8 @@ Shared HTTP MCP server running inside Junior's process. All spawned Claude insta
 |---|---|---|
 | `startMcpServer(botToken, store?, worktreeManager?)` | `slack-server.ts` | Starts HTTP server on `MCP_PORT` (default 3456). Called once from `index.ts`. |
 | `registerTools(server)` (internal) | `slack-server.ts` | Registers Slack, worktree, and agent-registry tools on a fresh `McpServer` per request. |
+| `handleMongoMcpRequest(req, res)` | `mongodb-proxy.ts` | Serves `/mcp/mongodb` as a stateless HTTP MCP proxy to one shared read-only MongoDB stdio backend. |
+| `closeMongoMcpBackend()` | `mongodb-proxy.ts` | Closes the shared backend immediately; also used by the idle TTL. |
 | `searchAgentDefinitions(options)` | `slack-server.ts` | Reads public/private agent markdown files and returns matching definitions plus dispatch registration state. |
 
 ### Tools
@@ -30,7 +32,7 @@ Shared HTTP MCP server running inside Junior's process. All spawned Claude insta
 
 | File | What |
 |---|---|
-| `.mcp.json` | `{ "type": "http", "url": "http://localhost:3456/mcp" }` |
+| `.mcp.json` | Root Claude config contains only Junior's `slack-bot` HTTP MCP. Per-agent generated configs add Playwright/MongoDB as needed. |
 | `.claude/settings.json` | `permissions.allow: ["mcp__slack-bot__*"]` |
 | `src/claude/spawner.ts` | Passes `--mcp-config` for worktree spawns |
 
@@ -38,7 +40,7 @@ Shared HTTP MCP server running inside Junior's process. All spawned Claude insta
 
 ### Stateless per request
 
-Each HTTP request creates a fresh `McpServer` + `StreamableHTTPServerTransport` (`sessionIdGenerator: undefined`). No sessions, no state between requests. All instances share the same `WebClient` (module-level singleton).
+Each HTTP request creates a fresh `McpServer` + `StreamableHTTPServerTransport` (`sessionIdGenerator: undefined`). No sessions, no state between HTTP requests. Slack requests share the same `WebClient` (module-level singleton). MongoDB proxy requests share one lazily started wrapped stdio backend and close it after an idle TTL.
 
 ### Identity model
 

--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -85,9 +85,12 @@ Status pill updates that agents post mid-run go through `slack_send_message` wit
   `OPENCODE_MIXPANEL_MCP_ENABLED=false`.
 - MongoDB MCP uses `MDB_MCP_CONNECTION_STRING` from the process environment.
   `.env.example` includes a placeholder; real values belong only in local
-  `.env` or secret managers. OpenCode injects MongoDB only for the
-  `db-executioner` worker and runs `mongodb-mcp-server@latest --readOnly`.
-  Disable with `OPENCODE_MONGODB_MCP_ENABLED=false`.
+  `.env` or secret managers. Junior exposes a shared read-only HTTP proxy at
+  `/mcp/mongodb`, backed by one wrapped `mongodb-mcp-server@latest --readOnly`
+  stdio child. Runner adapters inject that proxy only when the active agent
+  declares `permissions.mcp: mongodb` or lists `mcp__mongodb__*` tools.
+  Disable with `OPENCODE_MONGODB_MCP_ENABLED=false` /
+  `CODEX_MONGODB_MCP_ENABLED=false`.
 
 ### Agent registry tools
 

--- a/src/agents/loader.test.ts
+++ b/src/agents/loader.test.ts
@@ -41,6 +41,14 @@ describe("loadAgentDefinition", () => {
     });
   });
 
+  it("default agent explicitly keeps MongoDB MCP through Junior's proxy", async () => {
+    const def = await loadAgentDefinition(path.join(agentsDir, "default.md"));
+
+    expect(def).not.toBeNull();
+    expect(def!.permissions.mcp).toContain("slack-bot");
+    expect(def!.permissions.mcp).toContain("mongodb");
+  });
+
   it("parses typed permission frontmatter", async () => {
     const tmpPath = path.join(import.meta.dir, "__test_permissions_fm.md");
     const content = `---
@@ -61,6 +69,27 @@ body`;
         mcp: ["slack-bot", "playwright"],
         tools: [],
       });
+    } finally {
+      await fs.unlink(tmpPath).catch(() => {});
+    }
+  });
+
+  it("infers MCP permissions from Claude-style tool names", async () => {
+    const tmpPath = path.join(import.meta.dir, "__test_permissions_tools_fm.md");
+    const content = `---
+name: mcp-tools
+description: Test
+tools: Read, mcp__slack-bot__slack_send_message, mcp__mongodb__find, mcp__slack-bot__slack_read_thread
+---
+
+body`;
+    await Bun.write(tmpPath, content);
+
+    try {
+      const def = await loadAgentDefinition(tmpPath);
+      expect(def).not.toBeNull();
+      expect(def!.permissions.mcp).toEqual(["slack-bot", "mongodb"]);
+      expect(def!.permissions.tools).toContain("mcp__mongodb__find");
     } finally {
       await fs.unlink(tmpPath).catch(() => {});
     }

--- a/src/agents/loader.ts
+++ b/src/agents/loader.ts
@@ -124,12 +124,14 @@ function readContextProfile(
 }
 
 function readAgentPermissions(fm: Record<string, string>): AgentPermissions {
+  const tools = parseCsv(fm.tools);
+  const explicitMcp = parseCsv(fm["permissions.mcp"] ?? fm["permission.mcp"]);
   return {
     intent: parsePermissionIntent(
       fm["permissions.intent"] ?? fm["permission.intent"] ?? fm.permission,
     ),
-    mcp: parseCsv(fm["permissions.mcp"] ?? fm["permission.mcp"]),
-    tools: parseCsv(fm.tools),
+    mcp: unique([...explicitMcp, ...mcpServersFromTools(tools)]),
+    tools,
   };
 }
 
@@ -154,6 +156,16 @@ function parseCsv(value: string | undefined): string[] {
     .split(",")
     .map((part) => part.trim())
     .filter(Boolean);
+}
+
+function mcpServersFromTools(tools: string[]): string[] {
+  return tools
+    .map((tool) => tool.match(/^mcp__([^_]+(?:-[^_]+)*)__/)?.[1])
+    .filter((name): name is string => !!name);
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
 }
 
 function parseBool(value: string | undefined): boolean | undefined {

--- a/src/claude/spawner.test.ts
+++ b/src/claude/spawner.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "bun:test";
+import { createSession } from "../session/types.ts";
+import { shouldUseClaudeMcpConfig } from "./spawner.ts";
+
+describe("shouldUseClaudeMcpConfig", () => {
+  it("keeps the utility cwd carve-out even when the agent declares MCP servers", () => {
+    const session = createSession("thread-1", "C01");
+    session.cwd = "/tmp/junior-utility";
+    session.agentPermissions = { intent: "normal", mcp: ["slack-bot", "mongodb"], tools: [] };
+
+    expect(shouldUseClaudeMcpConfig(session, false)).toBe(false);
+  });
+
+  it("uses generated MCP config for root runs with declared MCP servers", () => {
+    const session = createSession("thread-1", "C01");
+    session.agentPermissions = { intent: "normal", mcp: ["mongodb"], tools: [] };
+
+    expect(shouldUseClaudeMcpConfig(session, false)).toBe(true);
+  });
+
+  it("uses generated MCP config for worktree-backed runs", () => {
+    const session = createSession("thread-1", "C01");
+
+    expect(shouldUseClaudeMcpConfig(session, true)).toBe(true);
+  });
+});

--- a/src/claude/spawner.ts
+++ b/src/claude/spawner.ts
@@ -32,7 +32,7 @@ export function spawnClaude(
     botToken,
     agentIdentity,
   });
-  const mcpConfigPath = runtime.needsProjectMcp || allowedMcpServers(session).size > 0
+  const mcpConfigPath = shouldUseClaudeMcpConfig(session, runtime.needsProjectMcp)
     ? writeClaudeMcpConfig(session)
     : undefined;
   const args = buildClaudeArgs(session, prompt, config, mcpConfigPath);
@@ -137,6 +137,14 @@ export function spawnClaude(
     },
     pid: proc.pid,
   };
+}
+
+export function shouldUseClaudeMcpConfig(
+  session: ThreadSession,
+  needsProjectMcp: boolean,
+): boolean {
+  if (session.cwd) return false;
+  return needsProjectMcp || allowedMcpServers(session).size > 0;
 }
 
 export function writeClaudeMcpConfig(session: ThreadSession): string {

--- a/src/claude/spawner.ts
+++ b/src/claude/spawner.ts
@@ -7,8 +7,14 @@ import type { RunnerEvent, SpawnHandle, SpawnResult } from "../runners/types.ts"
 import { buildRunnerRuntime } from "../runners/runtime.ts";
 import { buildClaudeArgs } from "./args.ts";
 import { createStreamParser } from "./parser.ts";
-import { buildSlackMcpUrl } from "../mcp/context.ts";
 import { signalProcessTree } from "../lifecycle/process-tree.ts";
+import {
+  allowedMcpServers,
+  mongoMcpUrl,
+  playwrightMcpCommand,
+  slackMcpUrl,
+  wantsMcp,
+} from "../runners/mcp-config.ts";
 
 const MCP_CONFIG_DIR = resolve(import.meta.dirname ?? ".", "../../data/mcp-configs");
 
@@ -26,7 +32,7 @@ export function spawnClaude(
     botToken,
     agentIdentity,
   });
-  const mcpConfigPath = runtime.needsProjectMcp
+  const mcpConfigPath = runtime.needsProjectMcp || allowedMcpServers(session).size > 0
     ? writeClaudeMcpConfig(session)
     : undefined;
   const args = buildClaudeArgs(session, prompt, config, mcpConfigPath);
@@ -137,26 +143,23 @@ export function writeClaudeMcpConfig(session: ThreadSession): string {
   mkdirSync(MCP_CONFIG_DIR, { recursive: true });
   const agent = session.activeAgentName ?? "default";
   const path = join(MCP_CONFIG_DIR, `${session.threadId}-${agent}.json`);
-  const config = {
-    mcpServers: {
-      playwright: {
-        command: "npx",
-        args: ["@playwright/mcp", "--headless"],
-      },
-      "slack-bot": {
-        type: "http",
-        url: buildSlackMcpUrl(session),
-      },
-      mongodb: {
-        type: "stdio",
-        command: "npx",
-        args: ["-y", "mongodb-mcp-server@latest", "--readOnly"],
-        env: {
-          MDB_MCP_CONNECTION_STRING: "${MDB_MCP_CONNECTION_STRING}",
-        },
-      },
-    },
-  };
+  const mcpServers: Record<string, unknown> = {};
+  if (wantsMcp(session, "slack-bot")) {
+    mcpServers["slack-bot"] = {
+      type: "http",
+      url: slackMcpUrl(session),
+    };
+  }
+  if (wantsMcp(session, "playwright")) {
+    mcpServers.playwright = playwrightMcpCommand();
+  }
+  if (wantsMcp(session, "mongodb")) {
+    mcpServers.mongodb = {
+      type: "http",
+      url: mongoMcpUrl(session),
+    };
+  }
+  const config = { mcpServers };
   writeFileSync(path, JSON.stringify(config, null, 2));
   return path;
 }

--- a/src/claude/tmux-driver.test.ts
+++ b/src/claude/tmux-driver.test.ts
@@ -161,6 +161,7 @@ describe("TmuxDriver with stubbed exec", () => {
     const session = makeSession({
       worktreePath: cwd,
       activeAgentName: "lead",
+      agentPermissions: { intent: "normal", mcp: ["slack-bot"], tools: [] },
     });
 
     const handle = driver.send({

--- a/src/codex-app-server/config.test.ts
+++ b/src/codex-app-server/config.test.ts
@@ -4,8 +4,9 @@ import { buildCodexConfigToml, buildCodexMcpConfig } from "./config.ts";
 import type { Config } from "../config.ts";
 
 describe("buildCodexMcpConfig", () => {
-  it("builds Junior-approved MCP servers and honors utility carve-out", () => {
+  it("builds only agent-declared MCP servers and honors utility carve-out", () => {
     const session = createSession("t", "c");
+    session.agentPermissions = { intent: "normal", mcp: ["slack-bot", "playwright"], tools: [] };
     const mcp = buildCodexMcpConfig(makeConfig(), session, true);
 
     expect(mcp).toMatchObject({
@@ -14,11 +15,17 @@ describe("buildCodexMcpConfig", () => {
         url: expect.stringContaining("http://localhost:3456/mcp?agent=default&channel=c&thread=t"),
       },
       playwright: {
-        command: "npx",
-        args: ["@playwright/mcp", "--headless"],
+        command: expect.stringContaining("junior-mcp-stdio-wrapper.js"),
+        args: ["--", "npx", "@playwright/mcp", "--headless"],
       },
     });
     expect(buildCodexMcpConfig(makeConfig(), session, false)).toBeNull();
+  });
+
+  it("does not start local MCP servers when the agent declares none", () => {
+    const session = createSession("t", "c");
+
+    expect(buildCodexMcpConfig(makeConfig(), session, true)).toBeNull();
   });
 
   it("limits MCP servers to explicitly declared agent permissions", () => {
@@ -27,8 +34,20 @@ describe("buildCodexMcpConfig", () => {
 
     expect(buildCodexMcpConfig(makeConfig(), session, true)).toEqual({
       playwright: {
-        command: "npx",
-        args: ["@playwright/mcp", "--headless"],
+        command: expect.stringContaining("junior-mcp-stdio-wrapper.js"),
+        args: ["--", "npx", "@playwright/mcp", "--headless"],
+      },
+    });
+  });
+
+  it("uses Junior's MongoDB HTTP proxy instead of spawning local MongoDB MCP", () => {
+    const session = createSession("t", "c");
+    session.agentPermissions = { intent: "normal", mcp: ["mongodb"], tools: [] };
+
+    expect(buildCodexMcpConfig(makeConfig(), session, true)).toEqual({
+      mongodb: {
+        transport: "http",
+        url: expect.stringContaining("http://localhost:3456/mcp/mongodb?agent=default&channel=c&thread=t"),
       },
     });
   });

--- a/src/codex-app-server/config.ts
+++ b/src/codex-app-server/config.ts
@@ -3,7 +3,13 @@ import { dirname, resolve } from "node:path";
 import type { Config } from "../config.ts";
 import type { ThreadSession } from "../session/types.ts";
 import type { CodexApprovalPolicy, CodexSandbox } from "./policy.ts";
-import { buildSlackMcpUrl } from "../mcp/context.ts";
+import {
+  mixpanelMcpCommand,
+  mongoMcpUrl,
+  playwrightMcpCommand,
+  slackMcpUrl,
+  wantsMcp,
+} from "../runners/mcp-config.ts";
 
 export interface CodexMcpServerConfig {
   transport?: "http";
@@ -22,32 +28,23 @@ export function buildCodexMcpConfig(
   if (!config.codex.mcpEnabled || !mcpAllowed) return null;
 
   const mcp: CodexMcpConfig = {};
-  const explicit = new Set(session.agentPermissions?.mcp ?? []);
-  const wantsExplicit = explicit.size > 0;
-  const wants = (name: string) => !wantsExplicit || explicit.has(name);
 
-  if (config.codex.slackMcpEnabled && wants("slack-bot")) {
+  if (config.codex.slackMcpEnabled && wantsMcp(session, "slack-bot")) {
     mcp["slack-bot"] = {
       transport: "http",
-      url: buildSlackMcpUrl(session),
+      url: slackMcpUrl(session),
     };
   }
-  if (config.codex.playwrightMcpEnabled && wants("playwright")) {
-    mcp.playwright = {
-      command: "npx",
-      args: ["@playwright/mcp", "--headless"],
-    };
+  if (config.codex.playwrightMcpEnabled && wantsMcp(session, "playwright")) {
+    mcp.playwright = playwrightMcpCommand();
   }
-  if (config.codex.mixpanelMcpEnabled && wants("mixpanel") && isFeatureMetricsSession(session)) {
-    mcp.mixpanel = {
-      command: "npx",
-      args: ["-y", "mcp-remote", "https://mcp.mixpanel.com/mcp"],
-    };
+  if (config.codex.mixpanelMcpEnabled && wantsMcp(session, "mixpanel") && isFeatureMetricsSession(session)) {
+    mcp.mixpanel = mixpanelMcpCommand();
   }
-  if (config.codex.mongodbMcpEnabled && wants("mongodb") && isDbExecutionerSession(session)) {
+  if (config.codex.mongodbMcpEnabled && wantsMcp(session, "mongodb")) {
     mcp.mongodb = {
-      command: "npx",
-      args: ["-y", "mongodb-mcp-server@latest", "--readOnly"],
+      transport: "http",
+      url: mongoMcpUrl(session),
     };
   }
 
@@ -139,12 +136,5 @@ function isFeatureMetricsSession(session: ThreadSession): boolean {
   return (
     session.agentType === "feature-metrics" ||
     session.activeAgentName === "feature-metrics"
-  );
-}
-
-function isDbExecutionerSession(session: ThreadSession): boolean {
-  return (
-    session.agentType === "db-executioner" ||
-    session.activeAgentName === "db-executioner"
   );
 }

--- a/src/mcp/context.test.ts
+++ b/src/mcp/context.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import { createSession } from "../session/types.ts";
-import { buildSlackMcpUrl, parseSlackMcpRunContext } from "./context.ts";
+import { buildMongoMcpUrl, buildSlackMcpUrl, parseSlackMcpRunContext } from "./context.ts";
 
 describe("Slack MCP run context", () => {
   it("encodes trusted run context in the MCP URL", () => {
@@ -9,6 +9,18 @@ describe("Slack MCP run context", () => {
 
     const parsed = new URL(buildSlackMcpUrl(session));
 
+    expect(parsed.searchParams.get("agent")).toBe("default");
+    expect(parsed.searchParams.get("channel")).toBe("C01");
+    expect(parsed.searchParams.get("thread")).toBe("thread-1");
+  });
+
+  it("encodes trusted run context in the MongoDB MCP proxy URL", () => {
+    const session = createSession("thread-1", "C01");
+    session.activeAgentName = "default";
+
+    const parsed = new URL(buildMongoMcpUrl(session));
+
+    expect(parsed.pathname).toBe("/mcp/mongodb");
     expect(parsed.searchParams.get("agent")).toBe("default");
     expect(parsed.searchParams.get("channel")).toBe("C01");
     expect(parsed.searchParams.get("thread")).toBe("thread-1");

--- a/src/mcp/context.ts
+++ b/src/mcp/context.ts
@@ -2,6 +2,7 @@ import type { ThreadSession } from "../session/types.ts";
 
 const MCP_PORT = Number(process.env.MCP_PORT ?? "3456");
 const DEFAULT_SLACK_MCP_URL = `http://localhost:${MCP_PORT}/mcp`;
+const DEFAULT_MONGODB_MCP_URL = `http://localhost:${MCP_PORT}/mcp/mongodb`;
 
 export interface SlackMcpRunContext {
   agent: string;
@@ -15,6 +16,14 @@ export function slackMcpAgentForSession(session: ThreadSession): string {
 
 export function buildSlackMcpUrl(session: ThreadSession): string {
   const url = new URL(process.env.SLACK_MCP_URL ?? DEFAULT_SLACK_MCP_URL);
+  url.searchParams.set("agent", slackMcpAgentForSession(session));
+  url.searchParams.set("channel", session.channel);
+  url.searchParams.set("thread", session.threadId);
+  return url.toString();
+}
+
+export function buildMongoMcpUrl(session: ThreadSession): string {
+  const url = new URL(process.env.MONGODB_MCP_URL ?? DEFAULT_MONGODB_MCP_URL);
   url.searchParams.set("agent", slackMcpAgentForSession(session));
   url.searchParams.set("channel", session.channel);
   url.searchParams.set("thread", session.threadId);

--- a/src/mcp/mongodb-proxy.ts
+++ b/src/mcp/mongodb-proxy.ts
@@ -1,0 +1,147 @@
+import { resolve } from "node:path";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
+import { log } from "../logger.ts";
+import { parseSlackMcpRunContext, type SlackMcpRunContext } from "./context.ts";
+
+const MONGODB_PROXY_IDLE_TTL_MS = Number(process.env.MONGODB_MCP_PROXY_IDLE_TTL_MS ?? "600000");
+const MONGODB_PROXY_REQUEST_TIMEOUT_MS = Number(process.env.MONGODB_MCP_PROXY_REQUEST_TIMEOUT_MS ?? "120000");
+const MONGODB_TOOL_NAMES = [
+  "aggregate",
+  "collection-schema",
+  "count",
+  "find",
+  "list-collections",
+  "list-databases",
+] as const;
+
+interface MongoBackend {
+  client: Client;
+  transport: StdioClientTransport;
+}
+
+let backend: Promise<MongoBackend> | null = null;
+let idleTimer: ReturnType<typeof setTimeout> | null = null;
+
+export async function handleMongoMcpRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  const runContext = parseSlackMcpRunContext(req.url);
+  const mcpServer = new McpServer({ name: "mongodb", version: "0.1.0" });
+  registerMongoProxyTools(mcpServer, runContext);
+
+  const transport = new StreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+  });
+
+  await mcpServer.connect(transport);
+  await transport.handleRequest(req, res);
+}
+
+export async function closeMongoMcpBackend(): Promise<void> {
+  if (idleTimer) clearTimeout(idleTimer);
+  idleTimer = null;
+  const current = backend;
+  backend = null;
+  if (!current) return;
+  const { client, transport } = await current.catch(() => ({ client: null, transport: null }));
+  await client?.close().catch(() => undefined);
+  await transport?.close().catch(() => undefined);
+}
+
+function registerMongoProxyTools(
+  server: McpServer,
+  runContext: SlackMcpRunContext | null,
+): void {
+  for (const name of MONGODB_TOOL_NAMES) {
+    server.registerTool(
+      name,
+      {
+        description: `Proxy to Junior's shared read-only MongoDB MCP backend (${name}).`,
+        inputSchema: z.record(z.string(), z.unknown()),
+      },
+      async (args) => {
+        if (!runContext) {
+          return {
+            isError: true,
+            content: [{
+              type: "text" as const,
+              text: "Error: MongoDB MCP run context missing; refused to proxy request.",
+            }],
+          };
+        }
+
+        try {
+          const { client } = await getMongoBackend();
+          armIdleTimer();
+          const result = await client.callTool(
+            { name, arguments: args },
+            undefined,
+            { timeout: MONGODB_PROXY_REQUEST_TIMEOUT_MS },
+          );
+          return result as CallToolResult;
+        } catch (err) {
+          return {
+            isError: true,
+            content: [{
+              type: "text" as const,
+              text: `MongoDB MCP proxy error: ${err instanceof Error ? err.message : String(err)}`,
+            }],
+          };
+        }
+      },
+    );
+  }
+}
+
+function getMongoBackend(): Promise<MongoBackend> {
+  if (!backend) backend = startMongoBackend();
+  armIdleTimer();
+  return backend;
+}
+
+async function startMongoBackend(): Promise<MongoBackend> {
+  const transport = new StdioClientTransport({
+    command: resolve(
+      import.meta.dirname ?? ".",
+      "../../bin/junior-mcp-stdio-wrapper.js",
+    ),
+    args: ["--", "npx", "-y", "mongodb-mcp-server@latest", "--readOnly"],
+    env: {
+      ...process.env,
+      MDB_MCP_CONNECTION_STRING: process.env.MDB_MCP_CONNECTION_STRING ?? "",
+    },
+    stderr: "pipe",
+  });
+  transport.onerror = (err) => {
+    log.warn("mongodb-mcp", `backend error: ${err.message}`);
+  };
+  transport.onclose = () => {
+    backend = null;
+    log.info("mongodb-mcp", "backend closed");
+  };
+
+  const client = new Client(
+    { name: "junior-mongodb-mcp-proxy", version: "0.1.0" },
+    { capabilities: {} },
+  );
+  await client.connect(transport);
+  log.info("mongodb-mcp", `backend started pid=${transport.pid ?? "unknown"}`);
+  return { client, transport };
+}
+
+function armIdleTimer(): void {
+  if (idleTimer) clearTimeout(idleTimer);
+  idleTimer = setTimeout(() => {
+    void closeMongoMcpBackend().catch((err) => {
+      log.warn("mongodb-mcp", `idle close failed: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  }, MONGODB_PROXY_IDLE_TTL_MS);
+  idleTimer.unref?.();
+}

--- a/src/mcp/slack-server.ts
+++ b/src/mcp/slack-server.ts
@@ -28,6 +28,7 @@ import {
 } from "../support/agents.ts";
 import { parsePureAgentDirectiveResponse } from "../support/directives.ts";
 import { parseSlackMcpRunContext, type SlackMcpRunContext } from "./context.ts";
+import { handleMongoMcpRequest } from "./mongodb-proxy.ts";
 
 const MCP_PORT = Number(process.env.MCP_PORT ?? "3456");
 const FALLBACK_AGENTS_DIR = ".claude/agents";
@@ -819,6 +820,12 @@ export function startMcpServer(
   sessionManager = manager;
 
   const httpServer = createServer(async (req, res) => {
+    const pathname = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`).pathname;
+    if (pathname === "/mcp/mongodb") {
+      await handleMongoMcpRequest(req, res);
+      return;
+    }
+
     // Each request gets its own transport (stateless mode).
     // Tools are registered fresh but share the same WebClient.
     const mcpServer = new McpServer({ name: "slack-bot", version: "0.1.0" });

--- a/src/runners/index.test.ts
+++ b/src/runners/index.test.ts
@@ -7,7 +7,9 @@ describe("buildOpenCodeMcpConfig", () => {
   it("only includes Mixpanel MCP for the feature-metrics agent", () => {
     const mainSession = createSession("thread-1", "C01");
     const featureMetricsSession = createSession("thread-1", "C01");
+    mainSession.agentPermissions = { intent: "normal", mcp: ["mixpanel"], tools: [] };
     featureMetricsSession.agentType = "feature-metrics";
+    featureMetricsSession.agentPermissions = { intent: "normal", mcp: ["mixpanel"], tools: [] };
 
     const mainMcp = buildOpenCodeMcpConfig(testConfig(), mainSession);
     const featureMetricsMcp = buildOpenCodeMcpConfig(
@@ -18,7 +20,14 @@ describe("buildOpenCodeMcpConfig", () => {
     expect(mainMcp?.mixpanel).toBeUndefined();
     expect(featureMetricsMcp?.mixpanel).toEqual({
       type: "local",
-      command: ["npx", "-y", "mcp-remote", "https://mcp.mixpanel.com/mcp"],
+      command: [
+        expect.stringContaining("junior-mcp-stdio-wrapper.js"),
+        "--",
+        "npx",
+        "-y",
+        "mcp-remote",
+        "https://mcp.mixpanel.com/mcp",
+      ],
       enabled: true,
     });
   });
@@ -26,6 +35,7 @@ describe("buildOpenCodeMcpConfig", () => {
   it("respects the Mixpanel MCP feature flag", () => {
     const session = createSession("thread-1", "C01");
     session.agentType = "feature-metrics";
+    session.agentPermissions = { intent: "normal", mcp: ["mixpanel"], tools: [] };
 
     const mcp = buildOpenCodeMcpConfig(
       testConfig({ mixpanelMcpEnabled: false }),
@@ -35,10 +45,12 @@ describe("buildOpenCodeMcpConfig", () => {
     expect(mcp?.mixpanel).toBeUndefined();
   });
 
-  it("only includes MongoDB MCP for the db-executioner agent", () => {
+  it("includes MongoDB MCP for agents with explicit MongoDB permission", () => {
     const mainSession = createSession("thread-1", "C01");
     const dbExecutionerSession = createSession("thread-1", "C01");
+    mainSession.agentPermissions = { intent: "normal", mcp: ["mongodb"], tools: [] };
     dbExecutionerSession.agentType = "db-executioner";
+    dbExecutionerSession.agentPermissions = { intent: "normal", mcp: ["mongodb"], tools: [] };
 
     const mainMcp = buildOpenCodeMcpConfig(testConfig(), mainSession);
     const dbExecutionerMcp = buildOpenCodeMcpConfig(
@@ -46,10 +58,14 @@ describe("buildOpenCodeMcpConfig", () => {
       dbExecutionerSession,
     );
 
-    expect(mainMcp?.mongodb).toBeUndefined();
+    expect(mainMcp?.mongodb).toEqual({
+      type: "remote",
+      url: expect.stringContaining("http://localhost:3456/mcp/mongodb?agent=default&channel=C01&thread=thread-1"),
+      enabled: true,
+    });
     expect(dbExecutionerMcp?.mongodb).toEqual({
-      type: "local",
-      command: ["npx", "-y", "mongodb-mcp-server@latest", "--readOnly"],
+      type: "remote",
+      url: expect.stringContaining("http://localhost:3456/mcp/mongodb?agent=default&channel=C01&thread=thread-1"),
       enabled: true,
     });
   });
@@ -57,6 +73,7 @@ describe("buildOpenCodeMcpConfig", () => {
   it("respects the MongoDB MCP feature flag", () => {
     const session = createSession("thread-1", "C01");
     session.agentType = "db-executioner";
+    session.agentPermissions = { intent: "normal", mcp: ["mongodb"], tools: [] };
 
     const mcp = buildOpenCodeMcpConfig(
       testConfig({ mongodbMcpEnabled: false }),

--- a/src/runners/index.ts
+++ b/src/runners/index.ts
@@ -6,7 +6,13 @@ import { spawnOpenCodeSdk } from "../opencode/sdk-provider.ts";
 import { spawnCodexAppServer } from "../codex-app-server/spawner.ts";
 import type { OpenCodeMcpConfig } from "../opencode/config.ts";
 import type { SpawnHandle } from "./types.ts";
-import { buildSlackMcpUrl } from "../mcp/context.ts";
+import {
+  mixpanelMcpCommand,
+  mongoMcpUrl,
+  playwrightMcpCommand,
+  slackMcpUrl,
+  wantsMcp,
+} from "./mcp-config.ts";
 
 export function sessionProvider(
   session: ThreadSession,
@@ -106,31 +112,33 @@ export function buildOpenCodeMcpConfig(
   if (!config.opencode.mcpEnabled) return null;
 
   const mcp: OpenCodeMcpConfig = {};
-  if (config.opencode.slackMcpEnabled) {
+  if (config.opencode.slackMcpEnabled && wantsMcp(session, "slack-bot")) {
     mcp["slack-bot"] = {
       type: "remote",
-      url: buildSlackMcpUrl(session),
+      url: slackMcpUrl(session),
       enabled: true,
     };
   }
-  if (config.opencode.playwrightMcpEnabled) {
+  if (config.opencode.playwrightMcpEnabled && wantsMcp(session, "playwright")) {
+    const command = playwrightMcpCommand();
     mcp.playwright = {
       type: "local",
-      command: ["npx", "@playwright/mcp", "--headless"],
+      command: [command.command, ...command.args],
       enabled: true,
     };
   }
-  if (config.opencode.mixpanelMcpEnabled && isFeatureMetricsSession(session)) {
+  if (config.opencode.mixpanelMcpEnabled && wantsMcp(session, "mixpanel") && isFeatureMetricsSession(session)) {
+    const command = mixpanelMcpCommand();
     mcp.mixpanel = {
       type: "local",
-      command: ["npx", "-y", "mcp-remote", "https://mcp.mixpanel.com/mcp"],
+      command: [command.command, ...command.args],
       enabled: true,
     };
   }
-  if (config.opencode.mongodbMcpEnabled && isDbExecutionerSession(session)) {
+  if (config.opencode.mongodbMcpEnabled && wantsMcp(session, "mongodb")) {
     mcp.mongodb = {
-      type: "local",
-      command: ["npx", "-y", "mongodb-mcp-server@latest", "--readOnly"],
+      type: "remote",
+      url: mongoMcpUrl(session),
       enabled: true,
     };
   }
@@ -142,12 +150,5 @@ function isFeatureMetricsSession(session: ThreadSession): boolean {
   return (
     session.agentType === "feature-metrics" ||
     session.activeAgentName === "feature-metrics"
-  );
-}
-
-function isDbExecutionerSession(session: ThreadSession): boolean {
-  return (
-    session.agentType === "db-executioner" ||
-    session.activeAgentName === "db-executioner"
   );
 }

--- a/src/runners/mcp-config.ts
+++ b/src/runners/mcp-config.ts
@@ -1,0 +1,57 @@
+import { resolve } from "node:path";
+import type { ThreadSession } from "../session/types.ts";
+import { buildMongoMcpUrl, buildSlackMcpUrl } from "../mcp/context.ts";
+
+export type McpServerName = "slack-bot" | "playwright" | "mixpanel" | "mongodb";
+
+export interface StdioMcpCommand {
+  command: string;
+  args: string[];
+}
+
+export function allowedMcpServers(session: ThreadSession): Set<McpServerName> {
+  const declared = session.agentPermissions?.mcp ?? [];
+  return new Set(
+    declared.filter((name): name is McpServerName =>
+      name === "slack-bot" ||
+      name === "playwright" ||
+      name === "mixpanel" ||
+      name === "mongodb"
+    ),
+  );
+}
+
+export function wantsMcp(session: ThreadSession, name: McpServerName): boolean {
+  return allowedMcpServers(session).has(name);
+}
+
+export function slackMcpUrl(session: ThreadSession): string {
+  return buildSlackMcpUrl(session);
+}
+
+export function mongoMcpUrl(session: ThreadSession): string {
+  return buildMongoMcpUrl(session);
+}
+
+export function playwrightMcpCommand(): StdioMcpCommand {
+  return wrappedStdioMcpCommand(["npx", "@playwright/mcp", "--headless"]);
+}
+
+export function mixpanelMcpCommand(): StdioMcpCommand {
+  return wrappedStdioMcpCommand([
+    "npx",
+    "-y",
+    "mcp-remote",
+    "https://mcp.mixpanel.com/mcp",
+  ]);
+}
+
+function wrappedStdioMcpCommand(command: string[]): StdioMcpCommand {
+  return {
+    command: resolve(
+      import.meta.dirname ?? ".",
+      "../../bin/junior-mcp-stdio-wrapper.js",
+    ),
+    args: ["--", ...command],
+  };
+}


### PR DESCRIPTION
## Summary
- Add a Junior-owned HTTP MongoDB MCP proxy at `/mcp/mongodb` backed by one shared read-only `mongodb-mcp-server` stdio child.
- Point Claude, Codex app-server, and OpenCode MongoDB MCP config at the proxy instead of spawning per-run `npx mongodb-mcp-server`.
- Keep default-agent MongoDB access explicit via `permissions.mcp: mongodb` while removing root project stdio MongoDB/Playwright MCP auto-starts.
- Wrap remaining local stdio MCP commands so child process groups terminate when stdio closes.

## Verification
- `bun test src/mcp/context.test.ts src/agents/loader.test.ts src/codex-app-server/config.test.ts src/runners/index.test.ts src/claude/tmux-driver.test.ts`
- `bun run typecheck`
- `bun test` currently has one unrelated pre-existing failure in `src/session/manager.test.ts` for the dormancy response copy: expected unbackticked `@` / `!listen`, implementation returns backticked text.
