### PR TITLE
fix(slack): render action buttons from MCP posts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,7 @@ const agentRouter = new AgentRouter(
 const worktreeManager = new WorktreeManager(config.repos);
 const devServerManager = new DevServerManager(config.repos, worktreeManager);
 const devServerQueue = new DevServerQueue(devServerManager, config.repos);
-startMcpServer(config.slack.botToken, store, worktreeManager, sessionManager);
+startMcpServer(config.slack.botToken, store, worktreeManager, sessionManager, actionStore);
 sessionManager.agentRouter = agentRouter;
 sessionManager.worktreeManager = worktreeManager;
 sessionManager.slackApp = app;
@@ -264,7 +264,9 @@ sessionManager.onAgentSettled = async (session, agentName, response) => {
 };
 
 registerHomeTab(app, store, config.session.homeWindowMs, workflowStore);
-registerAgentActionButtons(app, actionStore, sessionManager, worktreeManager);
+registerAgentActionButtons(app, actionStore, sessionManager, worktreeManager, {
+  supportChannels,
+});
 
 setupGracefulShutdown(sessionManager, devServerManager, async () => {
   await workflowScheduler.shutdown();

--- a/src/mcp/slack-server.ts
+++ b/src/mcp/slack-server.ts
@@ -29,6 +29,10 @@ import {
 import { parsePureAgentDirectiveResponse } from "../support/directives.ts";
 import { parseSlackMcpRunContext, type SlackMcpRunContext } from "./context.ts";
 import { handleMongoMcpRequest } from "./mongodb-proxy.ts";
+import { prepareSlackResponseWithActions } from "../slack/formatting.ts";
+import { buildActionBlocks, splitActionMessageText } from "../slack/responder.ts";
+import type { SlackActionStore } from "../slack/action-store.ts";
+import { disableAgentActionMessages } from "../slack/action-buttons.ts";
 
 const MCP_PORT = Number(process.env.MCP_PORT ?? "3456");
 const FALLBACK_AGENTS_DIR = ".claude/agents";
@@ -39,6 +43,7 @@ let slack: WebClient;
 let sessionStore: SessionStore | undefined;
 let worktreeManager: WorktreeManager | undefined;
 let sessionManager: SessionManager | undefined;
+let slackActionStore: SlackActionStore | undefined;
 
 function registerTools(server: McpServer, runContext: SlackMcpRunContext | null = null) {
   server.registerTool(
@@ -69,20 +74,78 @@ function registerTools(server: McpServer, runContext: SlackMcpRunContext | null 
         };
       }
 
+      const prepared = prepareSlackResponseWithActions(text);
+      if (prepared === null) {
+        return {
+          content: [{ type: "text" as const, text: "Message suppressed" }],
+        };
+      }
+
       const resolvedIconUrl = icon_url ?? image_url;
       const identity = {
         ...(username ? { username } : {}),
         ...(icon_emoji ? { icon_emoji } : {}),
         ...(resolvedIconUrl && !icon_emoji ? { icon_url: resolvedIconUrl } : {}),
       };
-      const message = reply_broadcast && thread_ts
-        ? { channel: channel_id, text, thread_ts, reply_broadcast: true, ...identity }
-        : thread_ts
-          ? { channel: channel_id, text, thread_ts, ...identity }
-          : { channel: channel_id, text, ...identity };
-      const result = await slack.chat.postMessage(message as Parameters<typeof slack.chat.postMessage>[0]);
+      const sourceAgent = runContext?.agent ?? "mcp";
+      if (slackActionStore && thread_ts && prepared.actions.length > 0) {
+        await disableAgentActionMessages(
+          slackActionStore,
+          slack,
+          thread_ts,
+          sourceAgent,
+        );
+      }
+      const buttonTokens = slackActionStore
+        ? prepared.actions.map((action) => ({
+            action,
+            token: crypto.randomUUID(),
+          }))
+        : [];
+      const chunks = buttonTokens.length > 0
+        ? splitActionMessageText(prepared.text)
+        : [prepared.text];
+      const blocks = buttonTokens.length > 0
+        ? buildActionBlocks(
+            chunks[0] ?? prepared.text,
+            buttonTokens.map(({ action, token }) => ({
+              token,
+              label: action.label,
+              style: action.style,
+            })),
+          )
+        : undefined;
+      let firstResult: Awaited<ReturnType<typeof slack.chat.postMessage>> | null = null;
+      let firstText = chunks[0] ?? prepared.text;
+      for (let i = 0; i < chunks.length; i++) {
+        const chunk = chunks[i]!;
+        const chunkBlocks = i === 0 ? blocks : undefined;
+        const message = reply_broadcast && thread_ts
+          ? { channel: channel_id, text: chunk, thread_ts, reply_broadcast: true, ...(chunkBlocks ? { blocks: chunkBlocks } : {}), ...identity }
+          : thread_ts
+            ? { channel: channel_id, text: chunk, thread_ts, ...(chunkBlocks ? { blocks: chunkBlocks } : {}), ...identity }
+            : { channel: channel_id, text: chunk, ...(chunkBlocks ? { blocks: chunkBlocks } : {}), ...identity };
+        const result = await slack.chat.postMessage(message as Parameters<typeof slack.chat.postMessage>[0]);
+        if (!firstResult) {
+          firstResult = result;
+          firstText = chunk;
+        }
+      }
+      if (slackActionStore && firstResult?.ts && buttonTokens.length > 0) {
+        await slackActionStore.createMany(
+          buttonTokens.map(({ action, token }) => ({
+            token,
+            channelId: channel_id,
+            threadTs: thread_ts ?? firstResult.ts!,
+            messageTs: firstResult.ts!,
+            messageText: firstText,
+            action,
+            sourceAgent,
+          })),
+        );
+      }
       return {
-        content: [{ type: "text" as const, text: `Message sent (ts: ${result.ts})` }],
+        content: [{ type: "text" as const, text: `Message sent (ts: ${firstResult?.ts})` }],
       };
     },
   );
@@ -813,11 +876,13 @@ export function startMcpServer(
   store?: SessionStore,
   wtManager?: WorktreeManager,
   manager?: SessionManager,
+  actionStore?: SlackActionStore,
 ): void {
   slack = new WebClient(botToken);
   sessionStore = store;
   worktreeManager = wtManager;
   sessionManager = manager;
+  slackActionStore = actionStore;
 
   const httpServer = createServer(async (req, res) => {
     const pathname = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`).pathname;

--- a/src/slack/action-buttons.test.ts
+++ b/src/slack/action-buttons.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import { resolveDispatchAgent } from "./action-buttons.ts";
+
+describe("resolveDispatchAgent", () => {
+  it("routes review make-fix to default outside support channels", () => {
+    expect(
+      resolveDispatchAgent(
+        {
+          channelId: "C-JUNIOR",
+          action: {
+            id: "review:make-fix",
+            label: "Make fix",
+            type: "dispatch_agent",
+            agent: "thinker",
+            prompt: "fix it",
+          },
+        },
+        new Set(["C-BUGS"]),
+      ),
+    ).toBe("default");
+  });
+
+  it("routes review make-fix to thinker in support channels", () => {
+    expect(
+      resolveDispatchAgent(
+        {
+          channelId: "C-BUGS",
+          action: {
+            id: "review:make-fix",
+            label: "Make fix",
+            type: "dispatch_agent",
+            agent: "default",
+            prompt: "fix it",
+          },
+        },
+        new Set(["C-BUGS"]),
+      ),
+    ).toBe("thinker");
+  });
+
+  it("leaves other dispatch actions unchanged", () => {
+    expect(
+      resolveDispatchAgent(
+        {
+          channelId: "C-JUNIOR",
+          action: {
+            id: "review:rereview",
+            label: "Re-review",
+            type: "dispatch_agent",
+            agent: "review",
+            prompt: "review again",
+          },
+        },
+        new Set(["C-BUGS"]),
+      ),
+    ).toBe("review");
+  });
+});

--- a/src/slack/action-buttons.ts
+++ b/src/slack/action-buttons.ts
@@ -8,6 +8,10 @@ import { log } from "../logger.ts";
 import type { SlackActionRecord, SlackActionStore } from "./action-store.ts";
 
 export const ACTION_BUTTON_ID = "junior_agent_action";
+export const ACTION_BUTTON_ID_PATTERN = new RegExp(`^${ACTION_BUTTON_ID}(?::\\d+)?$`);
+export interface RegisterAgentActionButtonsOptions {
+  supportChannels?: ReadonlySet<string>;
+}
 
 const ALLOWED_UNTRACKED_EXACT = new Set(["learnings.md", ".DS_Store"]);
 const ALLOWED_UNTRACKED_PREFIXES = [".codex/", ".claude/"];
@@ -17,8 +21,9 @@ export function registerAgentActionButtons(
   actionStore: SlackActionStore,
   sessionManager: SessionManager,
   worktreeManager: WorktreeManager,
+  options: RegisterAgentActionButtonsOptions = {},
 ): void {
-  app.action(ACTION_BUTTON_ID, async ({ ack, body, client }) => {
+  app.action(ACTION_BUTTON_ID_PATTERN, async ({ ack, body, client }) => {
     await ack();
 
     const token = actionTokenFromBody(body);
@@ -36,7 +41,7 @@ export function registerAgentActionButtons(
 
     try {
       if (record.action.type === "dispatch_agent") {
-        await handleDispatch(record, userId, sessionManager);
+        await handleDispatch(record, userId, sessionManager, options.supportChannels);
       } else if (record.action.type === "cleanup_worktree") {
         await handleCleanup(record, sessionManager, worktreeManager, client);
       }
@@ -76,11 +81,13 @@ async function handleDispatch(
   record: SlackActionRecord,
   userId: string,
   sessionManager: SessionManager,
+  supportChannels: ReadonlySet<string> | undefined,
 ): Promise<void> {
   const action = record.action;
   if (action.type !== "dispatch_agent") return;
-  if (!isPersistentAgent(action.agent) && action.agent !== "lead" && action.agent !== "default") {
-    throw new Error(`unknown agent: ${action.agent}`);
+  const targetAgent = resolveDispatchAgent(record, supportChannels);
+  if (!isPersistentAgent(targetAgent) && targetAgent !== "lead" && targetAgent !== "default") {
+    throw new Error(`unknown agent: ${targetAgent}`);
   }
 
   await sessionManager.handleAgentMessage(
@@ -93,8 +100,20 @@ async function handleDispatch(
       command: null,
       dedupeKey: `button:${record.token}`,
     },
-    action.agent,
+    targetAgent,
   );
+}
+
+export function resolveDispatchAgent(
+  record: Pick<SlackActionRecord, "action" | "channelId">,
+  supportChannels: ReadonlySet<string> | undefined,
+): string {
+  const action = record.action;
+  if (action.type !== "dispatch_agent") return "";
+  if (action.id === "review:make-fix") {
+    return supportChannels?.has(record.channelId) ? "thinker" : "default";
+  }
+  return action.agent;
 }
 
 async function handleCleanup(

--- a/src/slack/responder.test.ts
+++ b/src/slack/responder.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "bun:test";
-import { SlackResponder } from "./responder.ts";
+import { SlackResponder, splitActionMessageText } from "./responder.ts";
 
 /**
  * Minimal mock for Slack Bolt App with chat API stubs.
@@ -513,14 +513,14 @@ describe("SlackResponder", () => {
             {
               type: "button",
               text: { type: "plain_text", text: "Re-review", emoji: true },
-              action_id: "junior_agent_action",
+              action_id: "junior_agent_action:0",
               value: "tok-1",
               style: "primary",
             },
             {
               type: "button",
               text: { type: "plain_text", text: "Cleanup worktree", emoji: true },
-              action_id: "junior_agent_action",
+              action_id: "junior_agent_action:1",
               value: "tok-2",
             },
           ],
@@ -554,6 +554,12 @@ describe("SlackResponder", () => {
         text: { type: "mrkdwn", text: "a".repeat(3_000) },
       });
       expect(calls.postMessage[1].blocks).toBeUndefined();
+    });
+
+    it("exports the same Slack-safe chunks for MCP action posts", () => {
+      const chunks = splitActionMessageText("a".repeat(3_500));
+
+      expect(chunks).toEqual(["a".repeat(3_000), "a".repeat(500)]);
     });
   });
 });

--- a/src/slack/responder.ts
+++ b/src/slack/responder.ts
@@ -2,6 +2,7 @@ import type { App } from "@slack/bolt";
 import type { AgentIdentity } from "../session/types.ts";
 import { splitResponse } from "./formatting.ts";
 import { log } from "../logger.ts";
+import { ACTION_BUTTON_ID } from "./action-buttons.ts";
 
 export interface SlackMessageButton {
   token: string;
@@ -26,7 +27,7 @@ function preview(text: string, n = 80): string {
   return flat.length > n ? `${flat.slice(0, n)}…` : flat;
 }
 
-function buildActionBlocks(text: string, buttons: SlackMessageButton[]): Array<Record<string, unknown>> {
+export function buildActionBlocks(text: string, buttons: SlackMessageButton[]): Array<Record<string, unknown>> {
   return [
     {
       type: "section",
@@ -34,19 +35,25 @@ function buildActionBlocks(text: string, buttons: SlackMessageButton[]): Array<R
     },
     {
       type: "actions",
-      elements: buttons.slice(0, 5).map((button) => ({
+      elements: buttons.slice(0, 5).map((button, index) => ({
         type: "button",
         text: {
           type: "plain_text",
           text: button.label.slice(0, 30),
           emoji: true,
         },
-        action_id: "junior_agent_action",
+        action_id: `${ACTION_BUTTON_ID}:${index}`,
         value: button.token,
         ...(button.style ? { style: button.style } : {}),
       })),
     },
   ];
+}
+
+export function splitActionMessageText(text: string): string[] {
+  return splitResponse(text, SLACK_SECTION_TEXT_LIMIT).flatMap((chunk) =>
+    splitHard(chunk, SLACK_SECTION_TEXT_LIMIT),
+  );
 }
 
 export class SlackResponder {
@@ -78,12 +85,9 @@ export class SlackResponder {
     identity?: AgentIdentity,
     buttons: SlackMessageButton[] = [],
   ): Promise<PostedSlackMessage[]> {
-    const chunks =
-      buttons.length > 0
-        ? splitResponse(text, SLACK_SECTION_TEXT_LIMIT).flatMap((chunk) =>
-            splitHard(chunk, SLACK_SECTION_TEXT_LIMIT),
-          )
-        : splitResponse(text);
+    const chunks = buttons.length > 0
+      ? splitActionMessageText(text)
+      : splitResponse(text);
     const posted: PostedSlackMessage[] = [];
     log.info(
       "responder",


### PR DESCRIPTION
## Summary
- parse `<junior-actions>` in `slack_send_message` MCP posts
- render and store Slack action button tokens from MCP-posted messages
- split long action-bearing Slack posts so button blocks stay under the 3,000-character section limit
- use unique Slack `action_id`s per button while routing them to one handler
- route `review:make-fix` to `default` outside support channels and `thinker` only in support/bug channels
- update `agents-org` so approved reviews show `Merge via gxt-admin` + cleanup, and make-fix defaults to Junior outside bug channels

## Verification
- `bun run typecheck`
- `bun test src/slack/action-buttons.test.ts src/slack/responder.test.ts src/slack/action-store.test.ts src/slack/formatting.test.ts src/mcp/slack-server.test.ts`