### PR TITLE
chore: shift worktree-prune cron to 04:53 IST

### DIFF
--- a/workflows/worktree-prune.workflow.md
+++ b/workflows/worktree-prune.workflow.md
@@ -6,7 +6,7 @@ ownerSlackUserIds:
   - U03PNSJ33S5
 triggers:
   - type: schedule
-    cron: "20 7 * * *"
+    cron: "53 4 * * *"
     timezone: Asia/Kolkata
   - type: command
     command: worktree-prune


### PR DESCRIPTION
## What

Move the daily `worktree-prune` scheduled run from `20 7 * * *` (07:20) to `53 4 * * *` (04:53), timezone unchanged (Asia/Kolkata).

## Why

Runs the prune off-peak, before the workday starts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)