### PR TITLE
docs(readme): surface native resume + on-device embeddings in Stack line

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Slack bot that acts as the control plane for headless coding-agent sessions. O
 
 Successor to the OpenClaw-based agent system at [PranavBakre/openclaw-agents](https://github.com/PranavBakre/openclaw-agents) — same role (orchestrator + sub-agent dispatcher), rebuilt on top of coding-agent CLIs.
 
-**Stack:** Bun, TypeScript, [@slack/bolt](https://github.com/slackapi/bolt-js) (Socket Mode), OpenCode by default with Claude Code as an alternate provider, SQLite for session persistence.
+**Stack:** Bun, TypeScript, [@slack/bolt](https://github.com/slackapi/bolt-js) (Socket Mode), OpenCode by default with Claude Code as an alternate provider, native session-resume for cross-turn continuity, SQLite for session + long-term memory persistence, and on-device vector embeddings (local ONNX model — no remote embedding API).
 
 For deep architecture and the canonical "critical rules" list, see [CLAUDE.md](./CLAUDE.md). This README is the on-ramp.
 


### PR DESCRIPTION
Surfaces two already-shipped Junior features in the top-of-README **Stack** line, where they were previously only documented in deeper sections:

- **Native session-resume** — cross-turn continuity carried by the runner's native resume id (already covered in the intro + invariant 2).
- **On-device vector embeddings** — the local `onnx-community/harrier-oss-v1-270m-ONNX` provider (640-dim, in-process, no remote embedding API), previously only in the long-term-memory subsection.

Docs-only, one-line change. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)