### PR TITLE
fix(mcp): wire Figma MCP server into Claude runner

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -3,6 +3,10 @@
     "slack-bot": {
       "type": "http",
       "url": "http://localhost:3456/mcp"
+    },
+    "figma": {
+      "type": "http",
+      "url": "https://mcp.figma.com/mcp"
     }
   }
 }

--- a/bin/claude-with-mcp.sh
+++ b/bin/claude-with-mcp.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Launch an interactive Claude session with the same MCP wiring Junior's
+# spawner provides to claude -p processes.
+#
+# Use this to manually test MCP connectivity (Figma, Slack, Playwright,
+# MongoDB) from an interactive Claude session outside Junior.
+#
+# MCP servers are toggled via env flags (all default to true):
+#
+#   CLAUDE_MCP_SLACK=true|false
+#   CLAUDE_MCP_PLAYWRIGHT=true|false
+#   CLAUDE_MCP_FIGMA=true|false
+#   CLAUDE_MCP_MONGODB=true|false
+#
+# The generated config is written to a temp file and passed via --mcp-config.
+#
+# Requires: jq
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+parse_bool() {
+  local name="$1" value="$2" default="$3"
+  if [ -z "$value" ]; then
+    echo "$default"
+    return
+  fi
+  local normalized
+  normalized=$(echo "$value" | tr '[:upper:]' '[:lower:]' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+  case "$normalized" in
+    1|true|yes|on) echo "true"; return ;;
+    0|false|no|off) echo "false"; return ;;
+    *) echo "Error: Invalid $name: \"$value\" (expected true|false)" >&2; exit 1 ;;
+  esac
+}
+
+SLACK=$(parse_bool "CLAUDE_MCP_SLACK" "${CLAUDE_MCP_SLACK:-}" true)
+PLAYWRIGHT=$(parse_bool "CLAUDE_MCP_PLAYWRIGHT" "${CLAUDE_MCP_PLAYWRIGHT:-}" true)
+FIGMA=$(parse_bool "CLAUDE_MCP_FIGMA" "${CLAUDE_MCP_FIGMA:-}" true)
+MONGODB=$(parse_bool "CLAUDE_MCP_MONGODB" "${CLAUDE_MCP_MONGODB:-}" true)
+
+CONFIG='{"mcpServers":{}}'
+
+if [ "$SLACK" = "true" ]; then
+  CONFIG=$(echo "$CONFIG" | jq --arg url "http://localhost:3456/mcp" \
+    '.mcpServers["slack-bot"] = {type: "http", url: $url}')
+fi
+
+if [ "$PLAYWRIGHT" = "true" ]; then
+  WRAPPER="$PROJECT_ROOT/bin/junior-mcp-stdio-wrapper.js"
+  CONFIG=$(echo "$CONFIG" | jq --arg cmd "$WRAPPER" \
+    '.mcpServers.playwright = {command: $cmd, args: ["--", "npx", "@playwright/mcp", "--headless"]}')
+fi
+
+if [ "$FIGMA" = "true" ]; then
+  CONFIG=$(echo "$CONFIG" | jq \
+    '.mcpServers.figma = {type: "http", url: "https://mcp.figma.com/mcp"}')
+fi
+
+if [ "$MONGODB" = "true" ]; then
+  MONGO_URL="${MONGO_MCP_URL:-http://localhost:3456/mcp/mongodb}"
+  CONFIG=$(echo "$CONFIG" | jq --arg url "$MONGO_URL" \
+    '.mcpServers.mongodb = {type: "http", url: $url}')
+fi
+
+MCP_CONFIG=$(mktemp /tmp/claude-mcp-XXXXXX.json)
+echo "$CONFIG" > "$MCP_CONFIG"
+trap 'rm -f "$MCP_CONFIG"' EXIT
+
+SETTING_SOURCES="project"
+if [ "$FIGMA" = "true" ]; then
+  SETTING_SOURCES="user,project"
+fi
+
+echo "MCP config: $MCP_CONFIG"
+echo "$CONFIG" | jq .
+echo "setting-sources: $SETTING_SOURCES"
+echo ""
+
+exec claude --mcp-config "$MCP_CONFIG" --setting-sources "$SETTING_SOURCES" "$@"

