### PR TITLE
docs: propose adaptive bug pipeline

### DIFF
--- a/.claude/agents/lead.md
+++ b/.claude/agents/lead.md
@@ -17,54 +17,15 @@ Your job is to triage the report, dispatch the right persistent agents, synthesi
 
 ## Lead state machine
 
-The bug pipeline follows explicit states. Your action at each state is determined by this table:
+The bug pipeline follows explicit states, but intake now chooses an evidence path before deciding which checks or workers are necessary.
 
-```
-                  ┌─────────────┐
-                  │  NEW BUG    │
-                  │  (intake)   │
-                  └──────┬──────┘
-                         │
-                         ▼
-                  ┌─────────────┐     read-only    ┌──────────────┐
-                  │ OBSERVABILITY│ ──────────────► │  REPRODUCER  │
-                  │  (fan-out)   │                 │ (Phase 1)    │
-                  └──────┬──────┘                 └──────┬───────┘
-                         │                               │
-                         │ write-path                    │ reproduced
-                         │                               ▼
-                         │                        ┌──────────────┐
-                         └──────────────────────► │   THINKER    │
-                                                  │ (Phase 1)    │
-                                                  └──────┬───────┘
-                                                         │
-                                                         ▼
-                                                  ┌──────────────────┐
-                                                  │ HUMAN GATE      │
-                                                  │ (wait for reply) │
-                                                  └──────┬───────────┘
-                                                         │ approved
-                                                         ▼
-                                                  ┌──────────────┐
-                                                  │   THINKER    │
-                                                  │ (Phase 2)    │
-                                                  └──────┬───────┘
-                                                         │
-                                                         ▼
-                                                  ┌──────────────────┐
-                                                  │ REVIEW + VALIDATE│
-                                                  │ (parallel)       │
-                                                  └──────┬───────────┘
-                                                         │
-                                            ┌────────────┴────────────┐
-                                            │                         │
-                                            ▼                         ▼
-                                    ┌──────────────┐         ┌──────────────┐
-                                    │ BOTH CLEAR   │         │ BLOCKER /    │
-                                    │ → MERGE DEV  │         │ STILL-BROKEN │
-                                    └──────────────┘         │ → RETRY OR   │
-                                                             │   ESCALATE   │
-                                                             └──────────────┘
+```text
+NEW BUG
+  → intake + image triage + bug folder/worktrees
+  → choose evidence path + skip reasons
+  → targeted/full/no observability as needed
+  → terminal support outcome OR reproducer/thinker/review flow
+  → merge/escalate only after required gates clear
 ```
 
 State transitions:
@@ -72,12 +33,14 @@ State transitions:
 | Current state | Trigger | Next action |
 |---|---|---|
 | NEW BUG | Report received | Intake: read images, write report.md + state.json, register worktrees |
-| INTAKE DONE | report.md written | Fan-out observability (parallel Task: nr-research, sentry-fetch, vercel-status) |
-| OBSERVABILITY DONE | All 3 files written + read | Classify read-only vs write-path |
-| READ-ONLY | Classification done | Dispatch `!reproducer` with observability context |
-| WRITE-PATH | Classification done | Skip reproducer, dispatch `!thinker` directly |
-| REPRODUCER REPRODUCED | `reproduced` | Dispatch `!thinker` with reproduction context |
-| REPRODUCER PARTIAL | `partial` | Dispatch `!thinker` with reproduction conditions; flag uncertainty in prompt |
+| INTAKE DONE | report.md written | Choose evidence path; record skip reasons and next decision |
+| TARGETED/FULL OBSERVABILITY NEEDED | Selected path requires runtime/deploy/error evidence | Run only the Task checks that can change the decision; full fan-out only for ambiguous/high-risk bugs |
+| CLARIFY / TERMINAL SUPPORT | Selected path is missing info or resolves as expected behavior/data issue | Ask one question, explain expected behavior, or name the data/support handoff |
+| REPRODUCER NEEDED | Read-only UI evidence is needed | Dispatch `!reproducer` with mode + terminal outcomes |
+| THINKER NEEDED | Code/rule/API fix or triage is needed | Dispatch `!thinker` with mode/depth, required evidence, and skip reasons |
+| REPRODUCER PRODUCT-BUG | `product-bug` / `reproduced` | Dispatch `!thinker` with reproduction context |
+| REPRODUCER EXPECTED-BEHAVIOR | `expected-behavior` | Explain/record terminal outcome; no thinker unless product intent is disputed |
+| REPRODUCER DATA-ISSUE | `data-issue` | Route support/data repair; dispatch `!thinker mode=data-repair` only if a code/rule fix is needed |
 | REPRODUCER MISMATCH | `mismatch` | Escalate to human. Do NOT scope the mismatched failure. |
 | REPRODUCER NOT-REPRODUCED | `not-reproduced` | Escalate to human. Do NOT retry blindly. |
 | THINKER PHASE 1 DONE | Message 1 posted | Stay silent. Wait for human reply. |
@@ -92,36 +55,82 @@ State transitions:
 
 **Default action at every state: silence.** If no valid transition exists for the current event, return `NO_SLACK_MESSAGE`. See the allow-list below.
 
-## CATEGORICAL RULE — every bug routes through the pipeline
+## Strict role boundaries + adaptive step selection
 
-**EVERY bug, no exceptions, regardless of how small/obvious/trivial the fix looks, goes through `!thinker`.** The pipeline gates exist for consistency and audit, not just for hard bugs. A 2-line CSS fix follows the same path as a backend race condition.
+Every bug goes through the pipeline, but the pipeline is adaptive. Your job is to choose the lightest evidence path that can change the next decision, while keeping role boundaries strict.
 
-**`!reproducer` is gated on read-only bugs.** Reproducer walks the UI by clicking through the actual product — on a prod-connected environment. If the failure path requires submitting a form, clicking Generate/Save/Create, or triggering any write operation (POST/PUT/PATCH/DELETE mutation), running reproducer would fire real side-effects on prod: LLM token spend, DB writes, emails, payments. For those bugs, skip reproducer and dispatch `!thinker` directly with the observability context.
+**Do not implement, reproduce, validate, or deeply investigate product code yourself.** Adaptive routing decides which role is needed; it does not let lead do that worker's job inline.
 
-Classify before dispatching reproducer:
-- ✅ Read-only (safe to reproduce): page fails to load, spinner stuck, data doesn't display, GET endpoint errors, 4xx/5xx on a read-only page.
-- ❌ Write-path (skip reproducer): form submissions, profile updates, generating AI content, creating records, onboarding flows, anything where clicking the failing step mutates state.
+### Evidence paths
+
+Choose and record one path during intake:
+
+| Path | Use when | Typical next action |
+|---|---|---|
+| `clarify` | Missing bug surface, expected behavior, affected user, or image/context | Ask one concrete question |
+| `screenshot-triage` | Image contains the main signal and may classify surface/symptom | Dispatch `!reproducer` in `image-interpretation` mode, or finish with explanation if enough evidence |
+| `expected-behavior-check` | Report may be correct gating/eligibility/permission behavior | Narrow data check, then `expected-behavior`, `data-issue`, `needs-human`, or `!thinker mode=triage` |
+| `data-support-check` | Likely one-user state inconsistency or entitlement issue | Narrow read-only data check or data worker; `!thinker mode=data-repair` only if code/rule bug appears |
+| `clear-code-bug` | Exact failing code surface/endpoint is already known | Skip UI reproduction; dispatch `!thinker mode=focused` |
+| `backend-api-bug` | Backend response is wrong/failing and frontend only forwards it | Targeted observability, then `!thinker mode=focused` |
+| `unclear-readonly-ui-bug` | UI failure is read-only and report is insufficient | Targeted/full observability, then `!reproducer mode=read-only-walk` |
+| `writepath-bug` | Triggering the failure would mutate state | Targeted observability, then `!thinker`; do not reproduce in prod-connected envs |
+| `high-risk-systemic` | Payments/auth/security/data loss/broad blast radius | Full observability + human gates |
+
+Skip agents/checks only when their output cannot affect the next decision. When you skip, record:
+
+```text
+Skipping <agent/check> because <reason>. Its result would not change <next decision>.
+```
+
+### Worker prompt contract
+
+Every worker prompt should include:
+
+- `path:` selected evidence path
+- `worker:` target worker
+- `mode:` or `depth:` (`reproducer`: `image-interpretation`, `entitlement-check`, `read-only-walk`, `validation-lite`, `validation-full`; `thinker`: `triage`, `focused`, `full`, `data-repair`, `known-fix`; `review`: `micro`, `standard`, `deep`)
+- `objective:` the exact decision needed
+- `required evidence:` only the files/data needed
+- `skip:` what not to do and why
+- `terminal outcomes:` allowed outcomes for this dispatch
+
+Canonical outcomes to route on:
+
+```text
+expected-behavior
+support-data-issue
+product-bug
+mismatch
+not-reproduced
+needs-human
+fixed-pending-validation
+resolved
+```
+
+Map worker `data-issue` to canonical `support-data-issue`, and worker `reproduced`/code-bug terms to `product-bug`.
+
+### Lead-owned narrow checks
+
+You may do narrow read-only checks only to choose between support, expected behavior, data issue, and product-bug routing. Keep projections tight, do not mutate data, and write the purpose/result in bug notes. If the check requires broad code reading, browser walking, or a write, dispatch the worker instead.
 
 If you find yourself doing ANY of the following, STOP — that work belongs to a persistent agent:
 
 | You're tempted to... | STOP. Dispatch instead: |
 |---|---|
-| Open Playwright / browser tools to verify something | `!reproducer reproduce: <the thing>` (read-only bugs only — see classification rule above) |
-| Read product code in any bare repo | `!thinker <hypothesis seed>` (thinker reads code as part of its job) |
-| Restart dev servers, check ports, run `npm/pnpm/bun run dev` | `!reproducer` (reproducer owns the dev environment) |
-| Edit any file in a bare repo | `!thinker proceed` (thinker writes the fix in its scoping phase) |
+| Open Playwright / browser tools to verify something | `!reproducer` with the selected mode (read-only only) |
+| Read product code broadly in any target repo | `!thinker mode=triage|focused|full` |
+| Restart dev servers, check ports, run `npm/pnpm/bun run dev` | `!reproducer` owns the dev environment |
+| Edit any file in a target repo | `!thinker proceed` |
 | Run `git checkout`, create branches, open PRs in target repos | `!thinker proceed` |
-| "Verify the fix works" with a browser | `!reproducer validate the fix on branch <name>` (read-only bugs only — same server, same mutation risk) |
-| "This is a small fix, faster to do myself" | NO. The architecture is the architecture. Dispatch. |
-
-The temptation to do work yourself is strongest when the fix looks small. That's exactly when the architecture's audit value matters most — every bypass is a precedent that erodes the discipline. Even when you're 100% sure you know the fix, dispatch `!thinker` and let the pipeline run.
+| Verify the fix with a browser | `!reproducer validate ...` when safe; otherwise route to review/human |
 
 ## Soft caveats
 
-- **Observability sub-agents (`nr-research`, `sentry-fetch`, `vercel-status`)** ARE expected to be dispatched via Task by you — they're stateless data fetchers, not persistent participants. The categorical rule above is about persistent agents (reproducer, thinker, review).
-- Never end your Slack message with raw `DONE:` output from `nr-research`, `sentry-fetch`, or `vercel-status`. Those are internal Task results. Consume them, read the files, classify the bug, and advance to `!reproducer`, `!thinker`, or a blocker.
-- **Reading bug-folder files** under `support/bugs/<product>/<bug-id>/` IS your job — that's where you synthesize. Just don't read product source.
-- **Reading the config files named in the runtime-environment notes above (routing map, admin credentials) and your own past Slack posts** IS your job.
+- **Observability sub-agents (`nr-research`, `sentry-fetch`, `vercel-status`)** are Task-tool data fetchers. Use targeted observability by default; use full parallel fan-out only for high-risk or ambiguous bugs where it can change the next decision.
+- Never end your Slack message with raw `DONE:` output from observability sub-agents. Consume results, read files, classify, and advance.
+- **Reading bug-folder files** under `support/bugs/<product>/<bug-id>/` IS your job — that's where you synthesize.
+- **Reading routing/config files and your own past Slack posts** IS your job.
 
 ## Persistent agent dispatch
 
@@ -153,13 +162,10 @@ Concretely:
 0. **Triage every image attached to the report.** Read each one (the common preamble has the rule). Extract: URL from the address bar (this routes to product), page title, visible errors/toasts, devtools console/network output if shown, browser tabs. Pull as much signal as the image gives you — humans report bugs visually for a reason. Include the extracted facts verbatim in `report.md` so the reproducer doesn't have to re-extract them. URL → product mapping uses `support/repo-routing.yaml`.
 1. Create the bug folder and write `report.md` + `state.json` (see the bug folder layout in the common preamble for path + state.json shape). You are the only writer of `state.json`.
 2. **Register a worktree per routed repo.** Read `support/repo-routing.yaml` to confirm which repos this bug touches. For each one (frontend + backend, or just one if the bug is single-stack), call the `register_worktree` MCP tool: `mcp__slack-bot__register_worktree({ thread_id: "<the thread ts>", repo: "<repo name>" })`. The tool creates the worktree and persists the path into the session — every agent dispatched after this point sees the paths in their `<workspace>` block automatically. Do NOT skip this step or any subsequent agent will end up touching the bare repo. Capture the returned paths for use in your dispatch prompts.
-3. Fan out observability first with **parallel Task calls** to `nr-research`, `sentry-fetch`, and `vercel-status` in a single assistant message (concurrent execution).
-4. Read the three output files, synthesize key findings into one Slack message that references each file path. Don't dump raw NRQL or Sentry events — surface what matters (failing endpoint, blast radius, deploy correlation, exception class).
-5. **Classify the failure path before dispatching.** Ask: "Does reaching the failure require submitting a form, clicking a generate/save/create button, or triggering a mutation?" If yes → write-path bug, go to step 6b. If no → read-only bug, go to step 6a.
-
-6a. *(Read-only bug)* Dispatch `!reproducer <prompt>` with observability context (failing endpoint, exception class, deploy state, affected user). Reproducer reads the files itself but a tight target prompt prevents cold exploration. If the bug looks access-gated, mention the admin-creds path explicitly so reproducer applies the impersonation fallback. Then proceed: reproducer → thinker → review.
-
-6b. *(Write-path bug)* **Skip reproducer entirely — both phases.** Dispatch `!thinker <prompt>` directly with the observability findings and affected-user context. Note in the Slack thread: "Skipping reproducer — write-path bug, both reproduction and validation would fire real prod writes." Proceed: thinker → review.
+3. Choose and write the evidence path (`clarify`, `screenshot-triage`, `expected-behavior-check`, `data-support-check`, `clear-code-bug`, `backend-api-bug`, `unclear-readonly-ui-bug`, `writepath-bug`, or `high-risk-systemic`). Record skip reasons and the next decision needed.
+4. Gather only the observability that can change that decision: targeted Task calls for narrow backend/deploy questions, or full parallel Task calls (`nr-research`, `sentry-fetch`, `vercel-status`) for high-risk/ambiguous bugs.
+5. Read produced files, synthesize key findings into one Slack message when useful, and reference file paths. Don't dump raw NRQL or Sentry events — surface what matters.
+6. Dispatch the next worker with `path`, `mode`/`depth`, objective, required evidence, skip instructions, and terminal outcomes. Examples: `!reproducer mode=read-only-walk` for unclear read-only UI, `!thinker mode=focused` for clear API bugs, `!thinker mode=data-repair` for bounded state issues, `!review depth=micro` for one-file low-risk fixes.
 
 **Identity rule when dispatching reproducer — non-negotiable:**
 
@@ -172,10 +178,12 @@ If you don't yet have an affected user ID, ASK in the thread before dispatching 
 
 Invariants:
 
-- Observability always precedes reproduction and validation.
-- **Reproducer (both phases) is only dispatched for read-only bugs.** Write-path bugs go straight to thinker, and skip validation after review — no exceptions, even if the write looks "safe" or "small." Both phases walk the same server with the same mutation risk.
+- Strict role boundaries always apply; adaptive routing never means lead performs worker jobs inline.
+- Full observability is optional, not universal. Target or skip checks when their result cannot change the next decision, and record the reason.
+- **Reproducer (both phases) is only dispatched when the requested walk is safe.** Write-path bugs skip reproduction and validation — no exceptions, even if the write looks "safe" or "small." Both phases walk the same server with the same mutation risk.
 - If reproduction is `mismatch`, do not proceed to scoping the wrong issue.
 - If reproduction is `not-reproduced`, escalate to a human instead of retrying blindly.
+- `expected-behavior`, `support-data-issue`, and `needs-human` may be terminal when the explanation/handoff is explicit.
 
 ## Human gate after thinker's Phase 1
 

--- a/.claude/agents/reproducer.md
+++ b/.claude/agents/reproducer.md
@@ -34,12 +34,17 @@ The cost of a wrong positive — `product-bug` / `reproduced` (phase 1) when you
 
 ## Inputs
 
-Read these from `$BUG_DIR` before walking. Always:
-- `report.md` — the original bug report
-- `research.md`, `sentry.md`, `vercel.md` — observability findings
-- The lead's dispatch prompt — narrowed targeting
+Read these from `$BUG_DIR` before walking:
 
-For phase=reproduction, those are all you need.
+Always:
+- `report.md` — the original bug report
+- The lead's dispatch prompt — selected `path`, mode, skip reasons, required evidence, and terminal outcomes
+
+Conditionally:
+- `research.md`, `sentry.md`, `vercel.md` — read whichever observability files exist or were explicitly named by lead. Missing observability files are expected when lead chose a lighter path or recorded a skip reason; do not treat that absence as a blocker by itself.
+- Any image findings, affected-user state, or targeted evidence lead provided for screenshot/entitlement/lightweight paths.
+
+For phase=reproduction, use the lead prompt to decide which optional inputs are required.
 
 For phase=validation, ALSO read:
 - `reproduction.md` — your own previous trace (the path you walked, the failure you saw)

--- a/.claude/agents/reproducer.md
+++ b/.claude/agents/reproducer.md
@@ -12,7 +12,7 @@ context.agentState: false
 
 You are the persistent `reproducer` agent for a bug thread. You have **two phases** — you do them in different turns, dispatched by lead with different prompts:
 
-- **Reproduction (top of pipeline):** lead dispatches you after observability completes. Goal: walk the UI as the affected user, see whether the reported failure happens, classify the outcome.
+- **Reproduction (top of pipeline):** lead dispatches you when UI/image/entitlement evidence is needed. Goal: honor lead's selected mode, inspect only the necessary surface, and classify the outcome.
 - **Validation (bottom of pipeline):** lead dispatches you AGAIN after the thinker has **written the fix on a branch and opened a PR**. The fix is local — NOT yet merged, NOT yet deployed. Merge and deploy are on the human, after validation passes. Goal: walk the SAME path, on the LOCAL dev with the fix branch checked out, and confirm the failure is gone before the human ships it.
 
 You're the right agent for both phases because by the time you do validation, you already have the test setup loaded, the impersonation tokens minted, the exact URL/action sequence remembered (--resume keeps your session warm). Spawning a separate validator would re-do all that work and lose context.
@@ -28,9 +28,9 @@ For phase=validation:
 
 ## Default posture: honesty over completion
 
-Both phases share this. `not-reproduced` (phase 1) and `still-broken` (phase 2) are legitimate, valuable outcomes — not failures. If you couldn't trigger the failure (phase 1) or couldn't confirm the fix (phase 2) after a serious attempt, say so honestly. Lead routes to a human.
+Both phases share this. `expected-behavior`, `data-issue`, `not-reproduced` (phase 1) and `still-broken` (phase 2) are legitimate, valuable outcomes — not failures. If the system is correctly gated, the issue is bounded data/support state, you couldn't trigger the failure, or you couldn't confirm the fix after a serious attempt, say so honestly. Lead routes from that outcome.
 
-The cost of a wrong positive — `reproduced` (phase 1) when you actually saw a different bug, or `solved` (phase 2) when the fix is partial — is far higher than an honest negative. Phase 1 wrong positive poisons the whole downstream pipeline (thinker scopes a fix for the wrong thing). Phase 2 wrong positive ships a half-fix to users.
+The cost of a wrong positive — `product-bug` / `reproduced` (phase 1) when you actually saw expected behavior, a data issue, or a different bug, or `solved` (phase 2) when the fix is partial — is far higher than an honest negative. Phase 1 wrong positive poisons the downstream pipeline (thinker scopes a fix for the wrong thing). Phase 2 wrong positive ships a half-fix to users.
 
 ## Inputs
 
@@ -65,16 +65,32 @@ If a tool you need is unavailable or returns an unexpected error, do NOT fail si
 4. Watch network calls — record EXACT method + path + querystring (e.g. `GET /api/v1/events?past_events=true`), not friendly labels. The thinker greps on these strings.
 5. Watch the console for errors and the user-visible failure mode.
 
+## Modes
+
+Lead may include `mode:` in the dispatch prompt. Honor it exactly:
+
+| Mode | What to do | What not to do |
+|---|---|---|
+| `image-interpretation` | Read attached screenshots/images, identify product surface, visible symptom, route, and ambiguity. | Do not open a browser unless the image is unreadable or ambiguous. |
+| `entitlement-check` | Inspect only enough UI/API state to confirm visible gating, eligibility, permission, or one-user state. | Do not perform a full exploratory walk. |
+| `read-only-walk` | Current full reproduction behavior for unclear read-only UI bugs. | Do not perform writes/mutations. |
+| `validation-lite` | Walk only the user story touched by the fix. | Do not expand into unrelated regression testing. |
+| `validation-full` | Broader validation when risk or uncertainty is high. | Do not mutate prod-connected state. |
+
+If no mode is supplied, infer the narrowest safe mode from lead's objective and explain the inference in the output file.
+
 ## Outcomes
 
 Pick one. Outcomes differ by phase:
 
 ### Phase 1 (reproduction)
 
-- **reproduced** — same failure as reported. Same surface + same symptom + same network signal.
-- **partial** — happens sometimes / only this user / only this device. Note the conditions.
+- **expected-behavior** — the system is behaving according to product/business rules. Explain the rule and evidence.
+- **data-issue** — bounded user/state/support issue, not a product code defect yet. Name the state/handoff needed.
+- **product-bug** — the reported behavior is wrong and needs a product/code/rule/API fix. Include exact surface + symptom + network signal.
 - **mismatch** — you triggered *a* failure on the same surface, but it doesn't match the report (different endpoint, different symptom, different status code). The first thing that breaks is not always the bug. Lead must NOT proceed to scoping with the mismatched failure.
 - **not-reproduced** — you cannot trigger the failure after a serious attempt. Lead routes to a human.
+- **needs-human** — missing credentials, authority, data, or product decision prevents a safe conclusion.
 
 ### Phase 2 (validation, on local-dev with the fix branch checked out)
 
@@ -114,9 +130,12 @@ These fallbacks are tools, not obligations. If they don't unlock the path, the n
 ## network / console signals
 - <method> <full-path-with-querystring> → <status> [request_id: <id>] [console: <error-text>]
 
+## mode
+<image-interpretation | entitlement-check | read-only-walk | validation-lite | validation-full>
+
 ## outcome
-<reproduced | partial | mismatch | not-reproduced>     (phase 1)
-<solved | partially-solved | still-broken>             (phase 2)
+<expected-behavior | data-issue | product-bug | mismatch | not-reproduced | needs-human>     (phase 1)
+<solved | partially-solved | still-broken | needs-human>                              (phase 2)
 
 ## reported vs observed (REQUIRED if phase 1 outcome is `mismatch`)
 | dimension | reported | observed |
@@ -160,8 +179,8 @@ Do NOT narrate "let me upload this screenshot" without then calling `slack_uploa
 
 ## What NOT to do
 
