### PR TITLE
fix(slack): suppress NO_SLACK_MESSAGE sentinel at the posting choke-point

### DIFF
--- a/src/slack/responder.test.ts
+++ b/src/slack/responder.test.ts
@@ -432,6 +432,38 @@ describe("SlackResponder", () => {
     });
   });
 
+  describe("postResponse sentinel/empty suppression (choke-point guard)", () => {
+    it("posts nothing when the text is exactly the NO_SLACK_MESSAGE sentinel", async () => {
+      const { app, calls } = mockApp();
+      const responder = new SlackResponder(app);
+
+      const posted = await responder.postResponse("C123", "1234567890.123456", "NO_SLACK_MESSAGE");
+
+      expect(posted).toEqual([]);
+      expect(calls.postMessage).toHaveLength(0);
+    });
+
+    it("posts nothing for empty/whitespace text", async () => {
+      const { app, calls } = mockApp();
+      const responder = new SlackResponder(app);
+
+      const posted = await responder.postResponse("C123", "1234567890.123456", "   ");
+
+      expect(posted).toEqual([]);
+      expect(calls.postMessage).toHaveLength(0);
+    });
+
+    it("strips a trailing sentinel but still posts the real reply", async () => {
+      const { app, calls } = mockApp();
+      const responder = new SlackResponder(app);
+
+      await responder.postResponse("C123", "1234567890.123456", "Hey Captain\nNO_SLACK_MESSAGE");
+
+      expect(calls.postMessage).toHaveLength(1);
+      expect(calls.postMessage[0].text).toBe("Hey Captain");
+    });
+  });
+
   describe("postResponse with optional iconEmoji", () => {
     it("includes icon_emoji when identity has iconEmoji set", async () => {
       const { app, calls } = mockApp();

--- a/src/slack/responder.ts
+++ b/src/slack/responder.ts
@@ -1,6 +1,6 @@
 import type { App } from "@slack/bolt";
 import type { AgentIdentity } from "../session/types.ts";
-import { splitResponse } from "./formatting.ts";
+import { prepareSlackResponse, splitResponse } from "./formatting.ts";
 import { log } from "../logger.ts";
 import { ACTION_BUTTON_ID } from "./action-buttons.ts";
 
@@ -85,6 +85,20 @@ export class SlackResponder {
     identity?: AgentIdentity,
     buttons: SlackMessageButton[] = [],
   ): Promise<PostedSlackMessage[]> {
+    // Choke-point guard: every Slack reply funnels through here, so suppress the
+    // NO_SLACK_MESSAGE sentinel (and empty text) here rather than relying on
+    // each caller to pre-clean. Callers that build action buttons already run
+    // prepareSlackResponse; this is the backstop for the ones that don't
+    // (e.g. command/error responses) so the sentinel can never reach a channel.
+    const cleaned = prepareSlackResponse(text);
+    if (cleaned === null) {
+      log.info(
+        "responder",
+        `post.suppressed thread=${threadTs} reason=${text.trim() ? "sentinel" : "empty"}`,
+      );
+      return [];
+    }
+    text = cleaned;
     const chunks = buttons.length > 0
       ? splitActionMessageText(text)
       : splitResponse(text);


### PR DESCRIPTION
## Problem
The `NO_SLACK_MESSAGE` sentinel (an agent's "post nothing this turn" signal) leaked into a channel as a literal reply — Junior answered a "Hey kiddo" greeting with the raw string `NO_SLACK_MESSAGE`.

## Root cause
The suppression guard was **duplicated in individual callers** (`onResponse`, the MCP `slack_send_message` tool) but **missing at the choke point**. Any path that posts agent/handler text without pre-cleaning could leak the sentinel — `onCommandResponse` calls `responder.postResponse(response)` raw, and the guard lived nowhere central.

## Fix
Centralize the guard at `responder.postResponse`, the single function every Slack reply funnels through: run `prepareSlackResponse` on the text and post nothing when it's the exact sentinel (or empty); strip a trailing sentinel otherwise. Idempotent for callers that already prepared (they pass cleaned text + actions separately), so it's a pure backstop that closes the whole class regardless of caller.

## Tests
`postResponse` posts nothing for the exact sentinel and for empty/whitespace text, and strips a trailing sentinel while still posting the real reply.

Verified: typecheck clean; 18 responder tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)