### PR TITLE
feat(slack): add agent action buttons

### DIFF
--- a/docs/features/agent-action-buttons.md
+++ b/docs/features/agent-action-buttons.md
@@ -1,0 +1,87 @@
+# Agent Action Buttons
+
+Status: **implemented in progress**.
+
+Persistent agents can attach safe Slack action buttons to final responses. The first consumer is the review agent: `Re-review`, `Make fix`, and `Cleanup worktree`.
+
+## Contract
+
+Agents append a stripped sentinel block to the final response:
+
+```text
+<junior-actions>
+[
+  {
+    "id": "review:rereview",
+    "label": "Re-review",
+    "style": "primary",
+    "type": "dispatch_agent",
+    "agent": "review",
+    "prompt": "Re-review the latest PR/head. Read thread history first."
+  },
+  {
+    "id": "review:make-fix",
+    "label": "Make fix",
+    "style": "danger",
+    "type": "dispatch_agent",
+    "agent": "thinker",
+    "prompt": "Address the blockers from the latest review. Read thread history first."
+  },
+  {
+    "id": "thread:cleanup-worktree",
+    "label": "Cleanup worktree",
+    "type": "cleanup_worktree"
+  }
+]
+</junior-actions>
+```
+
+Junior validates the JSON, strips it from the Slack-visible text, renders Slack Block Kit buttons, and stores opaque button tokens in SQLite. Slack payloads carry only the token, never prompts, paths, or executable commands.
+
+## Decisions
+
+- Action records are stored in SQLite.
+- Buttons expire when the same source agent receives a new message or posts a newer response in the same thread.
+- Clicked buttons are disabled by updating the original Slack message and removing the actions block.
+- `Make fix` dispatches `thinker`; thinker reads Slack thread history instead of relying on copied review text.
+- `cleanup_worktree` may be clicked by any thread participant.
+- Worktree cleanup refuses tracked changes and unknown untracked files.
+- Cleanup may proceed when the only untracked paths are `learnings.md`, `.codex/`, `.claude/`, or `.DS_Store`.
+- `review: approved` triggers automatic safe worktree cleanup.
+
+## Action Types
+
+### `dispatch_agent`
+
+Dispatches a persistent agent in the same Slack thread without posting a public `!<agent>` directive.
+
+Validation:
+
+- The target agent must be registered.
+- The thread session must still exist and not be muted.
+- Duplicate clicks are blocked by claiming the SQLite token before execution.
+
+### `cleanup_worktree`
+
+Removes only worktrees registered on the session (`worktreePath` / `worktreePaths`).
+
+Validation:
+
+- The session must be idle.
+- No persistent agent in the thread may be busy.
+- Tracked changes refuse cleanup.
+- Unknown untracked files refuse cleanup.
+
+## Storage
+
+`slack_action_buttons` stores token, channel/thread/message ids, message text, source agent, action JSON, status, click metadata, and a long defensive expiry timestamp. The wall-clock timestamp is storage hygiene; user-facing expiry is same-agent invalidation.
+
+## Slack UX
+
+Final responses with actions post as:
+
+- section block: original response text
+- actions block: up to five buttons
+- fallback text: original response text
+
+Streaming status messages never carry buttons.

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,9 +7,16 @@ import {
   extractRunnerMessageText,
   formatRunnerToolStatuses,
   prepareSlackResponse,
+  prepareSlackResponseWithActions,
   sanitizeErrorForSlack,
 } from "./slack/formatting.ts";
 import { SlackResponder } from "./slack/responder.ts";
+import { SlackActionStore } from "./slack/action-store.ts";
+import {
+  cleanupThreadWorktrees,
+  disableAgentActionMessages,
+  registerAgentActionButtons,
+} from "./slack/action-buttons.ts";
 import { SessionManager } from "./session/manager.ts";
 import { createSessionStore } from "./session/store/factory.ts";
 import { setupGracefulShutdown } from "./lifecycle/shutdown.ts";
@@ -44,6 +51,7 @@ const app = createSlackApp(config);
 
 const store = createSessionStore(config);
 log.info("boot", `Session store: ${config.session.store}`);
+const actionStore = new SlackActionStore(resolve(config.session.sqlitePath));
 const memoryStore = createMemoryStore(config.memory.sqlitePath);
 const memoryIngestor = new MemoryIngestor(memoryStore);
 const sessionManager = new SessionManager(store, config);
@@ -102,21 +110,54 @@ const workflowController = new WorkflowController({
   isAdmin: (userId) => sessionManager.isAdmin(userId),
 });
 