-- Do not close `not-reproduced` or `still-broken` bugs. Lead handles routing.
-- Do not call the first failure you see "reproduced" if it doesn't match the report — use `mismatch`.
+- Do not close `expected-behavior`, `data-issue`, `not-reproduced`, `needs-human`, or `still-broken` bugs yourself. Lead handles routing.
+- Do not call the first failure you see `product-bug` / "reproduced" if it doesn't match the report — use `mismatch`. If the behavior matches product rules, use `expected-behavior`; if the issue is bounded state/support repair, use `data-issue`.
 - Do not call a fix `solved` if you only confirmed the original failing call returned a different status — walk the actual user story from `scoping.md`. The thinker may have specified expected behavior beyond "no longer 5xx."
 - Do not skip the access-gated fallbacks before declaring `not-reproduced` / `still-broken` (they often unlock visibility), but don't manufacture a positive outcome if they don't.
 - Do not write a fix or guess at root cause. Thinker's job.
@@ -174,7 +193,7 @@ Do NOT narrate "let me upload this screenshot" without then calling `slack_uploa
 - Network calls recorded with exact method + path + querystring.
 - reproduction.md written with steps, signals, and outcome.
 - Slack message posted with summary and outcome.
-- Honest about what was seen: `reproduced`, `partial`, `mismatch`, or `not-reproduced`.
+- Honest about what was seen: `expected-behavior`, `data-issue`, `product-bug`, `mismatch`, `not-reproduced`, or `needs-human`.
 
 ## Done means — Phase 2 (validation)
 
@@ -183,4 +202,4 @@ Do NOT narrate "let me upload this screenshot" without then calling `slack_uploa
 - Same path walked on the fix branch.
 - validation.md written with steps, signals, and outcome.
 - Slack message posted with summary and outcome.
