### PR TITLE
feat(claude): bring claude -p runner to parity with codex-app-server

### DIFF
--- a/src/agents/loader.test.ts
+++ b/src/agents/loader.test.ts
@@ -278,6 +278,50 @@ body`;
     }
   });
 
+  describe("modelClaude frontmatter field", () => {
+    it("parses model.claude frontmatter into modelClaude", async () => {
+      const tmpPath = path.join(import.meta.dir, "__test_model_claude.md");
+      const content = `---
+name: claude-override
+description: Test
+model: gpt-5.5
+model.claude: sonnet
+---
+
+body`;
+      await Bun.write(tmpPath, content);
+
+      try {
+        const def = await loadAgentDefinition(tmpPath);
+        expect(def).not.toBeNull();
+        expect(def!.model).toBe("gpt-5.5");
+        expect(def!.modelClaude).toBe("sonnet");
+      } finally {
+        await fs.unlink(tmpPath).catch(() => {});
+      }
+    });
+
+    it("modelClaude is null when model.claude is not declared", async () => {
+      const tmpPath = path.join(import.meta.dir, "__test_model_claude_absent.md");
+      const content = `---
+name: no-claude-override
+description: Test
+model: gpt-5.5
+---
+
+body`;
+      await Bun.write(tmpPath, content);
+
+      try {
+        const def = await loadAgentDefinition(tmpPath);
+        expect(def).not.toBeNull();
+        expect(def!.modelClaude).toBeNull();
+      } finally {
+        await fs.unlink(tmpPath).catch(() => {});
+      }
+    });
+  });
+
   it("handles incomplete frontmatter (missing closing ---)", async () => {
     const tmpPath = path.join(import.meta.dir, "__test_incomplete.md");
     const content = `---