-sessionManager.onResponse = (session, response) => {
-  const prepared = prepareSlackResponse(response);
+function isApprovedReviewResponse(response: string): boolean {
+  return /^review:\s*approved\b/i.test(response.trim());
+}
+
+sessionManager.onResponse = async (session, response) => {
+  const prepared = prepareSlackResponseWithActions(response);
   const agentName = session.activeAgentName ?? "lead";
   log.info(
     "response",
-    `thread=${session.threadId} agent=${agentName} len=${response.length} willPost=${prepared !== null}`,
+    `thread=${session.threadId} agent=${agentName} len=${response.length} willPost=${prepared !== null} actions=${prepared?.actions.length ?? 0}`,
   );
   responder.deleteStatus(session.channel, session.threadId, agentName);
   if (prepared !== null) {
-    responder.postResponse(
+    await disableAgentActionMessages(
+      actionStore,
+      app.client,
+      session.threadId,
+      agentName,
+    );
+    const buttonTokens = prepared.actions.map((action) => ({
+      action,
+      token: crypto.randomUUID(),
+    }));
+    const posted = await responder.postResponse(
       session.channel,
       session.threadId,
-      prepared,
+      prepared.text,
       session.slackIdentity,
+      buttonTokens.map(({ action, token }) => ({
+        token,
+        label: action.label,
+        style: action.style,
+      })),
     );
+    const first = posted[0];
+    if (first && buttonTokens.length > 0) {
+      await actionStore.createMany(
+        buttonTokens.map(({ action, token }) => ({
+          token,
+          channelId: session.channel,
+          threadTs: session.threadId,
+          messageTs: first.ts,
+          messageText: first.text,
+          action,
+          sourceAgent: agentName,
+        })),
+      );
+    }
   } else {
     log.info(
       "response",
@@ -189,12 +230,47 @@ sessionManager.onError = (session, error) => {
   );
 };
 
+sessionManager.onAgentDispatched = async (session, agentName) => {
+  await disableAgentActionMessages(
+    actionStore,
+    app.client,
+    session.threadId,
+    agentName,
+  );
+};
+
+sessionManager.onAgentSettled = async (session, agentName, response) => {
+  if (agentName !== "review" || !response || !isApprovedReviewResponse(response)) {
+    return;
+  }
+  const result = await cleanupThreadWorktrees(
+    session.threadId,
+    sessionManager,
+    worktreeManager,
+  );
+  await app.client.chat.postMessage({
+    channel: session.channel,
+    thread_ts: session.threadId,
+    text: result,
+  });
+  if (result.startsWith("Cleaned up worktree")) {
+    await disableAgentActionMessages(
+      actionStore,
+      app.client,
+      session.threadId,
+      "review",
+    );
+  }
+};
+
 registerHomeTab(app, store, config.session.homeWindowMs, workflowStore);
+registerAgentActionButtons(app, actionStore, sessionManager, worktreeManager);
 
 setupGracefulShutdown(sessionManager, devServerManager, async () => {
   await workflowScheduler.shutdown();
   workflowRegistry.stopWatching();
   workflowStore.close?.();
+  actionStore.close();
   memoryStore.close();
 });
 

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -65,7 +65,16 @@ export class SessionManager {
   selfBotId?: string;
   agentRouter?: AgentRouter;
   worktreeManager?: WorktreeManager;
-  onResponse?: (session: ThreadSession, response: string) => void;
+  onResponse?: (session: ThreadSession, response: string) => unknown;
+  onAgentSettled?: (
+    session: ThreadSession,
+    agentName: string,
+    response: string | null,
+  ) => void | Promise<void>;
+  onAgentDispatched?: (
+    session: ThreadSession,
+    agentName: string,
+  ) => void | Promise<void>;
   onEvent?: (session: ThreadSession, event: RunnerEvent) => void;
   onMessageBuffered?: (event: SlackMessageEvent) => void;
   onError?: (session: ThreadSession, error: string | null) => void;
@@ -253,6 +262,7 @@ export class SessionManager {
     if (session.muted) return;
 
     const agentSession = this.getOrCreateAgentSession(session, agentName);
+    await this.onAgentDispatched?.(session, agentName);
 
     if (agentSession.status === "busy") {
       agentSession.pendingMessages.push(this.toPendingMessage(event));
@@ -294,6 +304,8 @@ export class SessionManager {
 
     if (session.muted) return;
 
+    await this.onAgentDispatched?.(session, agentName);
+
     if (session.status === "busy") {
       session.pendingMessages.push({
         ...this.toPendingMessage(event),
@@ -314,6 +326,10 @@ export class SessionManager {
 
   async getSession(threadId: string): Promise<ThreadSession | undefined> {
     return this.store.get(threadId);
+  }
+
+  async updateSession(threadId: string, session: ThreadSession): Promise<void> {
+    await this.store.set(threadId, session);
   }
 
   async resetSession(threadId: string): Promise<void> {
@@ -1597,7 +1613,7 @@ export class SessionManager {
           `thread=${fresh.threadId} agent=${agentName} suppressed reason=duplicate-slack-tool-post`,
         );
       } else {
-        this.onResponse?.(
+        await this.onResponse?.(
           this.buildRunSession(fresh, agentName, agentIdentity),
           result.response,
         );
@@ -1651,6 +1667,7 @@ export class SessionManager {
         agentSession.lastActivity = Date.now();
       }
       await this.store.set(fresh.threadId, fresh);
+      await this.onAgentSettled?.(fresh, agentName, result.response ?? null);
     }
 
     if (internalDispatchDirectives.length > 0) {

--- a/src/slack/action-buttons.ts
+++ b/src/slack/action-buttons.ts
@@ -130,7 +130,10 @@ export async function cleanupThreadWorktrees(
 
   const unsafe: string[] = [];
   for (const worktree of worktrees) {
-    const status = await worktreeManager.getWorktreeStatus(worktree.path);
+    const status = await worktreeManager.getWorktreeStatus(
+      worktree.path,
+      worktree.repo,
+    );
     const reason = unsafeCleanupReason(status);
     if (reason) unsafe.push(`${worktree.repo}: ${reason}`);
   }
@@ -169,6 +172,9 @@ function registeredWorktrees(session: ThreadSession): Array<{ repo: string; path
 }
 
 function unsafeCleanupReason(status: WorktreeStatus): string | null {
+  if (status.unpushedCommits > 0) {
+    return `branch has ${status.unpushedCommits} commit${status.unpushedCommits === 1 ? "" : "s"} not in ${status.unpushedBase ?? "upstream"}`;
+  }
   if (status.tracked.length > 0) {
     return `tracked changes present (${status.tracked.join(", ")})`;
   }

--- a/src/slack/action-buttons.ts
+++ b/src/slack/action-buttons.ts
@@ -1,0 +1,260 @@
+import type { App } from "@slack/bolt";
+import type { WebClient } from "@slack/web-api";
+import type { SessionManager } from "../session/manager.ts";
+import type { ThreadSession } from "../session/types.ts";
+import { isPersistentAgent } from "../support/agents.ts";
+import type { WorktreeManager, WorktreeStatus } from "../worktree/manager.ts";
+import { log } from "../logger.ts";
+import type { SlackActionRecord, SlackActionStore } from "./action-store.ts";
+
+export const ACTION_BUTTON_ID = "junior_agent_action";
+
+const ALLOWED_UNTRACKED_EXACT = new Set(["learnings.md", ".DS_Store"]);
+const ALLOWED_UNTRACKED_PREFIXES = [".codex/", ".claude/"];
+
+export function registerAgentActionButtons(
+  app: App,
+  actionStore: SlackActionStore,
+  sessionManager: SessionManager,
+  worktreeManager: WorktreeManager,
+): void {
+  app.action(ACTION_BUTTON_ID, async ({ ack, body, client }) => {
+    await ack();
+
+    const token = actionTokenFromBody(body);
+    const userId = userIdFromBody(body);
+    if (!token || !userId) return;
+
+    const record = await actionStore.claim(token, userId);
+    if (!record) {
+      await postUnavailable(client, body);
+      return;
+    }
+
+    await actionStore.disableMessageActions(record.channelId, record.messageTs);
+    await removeMessageActions(client, record);
+
+    try {
+      if (record.action.type === "dispatch_agent") {
+        await handleDispatch(record, userId, sessionManager);
+      } else if (record.action.type === "cleanup_worktree") {
+        await handleCleanup(record, sessionManager, worktreeManager, client);
+      }
+    } catch (err) {
+      await actionStore.markFailed(record.token);
+      await client.chat.postMessage({
+        channel: record.channelId,
+        thread_ts: record.threadTs,
+        text: `Action failed: ${err instanceof Error ? err.message : String(err)}`,
+      });
+    }
+  });
+}
+
+export async function disableAgentActionMessages(
+  actionStore: SlackActionStore,
+  client: WebClient,
+  threadTs: string,
+  sourceAgent: string,
+  exceptMessageTs?: string,
+): Promise<void> {
+  const messages = await actionStore.disableSourceAgentActions(
+    threadTs,
+    sourceAgent,
+    exceptMessageTs,
+  );
+  for (const message of messages) {
+    await removeMessageActions(client, {
+      channelId: message.channelId,
+      messageTs: message.messageTs,
+      messageText: message.messageText,
+    });
+  }
+}
+
+async function handleDispatch(
+  record: SlackActionRecord,
+  userId: string,
+  sessionManager: SessionManager,
+): Promise<void> {
+  const action = record.action;
+  if (action.type !== "dispatch_agent") return;
+  if (!isPersistentAgent(action.agent) && action.agent !== "lead" && action.agent !== "default") {
+    throw new Error(`unknown agent: ${action.agent}`);
+  }
+
+  await sessionManager.handleAgentMessage(
+    {
+      threadId: record.threadTs,
+      channel: record.channelId,
+      user: userId,
+      text: action.prompt,
+      ts: `${record.messageTs}:button:${record.actionId}`,
+      command: null,
+      dedupeKey: `button:${record.token}`,
+    },
+    action.agent,
+  );
+}
+
+async function handleCleanup(
+  record: SlackActionRecord,
+  sessionManager: SessionManager,
+  worktreeManager: WorktreeManager,
+  client: WebClient,
+): Promise<void> {
+  const result = await cleanupThreadWorktrees(
+    record.threadTs,
+    sessionManager,
+    worktreeManager,
+  );
+  await postThread(client, record, result);
+}
+
+export async function cleanupThreadWorktrees(
+  threadTs: string,
+  sessionManager: SessionManager,
+  worktreeManager: WorktreeManager,
+): Promise<string> {
+  const session = await sessionManager.getSession(threadTs);
+  if (!session) return "Cleanup skipped: thread session no longer exists.";
+  const busy = session.status !== "idle" || Object.values(session.agentSessions ?? {}).some((agent) => agent.status === "busy");
+  if (busy) {
+    return "Cleanup skipped: an agent is still busy in this thread.";
+  }
+
+  const worktrees = registeredWorktrees(session);
+  if (worktrees.length === 0) {
+    return "Cleanup skipped: no registered worktree for this thread.";
+  }
+
+  const unsafe: string[] = [];
+  for (const worktree of worktrees) {
+    const status = await worktreeManager.getWorktreeStatus(worktree.path);
+    const reason = unsafeCleanupReason(status);
+    if (reason) unsafe.push(`${worktree.repo}: ${reason}`);
+  }
+
+  if (unsafe.length > 0) {
+    return `Cleanup skipped:\n${unsafe.map((line) => `- ${line}`).join("\n")}`;
+  }
+
+  const removed: string[] = [];
+  for (const worktree of worktrees) {
+    await worktreeManager.removeWorktree(worktree.repo, session.threadId);
+    removed.push(worktree.repo);
+    if (session.worktreePaths?.[worktree.repo]) {
+      delete session.worktreePaths[worktree.repo];
+    }
+    if (session.targetRepo === worktree.repo) {
+      session.worktreePath = null;
+      session.targetRepo = null;
+    }
+  }
+  await sessionManager.updateSession(session.threadId, session);
+  return `Cleaned up worktree${removed.length === 1 ? "" : "s"}: ${removed.join(", ")}.`;
+}
+
+function registeredWorktrees(session: ThreadSession): Array<{ repo: string; path: string }> {
+  const entries = Object.entries(session.worktreePaths ?? {}).filter(
+    ([, path]) => !!path,
+  );
+  if (entries.length > 0) {
+    return entries.map(([repo, path]) => ({ repo, path }));
+  }
+  if (session.targetRepo && session.worktreePath) {
+    return [{ repo: session.targetRepo, path: session.worktreePath }];
+  }
+  return [];
+}
+
+function unsafeCleanupReason(status: WorktreeStatus): string | null {
+  if (status.tracked.length > 0) {
+    return `tracked changes present (${status.tracked.join(", ")})`;
+  }
+  const unsafeUntracked = status.untracked.filter((path) => !isAllowedUntracked(path));
+  if (unsafeUntracked.length > 0) {
+    return `unknown untracked files present (${unsafeUntracked.join(", ")})`;
+  }
+  return null;
+}
+
+function isAllowedUntracked(path: string): boolean {
+  if (ALLOWED_UNTRACKED_EXACT.has(path)) return true;
+  return ALLOWED_UNTRACKED_PREFIXES.some((prefix) => path === prefix.slice(0, -1) || path.startsWith(prefix));
+}
+
+async function removeMessageActions(
+  client: WebClient,
+  message: { channelId: string; messageTs: string; messageText: string },
+): Promise<void> {
+  if (!message.messageText) return;
+  try {
+    await client.chat.update({
+      channel: message.channelId,
+      ts: message.messageTs,
+      text: message.messageText,
+      blocks: [{ type: "section", text: { type: "mrkdwn", text: message.messageText } }],
+    });
+  } catch (err) {
+    log.error(
+      "actions",
+      `disable.fail channel=${message.channelId} ts=${message.messageTs} err=${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+async function postThread(
+  client: WebClient,
+  record: SlackActionRecord,
+  text: string,
+): Promise<void> {
+  await client.chat.postMessage({
+    channel: record.channelId,
+    thread_ts: record.threadTs,
+    text,
+  });
+}
+
+async function postUnavailable(client: WebClient, body: unknown): Promise<void> {
+  const channel = channelIdFromBody(body);
+  const user = userIdFromBody(body);
+  if (!channel || !user) return;
+  try {
+    await client.chat.postEphemeral({
+      channel,
+      user,
+      text: "That action is no longer available.",
+    });
+  } catch {
+    // Best-effort UX only.
+  }
+}
+
+function actionTokenFromBody(body: unknown): string | null {
+  const action = firstAction(body);
+  return typeof action?.value === "string" ? action.value : null;
+}
+
+function firstAction(body: unknown): { value?: unknown } | null {
+  if (!isRecord(body) || !Array.isArray(body.actions)) return null;
+  const [action] = body.actions;
+  return isRecord(action) ? action : null;
+}
+
+function userIdFromBody(body: unknown): string | null {
+  if (!isRecord(body) || !isRecord(body.user)) return null;
+  return typeof body.user.id === "string" ? body.user.id : null;
+}
+
+function channelIdFromBody(body: unknown): string | null {
+  if (!isRecord(body)) return null;
+  if (isRecord(body.channel) && typeof body.channel.id === "string") {
+    return body.channel.id;
+  }
+  return null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/slack/action-store.test.ts
+++ b/src/slack/action-store.test.ts
@@ -1,0 +1,85 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "bun:test";
+import { SlackActionStore } from "./action-store.ts";
+
+function withStore(fn: (store: SlackActionStore) => Promise<void>): Promise<void> {
+  const dir = mkdtempSync(join(tmpdir(), "junior-actions-"));
+  const store = new SlackActionStore(join(dir, "actions.sqlite"));
+  return fn(store).finally(() => {
+    store.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+}
+
+describe("SlackActionStore", () => {
+  it("claims active actions only once", async () => {
+    await withStore(async (store) => {
+      await store.createMany([
+        {
+          token: "tok-1",
+          channelId: "C1",
+          threadTs: "100.1",
+          messageTs: "101.1",
+          messageText: "review: changes-requested",
+          sourceAgent: "review",
+          action: {
+            id: "review:rereview",
+            label: "Re-review",
+            type: "dispatch_agent",
+            agent: "review",
+            prompt: "re-review",
+          },
+        },
+      ]);
+
+      const claimed = await store.claim("tok-1", "U1", 123);
+      expect(claimed?.status).toBe("clicked");
+      expect(claimed?.clickedByUserId).toBe("U1");
+      expect(await store.claim("tok-1", "U2", 124)).toBeNull();
+    });
+  });
+
+  it("disables active actions for a source agent in a thread", async () => {
+    await withStore(async (store) => {
+      await store.createMany([
+        {
+          token: "old-review",
+          channelId: "C1",
+          threadTs: "100.1",
+          messageTs: "101.1",
+          messageText: "old review",
+          sourceAgent: "review",
+          action: {
+            id: "review:rereview",
+            label: "Re-review",
+            type: "dispatch_agent",
+            agent: "review",
+            prompt: "re-review",
+          },
+        },
+        {
+          token: "thinker",
+          channelId: "C1",
+          threadTs: "100.1",
+          messageTs: "102.1",
+          messageText: "thinker",
+          sourceAgent: "thinker",
+          action: {
+            id: "thread:cleanup-worktree",
+            label: "Cleanup worktree",
+            type: "cleanup_worktree",
+          },
+        },
+      ]);
+
+      const disabled = await store.disableSourceAgentActions("100.1", "review");
+      expect(disabled).toEqual([
+        { channelId: "C1", messageTs: "101.1", messageText: "old review" },
+      ]);
+      expect(await store.claim("old-review", "U1")).toBeNull();
+      expect((await store.claim("thinker", "U1"))?.status).toBe("clicked");
+    });
+  });
+});

--- a/src/slack/action-store.ts
+++ b/src/slack/action-store.ts
@@ -1,0 +1,260 @@
+import { Database } from "bun:sqlite";
+import { dirname } from "node:path";
+import { mkdirSync } from "node:fs";
+import type { SlackActionButtonSpec } from "./formatting.ts";
+
+export type SlackActionStatus =
+  | "active"
+  | "clicked"
+  | "expired"
+  | "disabled"
+  | "failed";
+
+export interface SlackActionRecord {
+  token: string;
+  channelId: string;
+  threadTs: string;
+  messageTs: string;
+  messageText: string;
+  actionId: string;
+  actionType: SlackActionButtonSpec["type"];
+  action: SlackActionButtonSpec;
+  sourceAgent: string;
+  createdByUserId: string | null;
+  createdAt: number;
+  expiresAt: number;
+  clickedAt: number | null;
+  clickedByUserId: string | null;
+  status: SlackActionStatus;
+}
+
+export interface CreateSlackActionRecord {
+  token: string;
+  channelId: string;
+  threadTs: string;
+  messageTs: string;
+  messageText: string;
+  action: SlackActionButtonSpec;
+  sourceAgent: string;
+  createdByUserId?: string | null;
+  expiresAt?: number;
+}
+
+const STORAGE_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+export class SlackActionStore {
+  private db: Database;
+
+  constructor(dbPath: string) {
+    mkdirSync(dirname(dbPath), { recursive: true });
+    this.db = new Database(dbPath);
+    this.db.run("PRAGMA journal_mode = WAL");
+    this.db.run("PRAGMA synchronous = NORMAL");
+    this.db.run(`
+      CREATE TABLE IF NOT EXISTS slack_action_buttons (
+        token TEXT PRIMARY KEY,
+        channel_id TEXT NOT NULL,
+        thread_ts TEXT NOT NULL,
+        message_ts TEXT NOT NULL,
+        message_text TEXT NOT NULL DEFAULT '',
+        action_id TEXT NOT NULL,
+        action_type TEXT NOT NULL,
+        action_json TEXT NOT NULL,
+        source_agent TEXT NOT NULL,
+        created_by_user_id TEXT,
+        created_at INTEGER NOT NULL,
+        expires_at INTEGER NOT NULL,
+        clicked_at INTEGER,
+        clicked_by_user_id TEXT,
+        status TEXT NOT NULL CHECK (status IN ('active', 'clicked', 'expired', 'disabled', 'failed'))
+      )
+    `);
+    this.ensureMessageTextColumn();
+    this.db.run(
+      "CREATE INDEX IF NOT EXISTS idx_slack_actions_thread_agent ON slack_action_buttons(thread_ts, source_agent, status)",
+    );
+    this.db.run(
+      "CREATE INDEX IF NOT EXISTS idx_slack_actions_message ON slack_action_buttons(channel_id, message_ts)",
+    );
+    this.db.run(
+      "CREATE INDEX IF NOT EXISTS idx_slack_actions_expires ON slack_action_buttons(expires_at, status)",
+    );
+  }
+
+  close(): void {
+    this.db.close();
+  }
+
+  async createMany(records: CreateSlackActionRecord[]): Promise<void> {
+    if (records.length === 0) return;
+    const now = Date.now();
+    const insert = this.db.query(
+      `INSERT INTO slack_action_buttons
+       (token, channel_id, thread_ts, message_ts, action_id, action_type, action_json,
+        message_text, source_agent, created_by_user_id, created_at, expires_at, clicked_at, clicked_by_user_id, status)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, 'active')`,
+    );
+    const txn = this.db.transaction((rows: CreateSlackActionRecord[]) => {
+      for (const row of rows) {
+        insert.run(
+          row.token,
+          row.channelId,
+          row.threadTs,
+          row.messageTs,
+          row.action.id,
+          row.action.type,
+          JSON.stringify(row.action),
+          row.messageText,
+          row.sourceAgent,
+          row.createdByUserId ?? null,
+          now,
+          row.expiresAt ?? now + STORAGE_TTL_MS,
+        );
+      }
+    });
+    txn(records);
+  }
+
+  async get(token: string): Promise<SlackActionRecord | null> {
+    const row = this.db
+      .query<ActionRow, [string]>(
+        "SELECT * FROM slack_action_buttons WHERE token = ?",
+      )
+      .get(token);
+    return row ? toRecord(row) : null;
+  }
+
+  async claim(token: string, userId: string, now = Date.now()): Promise<SlackActionRecord | null> {
+    this.expireStale(now);
+    const record = await this.get(token);
+    if (!record || record.status !== "active" || record.expiresAt <= now) {
+      if (record?.status === "active" && record.expiresAt <= now) {
+        await this.markExpired(token);
+      }
+      return null;
+    }
+
+    const result = this.db
+      .query(
+        `UPDATE slack_action_buttons
+         SET status = 'clicked', clicked_at = ?, clicked_by_user_id = ?
+         WHERE token = ? AND status = 'active'`,
+      )
+      .run(now, userId, token);
+    if (result.changes === 0) return null;
+    return {
+      ...record,
+      status: "clicked",
+      clickedAt: now,
+      clickedByUserId: userId,
+    };
+  }
+
+  async markFailed(token: string): Promise<void> {
+    this.db
+      .query("UPDATE slack_action_buttons SET status = 'failed' WHERE token = ?")
+      .run(token);
+  }
+
+  async disableSourceAgentActions(
+    threadTs: string,
+    sourceAgent: string,
+    exceptMessageTs?: string,
+  ): Promise<Array<{ channelId: string; messageTs: string; messageText: string }>> {
+    const params: string[] = [threadTs, sourceAgent];
+    let where =
+      "thread_ts = ? AND source_agent = ? AND status = 'active'";
+    if (exceptMessageTs) {
+      where += " AND message_ts != ?";
+      params.push(exceptMessageTs);
+    }
+
+    const rows = this.db
+      .query<{ channel_id: string; message_ts: string; message_text: string }, string[]>(
+        `SELECT DISTINCT channel_id, message_ts, message_text FROM slack_action_buttons WHERE ${where}`,
+      )
+      .all(...params);
+    this.db
+      .query(`UPDATE slack_action_buttons SET status = 'disabled' WHERE ${where}`)
+      .run(...params);
+    return rows.map((row) => ({
+      channelId: row.channel_id,
+      messageTs: row.message_ts,
+      messageText: row.message_text,
+    }));
+  }
+
+  async disableMessageActions(channelId: string, messageTs: string): Promise<void> {
+    this.db
+      .query(
+        `UPDATE slack_action_buttons
+         SET status = 'disabled'
+         WHERE channel_id = ? AND message_ts = ? AND status = 'active'`,
+      )
+      .run(channelId, messageTs);
+  }
+
+  private async markExpired(token: string): Promise<void> {
+    this.db
+      .query(
+        "UPDATE slack_action_buttons SET status = 'expired' WHERE token = ? AND status = 'active'",
+      )
+      .run(token);
+  }
+
+  private expireStale(now: number): void {
+    this.db
+      .query(
+        "UPDATE slack_action_buttons SET status = 'expired' WHERE status = 'active' AND expires_at <= ?",
+      )
+      .run(now);
+  }
+
+  private ensureMessageTextColumn(): void {
+    const columns = this.db
+      .query<{ name: string }, []>("PRAGMA table_info(slack_action_buttons)")
+      .all();
+    if (columns.some((column) => column.name === "message_text")) return;
+    this.db.run(
+      "ALTER TABLE slack_action_buttons ADD COLUMN message_text TEXT NOT NULL DEFAULT ''",
+    );
+  }
+}
+
+interface ActionRow {
+  token: string;
+  channel_id: string;
+  thread_ts: string;
+  message_ts: string;
+  message_text: string;
+  action_id: string;
+  action_type: SlackActionButtonSpec["type"];
+  action_json: string;
+  source_agent: string;
+  created_by_user_id: string | null;
+  created_at: number;
+  expires_at: number;
+  clicked_at: number | null;
+  clicked_by_user_id: string | null;
+  status: SlackActionStatus;
+}
+
+function toRecord(row: ActionRow): SlackActionRecord {
+  return {
+    token: row.token,
+    channelId: row.channel_id,
+    threadTs: row.thread_ts,
+    messageTs: row.message_ts,
+    messageText: row.message_text,
+    actionId: row.action_id,
+    actionType: row.action_type,
+    action: JSON.parse(row.action_json) as SlackActionButtonSpec,
+    sourceAgent: row.source_agent,
+    createdByUserId: row.created_by_user_id,
+    createdAt: row.created_at,
+    expiresAt: row.expires_at,
+    clickedAt: row.clicked_at,
+    clickedByUserId: row.clicked_by_user_id,
+    status: row.status,
+  };
+}

--- a/src/slack/formatting.test.ts
+++ b/src/slack/formatting.test.ts
@@ -4,6 +4,7 @@ import {
   formatRunnerToolStatuses,
   formatToolStatuses,
   isDuplicateSlackToolResponse,
+  prepareSlackResponseWithActions,
   sanitizeErrorForSlack,
   splitResponse,
 } from "./formatting.ts";
@@ -171,6 +172,59 @@ describe("extractRunnerMessageText", () => {
 
   it("returns null for non-message events", () => {
     expect(extractRunnerMessageText(makeToolEvent({ name: "Bash" }))).toBeNull();
+  });
+});
+
+describe("prepareSlackResponseWithActions", () => {
+  it("strips junior action specs and returns validated actions", () => {
+    const result = prepareSlackResponseWithActions(`review: changes-requested
+by review
+
+<junior-actions>
+[
+  {
+    "id": "review:rereview",
+    "label": "Re-review",
+    "style": "primary",
+    "type": "dispatch_agent",
+    "agent": "review",
+    "prompt": "read history and re-review"
+  },
+  {
+    "id": "thread:cleanup-worktree",
+    "label": "Cleanup worktree",
+    "type": "cleanup_worktree"
+  }
+]
+</junior-actions>`);
+
+    expect(result).toEqual({
+      text: "review: changes-requested\nby review",
+      actions: [
+        {
+          id: "review:rereview",
+          label: "Re-review",
+          style: "primary",
+          type: "dispatch_agent",
+          agent: "review",
+          prompt: "read history and re-review",
+        },
+        {
+          id: "thread:cleanup-worktree",
+          label: "Cleanup worktree",
+          type: "cleanup_worktree",
+        },
+      ],
+    });
+  });
+
+  it("drops malformed action specs without dropping visible text", () => {
+    const result = prepareSlackResponseWithActions(`ok
+<junior-actions>
+not json
+</junior-actions>`);
+
+    expect(result).toEqual({ text: "ok", actions: [] });
   });
 });
 

--- a/src/slack/formatting.ts
+++ b/src/slack/formatting.ts
@@ -53,6 +53,31 @@ export function extractRunnerMessageText(event: RunnerEvent): string | null {
 }
 
 export const NO_SLACK_MESSAGE = "NO_SLACK_MESSAGE";
+export const ACTIONS_START = "<junior-actions>";
+export const ACTIONS_END = "</junior-actions>";
+
+export type SlackActionButtonStyle = "primary" | "danger";
+
+export type SlackActionButtonSpec =
+  | {
+      id: string;
+      label: string;
+      style?: SlackActionButtonStyle;
+      type: "dispatch_agent";
+      agent: string;
+      prompt: string;
+    }
+  | {
+      id: string;
+      label: string;
+      style?: SlackActionButtonStyle;
+      type: "cleanup_worktree";
+    };
+
+export interface SlackResponseWithActions {
+  text: string;
+  actions: SlackActionButtonSpec[];
+}
 
 const MAX_SLACK_ERROR_LENGTH = 500;
 const PROMPT_LEAK_MARKERS = [
@@ -116,6 +141,107 @@ export function prepareSlackResponse(text: string): string | null {
     if (!normalized) return null;
   }
   return normalized;
+}
+
+export function prepareSlackResponseWithActions(
+  text: string,
+): SlackResponseWithActions | null {
+  const prepared = prepareSlackResponse(text);
+  if (prepared === null) return null;
+
+  const extracted = extractJuniorActions(prepared);
+  if (!extracted) return { text: prepared, actions: [] };
+
+  const visibleText = extracted.text.trim();
+  if (!visibleText) return null;
+
+  return {
+    text: visibleText,
+    actions: parseActionButtonSpecs(extracted.jsonText),
+  };
+}
+
+function extractJuniorActions(
+  text: string,
+): { text: string; jsonText: string } | null {
+  const start = text.indexOf(ACTIONS_START);
+  if (start === -1) return null;
+  const end = text.indexOf(ACTIONS_END, start + ACTIONS_START.length);
+  if (end === -1) {
+    return {
+      text: text.slice(0, start).trimEnd(),
+      jsonText: "",
+    };
+  }
+
+  return {
+    text: `${text.slice(0, start)}${text.slice(end + ACTIONS_END.length)}`.trim(),
+    jsonText: text.slice(start + ACTIONS_START.length, end).trim(),
+  };
+}
+
+export function parseActionButtonSpecs(jsonText: string): SlackActionButtonSpec[] {
+  if (!jsonText) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch {
+    return [];
+  }
+  if (!Array.isArray(parsed)) return [];
+
+  const actions: SlackActionButtonSpec[] = [];
+  for (const candidate of parsed) {
+    const action = normalizeActionButtonSpec(candidate);
+    if (action) actions.push(action);
+    if (actions.length >= 5) break;
+  }
+  return actions;
+}
+
+function normalizeActionButtonSpec(value: unknown): SlackActionButtonSpec | null {
+  if (!isRecord(value)) return null;
+  const id = normalizeActionString(value.id, 80);
+  const label = normalizeActionString(value.label, 30);
+  const style = normalizeActionStyle(value.style);
+  const type = value.type;
+  if (!id || !label) return null;
+
+  if (type === "dispatch_agent") {
+    const agent = normalizeActionString(value.agent, 80);
+    const prompt = normalizeActionString(value.prompt, 2_000);
+    if (!agent || !prompt) return null;
+    return {
+      id,
+      label,
+      ...(style ? { style } : {}),
+      type,
+      agent,
+      prompt,
+    };
+  }
+
+  if (type === "cleanup_worktree") {
+    return {
+      id,
+      label,
+      ...(style ? { style } : {}),
+      type,
+    };
+  }
+
+  return null;
+}
+
+function normalizeActionString(value: unknown, maxLength: number): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > maxLength) return null;
+  return trimmed;
+}
+
+function normalizeActionStyle(value: unknown): SlackActionButtonStyle | null {
+  return value === "primary" || value === "danger" ? value : null;
 }
 
 /**

--- a/src/slack/responder.test.ts
+++ b/src/slack/responder.test.ts
@@ -527,5 +527,33 @@ describe("SlackResponder", () => {
         },
       ]);
     });
+
+    it("caps the block-bearing chunk at Slack's 3000 char section limit", async () => {
+      const { app, calls } = mockApp({
+        postMessageResults: [{ ts: "response-ts-1" }, { ts: "response-ts-2" }],
+      });
+      const responder = new SlackResponder(app);
+      const longText = "a".repeat(3_500);
+
+      const posted = await responder.postResponse(
+        "C123",
+        "1234567890.123456",
+        longText,
+        undefined,
+        [{ token: "tok-1", label: "Re-review" }],
+      );
+
+      expect(posted).toEqual([
+        { ts: "response-ts-1", text: "a".repeat(3_000) },
+        { ts: "response-ts-2", text: "a".repeat(500) },
+      ]);
+      expect(calls.postMessage).toHaveLength(2);
+      expect(calls.postMessage[0].text).toHaveLength(3_000);
+      expect(calls.postMessage[0].blocks?.[0]).toEqual({
+        type: "section",
+        text: { type: "mrkdwn", text: "a".repeat(3_000) },
+      });
+      expect(calls.postMessage[1].blocks).toBeUndefined();
+    });
   });
 });

--- a/src/slack/responder.test.ts
+++ b/src/slack/responder.test.ts
@@ -25,6 +25,7 @@ function mockApp(stubs?: {
       username?: string;
       icon_emoji?: string;
       icon_url?: string;
+      blocks?: Array<Record<string, unknown>>;
     }>;
     delete: Array<{ channel: string; ts: string }>;
     update: Array<{ channel: string; ts: string; text: string }>;
@@ -479,6 +480,52 @@ describe("SlackResponder", () => {
       expect(calls.postMessage[0].username).toBe("GitHub Access");
       expect(calls.postMessage[0].icon_url).toBe("https://example.com/icon.png");
       expect(calls.postMessage[0].icon_emoji).toBeUndefined();
+    });
+
+    it("renders action buttons on the first response chunk", async () => {
+      const { app, calls } = mockApp({
+        postMessageResults: [{ ts: "response-ts-1" }],
+      });
+      const responder = new SlackResponder(app);
+
+      const posted = await responder.postResponse(
+        "C123",
+        "1234567890.123456",
+        "review: changes-requested",
+        { username: "Reviewer", iconEmoji: ":eyes:" },
+        [
+          { token: "tok-1", label: "Re-review", style: "primary" },
+          { token: "tok-2", label: "Cleanup worktree" },
+        ],
+      );
+
+      expect(posted).toEqual([
+        { ts: "response-ts-1", text: "review: changes-requested" },
+      ]);
+      expect(calls.postMessage[0].blocks).toEqual([
+        {
+          type: "section",
+          text: { type: "mrkdwn", text: "review: changes-requested" },
+        },
+        {
+          type: "actions",
+          elements: [
+            {
+              type: "button",
+              text: { type: "plain_text", text: "Re-review", emoji: true },
+              action_id: "junior_agent_action",
+              value: "tok-1",
+              style: "primary",
+            },
+            {
+              type: "button",
+              text: { type: "plain_text", text: "Cleanup worktree", emoji: true },
+              action_id: "junior_agent_action",
+              value: "tok-2",
+            },
+          ],
+        },
+      ]);
     });
   });
 });

--- a/src/slack/responder.ts
+++ b/src/slack/responder.ts
@@ -3,6 +3,17 @@ import type { AgentIdentity } from "../session/types.ts";
 import { splitResponse } from "./formatting.ts";
 import { log } from "../logger.ts";
 
+export interface SlackMessageButton {
+  token: string;
+  label: string;
+  style?: "primary" | "danger";
+}
+
+export interface PostedSlackMessage {
+  ts: string;
+  text: string;
+}
+
 interface StatusEntry {
   messageTs: string;
   lastUpdateTime: number;
@@ -11,6 +22,29 @@ interface StatusEntry {
 function preview(text: string, n = 80): string {
   const flat = text.replace(/\s+/g, " ").trim();
   return flat.length > n ? `${flat.slice(0, n)}…` : flat;
+}
+
+function buildActionBlocks(text: string, buttons: SlackMessageButton[]): Array<Record<string, unknown>> {
+  return [
+    {
+      type: "section",
+      text: { type: "mrkdwn", text },
+    },
+    {
+      type: "actions",
+      elements: buttons.slice(0, 5).map((button) => ({
+        type: "button",
+        text: {
+          type: "plain_text",
+          text: button.label.slice(0, 30),
+          emoji: true,
+        },
+        action_id: "junior_agent_action",
+        value: button.token,
+        ...(button.style ? { style: button.style } : {}),
+      })),
+    },
+  ];
 }
 
 export class SlackResponder {
@@ -40,8 +74,10 @@ export class SlackResponder {
     threadTs: string,
     text: string,
     identity?: AgentIdentity,
-  ): Promise<void> {
+    buttons: SlackMessageButton[] = [],
+  ): Promise<PostedSlackMessage[]> {
     const chunks = splitResponse(text);
+    const posted: PostedSlackMessage[] = [];
     log.info(
       "responder",
       `post.start thread=${threadTs} channel=${channel} chunks=${chunks.length} len=${text.length}`,
@@ -49,10 +85,14 @@ export class SlackResponder {
     for (let i = 0; i < chunks.length; i++) {
       const chunk = chunks[i];
       try {
+        const blocks = i === 0 && buttons.length > 0
+          ? buildActionBlocks(chunk, buttons)
+          : undefined;
         const message = {
           channel,
           thread_ts: threadTs,
           text: chunk,
+          ...(blocks ? { blocks } : {}),
           ...(identity
             ? {
                 username: identity.username,
@@ -70,12 +110,32 @@ export class SlackResponder {
           "responder",
           `post.ok thread=${threadTs} chunk=${i + 1}/${chunks.length} ts=${result.ts ?? "?"} preview="${preview(chunk)}"`,
         );
+        if (result.ts) {
+          posted.push({ ts: result.ts, text: chunk });
+        }
       } catch (err) {
         log.error(
           "responder",
           `post.fail thread=${threadTs} chunk=${i + 1}/${chunks.length} err=${err instanceof Error ? err.message : String(err)}`,
         );
       }
+    }
+    return posted;
+  }
+
+  async removeMessageActions(channel: string, ts: string, text: string): Promise<void> {
+    try {
+      await this.app.client.chat.update({
+        channel,
+        ts,
+        text,
+        blocks: [{ type: "section", text: { type: "mrkdwn", text } }],
+      });
+    } catch (err) {
+      log.error(
+        "responder",
+        `actions.disable.fail channel=${channel} ts=${ts} err=${err instanceof Error ? err.message : String(err)}`,
+      );
     }
   }
 

--- a/src/slack/responder.ts
+++ b/src/slack/responder.ts
@@ -14,6 +14,8 @@ export interface PostedSlackMessage {
   text: string;
 }
 
+const SLACK_SECTION_TEXT_LIMIT = 3_000;
+
 interface StatusEntry {
   messageTs: string;
   lastUpdateTime: number;
@@ -76,7 +78,12 @@ export class SlackResponder {
     identity?: AgentIdentity,
     buttons: SlackMessageButton[] = [],
   ): Promise<PostedSlackMessage[]> {
-    const chunks = splitResponse(text);
+    const chunks =
+      buttons.length > 0
+        ? splitResponse(text, SLACK_SECTION_TEXT_LIMIT).flatMap((chunk) =>
+            splitHard(chunk, SLACK_SECTION_TEXT_LIMIT),
+          )
+        : splitResponse(text);
     const posted: PostedSlackMessage[] = [];
     log.info(
       "responder",
@@ -367,4 +374,13 @@ export class SlackResponder {
     }
     log.info("responder", `status.clear.thread thread=${threadTs}`);
   }
+}
+
+function splitHard(text: string, maxLength: number): string[] {
+  if (text.length <= maxLength) return [text];
+  const chunks: string[] = [];
+  for (let i = 0; i < text.length; i += maxLength) {
+    chunks.push(text.slice(i, i + maxLength));
+  }
+  return chunks;
 }

--- a/src/worktree/manager.test.ts
+++ b/src/worktree/manager.test.ts
@@ -441,4 +441,45 @@ describe("WorktreeManager.createWorktree", () => {
       `${repoRoot}.junior-worktrees/slack-t1`,
     );
   });
+
+  it("reports zero unpushed commits for a fresh worktree", async () => {
+    const repos: RepoConfig[] = [
+      { name: "clean-status", path: repoRoot, defaultBase: "origin/main" },
+    ];
+    const wm = new WorktreeManager(repos);
+
+    const wtPath = await wm.createWorktree("clean-status", "clean-status-thread");
+    const status = await wm.getWorktreeStatus(wtPath, "clean-status");
+
+    expect(status.tracked).toEqual([]);
+    expect(status.untracked).toEqual([]);
+    expect(status.unpushedCommits).toBe(0);
+    expect(status.unpushedBase).toBe("origin/main");
+
+    await wm.removeWorktree("clean-status", "clean-status-thread");
+  });
+
+  it("detects committed local-only work when no upstream branch is configured", async () => {
+    const repos: RepoConfig[] = [
+      { name: "unpushed-status", path: repoRoot, defaultBase: "origin/main" },
+    ];
+    const wm = new WorktreeManager(repos);
+
+    const wtPath = await wm.createWorktree(
+      "unpushed-status",
+      "unpushed-status-thread",
+    );
+    writeFileSync(join(wtPath, "LOCAL.md"), "local only\n");
+    await runIn(wtPath, ["git", "add", "LOCAL.md"]);
+    await runIn(wtPath, ["git", "commit", "-q", "-m", "local only"]);
+
+    const status = await wm.getWorktreeStatus(wtPath, "unpushed-status");
+
+    expect(status.tracked).toEqual([]);
+    expect(status.untracked).toEqual([]);
+    expect(status.unpushedCommits).toBe(1);
+    expect(status.unpushedBase).toBe("origin/main");
+
+    await wm.removeWorktree("unpushed-status", "unpushed-status-thread");
+  });
 });

--- a/src/worktree/manager.ts
+++ b/src/worktree/manager.ts
@@ -3,6 +3,8 @@ import type { RepoConfig } from "../config.ts";
 export interface WorktreeStatus {
   tracked: string[];
   untracked: string[];
+  unpushedCommits: number;
+  unpushedBase: string | null;
 }
 
 export class WorktreeManager {
@@ -138,9 +140,16 @@ export class WorktreeManager {
     return output.trim().length > 0;
   }
 
-  async getWorktreeStatus(worktreePath: string): Promise<WorktreeStatus> {
+  async getWorktreeStatus(
+    worktreePath: string,
+    repoName?: string,
+  ): Promise<WorktreeStatus> {
     const output = await this.runGit(["status", "--porcelain"], worktreePath);
-    const status: WorktreeStatus = { tracked: [], untracked: [] };
+    const status: WorktreeStatus = {
+      tracked: [],
+      untracked: [],
+      ...(await this.getUnpushedStatus(worktreePath, repoName)),
+    };
     for (const line of output.split(/\r?\n/)) {
       if (!line.trim()) continue;
       const path = line.slice(3).trim();
@@ -152,6 +161,30 @@ export class WorktreeManager {
       }
     }
     return status;
+  }
+
+  private async getUnpushedStatus(
+    worktreePath: string,
+    repoName?: string,
+  ): Promise<Pick<WorktreeStatus, "unpushedCommits" | "unpushedBase">> {
+    const upstream = await this.tryRunGit(
+      ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
+      worktreePath,
+    );
+    const repo = repoName ? this.getRepo(repoName) : undefined;
+    const base = upstream.trim() || repo?.defaultBase || null;
+    if (!base) {
+      return { unpushedCommits: 0, unpushedBase: null };
+    }
+
+    const count = await this.tryRunGit(
+      ["rev-list", "--count", `${base}..HEAD`],
+      worktreePath,
+    );
+    return {
+      unpushedCommits: Number.parseInt(count.trim() || "0", 10) || 0,
+      unpushedBase: base,
+    };
   }
 
   /**
@@ -202,6 +235,14 @@ export class WorktreeManager {
       throw new Error(`git ${args[0]} failed: ${stderr.trim()}`);
     }
     return await new Response(proc.stdout).text();
+  }
+
+  private async tryRunGit(args: string[], cwd: string): Promise<string> {
+    try {
+      return await this.runGit(args, cwd);
+    } catch {
+      return "";
+    }
   }
 
   /**

--- a/src/worktree/manager.ts
+++ b/src/worktree/manager.ts
@@ -1,5 +1,10 @@
 import type { RepoConfig } from "../config.ts";
 
+export interface WorktreeStatus {
+  tracked: string[];
+  untracked: string[];
+}
+
 export class WorktreeManager {
   private repos: RepoConfig[];
 
@@ -131,6 +136,22 @@ export class WorktreeManager {
   async isWorktreeDirty(worktreePath: string): Promise<boolean> {
     const output = await this.runGit(["status", "--porcelain"], worktreePath);
     return output.trim().length > 0;
+  }
+
+  async getWorktreeStatus(worktreePath: string): Promise<WorktreeStatus> {
+    const output = await this.runGit(["status", "--porcelain"], worktreePath);
+    const status: WorktreeStatus = { tracked: [], untracked: [] };
+    for (const line of output.split(/\r?\n/)) {
+      if (!line.trim()) continue;
+      const path = line.slice(3).trim();
+      if (!path) continue;
+      if (line.startsWith("?? ")) {
+        status.untracked.push(path);
+      } else {
+        status.tracked.push(path);
+      }
+    }
+    return status;
   }
 
   /**


### PR DESCRIPTION
## Summary
- add a structured <junior-actions> contract for agents to attach Slack buttons to final responses
- persist action tokens in SQLite and disable stale buttons on click or same-agent follow-up
- wire dispatch_agent and cleanup_worktree actions, including safe worktree cleanup and auto-cleanup after review approval
- update the private review agent submodule to emit Re-review, Make fix, and Cleanup worktree actions

## Testing
- bun run typecheck
- bun test

## Notes
- agents-org branch pushed: GrowthX-Club/junior-private-agents:add-review-action-buttons
- parent submodule pointer references agents-org commit 7f6bdaa