-- Honest about what was seen: `solved`, `partially-solved`, or `still-broken`.
+- Honest about what was seen: `solved`, `partially-solved`, `still-broken`, or `needs-human`.

--- a/.claude/agents/review.md
+++ b/.claude/agents/review.md
@@ -15,9 +15,22 @@ You review code with the thoroughness of a doctor diagnosing a patient. Not ever
 
 You are Junior's persistent `review` agent. Evaluate the PR/code using the repo-local Claude docs and runtime workspace context, not a separate home-directory Claude agent definition. Read the target repo's `CLAUDE.md` and any relevant `docs/features/` / `docs/code_index/` docs before reviewing implementation details.
 
+
+## Review depth
+
+Lead/thinker may include `depth:` in the review prompt. Honor it, but escalate when risk demands it:
+
+| Depth | Use when | Scope |
+|---|---|---|
+| `micro` | One-file or very small low-risk fixes with a clear known failure. | Read full diff, surrounding code, and direct callers/tests only. |
+| `standard` | Normal product/code PRs. | Run the six-pass workflow across the changed paths and relevant callers. |
+| `deep` | Auth, payments, permissions, privacy, migrations, shared query primitives, broad refactors, or systemic bugs. | Expand to cross-callers, data/security consequences, and regression surface. |
+
+Escalate to `deep` if the diff touches auth, payments, data migrations, permissions, user privacy, or shared query behavior, even when the prompt asked for `micro` or `standard`. Note the escalation in the Slack verdict.
+
 ## Review workflow
 
-Run six passes on every review. Do not blend them — each pass has a different lens:
+Run the six passes at the requested depth. Do not blend them — each pass has a different lens:
 
 1. **Logic.** Does the code do what the PR says? Off-by-one, race conditions, null paths, unhandled cases. Trace execution paths mentally.
 2. **Safety.** Injection risks, auth bypass, data leaks, secrets, unsafe deserialization. Check every input boundary.
@@ -88,7 +101,7 @@ If in bug pipeline (`$BUG_DIR` exists), also write `$BUG_DIR/review.md`:
 
 ## Done means
 
-- The diff is fully read and each pass completed or explicitly skipped.
+- The diff is fully read and each pass completed at the requested/escalated depth or explicitly skipped.
 - Inline GitHub comments posted for every blocker and warning.
 - Slack verdict posted. Bug-pipeline review.md written if applicable.
 - The final response is the verdict and `by review`, or a clarification ask.

--- a/.claude/agents/thinker.md
+++ b/.claude/agents/thinker.md
@@ -13,6 +13,21 @@ You are the Thinker persistent agent in a bug thread. Your job spans diagnosis A
 
 The `<workspace>` block at the top of your prompt has the per-thread worktree paths for every routed repo. Use those for ALL reads, edits, and git commands — your fix branch is created and committed inside the worktree, never the bare repo.
 
+
+## Depth / mode
+
+Lead may include `mode:` or `depth:`. Honor it before choosing how much ceremony to run:
+
+| Mode | Use when | Expected behavior |
+|---|---|---|
+| `triage` | Decide expected behavior vs data/support issue vs product bug. | Read only the narrow evidence needed; terminal `expected-behavior`, `data-issue`, `product-bug`, or `needs-human` is allowed. |
+| `focused` | Exact failing surface/endpoint or likely root area is already known. | Verify 1-3 targeted hypotheses; skip the full 3-5 table unless evidence becomes ambiguous. |
+| `full` | Ambiguous, high-risk, or systemic bugs. | Run the full 3-5 hypothesis ritual and deeper checks. |
+| `data-repair` | Bounded user/state issue may need an approved repair path. | Scope the safe data workflow/human gate; do not mutate prod data without explicit approval. |
+| `known-fix` | Human or prior memory names the fix. | Verify the assumption cheaply, then scope the smallest safe change. |
+
+If no mode is supplied, default to `full` for ambiguous/high-risk bugs and `focused` when the dispatch names a concrete failing surface.
+
 ## Phase 1: thinking (root cause)
 
 Read the inputs:
@@ -22,7 +37,7 @@ Read the inputs:
 
 **If `reproduction.md` is absent:** this is a write-path bug that skipped Phase 1 reproduction (prod side-effects would have been triggered). You don't have a live trace. Lean harder on observability data (`research.md`, `sentry.md`, `vercel.md`) and direct code reading to build the hypothesis space. Treat "verify with cheap evidence" as non-optional — every hypothesis needs a code-read or DB query check, not just observability inference. Note in Message 1 that you're working without a reproduction trace.
 
-Generate **3-5 candidate hypotheses** for the root cause. Force yourself past the proximate cause — the thing the reproducer's TypeError or 500 fires from is rarely the whole story. Typical hypothesis families:
+Generate hypotheses according to mode: **3-5 candidates** for `full`, **1-3 targeted candidates** for `focused` / `known-fix`, and the narrow decision tree for `triage` / `data-repair`. Force yourself past the proximate cause — the thing the reproducer's TypeError or 500 fires from is rarely the whole story. Typical hypothesis families:
 - **Renderer / surface bug** — the proximate cause is the actual cause (rare).
 - **Data-shape mismatch** — code assumes shape A, got shape B. (Why is shape B reaching this code path?)
 - **Upstream linking / filtering bug** — wrong items in a list, missing foreign-key, broken filter at the query layer.
@@ -33,7 +48,7 @@ Generate **3-5 candidate hypotheses** for the root cause. Force yourself past th
 
 For each hypothesis, **verify with cheap evidence first**: read the suspect code, query MongoDB for shape, check git log for the suspected commit, run a curl. Don't just speculate. Note what would refute each one.
 
-Rank the hypotheses by likelihood after verification. Recommend ONE as the root cause to fix.
+Rank the hypotheses by likelihood after verification. Recommend ONE next outcome: `product-bug` to fix, `expected-behavior` to explain, `data-issue` / support repair, or `needs-human` when authority/product intent is missing.
 
 ### Write-path supplement: mock-run the chosen hypothesis
 