--- a/src/agents/loader.ts
+++ b/src/agents/loader.ts
@@ -53,6 +53,11 @@ export interface AgentDefinition {
   description: string;
   tools: string | null;
   model: string | null;
+  /**
+   * Explicit Claude-runner model override, from `model.claude` frontmatter.
+   * Wins over the GPT→Claude map.
+   */
+  modelClaude: string | null;
   common: string[];
   prompt: string;
   context: AgentContextProfile;
@@ -84,6 +89,7 @@ export async function loadAgentDefinition(
     description: frontmatter["description"] ?? "",
     tools: frontmatter["tools"] ?? null,
     model: frontmatter["model"] ?? null,
+    modelClaude: frontmatter["model.claude"] ?? null,
     common: readCommonProfile(frontmatter),
     prompt: body.trim(),
     context: readContextProfile(frontmatter),

--- a/src/claude/args.test.ts
+++ b/src/claude/args.test.ts
@@ -196,9 +196,9 @@ describe("buildClaudeArgs", () => {
     expect(args).toContain("project");
   });
 
-  it("wires the Slack approval round-trip for human-gated when approval enabled", () => {
+  it("wires the Slack approval round-trip for human-gated when approval enabled and slack-bot MCP present", () => {
     const session = makeSession({ agentPermissions: perms({ intent: "human-gated" }) });
-    const args = buildClaudeArgs(session, "gate", makeConfig({ approvalEnabled: true }), CWD);
+    const args = buildClaudeArgs(session, "gate", makeConfig({ approvalEnabled: true }), CWD, "/tmp/mcp.json");
     expect(args).toContain("--permission-prompt-tool");
     expect(args).toContain(APPROVAL_PERMISSION_TOOL);
     // Approval needs `default` mode so un-allowed tools consult the prompt tool.
@@ -206,9 +206,18 @@ describe("buildClaudeArgs", () => {
     expect(args[modeIdx + 1]).toBe("default");
   });
 
+  it("falls back to plan mode for human-gated when no MCP config is present (approval can't be wired)", () => {
+    const session = makeSession({ agentPermissions: perms({ intent: "human-gated" }) });
+    // No mcpConfigPath → slack-bot tool won't exist → don't advertise it.
+    const args = buildClaudeArgs(session, "gate", makeConfig({ approvalEnabled: true }), CWD);
+    expect(args).not.toContain("--permission-prompt-tool");
+    const modeIdx = args.indexOf("--permission-mode");
+    expect(args[modeIdx + 1]).toBe("plan");
+  });
+
   it("keeps human-gated on plan mode when approval disabled", () => {
     const session = makeSession({ agentPermissions: perms({ intent: "human-gated" }) });
-    const args = buildClaudeArgs(session, "gate", makeConfig({ approvalEnabled: false }), CWD);
+    const args = buildClaudeArgs(session, "gate", makeConfig({ approvalEnabled: false }), CWD, "/tmp/mcp.json");
     expect(args).not.toContain("--permission-prompt-tool");
     const modeIdx = args.indexOf("--permission-mode");
     expect(args[modeIdx + 1]).toBe("plan");

--- a/src/claude/args.test.ts
+++ b/src/claude/args.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from "bun:test";
-import { buildClaudeArgs } from "./args.ts";
+import { APPROVAL_PERMISSION_TOOL, buildClaudeArgs, juniorBaselinePrompt } from "./args.ts";
 import type { ThreadSession } from "../session/types.ts";
 import type { Config } from "../config.ts";
+import type { AgentPermissions } from "../agents/loader.ts";
+
+const CWD = "/work/repo";
 
 function makeSession(overrides: Partial<ThreadSession> = {}): ThreadSession {
   return {
@@ -44,6 +47,13 @@ function makeConfig(overrides: Partial<Config["claude"]> = {}): Config["claude"]
     timeoutMs: 300000,
     permissionMode: "bypassPermissions",
     defaultModel: null,
+    // New parity knobs default OFF here so core-arg assertions stay focused;
+    // dedicated tests below flip each one on.
+    strictMcp: false,
+    settingSources: "",
+    approvalEnabled: false,
+    maxBudgetUsd: null,
+    baselineEnabled: false,
     defaultDriver: "headless",
     tmuxIdleTtlMs: 14_400_000,
     tmuxSweepIntervalMs: 900_000,
@@ -51,9 +61,13 @@ function makeConfig(overrides: Partial<Config["claude"]> = {}): Config["claude"]
   };
 }
 
+function perms(overrides: Partial<AgentPermissions> = {}): AgentPermissions {
+  return { intent: null, mcp: [], tools: [], ...overrides };
+}
+
 describe("buildClaudeArgs", () => {
   it("includes basic required args", () => {
-    const args = buildClaudeArgs(makeSession(), "do something", makeConfig());
+    const args = buildClaudeArgs(makeSession(), "do something", makeConfig(), CWD);
     expect(args).toContain("-p");
     expect(args).toContain("do something");
     expect(args).toContain("--output-format");
@@ -61,45 +75,47 @@ describe("buildClaudeArgs", () => {
     expect(args).toContain("--max-turns");
     expect(args).toContain("25");
     expect(args).toContain("--permission-mode");
+    // No intent → normal branch → bypassPermissions.
     expect(args).toContain("bypassPermissions");
   });
 
   it("includes --resume when sessionId is present", () => {
     const session = makeSession({ sessionId: "sess-abc" });
-    const args = buildClaudeArgs(session, "continue", makeConfig());
+    const args = buildClaudeArgs(session, "continue", makeConfig(), CWD);
     expect(args).toContain("--resume");
     expect(args).toContain("sess-abc");
   });
 
   it("does not include --resume when sessionId is null", () => {
     const session = makeSession({ sessionId: null });
-    const args = buildClaudeArgs(session, "start fresh", makeConfig());
+    const args = buildClaudeArgs(session, "start fresh", makeConfig(), CWD);
     expect(args).not.toContain("--resume");
   });
 
   it("includes --append-system-prompt when systemPrompt is set", () => {
     const session = makeSession({ systemPrompt: "You are a build agent." });
-    const args = buildClaudeArgs(session, "build it", makeConfig());
+    const args = buildClaudeArgs(session, "build it", makeConfig(), CWD);
     expect(args).toContain("--append-system-prompt");
     expect(args).toContain("You are a build agent.");
   });
 
-  it("does not include --append-system-prompt when systemPrompt is null", () => {
+  it("does not include --append-system-prompt when systemPrompt is null and baseline off", () => {
     const session = makeSession({ systemPrompt: null });
-    const args = buildClaudeArgs(session, "do it", makeConfig());
+    const args = buildClaudeArgs(session, "do it", makeConfig(), CWD);
     expect(args).not.toContain("--append-system-prompt");
   });
 
   it("uses maxTurns from config", () => {
     const config = makeConfig({ maxTurns: 10 });
-    const args = buildClaudeArgs(makeSession(), "test", config);
+    const args = buildClaudeArgs(makeSession(), "test", config, CWD);
     expect(args).toContain("--max-turns");
     expect(args).toContain("10");
   });
 
-  it("uses permissionMode from config", () => {
+  it("uses permissionMode from config only for the utility intent", () => {
     const config = makeConfig({ permissionMode: "default" });
-    const args = buildClaudeArgs(makeSession(), "test", config);
+    const session = makeSession({ agentPermissions: perms({ intent: "utility" }) });
+    const args = buildClaudeArgs(session, "test", config, CWD);
     expect(args).toContain("--permission-mode");
     expect(args).toContain("default");
   });
@@ -109,7 +125,7 @@ describe("buildClaudeArgs", () => {
       sessionId: "sess-xyz",
       systemPrompt: "Be concise.",
     });
-    const args = buildClaudeArgs(session, "go", makeConfig());
+    const args = buildClaudeArgs(session, "go", makeConfig(), CWD);
     expect(args).toContain("--resume");
     expect(args).toContain("sess-xyz");
     expect(args).toContain("--append-system-prompt");
@@ -118,7 +134,7 @@ describe("buildClaudeArgs", () => {
 
   it("uses config.defaultModel when session.model is null", () => {
     const config = makeConfig({ defaultModel: "claude-opus-4-6[1M]" });
-    const args = buildClaudeArgs(makeSession(), "test", config);
+    const args = buildClaudeArgs(makeSession(), "test", config, CWD);
     expect(args).toContain("--model");
     expect(args).toContain("claude-opus-4-6[1M]");
   });
@@ -126,21 +142,103 @@ describe("buildClaudeArgs", () => {
   it("prefers session.model over config.defaultModel", () => {
     const config = makeConfig({ defaultModel: "claude-opus-4-6[1M]" });
     const session = makeSession({ model: "haiku" });
-    const args = buildClaudeArgs(session, "test", config);
+    const args = buildClaudeArgs(session, "test", config, CWD);
     expect(args).toContain("--model");
     expect(args).toContain("haiku");
     expect(args).not.toContain("claude-opus-4-6[1M]");
   });
 
   it("omits --model when neither session nor config provides one", () => {
-    const args = buildClaudeArgs(makeSession(), "test", makeConfig());
+    const args = buildClaudeArgs(makeSession(), "test", makeConfig(), CWD);
     expect(args).not.toContain("--model");
   });
 
   it("places prompt immediately after -p", () => {
-    const args = buildClaudeArgs(makeSession(), "my prompt", makeConfig());
+    const args = buildClaudeArgs(makeSession(), "my prompt", makeConfig(), CWD);
     const pIdx = args.indexOf("-p");
     expect(pIdx).toBeGreaterThanOrEqual(0);
     expect(args[pIdx + 1]).toBe("my prompt");
+  });
+
+  // --- parity additions ---
+
+  it("locks down writes for read-only intent", () => {
+    const session = makeSession({ agentPermissions: perms({ intent: "read-only" }) });
+    const args = buildClaudeArgs(session, "review", makeConfig(), CWD);
+    expect(args).toContain("--permission-mode");
+    expect(args).toContain("plan");
+    expect(args).toContain("--disallowedTools");
+    expect(args).toContain("Edit");
+    expect(args).toContain("Write");
+  });
+
+  it("passes declared tools as --allowedTools", () => {
+    const session = makeSession({
+      agentPermissions: perms({ intent: "read-only", tools: ["Read", "Grep"] }),
+    });
+    const args = buildClaudeArgs(session, "look", makeConfig(), CWD);
+    expect(args).toContain("--allowedTools");
+    expect(args).toContain("Read");
+    expect(args).toContain("Grep");
+  });
+
+  it("injects the Junior baseline prompt when baselineEnabled", () => {
+    const args = buildClaudeArgs(makeSession(), "x", makeConfig({ baselineEnabled: true }), CWD);
+    expect(args).toContain("--append-system-prompt");
+    expect(args).toContain(juniorBaselinePrompt());
+  });
+
+  it("adds --strict-mcp-config and --setting-sources when configured", () => {
+    const config = makeConfig({ strictMcp: true, settingSources: "project" });
+    const args = buildClaudeArgs(makeSession(), "x", config, CWD);
+    expect(args).toContain("--strict-mcp-config");
+    expect(args).toContain("--setting-sources");
+    expect(args).toContain("project");
+  });
+
+  it("wires the Slack approval round-trip for human-gated when approval enabled", () => {
+    const session = makeSession({ agentPermissions: perms({ intent: "human-gated" }) });
+    const args = buildClaudeArgs(session, "gate", makeConfig({ approvalEnabled: true }), CWD);
+    expect(args).toContain("--permission-prompt-tool");
+    expect(args).toContain(APPROVAL_PERMISSION_TOOL);
+    // Approval needs `default` mode so un-allowed tools consult the prompt tool.
+    const modeIdx = args.indexOf("--permission-mode");
+    expect(args[modeIdx + 1]).toBe("default");
+  });
+
+  it("keeps human-gated on plan mode when approval disabled", () => {
+    const session = makeSession({ agentPermissions: perms({ intent: "human-gated" }) });
+    const args = buildClaudeArgs(session, "gate", makeConfig({ approvalEnabled: false }), CWD);
+    expect(args).not.toContain("--permission-prompt-tool");
+    const modeIdx = args.indexOf("--permission-mode");
+    expect(args[modeIdx + 1]).toBe("plan");
+  });
+
+  it("maps a GPT frontmatter model to its Claude equivalent", () => {
+    const session = makeSession({ model: "gpt-5.5" });
+    const args = buildClaudeArgs(session, "x", makeConfig(), CWD);
+    expect(args).toContain("--model");
+    expect(args).toContain("opus");
+    expect(args).not.toContain("gpt-5.5");
+  });
+
+  it("honors an explicit model.claude override over the GPT map", () => {
+    const session = makeSession({ model: "gpt-5.5", modelClaude: "sonnet" });
+    const args = buildClaudeArgs(session, "x", makeConfig(), CWD);
+    expect(args).toContain("--model");
+    expect(args).toContain("sonnet");
+    expect(args).not.toContain("opus");
+  });
+
+  it("adds --mcp-config when a path is provided", () => {
+    const args = buildClaudeArgs(makeSession(), "x", makeConfig(), CWD, "/tmp/mcp.json");
+    expect(args).toContain("--mcp-config");
+    expect(args).toContain("/tmp/mcp.json");
+  });
+
+  it("adds --max-budget-usd when configured", () => {
+    const args = buildClaudeArgs(makeSession(), "x", makeConfig({ maxBudgetUsd: 2.5 }), CWD);
+    expect(args).toContain("--max-budget-usd");
+    expect(args).toContain("2.5");
   });
 });

--- a/src/claude/args.ts
+++ b/src/claude/args.ts
@@ -28,7 +28,13 @@ export function buildClaudeArgs(
 ): string[] {
   const policy = mapClaudeRunPolicy({ config, session, cwd });
   const intent = session.agentPermissions?.intent ?? null;
-  const approvalActive = config.approvalEnabled !== false && intent === "human-gated";
+  // Approval is only wired when the slack-bot MCP is actually configured for
+  // this run (mcpConfigPath present — the spawner forces slack-bot for
+  // human-gated runs). When it isn't (e.g. a session.cwd utility run that skips
+  // project MCP), we must NOT advertise --permission-prompt-tool for a tool that
+  // won't exist; fall back to the policy's safe `plan` base instead.
+  const approvalActive =
+    config.approvalEnabled !== false && intent === "human-gated" && mcpConfigPath != null;
 
   const args: string[] = [
     "-p",

--- a/src/claude/args.ts
+++ b/src/claude/args.ts
@@ -1,12 +1,35 @@
 import type { Config } from "../config.ts";
 import type { ThreadSession } from "../session/types.ts";
+import { mapClaudeRunPolicy } from "./policy.ts";
+import { resolveClaudeModel } from "./model.ts";
+
+/** Fully-qualified name of the slack-bot MCP approval tool (see src/mcp/approval.ts). */
+export const APPROVAL_PERMISSION_TOOL = "mcp__slack-bot__request_permission";
+
+/**
+ * Junior provider-baseline system prompt — the Claude-runner equivalent of the
+ * codex adapter's `baseInstructions`. Injected ahead of the agent's own
+ * `session.systemPrompt` so both layers are present.
+ */
+export function juniorBaselinePrompt(): string {
+  return [
+    "You are Junior, a Slack-controlled coding agent running headlessly via the Claude CLI.",
+    "Preserve Junior's Slack session semantics and respond with concise, useful final text.",
+    "Delegate to sub-agents only when the active Junior agent prompt explicitly asks for parallel or delegated work.",
+  ].join("\n");
+}
 
 export function buildClaudeArgs(
   session: ThreadSession,
   prompt: string,
   config: Config["claude"],
+  cwd: string,
   mcpConfigPath?: string,
 ): string[] {
+  const policy = mapClaudeRunPolicy({ config, session, cwd });
+  const intent = session.agentPermissions?.intent ?? null;
+  const approvalActive = config.approvalEnabled !== false && intent === "human-gated";
+
   const args: string[] = [
     "-p",
     prompt,
@@ -21,19 +44,58 @@ export function buildClaudeArgs(
     args.push("--resume", session.sessionId);
   }
 
+  // Two-layer system prompt: Junior baseline, then the agent's composed prompt.
+  if (config.baselineEnabled !== false) {
+    args.push("--append-system-prompt", juniorBaselinePrompt());
+  }
   if (session.systemPrompt) {
     args.push("--append-system-prompt", session.systemPrompt);
   }
 
-  const model = session.model ?? config.defaultModel;
+  const model = resolveClaudeModel({
+    modelClaude: session.modelClaude,
+    sessionModel: session.model,
+    configDefaultModel: config.defaultModel,
+  });
   if (model) {
     args.push("--model", model);
   }
 
-  args.push("--permission-mode", config.permissionMode);
+  // Permission surface from the agent's intent. When the Slack approval
+  // round-trip is active we need `default` mode (so un-allowed tools consult the
+  // prompt tool) rather than the policy's safe `plan` base.
+  const permissionMode = approvalActive ? "default" : policy.permissionMode;
+  args.push("--permission-mode", permissionMode);
+  if (approvalActive) {
+    args.push("--permission-prompt-tool", APPROVAL_PERMISSION_TOOL);
+  }
+
+  if (policy.allowedTools.length > 0) {
+    args.push("--allowedTools", ...policy.allowedTools);
+  }
+  if (policy.disallowedTools.length > 0) {
+    args.push("--disallowedTools", ...policy.disallowedTools);
+  }
+  // addDirs only carries extra roots beyond cwd (cwd is already accessible).
+  const extraDirs = policy.addDirs.filter((dir) => dir !== cwd);
+  if (extraDirs.length > 0) {
+    args.push("--add-dir", ...extraDirs);
+  }
+
+  if (config.maxBudgetUsd != null) {
+    args.push("--max-budget-usd", String(config.maxBudgetUsd));
+  }
 
   if (mcpConfigPath) {
     args.push("--mcp-config", mcpConfigPath);
+  }
+  // Isolation: only load Junior's generated MCP config (no developer-global
+  // `.mcp.json` / user MCP leak), and only project-level settings.
+  if (config.strictMcp !== false) {
+    args.push("--strict-mcp-config");
+  }
+  if (config.settingSources) {
+    args.push("--setting-sources", config.settingSources);
   }
 
   return args;

--- a/src/claude/model.test.ts
+++ b/src/claude/model.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect } from "bun:test";
+import { resolveClaudeModel } from "./model.ts";
+
+describe("resolveClaudeModel", () => {
+  const cfg = "claude-sonnet-4-5"; // stand-in configDefaultModel
+
+  describe("precedence 1 — modelClaude override wins", () => {
+    it("returns modelClaude when set, regardless of sessionModel", () => {
+      expect(
+        resolveClaudeModel({
+          modelClaude: "opus",
+          sessionModel: "gpt-5.5",
+          configDefaultModel: cfg,
+        }),
+      ).toBe("opus");
+    });
+
+    it("returns modelClaude when sessionModel is null", () => {
+      expect(
+        resolveClaudeModel({
+          modelClaude: "sonnet",
+          sessionModel: null,
+          configDefaultModel: cfg,
+        }),
+      ).toBe("sonnet");
+    });
+
+    it("ignores null modelClaude (falls through to next rule)", () => {
+      expect(
+        resolveClaudeModel({
+          modelClaude: null,
+          sessionModel: "sonnet",
+          configDefaultModel: cfg,
+        }),
+      ).toBe("sonnet");
+    });
+  });
+
+  describe("precedence 2 — Claude alias passthrough", () => {
+    it("passes 'opus' through verbatim", () => {
+      expect(
+        resolveClaudeModel({ sessionModel: "opus", configDefaultModel: cfg }),
+      ).toBe("opus");
+    });
+
+    it("passes 'sonnet' through verbatim", () => {
+      expect(
+        resolveClaudeModel({ sessionModel: "sonnet", configDefaultModel: cfg }),
+      ).toBe("sonnet");
+    });
+
+    it("passes 'haiku' through verbatim", () => {
+      expect(
+        resolveClaudeModel({ sessionModel: "haiku", configDefaultModel: cfg }),
+      ).toBe("haiku");
+    });
+
+    it("passes 'fable' through verbatim", () => {
+      expect(
+        resolveClaudeModel({ sessionModel: "fable", configDefaultModel: cfg }),
+      ).toBe("fable");
+    });
+
+    it("passes full claude- prefixed id through verbatim", () => {
+      expect(
+        resolveClaudeModel({
+          sessionModel: "claude-opus-4-8",
+          configDefaultModel: cfg,
+        }),
+      ).toBe("claude-opus-4-8");
+    });
+
+    it("passes claude/ prefixed id through verbatim", () => {
+      expect(
+        resolveClaudeModel({
+          sessionModel: "claude/opus",
+          configDefaultModel: cfg,
+        }),
+      ).toBe("claude/opus");
+    });
+  });
+
+  describe("precedence 3 — GPT model mapping", () => {
+    it("maps gpt-5.5 → opus", () => {
+      expect(
+        resolveClaudeModel({ sessionModel: "gpt-5.5", configDefaultModel: cfg }),
+      ).toBe("opus");
+    });
+
+    it("is case-insensitive for the gpt-5.5 → opus mapping", () => {
+      expect(
+        resolveClaudeModel({ sessionModel: "GPT-5.5", configDefaultModel: cfg }),
+      ).toBe("opus");
+    });
+
+    it("unmapped GPT model (gpt-5.1) falls back to configDefaultModel", () => {
+      expect(
+        resolveClaudeModel({ sessionModel: "gpt-5.1", configDefaultModel: cfg }),
+      ).toBe(cfg);
+    });
+
+    it("unmapped GPT model returns null when configDefaultModel is null", () => {
+      expect(
+        resolveClaudeModel({ sessionModel: "gpt-5.1", configDefaultModel: null }),
+      ).toBeNull();
+    });
+
+    it("o-series OpenAI model (o3) falls back to configDefaultModel", () => {
+      expect(
+        resolveClaudeModel({ sessionModel: "o3", configDefaultModel: cfg }),
+      ).toBe(cfg);
+    });
+  });
+
+  describe("precedence 4 — null / unknown sessionModel", () => {
+    it("null sessionModel returns configDefaultModel", () => {
+      expect(
+        resolveClaudeModel({ sessionModel: null, configDefaultModel: cfg }),
+      ).toBe(cfg);
+    });
+
+    it("null sessionModel returns null when configDefaultModel is null", () => {
+      expect(
+        resolveClaudeModel({ sessionModel: null, configDefaultModel: null }),
+      ).toBeNull();
+    });
+
+    it("unknown non-Claude non-GPT string falls back to configDefaultModel", () => {
+      expect(
+        resolveClaudeModel({
+          sessionModel: "some-mystery-model-9000",
+          configDefaultModel: cfg,
+        }),
+      ).toBe(cfg);
+    });
+  });
+});

--- a/src/claude/model.ts
+++ b/src/claude/model.ts
@@ -1,0 +1,65 @@
+/**
+ * Resolve the model id to pass to the Claude runner CLI.
+ *
+ * Mirrors `codexCompatibleModel` in `src/codex-app-server/spawner.ts` but in
+ * the opposite direction: instead of stripping Claude aliases so Codex doesn't
+ * choke, this function maps GPT/OpenAI model ids (historically written in agent
+ * frontmatter when Codex was the active runner) to their Claude equivalents so
+ * Claude doesn't choke.
+ *
+ * Product decision: `gpt-5.5` maps to `opus` — the two were considered
+ * equivalent capability tiers at the point of the runner switch.
+ */
+
+/**
+ * GPT/OpenAI model → Claude model alias.
+ *
+ * Keys are lowercase. Entries cover only the models that appeared in production
+ * agent frontmatter; anything not listed falls through to `configDefaultModel`.
+ */
+const GPT_TO_CLAUDE: Record<string, string> = {
+  "gpt-5.5": "opus",
+};
+
+/**
+ * Resolve which model id to hand the Claude runner.
+ *
+ * Precedence:
+ * 1. `modelClaude` — explicit per-agent Claude override (wins unconditionally).
+ * 2. `sessionModel` already a Claude model (alias or full id) — pass through.
+ * 3. `sessionModel` is a GPT/OpenAI id — map via `GPT_TO_CLAUDE`; unmapped
+ *    ids fall back to `configDefaultModel`.
+ * 4. `sessionModel` is null → `configDefaultModel`.
+ *    `sessionModel` is an unrecognised non-null string → `configDefaultModel`
+ *    (safe path; we won't pass an unknown non-Claude id to Claude).
+ */
+export function resolveClaudeModel(input: {
+  modelClaude?: string | null;
+  sessionModel: string | null;
+  configDefaultModel: string | null;
+}): string | null {
+  const { modelClaude, sessionModel, configDefaultModel } = input;
+
+  // 1. Explicit per-agent Claude override always wins.
+  if (modelClaude) return modelClaude;
+
+  // 2. Session model is already a Claude model — pass through verbatim.
+  if (sessionModel && isClaudeModel(sessionModel)) return sessionModel;
+
+  // 3. Session model is a GPT/OpenAI model — map or fall back.
+  if (sessionModel && isGptModel(sessionModel)) {
+    const mapped = GPT_TO_CLAUDE[sessionModel.toLowerCase()];
+    return mapped ?? configDefaultModel;
+  }
+
+  // 4. Null or unrecognised non-Claude, non-GPT string → fall back.
+  return configDefaultModel;
+}
+
+function isClaudeModel(model: string): boolean {
+  return /^(opus|sonnet|haiku|fable)$/i.test(model) || /^claude[-/]/i.test(model);
+}
+
+function isGptModel(model: string): boolean {
+  return /^gpt[-/]/i.test(model) || /^o[0-9]/i.test(model);
+}

--- a/src/claude/policy.test.ts
+++ b/src/claude/policy.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, test } from "bun:test";
+import { createSession } from "../session/types.ts";
+import type { ThreadSession } from "../session/types.ts";
+import { mapClaudeRunPolicy } from "./policy.ts";
+
+const config = {
+  maxTurns: 10,
+  timeoutMs: 300000,
+  permissionMode: "acceptEdits",
+  defaultModel: null,
+  defaultDriver: "headless" as const,
+  tmuxIdleTtlMs: 0,
+  tmuxSweepIntervalMs: 0,
+};
+
+function sessionWith(
+  permissions?: ThreadSession["agentPermissions"],
+): ThreadSession {
+  const session = createSession("t", "c");
+  session.agentPermissions = permissions;
+  return session;
+}
+
+describe("mapClaudeRunPolicy", () => {
+  test("read-only locks down writes and uses plan mode", () => {
+    const session = sessionWith({
+      intent: "read-only",
+      mcp: [],
+      tools: ["Read", "Grep", "Glob"],
+    });
+
+    const policy = mapClaudeRunPolicy({ config, session, cwd: "/repo" });
+
+    expect(policy.permissionMode).toBe("plan");
+    expect(policy.disallowedTools).toContain("Edit");
+    expect(policy.disallowedTools).toContain("Write");
+    expect(policy.disallowedTools).toContain("NotebookEdit");
+    // declared tools flow through verbatim
+    expect(policy.allowedTools).toEqual(["Read", "Grep", "Glob"]);
+    expect(policy.addDirs).toEqual([]);
+  });
+
+  test("read-only with no declared tools yields empty allowedTools", () => {
+    const session = sessionWith({ intent: "read-only", mcp: [], tools: [] });
+
+    const policy = mapClaudeRunPolicy({ config, session, cwd: "/repo" });
+
+    expect(policy.allowedTools).toEqual([]);
+    expect(policy.addDirs).toEqual([]);
+  });
+
+  test("no-tools is the hardest lockdown", () => {
+    const session = sessionWith({ intent: "no-tools", mcp: [], tools: ["Read"] });
+
+    const policy = mapClaudeRunPolicy({ config, session, cwd: "/repo" });
+
+    expect(policy.permissionMode).toBe("plan");
+    expect(policy.disallowedTools).toEqual([
+      "Edit",
+      "Write",
+      "NotebookEdit",
+      "Bash",
+    ]);
+    expect(policy.allowedTools).toEqual([]);
+    expect(policy.addDirs).toEqual([]);
+  });
+
+  test("human-gated proposes in plan mode with cwd access", () => {
+    const session = sessionWith({
+      intent: "human-gated",
+      mcp: [],
+      tools: ["Read", "Edit"],
+    });
+
+    const policy = mapClaudeRunPolicy({ config, session, cwd: "/repo" });
+
+    expect(policy.permissionMode).toBe("plan");
+    expect(policy.allowedTools).toEqual(["Read", "Edit"]);
+    expect(policy.disallowedTools).toEqual([]);
+    expect(policy.addDirs).toEqual(["/repo"]);
+  });
+
+  test("utility preserves the configured permission mode", () => {
+    const session = sessionWith({ intent: "utility", mcp: [], tools: ["Read"] });
+
+    const policy = mapClaudeRunPolicy({ config, session, cwd: "/repo" });
+
+    expect(policy.permissionMode).toBe("acceptEdits");
+    expect(policy.allowedTools).toEqual(["Read"]);
+    expect(policy.disallowedTools).toEqual([]);
+    expect(policy.addDirs).toEqual(["/repo"]);
+  });
+
+  test("normal agents get bypassPermissions confined to cwd", () => {
+    const session = sessionWith({ intent: "normal", mcp: [], tools: [] });
+
+    const policy = mapClaudeRunPolicy({ config, session, cwd: "/repo" });
+
+    expect(policy.permissionMode).toBe("bypassPermissions");
+    expect(policy.allowedTools).toEqual([]);
+    expect(policy.disallowedTools).toEqual([]);
+    expect(policy.addDirs).toEqual(["/repo"]);
+  });
+
+  test("null/unset intent behaves like normal", () => {
+    const session = createSession("t", "c");
+
+    const policy = mapClaudeRunPolicy({ config, session, cwd: "/repo" });
+
+    expect(policy.permissionMode).toBe("bypassPermissions");
+    expect(policy.allowedTools).toEqual([]);
+    expect(policy.disallowedTools).toEqual([]);
+    expect(policy.addDirs).toEqual(["/repo"]);
+  });
+});

--- a/src/claude/policy.ts
+++ b/src/claude/policy.ts
@@ -48,7 +48,10 @@ export function mapClaudeRunPolicy(options: {
 
   if (intent === "read-only") {
     // Critical safety case: review / reproducer-validation agents must not
-    // be able to mutate the worktree. Propose-only mode + explicit deny list.
+    // be able to mutate the worktree. `plan` mode is the ACTUAL gate — it
+    // blocks edits and write-Bash wholesale; the deny list below is
+    // defense-in-depth for specific high-blast-radius commands, not the
+    // primary enforcer. Don't loosen plan mode assuming the deny list confines.
     return {
       permissionMode: "plan",
       allowedTools: declaredTools,

--- a/src/claude/policy.ts
+++ b/src/claude/policy.ts
@@ -1,0 +1,100 @@
+import type { Config } from "../config.ts";
+import type { AgentPermissions } from "../agents/loader.ts";
+import type { ThreadSession } from "../session/types.ts";
+
+/**
+ * Claude-runner mirror of `mapCodexRunPolicy` (`src/codex-app-server/policy.ts`).
+ *
+ * Maps a Junior agent's permission *intent* onto the `claude -p` CLI permission
+ * surface: `--permission-mode`, `--allowedTools`, `--disallowedTools`, and
+ * `--add-dir`.
+ *
+ * Unlike Codex, Claude Code has NO OS-level sandbox. There is no read-only /
+ * workspace-write filesystem jail to lean on, so confinement here is purely
+ * tool-based (allow/deny lists + permission mode) plus the working directory
+ * we hand it. Write lockdown for read-only/no-tools agents is therefore
+ * enforced by explicitly disallowing the mutating tools, not by a sandbox.
+ *
+ * Pure function — no IO.
+ */
+export interface ClaudeRunPolicy {
+  permissionMode: string;
+  allowedTools: string[];
+  disallowedTools: string[];
+  addDirs: string[];
+}
+
+/** Mutating tools we strip for read-only agents. */
+const READ_ONLY_DISALLOWED = [
+  "Edit",
+  "Write",
+  "NotebookEdit",
+  "Bash(rm *)",
+  "Bash(git push *)",
+];
+
+/** Hardest lockdown — no edits and no shell at all. */
+const NO_TOOLS_DISALLOWED = ["Edit", "Write", "NotebookEdit", "Bash"];
+
+export function mapClaudeRunPolicy(options: {
+  config: Config["claude"];
+  session: ThreadSession;
+  cwd: string;
+}): ClaudeRunPolicy {
+  const { config, session, cwd } = options;
+  const permissions: AgentPermissions | undefined = session.agentPermissions;
+  const intent = permissions?.intent ?? null;
+  const declaredTools = permissions?.tools ?? [];
+
+  if (intent === "read-only") {
+    // Critical safety case: review / reproducer-validation agents must not
+    // be able to mutate the worktree. Propose-only mode + explicit deny list.
+    return {
+      permissionMode: "plan",
+      allowedTools: declaredTools,
+      disallowedTools: [...READ_ONLY_DISALLOWED],
+      addDirs: [],
+    };
+  }
+
+  if (intent === "no-tools") {
+    return {
+      permissionMode: "plan",
+      allowedTools: [],
+      disallowedTools: [...NO_TOOLS_DISALLOWED],
+      addDirs: [],
+    };
+  }
+
+  if (intent === "human-gated") {
+    // Propose, don't execute. A later phase layers live approval on top; the
+    // policy module's safe base is `plan`.
+    return {
+      permissionMode: "plan",
+      allowedTools: declaredTools,
+      disallowedTools: [],
+      addDirs: [cwd],
+    };
+  }
+
+  if (intent === "utility") {
+    // Preserve configured behavior for utility commands.
+    return {
+      permissionMode: config.permissionMode,
+      allowedTools: declaredTools,
+      disallowedTools: [],
+      addDirs: [cwd],
+    };
+  }
+
+  // "normal" and null/unset: build agents need full bash to run tests/builds.
+  // Claude has no OS sandbox, so they run broadly, confined only by the
+  // worktree cwd (accepted trade-off). bypassPermissions makes an allow-list
+  // redundant.
+  return {
+    permissionMode: "bypassPermissions",
+    allowedTools: [],
+    disallowedTools: [],
+    addDirs: [cwd],
+  };
+}

--- a/src/claude/spawner.ts
+++ b/src/claude/spawner.ts
@@ -2,7 +2,7 @@ import { mkdirSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import type { Config } from "../config.ts";
 import type { AgentIdentity, ThreadSession } from "../session/types.ts";
-import type { ContentBlockToolUse, StreamEvent } from "./types.ts";
+import type { ContentBlockToolUse, StreamEvent, StreamEventResult } from "./types.ts";
 import type { RunnerEvent, SpawnHandle, SpawnResult } from "../runners/types.ts";
 import { buildRunnerRuntime } from "../runners/runtime.ts";
 import { buildClaudeArgs } from "./args.ts";
@@ -10,6 +10,7 @@ import { createStreamParser } from "./parser.ts";
 import { signalProcessTree } from "../lifecycle/process-tree.ts";
 import {
   allowedMcpServers,
+  mixpanelMcpCommand,
   mongoMcpUrl,
   playwrightMcpCommand,
   slackMcpUrl,
@@ -32,10 +33,14 @@ export function spawnClaude(
     botToken,
     agentIdentity,
   });
-  const mcpConfigPath = shouldUseClaudeMcpConfig(session, runtime.needsProjectMcp)
-    ? writeClaudeMcpConfig(session)
+  // Human-gated agents route approvals through the slack-bot MCP permission
+  // tool, so that server must be present even if the agent declared no MCP.
+  const intent = session.agentPermissions?.intent ?? null;
+  const forceSlackMcp = config.approvalEnabled !== false && intent === "human-gated";
+  const mcpConfigPath = shouldUseClaudeMcpConfig(session, runtime.needsProjectMcp, forceSlackMcp)
+    ? writeClaudeMcpConfig(session, forceSlackMcp)
     : undefined;
-  const args = buildClaudeArgs(session, prompt, config, mcpConfigPath);
+  const args = buildClaudeArgs(session, prompt, config, runtime.cwd, mcpConfigPath);
 
   const proc = Bun.spawn(["claude", ...args], {
     cwd: runtime.cwd,
@@ -142,17 +147,21 @@ export function spawnClaude(
 export function shouldUseClaudeMcpConfig(
   session: ThreadSession,
   needsProjectMcp: boolean,
+  forceSlackMcp = false,
 ): boolean {
   if (session.cwd) return false;
-  return needsProjectMcp || allowedMcpServers(session).size > 0;
+  return forceSlackMcp || needsProjectMcp || allowedMcpServers(session).size > 0;
 }
 
-export function writeClaudeMcpConfig(session: ThreadSession): string {
+export function writeClaudeMcpConfig(
+  session: ThreadSession,
+  forceSlackMcp = false,
+): string {
   mkdirSync(MCP_CONFIG_DIR, { recursive: true });
   const agent = session.activeAgentName ?? "default";
   const path = join(MCP_CONFIG_DIR, `${session.threadId}-${agent}.json`);
   const mcpServers: Record<string, unknown> = {};
-  if (wantsMcp(session, "slack-bot")) {
+  if (forceSlackMcp || wantsMcp(session, "slack-bot")) {
     mcpServers["slack-bot"] = {
       type: "http",
       url: slackMcpUrl(session),
@@ -160,6 +169,9 @@ export function writeClaudeMcpConfig(session: ThreadSession): string {
   }
   if (wantsMcp(session, "playwright")) {
     mcpServers.playwright = playwrightMcpCommand();
+  }
+  if (wantsMcp(session, "mixpanel") && isFeatureMetricsSession(session)) {
+    mcpServers.mixpanel = mixpanelMcpCommand();
   }
   if (wantsMcp(session, "mongodb")) {
     mcpServers.mongodb = {
@@ -170,6 +182,13 @@ export function writeClaudeMcpConfig(session: ThreadSession): string {
   const config = { mcpServers };
   writeFileSync(path, JSON.stringify(config, null, 2));
   return path;
+}
+
+function isFeatureMetricsSession(session: ThreadSession): boolean {
+  return (
+    session.agentType === "feature-metrics" ||
+    session.activeAgentName === "feature-metrics"
+  );
 }
 
 export function mapClaudeEvent(event: StreamEvent): RunnerEvent[] {
@@ -198,11 +217,23 @@ export function mapClaudeEvent(event: StreamEvent): RunnerEvent[] {
       }
       return events;
     }
-    case "result":
-      return [{ type: "done", provider: "claude" }];
+    case "result": {
+      const usage = claudeDoneUsage(event);
+      return [{ type: "done", provider: "claude", ...(usage ? { usage } : {}) }];
+    }
     default:
       return [];
   }
+}
+
+function claudeDoneUsage(
+  event: StreamEventResult,
+): Record<string, unknown> | undefined {
+  const usage: Record<string, unknown> = {};
+  if (event.total_cost_usd != null) usage.total_cost_usd = event.total_cost_usd;
+  if (event.usage) usage.usage = event.usage;
+  if (event.num_turns != null) usage.num_turns = event.num_turns;
+  return Object.keys(usage).length > 0 ? usage : undefined;
 }
 
 function mapClaudeToolUse(block: ContentBlockToolUse): RunnerEvent {

--- a/src/claude/tmux-driver.ts
+++ b/src/claude/tmux-driver.ts
@@ -580,10 +580,13 @@ function encodeCwd(cwd: string): string {
 function buildInteractiveClaudeArgs(input: DriverSendInput, needsProjectMcp: boolean): string[] {
   // Lean on the existing arg builder but strip the `-p <prompt>` and
   // `--output-format` flags — those are headless-only.
+  const cwd =
+    input.session.cwd ?? input.session.worktreePath ?? process.cwd();
   const all = buildClaudeArgs(
     input.session,
     /*prompt*/ "",
     input.config,
+    cwd,
     needsProjectMcp ? writeClaudeMcpConfig(input.session) : undefined,
   );
   const out: string[] = [];
@@ -595,6 +598,11 @@ function buildInteractiveClaudeArgs(input: DriverSendInput, needsProjectMcp: boo
     }
     if (arg === "--output-format" || arg === "--verbose") {
       if (arg === "--output-format") i++;
+      continue;
+    }
+    // Headless-only: interactive tmux has a human at the TUI to approve tools.
+    if (arg === "--permission-prompt-tool") {
+      i++; // skip the tool-name value
       continue;
     }
     out.push(arg);

--- a/src/claude/types.ts
+++ b/src/claude/types.ts
@@ -42,6 +42,9 @@ export interface StreamEventResult {
   subtype: string; // "success", "error_max_turns", etc.
   result?: string;
   text?: string;
+  total_cost_usd?: number;
+  usage?: Record<string, unknown>;
+  num_turns?: number;
 }
 
 export interface StreamEventUser {

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,8 +52,34 @@ export interface Config {
   claude: {
     maxTurns: number;
     timeoutMs: number;
+    /**
+     * Fallback permission mode, used only for the `utility` intent and as the
+     * baseline when an agent declares no intent path that overrides it. Per-agent
+     * intent (read-only/normal/human-gated/…) is resolved by `mapClaudeRunPolicy`,
+     * which is the authoritative permission surface — this is no longer a blanket
+     * setting.
+     */
     permissionMode: string;
     defaultModel: string | null;
+    /**
+     * Pass `--strict-mcp-config` so Claude only loads MCP servers from Junior's
+     * generated `--mcp-config` (no developer-global `.mcp.json` / user MCP leak).
+     * Optional so existing test fixtures stay valid; production loader always
+     * sets it and read sites default to true.
+     */
+    strictMcp?: boolean;
+    /**
+     * Value for `--setting-sources` (e.g. "project"). Empty string omits the flag.
+     * "project" isolates the spawn from the developer's user-global `~/.claude`
+     * settings/hooks.
+     */
+    settingSources?: string;
+    /** Enable the Slack permission approval round-trip for human-gated agents. */
+    approvalEnabled?: boolean;
+    /** Per-turn spend cap via `--max-budget-usd`. null omits the flag. */
+    maxBudgetUsd?: number | null;
+    /** Inject the Junior provider-baseline system prompt via `--append-system-prompt`. */
+    baselineEnabled?: boolean;
     /**
      * Default driver for new threads. Override per-thread via `!driver`.
      * Set via `DEFAULT_CLAUDE_DRIVER` env (headless|tmux). Defaults to
@@ -157,6 +183,13 @@ export function loadConfig(): Config {
       timeoutMs: Number(optional("CLAUDE_TIMEOUT_MS", "300000")),
       permissionMode: optional("CLAUDE_PERMISSION_MODE", "bypassPermissions"),
       defaultModel: process.env.CLAUDE_MODEL ?? null,
+      strictMcp: parseBooleanEnv("CLAUDE_STRICT_MCP", true),
+      settingSources: optional("CLAUDE_SETTING_SOURCES", "project"),
+      approvalEnabled: parseBooleanEnv("CLAUDE_APPROVAL_ENABLED", true),
+      maxBudgetUsd: process.env.CLAUDE_MAX_BUDGET_USD
+        ? Number(process.env.CLAUDE_MAX_BUDGET_USD)
+        : null,
+      baselineEnabled: parseBooleanEnv("CLAUDE_BASELINE_PROMPT_ENABLED", true),
       defaultDriver: parseDriverMode(optional("DEFAULT_CLAUDE_DRIVER", "headless")),
       tmuxIdleTtlMs: Number(optional("TMUX_IDLE_TTL_MS", "14400000")), // 4h
       tmuxSweepIntervalMs: Number(optional("TMUX_SWEEP_INTERVAL_MS", "900000")), // 15min

--- a/src/mcp/approval.test.ts
+++ b/src/mcp/approval.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+  approvalTimeoutMs,
+  registerPendingApproval,
+  resolvePendingApproval,
+} from "./approval.ts";
+
+afterEach(() => {
+  delete process.env.CLAUDE_APPROVAL_TIMEOUT_MS;
+});
+
+describe("pending approval registry", () => {
+  it("resolves with the human decision via resolvePendingApproval", async () => {
+    const token = crypto.randomUUID();
+    const promise = registerPendingApproval(token, 5_000);
+    expect(resolvePendingApproval(token, "allow")).toBe(true);
+    await expect(promise).resolves.toBe("allow");
+  });
+
+  it("default-denies after the timeout", async () => {
+    const token = crypto.randomUUID();
+    const promise = registerPendingApproval(token, 20);
+    await expect(promise).resolves.toBe("deny");
+  });
+
+  it("returns false for an unknown token", () => {
+    expect(resolvePendingApproval("nope", "allow")).toBe(false);
+  });
+
+  it("is idempotent — second resolve returns false", async () => {
+    const token = crypto.randomUUID();
+    const promise = registerPendingApproval(token, 5_000);
+    expect(resolvePendingApproval(token, "deny")).toBe(true);
+    expect(resolvePendingApproval(token, "allow")).toBe(false);
+    await expect(promise).resolves.toBe("deny");
+  });
+
+  it("reads CLAUDE_APPROVAL_TIMEOUT_MS lazily from env", () => {
+    process.env.CLAUDE_APPROVAL_TIMEOUT_MS = "1234";
+    expect(approvalTimeoutMs()).toBe(1234);
+  });
+
+  it("falls back to the default timeout for invalid env", () => {
+    process.env.CLAUDE_APPROVAL_TIMEOUT_MS = "not-a-number";
+    expect(approvalTimeoutMs()).toBe(240_000);
+  });
+});

--- a/src/mcp/approval.ts
+++ b/src/mcp/approval.ts
@@ -33,6 +33,12 @@ const pending = new Map<string, PendingEntry>();
  * override `CLAUDE_APPROVAL_TIMEOUT_MS` before calling. Default 240000ms —
  * deliberately under Junior's 5-min idle/turn timeout so the wait resolves
  * cleanly (default-deny) before the turn is killed.
+ *
+ * INVARIANT: this must stay below `config.session.idleTimeoutMs` (default
+ * 300000). The `request_permission` tool_use event resets the idle timer right
+ * before the block, giving the human `approvalTimeoutMs` to respond; if
+ * `SESSION_IDLE_TIMEOUT_MS` is ever set at/below `CLAUDE_APPROVAL_TIMEOUT_MS`,
+ * the turn gets SIGINT'd mid-approval. Keep the approval timeout the smaller.
  */
 export function approvalTimeoutMs(): number {
   const raw = Number(process.env.CLAUDE_APPROVAL_TIMEOUT_MS);

--- a/src/mcp/approval.ts
+++ b/src/mcp/approval.ts
@@ -1,0 +1,79 @@
+/**
+ * Pending-approval registry for Slack-mediated permission round-trips.
+ *
+ * When a human-gated Claude turn hits a tool that needs approval, Claude calls
+ * the `request_permission` MCP tool (via `--permission-prompt-tool`). That tool
+ * posts an Allow/Deny prompt to the Slack thread and must BLOCK until a human
+ * clicks a button. The MCP server and the Bolt `app.action` click handler run
+ * in the SAME process, so this in-memory registry is the wakeup bridge: the
+ * tool awaits a promise keyed by a token; the click handler resolves it.
+ *
+ * No SQLite here — durable button records live in SlackActionStore. This
+ * registry is purely the in-process resolver + default-deny timeout.
+ */
+
+export type ApprovalDecision = "allow" | "deny";
+
+export interface PendingApproval {
+  token: string;
+  resolve: (decision: ApprovalDecision) => void;
+}
+
+const DEFAULT_APPROVAL_TIMEOUT_MS = 240_000;
+
+interface PendingEntry {
+  resolve: (decision: ApprovalDecision) => void;
+  timer: ReturnType<typeof setTimeout>;
+}
+
+const pending = new Map<string, PendingEntry>();
+
+/**
+ * Read the approval timeout from env lazily (not cached at import) so tests can
+ * override `CLAUDE_APPROVAL_TIMEOUT_MS` before calling. Default 240000ms —
+ * deliberately under Junior's 5-min idle/turn timeout so the wait resolves
+ * cleanly (default-deny) before the turn is killed.
+ */
+export function approvalTimeoutMs(): number {
+  const raw = Number(process.env.CLAUDE_APPROVAL_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_APPROVAL_TIMEOUT_MS;
+}
+
+/**
+ * Register a pending approval and return a promise that resolves when a human
+ * responds via {@link resolvePendingApproval} or default-denies after
+ * `timeoutMs` (defaults to {@link approvalTimeoutMs}).
+ */
+export function registerPendingApproval(
+  token: string,
+  timeoutMs: number = approvalTimeoutMs(),
+): Promise<ApprovalDecision> {
+  return new Promise<ApprovalDecision>((resolve) => {
+    const timer = setTimeout(() => {
+      // Default-deny on timeout, then clean up.
+      const entry = pending.get(token);
+      if (entry) {
+        pending.delete(token);
+        entry.resolve("deny");
+      }
+    }, timeoutMs);
+    timer.unref?.();
+    pending.set(token, { resolve, timer });
+  });
+}
+
+/**
+ * Resolve a pending approval with a human decision. Idempotent: returns true
+ * the first time the token is found, false for unknown/already-resolved tokens.
+ */
+export function resolvePendingApproval(
+  token: string,
+  decision: ApprovalDecision,
+): boolean {
+  const entry = pending.get(token);
+  if (!entry) return false;
+  pending.delete(token);
+  clearTimeout(entry.timer);
+  entry.resolve(decision);
+  return true;
+}

--- a/src/mcp/slack-server.ts
+++ b/src/mcp/slack-server.ts
@@ -29,7 +29,8 @@ import {
 import { parsePureAgentDirectiveResponse } from "../support/directives.ts";
 import { parseSlackMcpRunContext, type SlackMcpRunContext } from "./context.ts";
 import { handleMongoMcpRequest } from "./mongodb-proxy.ts";
-import { prepareSlackResponseWithActions } from "../slack/formatting.ts";
+import { registerPendingApproval } from "./approval.ts";
+import { prepareSlackResponseWithActions, type SlackActionButtonSpec } from "../slack/formatting.ts";
 import { buildActionBlocks, splitActionMessageText } from "../slack/responder.ts";
 import type { SlackActionStore } from "../slack/action-store.ts";
 import { disableAgentActionMessages } from "../slack/action-buttons.ts";
@@ -147,6 +148,104 @@ function registerTools(server: McpServer, runContext: SlackMcpRunContext | null 
       return {
         content: [{ type: "text" as const, text: `Message sent (ts: ${firstResult?.ts})` }],
       };
+    },
+  );
+
+  server.registerTool(
+    "request_permission",
+    {
+      description:
+        "Ask a human in the Slack thread to approve or deny a pending tool call, and BLOCK until they respond. " +
+        "Wired to Claude's --permission-prompt-tool: Claude passes the pending tool's name and input; " +
+        "this posts Allow/Deny buttons and returns the human's decision.",
+      // Claude's permission-prompt-tool passes the pending tool name plus its
+      // input. Accept a permissive shape (loosest pattern in this codebase,
+      // matching the mongodb proxy) so we never reject Claude's payload.
+      inputSchema: z.object({ tool_name: z.string() }).passthrough(),
+    },
+    async (args) => {
+      const toolName = typeof args.tool_name === "string" ? args.tool_name : "(unknown tool)";
+      // The original tool input Claude wants approved. Claude may send it under
+      // `input` or `tool_input`; fall back to the remaining args.
+      const { tool_name: _toolName, input, tool_input, ...rest } = args as Record<string, unknown>;
+      const toolInput = input ?? tool_input ?? (Object.keys(rest).length > 0 ? rest : undefined);
+
+      if (!runContext || !slackActionStore) {
+        // Fail closed: without a thread to ask or a store to persist the
+        // buttons, we cannot get a human decision. Deny.
+        return permissionResult("deny", undefined, "Denied: Slack approval context unavailable.");
+      }
+
+      const channelId = runContext.channel;
+      const threadTs = runContext.threadId;
+      const approvalToken = crypto.randomUUID();
+
+      const inputPreview = renderPermissionInput(toolInput);
+      const text =
+        `:lock: *Permission requested* by \`${runContext.agent}\`\n\`${toolName}\`` +
+        (inputPreview ? `\n${inputPreview}` : "");
+
+      const buttons: Array<{ action: SlackActionButtonSpec; token: string }> = [
+        {
+          action: {
+            id: "permission-allow",
+            label: "Allow",
+            style: "primary",
+            type: "request_permission",
+            approvalToken,
+            decision: "allow",
+          },
+          token: crypto.randomUUID(),
+        },
+        {
+          action: {
+            id: "permission-deny",
+            label: "Deny",
+            style: "danger",
+            type: "request_permission",
+            approvalToken,
+            decision: "deny",
+          },
+          token: crypto.randomUUID(),
+        },
+      ];
+
+      const blocks = buildActionBlocks(
+        text,
+        buttons.map(({ action, token }) => ({
+          token,
+          label: action.label,
+          style: action.style,
+        })),
+      );
+
+      const posted = await slack.chat.postMessage({
+        channel: channelId,
+        thread_ts: threadTs,
+        text,
+        blocks,
+      } as Parameters<typeof slack.chat.postMessage>[0]);
+
+      if (!posted.ts) {
+        return permissionResult("deny", toolInput, "Denied: failed to post approval prompt to Slack.");
+      }
+
+      await slackActionStore.createMany(
+        buttons.map(({ action, token }) => ({
+          token,
+          channelId,
+          threadTs,
+          messageTs: posted.ts!,
+          messageText: text,
+          action,
+          sourceAgent: runContext.agent,
+        })),
+      );
+
+      const decision = await registerPendingApproval(approvalToken);
+      return decision === "allow"
+        ? permissionResult("allow", toolInput)
+        : permissionResult("deny", toolInput, "Denied by human in Slack");
     },
   );
 
@@ -686,6 +785,41 @@ function registerTools(server: McpServer, runContext: SlackMcpRunContext | null 
       });
     },
   );
+}
+
+/**
+ * Build the MCP tool result Claude's `--permission-prompt-tool` contract
+ * expects: a single text content block whose text is a JSON-stringified
+ * `{ behavior, updatedInput }` (allow) or `{ behavior, message }` (deny).
+ *
+ * On allow we echo the original tool input as `updatedInput` (the documented
+ * safe form — Claude requires the updated input it should run with).
+ */
+function permissionResult(
+  behavior: "allow" | "deny",
+  input: unknown,
+  message?: string,
+): { content: Array<{ type: "text"; text: string }> } {
+  const payload =
+    behavior === "allow"
+      ? { behavior, updatedInput: (input ?? {}) as Record<string, unknown> }
+      : { behavior, message: message ?? "Denied by human in Slack" };
+  return { content: [{ type: "text" as const, text: JSON.stringify(payload) }] };
+}
+
+/** Compact, Slack-safe rendering of the pending tool's input for the prompt. */
+function renderPermissionInput(input: unknown): string {
+  if (input === undefined || input === null) return "";
+  let serialized: string;
+  try {
+    serialized = typeof input === "string" ? input : JSON.stringify(input, null, 2);
+  } catch {
+    serialized = String(input);
+  }
+  if (!serialized.trim()) return "";
+  const MAX = 1_500;
+  const clipped = serialized.length > MAX ? `${serialized.slice(0, MAX)}\n… (truncated)` : serialized;
+  return "```\n" + clipped + "\n```";
 }
 
 interface SlackDirectMessageClient {

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -1060,6 +1060,13 @@ export class SessionManager {
           await this.store.set(session.threadId, session);
         }
       }
+      // Per-agent Claude-runner model override (`model.claude` frontmatter).
+      // Resolved by resolveClaudeModel at spawn; carried the same way as `model`.
+      runSession.modelClaude = agentDefinition?.modelClaude ?? null;
+      if (isTopLevel && agentDefinition?.modelClaude) {
+        session.modelClaude = agentDefinition.modelClaude;
+        await this.store.set(session.threadId, session);
+      }
       runSession.agentPermissions = agentDefinition?.permissions;
 
       // Build the prompt. On the first turn (no sessionId yet), inject the

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -135,6 +135,12 @@ export interface ThreadSession {
    */
   humanParticipants: string[];
   model: string | null;
+  /**
+   * Explicit Claude-runner model override, sourced from the active agent's
+   * `model.claude` frontmatter. Wins over the GPT→Claude fallback map in
+   * `resolveClaudeModel`. Null when the agent declares no Claude override.
+   */
+  modelClaude?: string | null;
   cwd: string | null;
   pid: number | null;
   lastActivity: number;

--- a/src/slack/action-buttons.ts
+++ b/src/slack/action-buttons.ts
@@ -5,6 +5,7 @@ import type { ThreadSession } from "../session/types.ts";
 import { isPersistentAgent } from "../support/agents.ts";
 import type { WorktreeManager, WorktreeStatus } from "../worktree/manager.ts";
 import { log } from "../logger.ts";
+import { resolvePendingApproval } from "../mcp/approval.ts";
 import type { SlackActionRecord, SlackActionStore } from "./action-store.ts";
 
 export const ACTION_BUTTON_ID = "junior_agent_action";
@@ -44,6 +45,8 @@ export function registerAgentActionButtons(
         await handleDispatch(record, userId, sessionManager, options.supportChannels);
       } else if (record.action.type === "cleanup_worktree") {
         await handleCleanup(record, sessionManager, worktreeManager, client);
+      } else if (record.action.type === "request_permission") {
+        await handlePermission(record, userId, client);
       }
     } catch (err) {
       await actionStore.markFailed(record.token);
@@ -114,6 +117,22 @@ export function resolveDispatchAgent(
     return supportChannels?.has(record.channelId) ? "thinker" : "default";
   }
   return action.agent;
+}
+
+async function handlePermission(
+  record: SlackActionRecord,
+  userId: string,
+  client: WebClient,
+): Promise<void> {
+  const action = record.action;
+  if (action.type !== "request_permission") return;
+
+  const resolved = resolvePendingApproval(action.approvalToken, action.decision);
+  const verb = action.decision === "allow" ? "Allowed" : "Denied";
+  const text = resolved
+    ? `${verb} by <@${userId}>.`
+    : `${verb} by <@${userId}> — but the request had already resolved or expired.`;
+  await postThread(client, record, text);
 }
 
 async function handleCleanup(

--- a/src/slack/formatting.ts
+++ b/src/slack/formatting.ts
@@ -72,6 +72,15 @@ export type SlackActionButtonSpec =
       label: string;
       style?: SlackActionButtonStyle;
       type: "cleanup_worktree";
+    }
+  | {
+      id: string;
+      label: string;
+      style?: SlackActionButtonStyle;
+      type: "request_permission";
+      // The in-process pending-approval token both Allow/Deny buttons resolve.
+      approvalToken: string;
+      decision: "allow" | "deny";
     };
 
 export interface SlackResponseWithActions {


### PR DESCRIPTION
## Why

Junior is switching its default runner back to Claude from `codex-app-server`. The Claude `claude -p` adapter was deliberately minimal — it ignored per-agent permission intent, lacked the MCP/model/isolation features the codex adapter had grown, and had no human-gated approval path. This brings the **mechanism** to parity.

## What

- **Permissions** — `src/claude/policy.ts` maps `session.agentPermissions.intent` to Claude flags: read-only/no-tools → `--permission-mode plan` + `--disallowedTools`; human-gated → `plan` (or approval, below); utility → config; **normal/unset → `bypassPermissions`**.
- **Model resolution** — `src/claude/model.ts`: `model.claude` override > Claude alias > GPT map (`gpt-5.5 → opus`) > config default. Mirror of `codexCompatibleModel`.
- **Slack approval round-trip** — human-gated agents get `--permission-prompt-tool mcp__slack-bot__request_permission`; the tool posts Allow/Deny buttons (reusing `SlackActionStore`) and blocks on an in-process registry (`src/mcp/approval.ts`), default-denying after `CLAUDE_APPROVAL_TIMEOUT_MS` (240s). Only wired when the slack-bot MCP is actually configured for the run.
- **Isolation** — `--strict-mcp-config` + `--setting-sources project` keep developer-global `~/.claude` config/MCP out.
- **MCP / prompt / cost** — mixpanel MCP parity; Junior baseline `--append-system-prompt`; `total_cost_usd`/`usage` on the done event + `--max-budget-usd`.

All knobs config-gated, default-on except the budget cap.

## ⚠️ Scope / honest limitations (read before flipping the runner)

- **Claude has no OS-level sandbox.** Unlike codex's Seatbelt (`workspace-write`, network off), Claude can only confine via tool allow/deny + the working directory. So **writer agents run broad** on the Claude path — that's inherent, not a gap this PR can close.
- **The lockdown only activates for agents that declare `permissions.intent`.** Today only `agents-org/onboarding.md` does; the main agents (review/thinker/pm/architect/build/…) are intent-unset and therefore hit `bypassPermissions`. **Declaring per-agent intents is a deliberate follow-up**, not part of this PR. Until then, null-intent agents are *more* permissive on Claude than on codex — factor this into the runner-flip decision.
- **Unverified assumption (#2):** the approval path relies on headless `--permission-mode default` routing un-allowed tools to `--permission-prompt-tool`. This needs **one live human-gated turn** (tool call → Slack buttons → Allow → tool runs) confirmed before the default runner is flipped to Claude.

## Verification

- `bun run typecheck` clean; `bun test` → **755 pass / 0 fail** (two consecutive clean passes).
- Reviewed by the structured reviewer agent; should-fix items addressed in `f520af2` (approval gated on MCP presence; doc nits). #4 (tmux permission-mode) was a false positive — tmux already inherited `--permission-mode` pre-PR.

## Deferred (from the audit)

Graceful mid-turn interrupt (needs Agent SDK), `--json-schema` structured output, `--include-partial-messages` streaming, and the per-agent intent declarations above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)