### PR TITLE
fix(slack): parse HTML-escaped <junior-actions> markers

### DIFF
--- a/src/slack/formatting.test.ts
+++ b/src/slack/formatting.test.ts
@@ -218,6 +218,48 @@ by review
     });
   });
 
+  it("accepts HTML-escaped junior action delimiters from tool payloads", () => {
+    const result = prepareSlackResponseWithActions(`review: approved
+by review
+
+&lt;junior-actions&gt;
+[
+  {
+    "id": "review:merge-gxt-admin",
+    "label": "Merge via gxt-admin",
+    "style": "primary",
+    "type": "dispatch_agent",
+    "agent": "lead",
+    "prompt": "merge with the admin token"
+  },
+  {
+    "id": "thread:cleanup-worktree",
+    "label": "Cleanup worktree",
+    "type": "cleanup_worktree"
+  }
+]
+&lt;/junior-actions&gt;`);
+
+    expect(result).toEqual({
+      text: "review: approved\nby review",
+      actions: [
+        {
+          id: "review:merge-gxt-admin",
+          label: "Merge via gxt-admin",
+          style: "primary",
+          type: "dispatch_agent",
+          agent: "lead",
+          prompt: "merge with the admin token",
+        },
+        {
+          id: "thread:cleanup-worktree",
+          label: "Cleanup worktree",
+          type: "cleanup_worktree",
+        },
+      ],
+    });
+  });
+
   it("drops malformed action specs without dropping visible text", () => {
     const result = prepareSlackResponseWithActions(`ok
 <junior-actions>

--- a/src/slack/formatting.ts
+++ b/src/slack/formatting.ts
@@ -55,6 +55,8 @@ export function extractRunnerMessageText(event: RunnerEvent): string | null {
 export const NO_SLACK_MESSAGE = "NO_SLACK_MESSAGE";
 export const ACTIONS_START = "<junior-actions>";
 export const ACTIONS_END = "</junior-actions>";
+const ACTIONS_START_ESCAPED = "&lt;junior-actions&gt;";
+const ACTIONS_END_ESCAPED = "&lt;/junior-actions&gt;";
 
 export type SlackActionButtonStyle = "primary" | "danger";
 
@@ -173,9 +175,10 @@ export function prepareSlackResponseWithActions(
 function extractJuniorActions(
   text: string,
 ): { text: string; jsonText: string } | null {
-  const start = text.indexOf(ACTIONS_START);
-  if (start === -1) return null;
-  const end = text.indexOf(ACTIONS_END, start + ACTIONS_START.length);
+  const markers = findActionMarkers(text);
+  if (!markers) return null;
+  const { start, startMarker, endMarker } = markers;
+  const end = text.indexOf(endMarker, start + startMarker.length);
   if (end === -1) {
     return {
       text: text.slice(0, start).trimEnd(),
@@ -184,8 +187,30 @@ function extractJuniorActions(
   }
 
   return {
-    text: `${text.slice(0, start)}${text.slice(end + ACTIONS_END.length)}`.trim(),
-    jsonText: text.slice(start + ACTIONS_START.length, end).trim(),
+    text: `${text.slice(0, start)}${text.slice(end + endMarker.length)}`.trim(),
+    jsonText: text.slice(start + startMarker.length, end).trim(),
+  };
+}
+
+function findActionMarkers(
+  text: string,
+): { start: number; startMarker: string; endMarker: string } | null {
+  const literalStart = text.indexOf(ACTIONS_START);
+  const escapedStart = text.indexOf(ACTIONS_START_ESCAPED);
+  if (literalStart === -1 && escapedStart === -1) return null;
+
+  if (escapedStart !== -1 && (literalStart === -1 || escapedStart < literalStart)) {
+    return {
+      start: escapedStart,
+      startMarker: ACTIONS_START_ESCAPED,
+      endMarker: ACTIONS_END_ESCAPED,
+    };
+  }
+
+  return {
+    start: literalStart,
+    startMarker: ACTIONS_START,
+    endMarker: ACTIONS_END,
   };
 }
 


### PR DESCRIPTION
Recreated against `main` (the original #104 was auto-closed when its stacked base branch `feat/notion-mcp-config` was deleted on merge of #103).

## What
Slack escapes angle brackets in agent output, so action-button markers can arrive as `&lt;junior-actions&gt;`. Those escaped markers previously slipped through unparsed.

## Changes
- **`src/slack/formatting.ts`** — `findActionMarkers()` detects both literal and escaped marker forms (whichever appears first) and slices with the matched pair.
- **`src/slack/formatting.test.ts`** — coverage for the escaped-marker path.

## Verification
- `bun run typecheck` clean
- `bun test src/slack/formatting.test.ts` → 45 pass / 0 fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)