### PR TITLE
chore: move worktree-prune cron to 07:00 IST, ignore tmp/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ support/admin-credentials.yaml
 # Bug pipeline runtime artifacts — contain real user data (emails, member IDs)
 support/bugs/
 .playwright-mcp/
+tmp/

--- a/workflows/worktree-prune.workflow.md
+++ b/workflows/worktree-prune.workflow.md
@@ -6,7 +6,7 @@ ownerSlackUserIds:
   - U03PNSJ33S5
 triggers:
   - type: schedule
-    cron: "20 7 * * *"
+    cron: "00 7 * * *"
     timezone: Asia/Kolkata
   - type: command
     command: worktree-prune


### PR DESCRIPTION
> Stacked on #107 (top of the chain #103 → #104 → #105 → #106 → #107).

## Changes

- **`workflows/worktree-prune.workflow.md`** — cron `07:20` → `07:00` Asia/Kolkata
- **`.gitignore`** — add `tmp/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)