### PR TITLE
feat(mcp): wire Notion MCP server into Claude runner

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -7,6 +7,10 @@
     "figma": {
       "type": "http",
       "url": "https://mcp.figma.com/mcp"
+    },
+    "notion": {
+      "type": "http",
+      "url": "https://mcp.notion.com/mcp"
     }
   }
 }

--- a/bin/claude-with-mcp.sh
+++ b/bin/claude-with-mcp.sh
@@ -2,7 +2,7 @@
 # Launch an interactive Claude session with the same MCP wiring Junior's
 # spawner provides to claude -p processes.
 #
-# Use this to manually test MCP connectivity (Figma, Slack, Playwright,
+# Use this to manually test MCP connectivity (Figma, Notion, Slack, Playwright,
 # MongoDB) from an interactive Claude session outside Junior.
 #
 # MCP servers are toggled via env flags (all default to true):
@@ -10,6 +10,7 @@
 #   CLAUDE_MCP_SLACK=true|false
 #   CLAUDE_MCP_PLAYWRIGHT=true|false
 #   CLAUDE_MCP_FIGMA=true|false
+#   CLAUDE_MCP_NOTION=true|false
 #   CLAUDE_MCP_MONGODB=true|false
 #
 # The generated config is written to a temp file and passed via --mcp-config.
@@ -39,6 +40,7 @@ parse_bool() {
 SLACK=$(parse_bool "CLAUDE_MCP_SLACK" "${CLAUDE_MCP_SLACK:-}" true)
 PLAYWRIGHT=$(parse_bool "CLAUDE_MCP_PLAYWRIGHT" "${CLAUDE_MCP_PLAYWRIGHT:-}" true)
 FIGMA=$(parse_bool "CLAUDE_MCP_FIGMA" "${CLAUDE_MCP_FIGMA:-}" true)
+NOTION=$(parse_bool "CLAUDE_MCP_NOTION" "${CLAUDE_MCP_NOTION:-}" true)
 MONGODB=$(parse_bool "CLAUDE_MCP_MONGODB" "${CLAUDE_MCP_MONGODB:-}" true)
 
 CONFIG='{"mcpServers":{}}'
@@ -59,6 +61,11 @@ if [ "$FIGMA" = "true" ]; then
     '.mcpServers.figma = {type: "http", url: "https://mcp.figma.com/mcp"}')
 fi
 
+if [ "$NOTION" = "true" ]; then
+  CONFIG=$(echo "$CONFIG" | jq \
+    '.mcpServers.notion = {type: "http", url: "https://mcp.notion.com/mcp"}')
+fi
+
 if [ "$MONGODB" = "true" ]; then
   MONGO_URL="${MONGO_MCP_URL:-http://localhost:3456/mcp/mongodb}"
   CONFIG=$(echo "$CONFIG" | jq --arg url "$MONGO_URL" \
@@ -70,7 +77,7 @@ echo "$CONFIG" > "$MCP_CONFIG"
 trap 'rm -f "$MCP_CONFIG"' EXIT
 
 SETTING_SOURCES="project"
-if [ "$FIGMA" = "true" ]; then
+if [ "$FIGMA" = "true" ] || [ "$NOTION" = "true" ]; then
   SETTING_SOURCES="user,project"
 fi
 

--- a/src/claude/spawner.ts
+++ b/src/claude/spawner.ts
@@ -186,6 +186,10 @@ export function writeClaudeMcpConfig(
     type: "http",
     url: "https://mcp.figma.com/mcp",
   };
+  mcpServers.notion = {
+    type: "http",
+    url: "https://mcp.notion.com/mcp",
+  };
   const config = { mcpServers };
   writeFileSync(path, JSON.stringify(config, null, 2));
   return path;

--- a/src/runners/mcp-config.ts
+++ b/src/runners/mcp-config.ts
@@ -2,7 +2,7 @@ import { resolve } from "node:path";
 import type { ThreadSession } from "../session/types.ts";
 import { buildMongoMcpUrl, buildSlackMcpUrl } from "../mcp/context.ts";
 
-export type McpServerName = "slack-bot" | "playwright" | "mixpanel" | "mongodb" | "figma";
+export type McpServerName = "slack-bot" | "playwright" | "mixpanel" | "mongodb" | "figma" | "notion";
 
 export interface StdioMcpCommand {
   command: string;
@@ -17,7 +17,8 @@ export function allowedMcpServers(session: ThreadSession): Set<McpServerName> {
       name === "playwright" ||
       name === "mixpanel" ||
       name === "mongodb" ||
-      name === "figma"
+      name === "figma" ||
+      name === "notion"
     ),
   );
 }
@@ -48,8 +49,8 @@ export function mixpanelMcpCommand(): StdioMcpCommand {
 }
 
 export function needsUserSettings(): boolean {
-  // Figma MCP is unconditionally included and requires OAuth tokens stored
-  // at the user level (~/.claude/). Always widen setting sources.
+  // Figma and Notion MCP are unconditionally included and require OAuth tokens
+  // stored at the user level (~/.claude/). Always widen setting sources.
   return true;
 }
 


### PR DESCRIPTION
## What

Wire the Notion HTTP MCP server (`https://mcp.notion.com/mcp`) into the Claude runner paths, mirroring how Figma is wired.

## Changes

- **`.mcp.json`** — register the `notion` http server for project runs
- **`bin/claude-with-mcp.sh`** — add `CLAUDE_MCP_NOTION` toggle (default `true`); widen `SETTING_SOURCES` to `user,project` when Notion is enabled (OAuth tokens live at the user level)
- **`src/claude/spawner.ts`** — inject `notion` into the generated headless config
- **`src/runners/mcp-config.ts`** — add `"notion"` to `McpServerName` and the unconditional setting-source widening

## Notes

Notion uses OAuth (no inline secrets). Same pattern as the existing Figma wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)