### PR TITLE
chore(review): add spec-completeness Pass 0 to review agent

### DIFF
--- a/.claude/agents/review.md
+++ b/.claude/agents/review.md
@@ -17,13 +17,27 @@ You are Junior's persistent `review` agent. Evaluate the PR/code using the repo-
 
 ## Review workflow
 
-Run six passes on every review. Do not blend them — each pass has a different lens:
+### Pass 0 — Spec completeness
+
+Before reviewing code quality, check whether the PR references a design doc, feature spec, or phase plan (look in PR description, linked docs, and `docs/` directories matching the feature name). If one exists:
+
+- Read the spec and build a checklist of what it says should ship.
+- Compare against what the PR actually implements.
+- Flag missing items, interface mismatches, and constant/config discrepancies (e.g. wrong model name, wrong default) as **blockers** or **warnings** depending on severity.
+- Items the PR description explicitly defers ("not in this PR", "phase N") are fine — note them but don't block.
+- Items the spec requires but the PR silently omits are blockers.
+
+If no spec exists, skip this pass.
+
+### Passes 1–6 — Code quality
+
+Run six passes on the code. Do not blend them — each pass has a different lens:
 
 1. **Logic.** Does the code do what the PR says? Off-by-one, race conditions, null paths, unhandled cases. Trace execution paths mentally.
-2. **Safety.** Injection risks, auth bypass, data leaks, secrets, unsafe deserialization. Check every input boundary.
+2. **Safety.** Injection risks, auth bypass, data leaks, secrets, unsafe deserialization. Check every input boundary. Flag `as any` casts — they bypass type checking and can hide real bugs. Each one is a warning unless it masks an unsafe boundary (then blocker).
 3. **Product thinking.** Does the change make sense for the user? Missing loading/error/empty states, confusing messages, accessibility gaps.
 4. **Query performance.** Missing indexes, N+1 queries, unbounded result sets, expensive aggregations without limits.
-5. **Consistency.** Follows the repo's established patterns? Wrong auth middleware, queries outside service layer, direct model calls from routes.
+5. **Consistency.** Follows the repo's established patterns? Wrong auth middleware, queries outside service layer, direct model calls from routes. Check that Joi validators carry proper TypeScript types and that route handlers use the validated/typed values — untyped `req.query` destructuring or missing validator generics are warnings.
 6. **Surface.** Naming, unused imports, dead code, formatting that harms readability. Skip purely stylistic preferences.
 
 ## Scope boundaries


### PR DESCRIPTION
> Stacked on #104. Review/merge the chain (#103 → #104) first.

## What

Strengthen the `review` agent so it checks PRs against their own spec, and tightens two existing passes.

## Changes (`.claude/agents/review.md`)

- **New Pass 0 — Spec completeness.** If a PR references a design doc / feature spec / phase plan, build a checklist from the spec and compare against what shipped. Missing items, interface mismatches, and constant/config discrepancies are blockers/warnings by severity. Explicitly-deferred items are fine; silent omissions block. Skipped when no spec exists.
- **Passes 1–6 relabeled** as "Code quality".
- **Pass 2 (Safety):** flag `as any` casts — warning, or blocker when masking an unsafe boundary.
- **Pass 5 (Consistency):** flag untyped `req.query` destructuring / missing Joi validator generics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)