--- a/src/claude/spawner.ts
+++ b/src/claude/spawner.ts
@@ -9,9 +9,9 @@ import { buildClaudeArgs } from "./args.ts";
 import { createStreamParser } from "./parser.ts";
 import { signalProcessTree } from "../lifecycle/process-tree.ts";
 import {
-  allowedMcpServers,
   mixpanelMcpCommand,
   mongoMcpUrl,
+  needsUserSettings,
   playwrightMcpCommand,
   slackMcpUrl,
   wantsMcp,
@@ -40,7 +40,10 @@ export function spawnClaude(
   const mcpConfigPath = shouldUseClaudeMcpConfig(session, runtime.needsProjectMcp, forceSlackMcp)
     ? writeClaudeMcpConfig(session, forceSlackMcp)
     : undefined;
-  const args = buildClaudeArgs(session, prompt, config, runtime.cwd, mcpConfigPath);
+  const effectiveConfig = needsUserSettings()
+    ? widenSettingSources(config)
+    : config;
+  const args = buildClaudeArgs(session, prompt, effectiveConfig, runtime.cwd, mcpConfigPath);
 
   const proc = Bun.spawn(["claude", ...args], {
     cwd: runtime.cwd,
@@ -146,11 +149,11 @@ export function spawnClaude(
 
 export function shouldUseClaudeMcpConfig(
   session: ThreadSession,
-  needsProjectMcp: boolean,
-  forceSlackMcp = false,
+  _needsProjectMcp: boolean,
+  _forceSlackMcp = false,
 ): boolean {
   if (session.cwd) return false;
-  return forceSlackMcp || needsProjectMcp || allowedMcpServers(session).size > 0;
+  return true;
 }
 
 export function writeClaudeMcpConfig(
@@ -179,6 +182,10 @@ export function writeClaudeMcpConfig(
       url: mongoMcpUrl(session),
     };
   }
+  mcpServers.figma = {
+    type: "http",
+    url: "https://mcp.figma.com/mcp",
+  };
   const config = { mcpServers };
   writeFileSync(path, JSON.stringify(config, null, 2));
   return path;
@@ -234,6 +241,12 @@ function claudeDoneUsage(
   if (event.usage) usage.usage = event.usage;
   if (event.num_turns != null) usage.num_turns = event.num_turns;
   return Object.keys(usage).length > 0 ? usage : undefined;
+}
+
+function widenSettingSources(config: Config["claude"]): Config["claude"] {
+  const base = config.settingSources ?? "";
+  if (!base || base.includes("user")) return config;
+  return { ...config, settingSources: `user,${base}` };
 }
 
 function mapClaudeToolUse(block: ContentBlockToolUse): RunnerEvent {

--- a/src/runners/mcp-config.ts
+++ b/src/runners/mcp-config.ts
@@ -2,7 +2,7 @@ import { resolve } from "node:path";
 import type { ThreadSession } from "../session/types.ts";
 import { buildMongoMcpUrl, buildSlackMcpUrl } from "../mcp/context.ts";
 
-export type McpServerName = "slack-bot" | "playwright" | "mixpanel" | "mongodb";
+export type McpServerName = "slack-bot" | "playwright" | "mixpanel" | "mongodb" | "figma";
 
 export interface StdioMcpCommand {
   command: string;
@@ -16,7 +16,8 @@ export function allowedMcpServers(session: ThreadSession): Set<McpServerName> {
       name === "slack-bot" ||
       name === "playwright" ||
       name === "mixpanel" ||
-      name === "mongodb"
+      name === "mongodb" ||
+      name === "figma"
     ),
   );
 }
@@ -44,6 +45,12 @@ export function mixpanelMcpCommand(): StdioMcpCommand {
     "mcp-remote",
     "https://mcp.mixpanel.com/mcp",
   ]);
+}
+
+export function needsUserSettings(): boolean {
+  // Figma MCP is unconditionally included and requires OAuth tokens stored
+  // at the user level (~/.claude/). Always widen setting sources.
+  return true;
 }
 
 function wrappedStdioMcpCommand(command: string[]): StdioMcpCommand {


### PR DESCRIPTION
## What

Wires the Figma HTTP MCP server (`https://mcp.figma.com/mcp`) into Junior's Claude runner so worktree-backed turns can read from and write to Figma designs.

## Changes

- **`.mcp.json`** — register the `figma` http server in the project MCP config Claude receives via `--mcp-config`.
- **`src/runners/mcp-config.ts`** — add `"figma"` to `McpServerName` and `wantsMcp`; expose `needsUserSettings()` (Figma OAuth tokens live at the user level `~/.claude/`, so setting sources must be widened).
- **`src/claude/spawner.ts`** — always emit the project MCP config, inject the figma server, and prepend `user` to `settingSources` when user-level settings are needed (`widenSettingSources`).
- **`bin/claude-with-mcp.sh`** — dev launcher that mirrors the same MCP wiring with per-server `CLAUDE_MCP_*` toggles (slack/playwright/figma/mongodb).

## Notes

- `wantsMcp` now returns `true` unconditionally for non-`session.cwd` runs (Rule 9: worktree-backed target-repo runs get Junior's local MCP wiring). The `needsProjectMcp`/`forceSlackMcp` params are retained but no longer gate the decision.
- Unrelated local changes (worktree-prune cron tweak, scratch docs/session dumps) were intentionally left out of this branch — one concern per branch.

## Test

- `bun run typecheck` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)