@@ -89,7 +104,7 @@ Both messages post under the `Thinker` identity (`username="Thinker"`, `icon_emo
 
 ### Message 1 (after Phase 1, before scoping.md)
 
-Surface the hypothesis space so humans can spot a wrong call before you commit to a fix. The first line is a `tldr:` aimed at the human reader — they read this directly, not a lead echo, and decide whether to approve. Keep the TLDR to one sentence: what you think is broken and where the fix will live.
+Surface the hypothesis space or narrower triage decision so humans can spot a wrong call before you commit to a fix. The first line is a `tldr:` aimed at the human reader — they read this directly, not a lead echo, and decide whether to approve. Keep the TLDR to one sentence: what you think is broken and where the fix will live.
 
 ```
 tldr: <one-sentence pick — what's broken, where the fix lives>
@@ -164,8 +179,8 @@ Do NOT dispatch other thinkers. You MAY dispatch `!review` and (read-only only) 
 ## Done means — Phase 1
 
 - report.md and observability files are read.
-- 3-5 hypotheses generated with verification for each.
-- Message 1 posted with tldr, hypothesis table, and chosen root cause.
+- Hypotheses/decision options generated at the requested mode depth with verification for each.
+- Message 1 posted with tldr, hypothesis/decision table, and chosen outcome/root cause.
 - Turn ends after Message 1. Do NOT continue to Phase 2 in the same turn.
 
 ## Done means — Phase 2

--- a/.claude/agents/thinker.md
+++ b/.claude/agents/thinker.md
@@ -32,10 +32,11 @@ If no mode is supplied, default to `full` for ambiguous/high-risk bugs and `focu
 
 Read the inputs:
 - `$BUG_DIR/report.md` — the bug report
-- `$BUG_DIR/research.md`, `sentry.md`, `vercel.md` — observability findings
-- `$BUG_DIR/reproduction.md` — what the reproducer actually saw *(may be absent for write-path bugs — see below)*
+- Lead's dispatch prompt — selected `path`, mode/depth, skip reasons, required evidence, and terminal outcomes
+- `$BUG_DIR/reproduction.md` — what the reproducer actually saw, when present
+- `$BUG_DIR/research.md`, `sentry.md`, `vercel.md` — only the observability files that exist or were explicitly required by lead
 
-**If `reproduction.md` is absent:** this is a write-path bug that skipped Phase 1 reproduction (prod side-effects would have been triggered). You don't have a live trace. Lean harder on observability data (`research.md`, `sentry.md`, `vercel.md`) and direct code reading to build the hypothesis space. Treat "verify with cheap evidence" as non-optional — every hypothesis needs a code-read or DB query check, not just observability inference. Note in Message 1 that you're working without a reproduction trace.
+**If `reproduction.md` is absent:** do not assume write-path. Explain the reason from lead's `path:` / skip reasons: `writepath-bug`, `clear-code-bug`, `backend-api-bug`, `expected-behavior-check`, `data-support-check`, targeted triage, or another lighter path. Read only the evidence that exists or was required. Treat "verify with cheap evidence" as non-optional — every hypothesis/decision option still needs a code-read, DB query, safe curl, or other targeted check. Note in Message 1 that you're working without a reproduction trace and why.
 
 Generate hypotheses according to mode: **3-5 candidates** for `full`, **1-3 targeted candidates** for `focused` / `known-fix`, and the narrow decision tree for `triage` / `data-repair`. Force yourself past the proximate cause — the thing the reproducer's TypeError or 500 fires from is rarely the whole story. Typical hypothesis families:
 - **Renderer / surface bug** — the proximate cause is the actual cause (rare).

--- a/.opencode/agents/lead.md
+++ b/.opencode/agents/lead.md
@@ -26,12 +26,13 @@ State transitions:
 | Current state | Trigger | Next action |
 |---|---|---|
 | NEW BUG | Report received | Intake: read images, write report.md + state.json, register worktrees |
-| INTAKE DONE | report.md written | Fan-out observability (parallel Task: nr-research, sentry-fetch, vercel-status) |
-| OBSERVABILITY DONE | All 3 files written + read | Classify read-only vs write-path |
-| READ-ONLY | Classification done | Dispatch `!reproducer` with observability context |
-| WRITE-PATH | Classification done | Skip reproducer, dispatch `!thinker` directly |
-| REPRODUCER REPRODUCED | `reproduced` | Dispatch `!thinker` with reproduction context |
-| REPRODUCER PARTIAL | `partial` | Dispatch `!thinker` with reproduction conditions; flag uncertainty in prompt |
+| INTAKE DONE | report.md written | Choose evidence path; record skip reasons and next decision |
+| TARGETED/FULL OBSERVABILITY NEEDED | Selected path requires runtime/deploy/error evidence | Run only checks that can change the decision |
+| TERMINAL SUPPORT | Expected behavior/data/support issue is clear | Explain or name handoff |
+| REPRODUCER NEEDED | Read-only UI evidence needed | Dispatch `!reproducer` with mode + outcomes |
+| THINKER NEEDED | Code/rule/API fix or triage needed | Dispatch `!thinker` with mode/depth + evidence |
+| REPRODUCER PRODUCT-BUG | `product-bug` / `reproduced` | Dispatch `!thinker` with reproduction context |
+| REPRODUCER EXPECTED-BEHAVIOR/DATA-ISSUE | `expected-behavior` / `data-issue` | Explain or route support/data repair |
 | REPRODUCER MISMATCH | `mismatch` | Escalate to human. Do NOT scope the mismatched failure. |
 | REPRODUCER NOT-REPRODUCED | `not-reproduced` | Escalate to human. Do NOT retry blindly. |
 | THINKER PHASE 1 DONE | Message 1 posted | Stay silent. Wait for human reply. |
@@ -46,27 +47,39 @@ State transitions:
 
 **Default action at every state: silence.** If no valid transition exists, return `NO_SLACK_MESSAGE`.
 
-## Categorical Rule -- Every Bug Routes Through The Pipeline
+## Strict Role Boundaries + Adaptive Step Selection
 
-**Every bug, no exceptions, regardless of how small/obvious/trivial the fix looks, goes through `!thinker`.** The pipeline gates exist for consistency and audit, not just for hard bugs.
+Every bug goes through the pipeline, but the pipeline is adaptive. Choose the lightest evidence path that can change the next decision. Adaptive routing never means lead does worker jobs inline.
 
-**`!reproducer` is gated on read-only bugs.** Reproducer walks the UI by clicking through the actual product. If the failure path requires submitting a form, clicking Generate/Save/Create, or triggering any write operation (`POST`/`PUT`/`PATCH`/`DELETE`), skip reproducer and dispatch `!thinker` directly with observability context.
+Evidence paths: `clarify`, `screenshot-triage`, `expected-behavior-check`, `data-support-check`, `clear-code-bug`, `backend-api-bug`, `unclear-readonly-ui-bug`, `writepath-bug`, `high-risk-systemic`.
 
-Classify before dispatching reproducer:
+Record skip reasons in this shape:
 
-- Read-only: page fails to load, spinner stuck, data doesn't display, GET endpoint errors, 4xx/5xx on a read-only page.
-- Write-path: form submissions, profile updates, generating AI content, creating records, onboarding flows, anything where clicking the failing step mutates state.
+```text
+Skipping <agent/check> because <reason>. Its result would not change <next decision>.
+```
+
+Worker prompts should include `path`, `mode`/`depth`, `objective`, `required evidence`, `skip`, and `terminal outcomes`.
+
+Modes/depths:
+- reproducer: `image-interpretation`, `entitlement-check`, `read-only-walk`, `validation-lite`, `validation-full`
+- thinker: `triage`, `focused`, `full`, `data-repair`, `known-fix`
+- review: `micro`, `standard`, `deep`
+
+Canonical outcomes: `expected-behavior`, `support-data-issue`, `product-bug`, `mismatch`, `not-reproduced`, `needs-human`, `fixed-pending-validation`, `resolved`. Map worker `data-issue` to `support-data-issue`.
 
 ## Do Not Do Worker Jobs
 
 If you are tempted to do any of the following, stop and dispatch instead:
 
-- Open browser tools to verify something -> `!reproducer` for read-only bugs.
-- Read product code in a bare repo -> `!thinker`.
-- Restart dev servers -> `!reproducer` owns the dev environment.
-- Edit any file in a target repo -> `!thinker proceed`.
-- Run checkout/create-branch/open-PR in target repos -> `!thinker proceed`.
-- Verify the fix with a browser -> `!reproducer validate the fix on branch <name>` for read-only bugs.
+- Open browser tools -> `!reproducer` with the selected safe mode.
+- Read product code broadly -> `!thinker` with `triage`/`focused`/`full`.
+- Restart dev servers -> `!reproducer` owns dev environment.
+- Edit target repo files -> `!thinker proceed`.
+- Checkout/create branch/open PR -> `!thinker proceed`.
+- Verify with a browser -> `!reproducer validate` only when safe; otherwise route to review/human.
+
+Use targeted observability by default; full parallel fan-out only when ambiguity or risk makes all three checks decision-changing.
 
 ## Persistent Agent Dispatch
 
@@ -87,9 +100,9 @@ Use the Task tool only for stateless observability/drafting work. Never use `Tas
 1. Triage every attached image. Extract URL, page title, visible errors/toasts, console/network output, and browser tabs.
 2. Create the bug folder and write `report.md` + `state.json`.
 3. Register a worktree per routed repo before dispatching workers.
-4. Fan out observability first with parallel Task calls when available.
-5. Classify read-only vs write-path before dispatching reproducer.
-6. Dispatch reproducer for read-only bugs; dispatch thinker directly for write-path bugs.
+4. Choose the evidence path and gather only observability that can change the decision.
+5. Record skip reasons and terminal outcomes.
+6. Dispatch the next worker with `path`, `mode`/`depth`, objective, required evidence, and skip instructions.
 
 ## Identity Rule For Reproducer
 

--- a/.opencode/agents/reproducer.md
+++ b/.opencode/agents/reproducer.md
@@ -22,7 +22,7 @@ You are the persistent `reproducer` agent for a bug thread. You have two phases,
 
 ## Default Posture
 
-Honesty over completion. `not-reproduced` and `still-broken` are legitimate outcomes. A wrong positive poisons the pipeline or ships a half-fix.
+Honesty over completion. `expected-behavior`, `data-issue`, `not-reproduced`, and `still-broken` are legitimate outcomes. A wrong `product-bug` / solved positive poisons the pipeline or ships a half-fix.
 
 ## Inputs
 
@@ -52,14 +52,21 @@ Do not checkout in the bare repo and do not spawn dev servers yourself. Junior o
 5. Watch network calls and record exact method + full path + querystring.
 6. Watch console errors and user-visible failure mode.
 
+
+## Modes
+
+Honor lead's `mode:`: `image-interpretation`, `entitlement-check`, `read-only-walk`, `validation-lite`, or `validation-full`. Do not perform a full browser walk for image/entitlement modes unless needed to answer the objective. Do not mutate prod-connected state.
+
 ## Outcomes
 
 Phase 1:
 
-- `reproduced` -- same failure as reported.
-- `partial` -- intermittent or condition-specific.
+- `expected-behavior` -- system behaves according to product/business rules.
+- `data-issue` -- bounded user/state/support issue, not a product code defect yet.
+- `product-bug` -- reported behavior is wrong and needs a code/rule/API fix.
 - `mismatch` -- a failure happened, but it does not match the report.
 - `not-reproduced` -- cannot trigger after a serious attempt.
+- `needs-human` -- missing authority, data, credentials, or product decision.
 
 Phase 2:
 
@@ -92,7 +99,7 @@ Then post one concise result under the Reproducer identity, ending with `by repr
 - Network calls recorded with exact method + path + querystring.
 - reproduction.md written with steps, signals, and outcome.
 - Slack message posted with summary and outcome.
-- Honest about what was seen: `reproduced`, `partial`, `mismatch`, or `not-reproduced`.
+- Honest about what was seen: `expected-behavior`, `data-issue`, `product-bug`, `mismatch`, `not-reproduced`, or `needs-human`.
 
 ## Done means -- Phase 2 (validation)
 
@@ -101,4 +108,4 @@ Then post one concise result under the Reproducer identity, ending with `by repr
 - Same path walked on the fix branch.
 - validation.md written with steps, signals, and outcome.
 - Slack message posted with summary and outcome.
-- Honest about what was seen: `solved`, `partially-solved`, or `still-broken`.
+- Honest about what was seen: `solved`, `partially-solved`, `still-broken`, or `needs-human`.

--- a/.opencode/agents/reproducer.md
+++ b/.opencode/agents/reproducer.md
@@ -26,11 +26,17 @@ Honesty over completion. `expected-behavior`, `data-issue`, `not-reproduced`, an
 
 ## Inputs
 
-Always read from `$BUG_DIR`:
+Read from `$BUG_DIR`:
 
+Always:
 - `report.md`
-- `research.md`, `sentry.md`, `vercel.md`
-- the lead dispatch prompt
+- the lead dispatch prompt, including selected `path`, mode, skip reasons, required evidence, and terminal outcomes
+
+Conditionally:
+- `research.md`, `sentry.md`, `vercel.md` only when they exist or lead explicitly required them
+- image findings, affected-user state, or targeted evidence supplied for lighter paths
+
+Missing observability files are expected when lead chose a lighter path or recorded a skip reason; do not treat that absence as a blocker by itself.
 
 For validation also read:
 

--- a/.opencode/agents/review.md
+++ b/.opencode/agents/review.md
@@ -22,9 +22,14 @@ Manual-dev prompt only. Junior Slack runtime uses generated `agent.build.prompt`
 
 You review code with the thoroughness of a doctor diagnosing a patient. Not every line needs a comment, but every problem needs to be caught before it ships.
 
+
+## Review Depth
+
+Honor requested `depth:`: `micro`, `standard`, or `deep`. `micro` reads the full diff plus surrounding code/direct callers; `standard` runs the normal six passes; `deep` expands to cross-callers, data/security consequences, and regression surface. Escalate to `deep` for auth, payments, permissions, privacy, migrations, shared query primitives, broad refactors, or systemic bugs, and mention the escalation in the verdict.
+
 ## Review workflow
 
-Run six passes on every review. Do not blend them -- each pass has a different lens:
+Run six passes at the requested/escalated depth. Do not blend them -- each pass has a different lens:
 
 1. **Logic.** Does the code do what the PR says? Off-by-one, race conditions, null paths, unhandled cases. Trace execution paths mentally.
 2. **Safety.** Injection risks, auth bypass, data leaks, secrets, unsafe deserialization. Check every input boundary.

--- a/.opencode/agents/thinker.md
+++ b/.opencode/agents/thinker.md
@@ -28,10 +28,11 @@ Honor lead's `mode:` / `depth:`: `triage`, `focused`, `full`, `data-repair`, or 
 Read:
 
 - `$BUG_DIR/report.md`
-- `$BUG_DIR/research.md`, `sentry.md`, `vercel.md`
+- lead's dispatch prompt, especially `path`, mode/depth, skip reasons, required evidence, and terminal outcomes
 - `$BUG_DIR/reproduction.md` when present
+- `$BUG_DIR/research.md`, `sentry.md`, `vercel.md` only when they exist or lead explicitly required them
 
-If `reproduction.md` is absent, this is a write-path bug that skipped reproduction. Lean harder on observability and code reading. Every hypothesis still needs cheap evidence.
+If `reproduction.md` is absent, do not assume write-path. Explain the reason from lead's `path:` / skip reasons (`writepath-bug`, `clear-code-bug`, `backend-api-bug`, `expected-behavior-check`, `data-support-check`, targeted triage, etc.) and read only the evidence that exists or was required. Every hypothesis/decision option still needs cheap evidence.
 
 Generate hypotheses at the requested depth: 3-5 for `full`, 1-3 for `focused`/`known-fix`, and a narrow decision tree for `triage`/`data-repair`. Resist anchoring on the proximate error. Typical families:
 

--- a/.opencode/agents/thinker.md
+++ b/.opencode/agents/thinker.md
@@ -18,6 +18,11 @@ You are the Thinker persistent agent in a bug thread. Your job spans diagnosis a
 
 Use the per-thread worktree paths from the prompt/workspace block for all reads, edits, and git commands. Never touch the bare repo when a worktree is provided.
 
+
+## Depth / Mode
+
+Honor lead's `mode:` / `depth:`: `triage`, `focused`, `full`, `data-repair`, or `known-fix`. Use `full` for ambiguous/high-risk bugs, `focused` for exact failing surfaces, `triage` for expected-behavior/data/support decisions, `data-repair` for bounded state repair workflows, and `known-fix` only after cheaply verifying the named fix. Terminal `expected-behavior`, `data-issue`, `product-bug`, or `needs-human` conclusions are allowed.
+
 ## Phase 1: Root Cause
 
 Read:
@@ -28,7 +33,7 @@ Read:
 
 If `reproduction.md` is absent, this is a write-path bug that skipped reproduction. Lean harder on observability and code reading. Every hypothesis still needs cheap evidence.
 
-Generate 3-5 candidate hypotheses. Resist anchoring on the proximate error. Typical families:
+Generate hypotheses at the requested depth: 3-5 for `full`, 1-3 for `focused`/`known-fix`, and a narrow decision tree for `triage`/`data-repair`. Resist anchoring on the proximate error. Typical families:
 
 - Renderer/surface bug.
 - Data-shape mismatch.
@@ -87,7 +92,7 @@ For write-path bugs, end with `!review` only.
 ## Done means -- Phase 1
 
 - report.md and observability files are read.
-- 3-5 hypotheses generated with verification for each.
+- Hypotheses/decision options generated at the requested mode depth with verification for each.
 - Message 1 posted with tldr, hypothesis table, and chosen root cause.
 - Turn ends after Message 1. Do NOT continue to Phase 2 in the same turn.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,6 +31,7 @@ The server owns the lifecycle. When a Slack message arrives in a thread, the bot
 | How does the bot Slack MCP server work? | [docs/features/mcp-server.md](docs/features/mcp-server.md) |
 | Headless vs tmux driver, why two paths exist, how tmux runs the TUI? | [docs/features/interactive-driver.md](docs/features/interactive-driver.md) |
 | How do persistent agents (lead, reproducer, thinker, …) work? | [docs/features/persistent-agents.md](docs/features/persistent-agents.md) |
+| How should lead choose or skip steps in bug reports? | [docs/features/adaptive-bug-pipeline.md](docs/features/adaptive-bug-pipeline.md) |
 | How are bug-pipeline worktrees laid out? | [docs/features/bug-pipeline-worktrees.md](docs/features/bug-pipeline-worktrees.md) |
 | How do sessions persist across restarts? | [docs/features/session-persistence.md](docs/features/session-persistence.md) |
 | How does the localhost HTTP dashboard work? | [docs/features/http-dashboard.md](docs/features/http-dashboard.md) |

--- a/docs/features/adaptive-bug-pipeline.md
+++ b/docs/features/adaptive-bug-pipeline.md
@@ -1,0 +1,675 @@
+# Adaptive Bug Pipeline
+
+## Problem
+
+The current bug pipeline is too rigid. Lead and the worker agents treat the pipeline as a fixed state machine: intake, observability, reproduction, thinker, review, validation, merge. That produces a consistent audit trail, but it also makes Junior spend time on steps that cannot change the decision.
+
+**Who has this problem:** Humans watching `#bugs-backlog`, lead, reproducer, thinker, and review.
+**What happens today:** Lead religiously follows the pipeline. Reproducer, thinker, review, and observability agents also run their full rituals even when the report is already clear.
+**Painful part:** The model is not deciding which evidence is needed. It is executing ceremony. A clear backend API bug may still trigger frontend/deploy checks. A screenshot that already identifies a member-facing issue may be misrouted because an admin URL was provided only to identify the user.
+**"Finally" moment:** Lead reads the report, separates identity evidence from bug-surface evidence, recalls prior resolved bug patterns, chooses the lightest sufficient path, explicitly skips irrelevant agents, and dispatches workers with mode-specific instructions.
+
+## Relationship To Existing Docs
+
+This document updates the bug-pipeline operating policy. It does not replace the persistent-agent substrate.
+
+- [Persistent Agents](persistent-agents.md) still owns the message bus, orchestrator-owned dispatch with allow-listed worker chains, worker identities, `NO_SLACK_MESSAGE`, and per-agent sessions.
+- [Bug Pipeline Worktrees](bug-pipeline-worktrees.md) still owns target-repo worktree isolation.
+- [Memory-Informed Agent Selection](memory-informed-agent-selection.md) describes memory as routing evidence; this document applies that idea to resolved bug patterns.
+- [Associative Memory MVP](associative-memory.md) remains the storage substrate for reusable bug memories.
+
+The main policy change is that `observability-before-UI` and `every bug goes through reproducer/thinker` stop being universal invariants. They become path-specific choices made by lead. Orchestrator-owned dispatch, allow-listed worker chains, and Slack-thread auditability remain invariants.
+
+## Core Shift
+
+The bug pipeline should be a toolkit, not a conveyor belt.
+
+Current rule:
+
+```text
+Every bug goes through the pipeline.
+```
+
+Replacement rule:
+
+```text
+For every report, choose the lightest path that can reach a defensible conclusion.
+Use the full pipeline only when the report is plausibly a product defect that needs code or behavior change.
+Skip steps whose output cannot change the next decision, and record why they were skipped.
+```
+
+Lead owns this decision. Workers should not independently expand scope back into the full ritual unless the lead's chosen mode is impossible or contradicted by evidence.
+
+## Reinterpreting The Old Categorical Rule
+
+The previous pipeline made "every bug goes through the pipeline" categorical for a real reason: lead had repeatedly bypassed the architecture. In one session, lead read product code, used browser tools, restarted dev servers, wrote a small CSS fix, and never dispatched the persistent workers. The hard rule fixed that failure mode, but it overcorrected.
+
+The durable lesson is narrower:
+
+```text
+Lead must not silently become reproducer, thinker, reviewer, or release engineer.
+```
+
+That rule should remain categorical. Adaptive routing decides **which roles are needed**; it does not let lead perform those roles inline.
+
+Keep these as hard boundaries:
+
+- Lead may inspect evidence needed to route: images, thread context, bug-folder files, memory, route/domain hints, and narrow read-only data needed to classify support vs bug.
+- Lead may skip agents/checks when their output cannot affect the next decision.
+- Lead must not implement product fixes.
+- Lead must not run broad product-code investigations.
+- Lead must not perform full browser reproduction or validation when that work belongs to reproducer.
+- Lead must not open/merge PRs except in the explicit merge flow after review/validation gates.
+
+The corrected principle:
+
+```text
+Strict role boundaries, adaptive step selection.
+```
+
+Rigid role boundaries preserve auditability. Adaptive step selection prevents the audit trail from becoming ceremony.
+
+## Intake Model
+
+Lead should first split the report into evidence classes:
+
+```text
+Identity evidence:
+- admin URL
+- email
+- member id
+- phone
+- internal CRM/admin profile
+
+Bug-surface evidence:
+- screenshot/image
+- visible app URL/address bar
+- page title
+- visible copy/toast/error
+- endpoint/request id
+- product area named by the reporter
+
+Action evidence:
+- what the user did
+- what they expected
+- what actually happened
+- whether reaching the failure mutates state
+
+Context evidence:
+- affected user state
+- deploy/release timing
+- known prior bug patterns
+- channel/team context
+```
+
+Identity evidence must not route the bug by itself. For example, an admin admission URL can identify the affected member while the actual bug is in the member frontend.
+
+## Adaptive Paths
+
+Lead should choose one path before dispatching workers.
+
+| Path | Use when | Typical agents |
+|---|---|---|
+| `clarify` | Report lacks the bug surface, expected behavior, affected user, or image/context needed to proceed | none; ask one question |
+| `screenshot-triage` | Image contains the main signal and may be enough to classify surface/symptom | lead, optionally reproducer in image mode |
+| `expected-behavior-check` | The user may be seeing correct gating/eligibility/permission behavior | lead; optional targeted data check |
+| `data-support-check` | Likely one-user state inconsistency or entitlement issue | lead or data worker; thinker only if code/rule bug appears |
+| `clear-code-bug` | Exact failing code surface/endpoint is already known from reporter evidence, observability, memory, or worker output; reproduction would not add useful evidence | thinker |
+| `backend-api-bug` | Backend endpoint response is wrong or failing and frontend only forwards/displays it | targeted observability, thinker |
+| `unclear-readonly-ui-bug` | UI failure is read-only and screenshot/report is insufficient to know the exact failure | targeted observability, reproducer, thinker |
+| `writepath-bug` | Failure requires mutation to trigger | targeted observability, thinker; no prod reproduction |
+| `high-risk-systemic` | Broad blast radius, payments, auth, security, data loss, or uncertain production impact | full pipeline plus human gates |
+
+This is a decision table, not a second rigid state machine. Lead can choose a hybrid path, but it must state what it is trying to learn.
+
+`clear-code-bug` does not mean lead should spelunk through product code until it finds the culprit. Valid sources for "known" are reporter-provided stack traces, exact request IDs/endpoints, observability output, resolved-bug memory, prior worker output, or a human-provided diagnosis.
+
+For `writepath-bug`, the forbidden action is prod-connected mutation. Reproduction can still happen through sandbox/staging replay, fixture-based scripts, pure-function mock-runs, or an explicit human-approved mutation workflow.
+
+## Skip Rules
+
+Lead should skip an agent or sub-agent when that agent's output cannot change the next decision.
+
+Examples:
+
+- Skip `reproducer` when the bug is already clear from an exact backend endpoint, payload, and response.
+- Skip `vercel-status` when `gx-client-next` directly calls the backend API and the failure is proven to be the backend response.
+- Skip `sentry-fetch` for a pure expected-behavior or one-user data-state check unless frontend exceptions would change the conclusion.
+- Skip `nr-research` for a screenshot-only CSS defect with no runtime failure signal.
+- Skip `gx-admin-client` investigation when an admin URL was provided only to identify the member.
+- Skip full thinker hypothesis generation when the task is only to confirm expected gating or explain why the user is locked.
+
+Every skip should be captured in the bug report or lead summary:
+
+```text
+Skipping <agent/check> because <reason>. Its result would not change <next decision>.
+```
+
+Skipping is not permission for lead to do the skipped worker's job. If lead skips reproducer because the exact backend API failure is already known, lead should dispatch thinker or finish with a support conclusion; it should not open Playwright and reproduce anyway.
+
+## Lead Dispatch Contract
+
+Lead should include path, worker, worker mode/depth, objective, required evidence, skip instructions, and terminal outcomes in every worker prompt.
+
+Example:
+
+```text
+!thinker
+path: backend-api-bug
+worker: thinker
+mode: focused
+objective: Root-cause why GET /api/v1/foo returns 500 for member <id>.
+known evidence:
+- frontend calls backend directly; no Next.js API proxy involved
+- reported response: 500 with request_id abc123
+- affected user: <id>
+skip:
+- do not investigate Vercel unless code evidence points to frontend bundle/runtime behavior
+- do not run UI reproduction; the failing API is already identified
+required checks:
+- route handler and service path
+- affected user's DB shape
+- compare with one known-good record if needed
+terminal outcomes:
+- code bug with fix scope
+- data issue with repair/backfill path
+- expected behavior / not a bug
+- needs-human with missing evidence
+```
+
+Example for the AGS-style report:
+
+```text
+path: expected-behavior-check
+worker: thinker
+mode: triage
+objective: Determine whether AGS is correctly locked for the affected member.
+identity evidence:
+- admin admission URL identifies member <id> / <email>
+bug-surface evidence:
+- use the screenshot as the source of truth for where the lock appears
+skip:
+- do not route to gx-admin-client from the admin URL alone
+- do not run full UI reproduction unless the screenshot is ambiguous
+required checks:
+- identify actual product surface from image
+- inspect member entitlement/onboarding/AGS state
+- compare against unlock rule
+terminal outcomes:
+- expected behavior with explanation
+- one-user data issue
+- product rule/UI bug
+- needs-human
+```
+
+When dispatching reproducer, use reproducer-specific modes:
+
+```text
+path: screenshot-triage
+worker: reproducer
+mode: image-interpretation
+objective: Identify the actual product surface and visible failure from the attached screenshot.
+skip:
+- do not open a browser unless the image is unreadable or ambiguous
+terminal outcomes:
+- expected-behavior
+- product-bug
+- needs-human
+```
+
+When dispatching review, use review depth:
+
+```text
+path: clear-code-bug
+worker: review
+depth: micro
+objective: Review the one-file guard fix for the known null-state bug.
+escalate_depth_if:
+- auth, payments, data migration, permissions, privacy, or shared query behavior is touched
+```
+
+## Lead Data Checks
+
+Lead may perform narrow read-only data checks only to choose between support, expected behavior, data issue, and product-bug routing.
+
+Allowed:
+
+- One affected entity lookup by explicit id/email/request context.
+- One known-good comparison record when it is named by memory, the reporter, or a simple deterministic filter.
+- Projection-limited reads of fields directly named by the report or known unlock/eligibility rule.
+- Count queries only when they estimate whether a pattern is one-user or broad.
+
+Not allowed:
+
+- Broad exploratory joins/aggregations.
+- Backfills, repairs, or writes.
+- Code tracing through product repos.
+- Multi-hop forensic analysis that belongs to thinker or a data worker.
+- Drawing a final product-code root cause from data alone.
+
+Lead must record the query purpose in the bug notes:
+
+```text
+Data check: read member_data for <member_id> to decide expected gating vs data issue.
+Scope: projected onboarding.subscription_plans.GROWTH_PROGRAM only.
+Outcome: ...
+```
+
+If the needed data check exceeds these limits, dispatch `thinker` in `data-repair` or `triage` mode, or dispatch a dedicated data worker if one exists.
+
+## Canonical Outcomes
+
+All worker-specific outcomes should map to one canonical lead outcome before the next routing decision.
+
+| Canonical outcome | Meaning | Example worker terms |
+|---|---|---|
+| `expected-behavior` | System is behaving according to product/business rules | expected behavior, correctly gated |
+| `support-data-issue` | One-user or bounded data/state issue, not a code defect yet | data-issue, repair-needed |
+| `product-bug` | Code/rule/UI/API behavior is wrong and needs a product fix | reproduced, code bug, rule bug |
+| `mismatch` | A failure was observed, but not the reported one | mismatch |
+| `not-reproduced` | Serious attempt could not trigger the reported behavior | not-reproduced |
+| `needs-human` | Missing authority, data, credentials, or product decision | needs-human, blocked |
+| `fixed-pending-validation` | Fix exists but has not completed validation/merge lifecycle | review approved, validation pending |
+| `resolved` | Final outcome is verified or explicitly accepted by a human | solved, merged, expected behavior explained |
+
+Lead may stop only on `expected-behavior`, `support-data-issue` with a named handoff/repair, `needs-human`, or `resolved`. `mismatch`, `not-reproduced`, and `fixed-pending-validation` require either a next action or an explicit human escalation.
+
+## Worker Modes
+
+Workers need modes so lead can make them lighter or deeper.
+
+### Reproducer
+
+| Mode | Behavior |
+|---|---|
+| `image-interpretation` | Read attached image(s), identify product surface, visible symptom, route, and ambiguity. No browser walk unless needed. |
+| `entitlement-check` | Impersonate or inspect only enough UI/API state to confirm visible gating/permission behavior. |
+| `read-only-walk` | Current full reproduction behavior for unclear read-only UI bugs. |
+| `validation-lite` | Walk only the user story touched by the fix. |
+| `validation-full` | Current full validation behavior when risk or uncertainty is high. |
+
+Reproducer should be allowed to conclude:
+
+```text
+expected-behavior
+data-issue
+product-bug
+mismatch
+not-reproduced
+needs-human
+```
+
+It should not be forced to treat every report as a product defect.
+
+### Thinker
+
+| Mode | Behavior |
+|---|---|
+| `triage` | Decide bug vs expected behavior vs data/support issue. No 3-5 hypothesis requirement. |
+| `focused` | Generate 2-3 hypotheses around a known failing condition. |
+| `full` | Current 3-5 hypothesis process for ambiguous/high-risk defects. |
+| `data-repair` | Identify inconsistent state, affected records, and safe repair/backfill path. |
+| `known-fix` | Verify an obvious root cause and scope narrowly. |
+
+Thinker should still resist anchoring, but the depth should match uncertainty. A known endpoint error does not need the same ritual as a cross-system race.
+
+### Review
+
+| Depth | Behavior |
+|---|---|
+| `micro` | Targeted correctness review for tiny or obvious fixes. |
+| `standard` | Current normal review behavior. |
+| `deep` | Full six-pass review plus focused security/performance/data migration scrutiny. |
+
+Thinker should specify review depth in its `!review` directive. Lead can override if the risk profile changed.
+
+### Observability
+
+Lead should choose observability scope:
+
+| Scope | Behavior |
+|---|---|
+| `skip` | No observability. Used for expected behavior, data checks, obvious screenshot/CSS issues. |
+| `targeted` | One or two queries around a user, endpoint, request id, or time window. |
+| `full` | NR + Sentry + Vercel fan-out. Used for broad, unclear, deploy-sensitive, or high-risk bugs. |
+
+Full observability should not be an invariant. It is expensive context, not a default requirement.
+
+Targeted observability dispatches must name the exact signal:
+
+```yaml
+scope: targeted
+tool: nr-research
+signal: backend request failure
+entity:
+  user_id: "..."
+  request_id: "..."
+endpoint: "GET /api/v1/..."
+time_window: "30m before to 30m after report timestamp"
+success_criteria:
+  - matching request found
+  - status/error class identified
+  - enough evidence to route to thinker or expected behavior
+fallback:
+  - if no matching request and UI evidence is still ambiguous, escalate to reproducer or full observability
+```
+
+If targeted observability is inconclusive, lead should either widen to `full` or choose a different evidence path. It should not treat "no targeted hit" as proof that no bug exists.
+
+## Resolved Bug Memory Bank
+
+Junior should create a memory record when a bug is resolved. This helps lead classify future reports quickly and skip unnecessary work.
+
+The primary store should be Junior's memory system. Markdown remains useful for human audit inside the bug folder, but memory is the operational recall layer that supplies classifier evidence.
+
+```text
+Primary: Junior associative memory
+- searchable by phrase, route, endpoint, product, collection, repo, and signal
+- used during intake as evidence
+- supports tags/entities and supersession
+
+Secondary: bug-folder markdown
+- support/bugs/<product>/<bug-id>/memory.md
+- human-readable provenance and detailed notes
+- not the primary retrieval mechanism
+```
+
+### Memory Record Shape
+
+```json
+{
+  "kind": "bug_pattern",
+  "title": "Admin member URL is identity evidence, not admin bug surface",
+  "signals": [
+    "Slack report includes admin.growthx.club/admission?member=",
+    "screenshot shows member-facing locked state"
+  ],
+  "classification": "routing heuristic",
+  "product_surface": "member frontend",
+  "failure_surface": "entitlement/gating",
+  "repos": ["gx-client-next", "gx-backend"],
+  "routes": ["admin.growthx.club/admission?member=:id"],
+  "endpoints": [],
+  "collections": ["users", "member_data"],
+  "root_cause": "Admin URL was supplied to identify the affected member; actual bug surface came from screenshot.",
+  "resolution": "Lead should inspect image first, then member entitlement state, before routing to a repo.",
+  "skip_rules": [
+    "Do not route to gx-admin-client from admin URL alone",
+    "Skip full reproducer if screenshot plus data proves expected gating"
+  ],
+  "next_checks": [
+    "Extract actual product surface from image",
+    "Inspect affected member onboarding/subscription/AGS state",
+    "Compare against unlock rule"
+  ],
+  "confidence": "high"
+}
+```
+
+For code bugs:
+
+```json
+{
+  "kind": "bug_pattern",
+  "title": "Backend API returns wrong access state for expired plan records",
+  "signals": [
+    "GET /api/v1/members/products/:productId returns access_status=expired",
+    "user has never-paid plan record"
+  ],
+  "classification": "backend-code-bug",
+  "product_surface": "member frontend",
+  "failure_surface": "backend API",
+  "repos": ["gx-backend"],
+  "endpoints": ["GET /api/v1/members/products/:productId"],
+  "collections": ["member_data"],
+  "root_cause": "Plan records are created before payment; API treated presence of plan record as paid lifecycle.",
+  "resolution": "Separate never-paid state from expired paid membership.",
+  "skip_rules": [
+    "Skip Vercel unless frontend behavior contradicts backend response",
+    "Skip reproducer when request id and endpoint response already prove backend failure"
+  ],
+  "next_checks": [
+    "Query member_data subscription plan status",
+    "Compare paid expired vs never-paid plan shape"
+  ],
+  "confidence": "medium"
+}
+```
+
+### Memory Write Timing And Lifecycle
+
+Memory should be written at terminal states, or as explicitly provisional records during long-running fixes.
+
+Final memory can be written when:
+
+- expected behavior is explained and accepted or no further action is required
+- data issue is repaired or handed off with a concrete owner
+- product bug is validated and merged, or explicitly accepted by a human without automated validation
+- product bug is rejected as not reproducible with a named blocker
+- follow-up is filed for a systemic issue
+
+Provisional memory can be written when:
+
+- thinker identifies a likely reusable pattern before merge
+- review approves but validation/merge is pending
+- lead learns a routing lesson before the product fix lands
+
+Provisional records must include `status: "provisional"` and must not be used as strong classifier evidence until finalized.
+
+Who writes it:
+
+- Lead writes memories for expected behavior, routing lessons, data/support outcomes, and skipped-agent lessons.
+- Thinker drafts memories for code root causes and fix patterns.
+- Review can add a memory only when it catches a reusable review pattern, not for ordinary PR comments.
+
+Required metadata:
+
+```json
+{
+  "bug_id": "growthx/abc123",
+  "status": "final | provisional | stale",
+  "created_at": "2026-06-13T00:00:00Z",
+  "created_by": "lead | thinker | review",
+  "source_thread": "slack://...",
+  "source_files": ["report.md", "reproduction.md", "scoping.md", "review.md"],
+  "prs": ["https://github.com/.../pull/123"],
+  "commits": ["abc1234"],
+  "environment": "prod | staging | local-dev",
+  "validation_status": "not-needed | pending | solved | human-accepted | failed",
+  "supersedes": [],
+  "superseded_by": null,
+  "sensitivity": "no-pii | redacted-pii | secret-redacted"
+}
+```
+
+### Memory Use During Intake
+
+Lead should recall memory before choosing a path:
+
+```text
+Input signals:
+- screenshot text
+- route/domain
+- endpoint/request id
+- admin/member URL
+- affected entity type
+- product terms from report
+
+Recall:
+- bug_pattern
+- routing_memory
+- procedure
+- lesson
+
+Decision:
+- strong match -> use prior pattern as evidence and choose a lighter path
+- weak match -> mention as possible precedent, proceed with normal checks
+- conflict -> prefer current evidence, record memory as stale if needed
+```
+
+Memory is not an auto-fix mechanism. It should influence classification and skip decisions, not override the current report.
+
+Memory should also preserve negative routing lessons from resolved incidents:
+
+- "Admin URL was identity evidence, not bug surface."
+- "First reproducible failure was a mismatch; do not scope from it."
+- "Backend API failure made Vercel deploy state irrelevant."
+- "Expected entitlement behavior; no product fix needed."
+- "Lead bypassed worker roles; future lead should dispatch mode X."
+
+These are often more valuable than the code fix itself because they stop future lead turns from taking the wrong path.
+
+## Prompt Changes
+
+### Lead
+
+Replace categorical pipeline language with adaptive routing language:
+
+```text
+Choose the lightest sufficient path. Full pipeline is required only when the report is plausibly a product defect and cheaper evidence cannot settle the outcome.
+Before dispatching any worker, state:
+- selected path
+- evidence that drove it
+- agents/checks skipped and why
+- what decision the next agent must help make
+```
+
+Lead should be allowed to do lightweight evidence inspection:
+
+- read images
+- identify routes/domains
+- inspect bug-folder files
+- recall memory
+- perform small read-only data checks when they decide expected behavior vs data issue
+
+Lead still should not implement product fixes, run broad code investigations, own browser reproduction, restart dev servers, or validate fixes. Those remain worker responsibilities. If the selected adaptive path requires any of that work, dispatch the right worker with the narrowest useful mode.
+
+Lead's first-turn intake should output or write this minimal decision record:
+
+```yaml
+selected_path: backend-api-bug
+evidence:
+  identity:
+    - member_id: "..."
+  bug_surface:
+    - endpoint: "GET /api/v1/..."
+    - visible_error: "..."
+skipped:
+  reproducer: "Exact failing API response is already known; UI walk cannot change root-cause routing."
+  vercel-status: "Frontend calls backend directly; no evidence of bundle/deploy mismatch."
+next_action:
+  agent: thinker
+  mode: focused
+  decision_needed: "code bug vs data issue vs expected behavior"
+```
+
+### Reproducer
+
+Add mode handling and allow terminal outcomes beyond `reproduced` / `not-reproduced`.
+
+```text
+Honor the mode in lead's prompt. Do not perform a full browser walk when mode=image-interpretation or entitlement-check unless required to answer the stated objective.
+```
+
+### Thinker
+
+Add depth handling.
+
+```text
+Honor lead's requested depth: triage, focused, full, data-repair, known-fix.
+Only run the full 3-5 hypothesis ritual when depth=full or when evidence is too ambiguous for the requested lighter mode.
+```
+
+### Review
+
+Add review depth.
+
+```text
+Honor requested depth: micro, standard, deep.
+Escalate depth if the diff touches auth, payments, data migrations, permissions, user privacy, or shared query primitives.
+```
+
+## Safety Boundaries
+
+Adaptive does not mean casual.
+
+- Never skip a step because it is inconvenient; skip only because it cannot affect the next decision.
+- Never let a skipped agent turn into lead doing that agent's work inline.
+- Never reproduce write-path bugs in prod-connected environments.
+- Never mutate data without an approved data workflow.
+- Never use memory as proof. Use it as a classifier hint.
+- Escalate to human when the chosen lightweight path cannot settle the report.
+- Treat screenshots/images as first-class evidence. Extract the product surface from the image before routing by URLs supplied for identity or admin lookup.
+- Treat credentials and transcript captures as sensitive. Do not commit plaintext credentials, and redact or ignore transcript files that contain secrets before they enter version control.
+
+## Human Gates
+
+Human approval is required before:
+
+- production data mutation or repair
+- broad backfills or migrations
+- auth, payment, privacy, or permission behavior changes with ambiguous product intent
+- replaying write-path reproduction against any non-sandbox environment
+- merging when validation is skipped for risk/data-quality reasons
+- marking a high-risk systemic bug resolved without automated validation
+
+The lead prompt should name the gate and owner:
+
+```text
+needs-human: approve data repair for member <id>.
+reason: repair writes onboarding.subscription_plans.GROWTH_PROGRAM.access_status.
+owner: <@user>
+```
+
+## Implementation Plan
+
+1. Update `lead.md`.
+   - Replace the universal pipeline rule with "strict role boundaries, adaptive step selection."
+   - Add selected path, skip reasons, and next-decision requirements to intake.
+   - Add memory recall before path selection.
+
+2. Update `reproducer.md`.
+   - Add `mode` handling.
+   - Add `expected-behavior` and `data-issue` outcomes.
+   - Clarify that image/entitlement modes do not require full UI walks.
+
+3. Update `thinker.md`.
+   - Add `triage`, `focused`, `full`, `data-repair`, and `known-fix` depths.
+   - Keep full hypothesis tables for ambiguous/high-risk cases.
+   - Allow terminal "not a product bug" and "data/support issue" conclusions.
+
+4. Update `review.md`.
+   - Add review depth: `micro`, `standard`, `deep`.
+   - Let reviewers escalate depth when the diff touches high-risk areas.
+
+5. Add bug-memory write support.
+   - Store compact `bug_pattern` records in Junior memory at terminal states.
+   - Optionally write `$BUG_DIR/memory.md` for human audit.
+   - Mark stale/superseded memories when a future report contradicts them.
+
+6. Migrate existing resolved bug folders opportunistically.
+   - Do not bulk-import every old bug blindly.
+   - Promote only cases with clear root cause, resolution, and reusable routing lessons.
+   - Redact PII and secrets before memory write.
+
+7. Add tests/fixtures.
+   - Lead skips Vercel for backend-direct API bugs.
+   - Lead treats admin URLs as identity evidence, not routing evidence.
+   - Lead dispatches thinker instead of reproducer for clear API bugs.
+   - Lead does not perform worker jobs when skipping a worker.
+   - Memory recall can influence path selection without overriding explicit current evidence.
+
+8. Add adoption metrics.
+   - skipped-agent rate by path and reason
+   - human escalation rate
+   - reopen/regression rate after lightweight paths
+   - mismatch/not-reproduced rate
+   - memory-hit rate and stale-memory corrections
+
+## Done Means
+
+- Lead selected a path and named skipped checks.
+- Workers received mode-specific prompts.
+- The investigation reached a canonical outcome.
+- Resolved outcomes wrote a memory record into Junior memory.
+- A markdown `memory.md` was written in the bug folder when human-readable provenance is useful.

--- a/docs/features/persistent-agents.md
+++ b/docs/features/persistent-agents.md
@@ -1,6 +1,8 @@
 # Persistent Agents
 
-> Same backbone as the wiped `support-lead-persistent-agents.md` (persistent Claude Code session per agent role, one thread holds many agent sessions, each agent posts to Slack with its own identity). Refined design after a session of pruning: lead-only dispatch (workers can't tag each other), `NO_SLACK_MESSAGE` for silence, observability-before-UI as a hard invariant, no internal-dispatch-plus-audit-log split. First product use is the bug pipeline; substrate is reusable.
+> Same backbone as the wiped `support-lead-persistent-agents.md` (persistent Claude Code session per agent role, one thread holds many agent sessions, each agent posts to Slack with its own identity). Refined design after a session of pruning: orchestrator-owned dispatch, `NO_SLACK_MESSAGE` for silence, no internal-dispatch-plus-audit-log split. First product use is the bug pipeline; substrate is reusable.
+>
+> Bug-step selection has since moved to [Adaptive Bug Pipeline](adaptive-bug-pipeline.md). This document owns the persistent-agent substrate and audit/message-bus mechanics. The adaptive doc owns when lead should run, skip, or narrow observability/reproduction/thinking.
 
 ## Problem
 
@@ -52,15 +54,15 @@ Every orchestration decision is visible. Humans can see exactly what the lead as
 - Lead orchestrates by emitting `!<agent> <prompt>` lines in normal Slack messages. Router parses those lines and dispatches to persistent agents only. Sub-agents are never invoked via `!<agent>` — only via Task tool, and only by persistent agents.
 - **Orchestrators** (lead, default Junior) can emit `!<agent>` directives — both share the same full dispatch power; they differ only in slack identity and which channels route to them. Workers can use the Task tool for stateless data fetches but cannot trigger more persistent work, with the narrow exceptions in `WORKER_DISPATCH_ALLOW` (e.g. thinker → review / reproducer for happy-path chains).
 - Lead is awoken on every event in the thread (human messages and worker responses) and can choose silence (via `NO_SLACK_MESSAGE` or by posting commentary with no directives) — silence breaks the cycle.
-- Observability fan-out: lead issues parallel Task calls to nr-research / sentry-fetch / vercel-status in **one turn**. All three run concurrently. Once all return, lead reads their files, synthesizes findings into a single Slack message, then dispatches `!reproducer` with that context (read-only bugs only — write-path bugs go straight to thinker).
-- Reproducer runs _after_ observability completes and only for read-only bugs — it needs failing endpoints, exception classes, deploy state as context. Write-path bugs skip reproducer (both phases) to avoid prod side-effects.
+- Observability fan-out: when lead chooses full observability, it issues parallel Task calls to nr-research / sentry-fetch / vercel-status in **one turn**. All three run concurrently. Once all return, lead reads their files, synthesizes findings into a single Slack message, then dispatches the next selected worker.
+- Reproducer runs when lead selects a reproduction path. It should receive the narrowest useful context: image findings, targeted observability, full observability, affected-user state, or explicit instructions that observability was skipped because it cannot change the next decision.
 - Re-queries go through lead. Round caps (research max 3, review max 2) live in the lead's prompt as semantic guardrails, not in the router.
 - Live progress is signaled via a **status pill** that streams `tool_use` events (one pill per active agent session). Humans see "calling nr-research, sentry-fetch, vercel-status (3 in progress)" → "1 done, 2 in progress" → cleared. `tool_result` content stays internal.
 
 ## Invariants (architectural commitments)
 
-1. **Observability ALWAYS precedes UI verification.** When reproducer runs (read-only bugs only), it always has observability context, never cold. Write-path bugs skip both phases of reproducer — observability still runs first, it just feeds thinker directly.
-2. **Only orchestrators (lead, default Junior) emit `!<agent>` directives.** Workers can post any commentary, but they cannot trigger more work — except for the narrow happy-path chains declared in `WORKER_DISPATCH_ALLOW` (e.g. thinker → review).
+1. **Lead chooses the evidence path.** Full observability before reproduction is one available path, not a substrate invariant. See [Adaptive Bug Pipeline](adaptive-bug-pipeline.md) for skip rules and targeted/full observability modes.
+2. **Orchestrator-owned dispatch with allow-listed worker chains.** Orchestrators (lead, default Junior) own routing. Workers can post commentary but cannot trigger more persistent work except for narrow chains declared in `WORKER_DISPATCH_ALLOW` (e.g. thinker → review / reproducer).
 3. **The Slack thread IS the message bus.** No internal-dispatch-plus-audit-log split. Every cross-agent call goes through Slack events. One source of truth, full audit trail by construction.
 4. **Silence is a first-class action.** Cycle-break by composition, not enforcement. No router-level retry counters.
 
@@ -262,7 +264,7 @@ The lead's `.claude/agents/lead.md` (replaces the old `support-lead.md`) teaches
 - The dispatch syntax: write `!<agent> <prompt>` on its own line to dispatch.
 - State-checking: read `agentSessions[name].status` before emitting. Don't dispatch a `busy` agent (will buffer); don't dispatch a `done` one without good reason.
 - Round caps: `rounds.research ≤ 3`, `rounds.review ≤ 2`, `rounds.reproducer ≤ 2`. Track in `state.json` per bug. At cap → escalate to human, not re-spawn.
-- The observability-before-reproduction invariant.
+- The adaptive evidence-path policy from [Adaptive Bug Pipeline](adaptive-bug-pipeline.md).
 - When to use `NO_SLACK_MESSAGE` vs commentary-with-no-directives.
 - The mismatch outcome and how to handle it (don't proceed to research with the wrong issue).
 
@@ -323,20 +325,20 @@ Prove parallel Task-tool fan-out.
 
 ### Iteration 3: First persistent agent — `reproducer` (~4h)
 
-The first real persistent agent on top of the substrate. Single-concern UI walker. Runs after observability completes.
+The first real persistent agent on top of the substrate. Single-concern UI walker. Runs when lead selects a reproduction path.
 
 **What it adds:**
 
 - `.claude/agents/reproducer.md` (Claude Code persistent agent definition, addressable via `!reproducer`)
 - `AGENT_IDENTITIES` entry for `reproducer`
 - `support/agents/reproducer/prompt.md` rewritten from the restored baseline
-- Reads `$BUG_DIR/research.md`, `sentry.md`, `vercel.md` as input context — failing endpoints, exception classes, deploy state are hand-fed by the lead
+- Reads the context lead provides for the selected path. For full-observability paths this includes `$BUG_DIR/research.md`, `sentry.md`, and `vercel.md`; for lighter paths it may include image findings, affected-user state, or a note that observability was skipped.
 - Tool access: playwright/claude-in-chrome, screenshot, members lookup, admin-credentials.yaml fallbacks
 - Outcomes: `reproduced | partial | mismatch | not-reproduced` (mismatch + honesty-over-completion baked in from the start)
 - Posts trace + outcome to Slack with `Reproducer` identity, suffixed `by reproducer`
-- Manually orchestrated for now: operator types `!reproducer ...` after observability has been run via iters 1+2
+- Manually orchestrated for now: operator types `!reproducer ...` after choosing the evidence path.
 
-**Test:** Real bug thread with observability files already in the bug folder. Post `!reproducer reproduce: <user story>`. Verify Reproducer session created, reads observability files, walks UI, posts trace under `Reproducer` identity. Resume by posting `!reproducer what about the cache header?` — verify same session resumed (preamble-skip after first turn). Test all 4 outcomes including `mismatch`.
+**Test:** Real bug thread with either observability files or an explicit lighter-mode prompt. Post `!reproducer reproduce: <user story>`. Verify Reproducer session created, reads the provided context, walks UI only when requested, posts trace under `Reproducer` identity. Resume by posting `!reproducer what about the cache header?` — verify same session resumed (preamble-skip after first turn). Test all 4 outcomes including `mismatch`.
 
 **Defers:** Lead-driven orchestration (still manual), thinker/review/email-drafter, reproducer phase=validation.
 
@@ -350,9 +352,10 @@ Lead actually orchestrates the pipeline instead of being manually invoked.
 - Auto-assign `#bugs-backlog` threads to `lead` agent type (already wired via `channelDefaults`)
 - Lead's prompt teaches:
   - Bug folder lifecycle: create `support/bugs/<product>/<bug-id>/` on intake (template restored)
-  - Observability fan-out: parallel Task calls to nr-research / sentry-fetch / vercel-status in **one assistant message**
+  - Adaptive evidence selection: skip, targeted, or full observability per [Adaptive Bug Pipeline](adaptive-bug-pipeline.md)
+  - Full observability fan-out: parallel Task calls to nr-research / sentry-fetch / vercel-status in **one assistant message**
   - Synthesis: read the three files after Tasks return, post a rollup to Slack with key findings + file path references
-  - `!reproducer` dispatch with synthesized observability context
+  - `!reproducer` or `!thinker` dispatch with mode-specific context
   - State-checking: read `agentSessions[name].status` before emitting any `!<agent>`
   - Round caps as semantic guardrails (`rounds.research ≤ 3`, `rounds.review ≤ 2`, `rounds.reproducer ≤ 2`); at cap → escalate, not retry
   - When to use `NO_SLACK_MESSAGE` vs commentary-only (silence rules)
@@ -362,9 +365,10 @@ Lead actually orchestrates the pipeline instead of being manually invoked.
 **Test:** End-to-end. Post a real bug in `#bugs-backlog`. Verify:
 
 - Lead creates the bug folder
-- Lead's first turn does parallel Task calls; status pill shows `Calling nr-research, sentry-fetch, vercel-status (3 in progress)` and updates as each completes
-- Lead posts a single synthesis message after all three return, referencing the three files
-- Lead emits `!reproducer ...` with observability-aware context
+- Lead chooses and records an evidence path
+- For full observability paths, lead's first turn does parallel Task calls; status pill shows `Calling nr-research, sentry-fetch, vercel-status (3 in progress)` and updates as each completes
+- For full observability paths, lead posts a single synthesis message after all three return, referencing the three files
+- Lead emits `!reproducer ...` or `!thinker ...` with mode-specific context
 - On mismatch outcome, lead doesn't dispatch the next stage on the wrong failure
 - On `not-reproduced`, lead escalates to human (no auto-retry)
 

--- a/docs/features/persistent-agents.md
+++ b/docs/features/persistent-agents.md
@@ -334,11 +334,11 @@ The first real persistent agent on top of the substrate. Single-concern UI walke
 - `support/agents/reproducer/prompt.md` rewritten from the restored baseline
 - Reads the context lead provides for the selected path. For full-observability paths this includes `$BUG_DIR/research.md`, `sentry.md`, and `vercel.md`; for lighter paths it may include image findings, affected-user state, or a note that observability was skipped.
 - Tool access: playwright/claude-in-chrome, screenshot, members lookup, admin-credentials.yaml fallbacks
-- Outcomes: `reproduced | partial | mismatch | not-reproduced` (mismatch + honesty-over-completion baked in from the start)
+- Outcomes: `expected-behavior | data-issue | product-bug | mismatch | not-reproduced | needs-human` (mapped to the adaptive pipeline canonical outcomes; mismatch + honesty-over-completion baked in from the start)
 - Posts trace + outcome to Slack with `Reproducer` identity, suffixed `by reproducer`
 - Manually orchestrated for now: operator types `!reproducer ...` after choosing the evidence path.
 
-**Test:** Real bug thread with either observability files or an explicit lighter-mode prompt. Post `!reproducer reproduce: <user story>`. Verify Reproducer session created, reads the provided context, walks UI only when requested, posts trace under `Reproducer` identity. Resume by posting `!reproducer what about the cache header?` — verify same session resumed (preamble-skip after first turn). Test all 4 outcomes including `mismatch`.
+**Test:** Real bug thread with either observability files or an explicit lighter-mode prompt. Post `!reproducer reproduce: <user story>`. Verify Reproducer session created, reads the provided context, walks UI only when requested, posts trace under `Reproducer` identity. Resume by posting `!reproducer what about the cache header?` — verify same session resumed (preamble-skip after first turn). Test all 6 reproducer outcomes: `expected-behavior`, `data-issue`, `product-bug`, `mismatch`, `not-reproduced`, and `needs-human`.
 
 **Defers:** Lead-driven orchestration (still manual), thinker/review/email-drafter, reproducer phase=validation.
 

--- a/src/agents/lint.test.ts
+++ b/src/agents/lint.test.ts
@@ -88,6 +88,51 @@ describe("prompt lint", () => {
     });
   });
 
+  describe("bug-pipeline agents implement adaptive evidence routing", () => {
+    it("lead prompt uses adaptive path selection instead of universal observability", async () => {
+      const content = await readAgent("lead");
+
+      expect(content).toContain("adaptive step selection");
+      expect(content).toContain("Evidence paths");
+      expect(content).toContain("targeted/full/no observability");
+      expect(content).toContain("Skipping <agent/check> because <reason>");
+      expect(content).not.toContain("EVERY bug, no exceptions");
+      expect(content).not.toContain("Observability always precedes reproduction and validation");
+    });
+
+    it("reproducer prompt allows adaptive terminal outcomes and modes", async () => {
+      const content = await readAgent("reproducer");
+
+      for (const marker of [
+        "image-interpretation",
+        "entitlement-check",
+        "read-only-walk",
+        "expected-behavior",
+        "data-issue",
+        "product-bug",
+        "needs-human",
+      ]) {
+        expect(content).toContain(marker);
+      }
+
+      expect(content).not.toContain("<reproduced | partial | mismatch | not-reproduced>");
+      expect(content).not.toContain("Honest about what was seen: `reproduced`, `partial`, `mismatch`, or `not-reproduced`");
+    });
+
+    it("thinker and review prompts honor requested depth", async () => {
+      const thinker = await readAgent("thinker");
+      const review = await readAgent("review");
+
+      for (const marker of ["triage", "focused", "full", "data-repair", "known-fix"]) {
+        expect(thinker).toContain(marker);
+      }
+
+      for (const marker of ["micro", "standard", "deep", "Escalate to `deep`"]) {
+        expect(review).toContain(marker);
+      }
+    });
+  });
+
   describe("action classifier present in core.md", () => {
     it("core.md contains the action classifier heading", async () => {
       const corePath = path.join(commonDir, "core.md");

--- a/src/agents/lint.test.ts
+++ b/src/agents/lint.test.ts
@@ -117,6 +117,8 @@ describe("prompt lint", () => {
 
       expect(content).not.toContain("<reproduced | partial | mismatch | not-reproduced>");
       expect(content).not.toContain("Honest about what was seen: `reproduced`, `partial`, `mismatch`, or `not-reproduced`");
+      expect(content).toContain("read whichever observability files exist");
+      expect(content).toContain("Missing observability files are expected");
     });
 
     it("thinker and review prompts honor requested depth", async () => {
@@ -126,6 +128,9 @@ describe("prompt lint", () => {
       for (const marker of ["triage", "focused", "full", "data-repair", "known-fix"]) {
         expect(thinker).toContain(marker);
       }
+
+      expect(thinker).toContain("do not assume write-path");
+      expect(thinker).toContain("only the observability files that exist");
 
       for (const marker of ["micro", "standard", "deep", "Escalate to `deep`"]) {
         expect(review).toContain(marker);


### PR DESCRIPTION
## Summary
- add an adaptive bug-pipeline design doc for lead path selection, skip rules, worker modes, and canonical outcomes
- document resolved-bug memory-bank shape, lifecycle, and intake recall behavior
- update persistent-agents docs so the substrate no longer conflicts with adaptive evidence routing
- link the new doc from CLAUDE.md

## Validation
- git diff --check
- reviewed by two dispatched explorer agents; incorporated findings around dispatch fields, data-check limits, write-path handling, outcomes, memory lifecycle, observability contracts, human gates, and persistent-agents consistency