### PR TITLE
fix(opencode): resolve session model aliases to valid opencode refs

### DIFF
--- a/docs/code_index/runner-providers.md
+++ b/docs/code_index/runner-providers.md
@@ -25,7 +25,8 @@ and MCP wiring.
 | `buildOpenCodeConfig(...)` | `config.ts` | Generates model, permissions, primary `agent.build`, MCP entries, and subagent entries. |
 | `loadOpenCodeSupportSubagents()` | `support-agents.ts` | Exposes standalone stateless support prompts as generated OpenCode subagents. |
 | `buildOpenCodeAgentPrompt(...)` | `prompt.ts` | Wraps Junior core + active-agent prompt in the OpenCode provider baseline. |
-| `createOpenCodeStreamParser()` / `createOpenCodeEventMapper()` | `parser.ts` | Converts OpenCode JSON events into normalized runner events. |
+| `resolveOpenCodeModel(...)` | `model.ts` | Resolves session/config model to a valid `provider/model` OpenCode ref; runner-specific aliases (`gpt-5.5`, `opus`, ...) fall back to the config default or null (omit `--model`). |
+| `createOpenCodeStreamParser()` / `createOpenCodeEventMapper()` | `parser.ts` | Converts OpenCode JSON events into normalized runner events; captures native `{"type":"error"}` events on `mapper.error`. |
 
 ## Current OpenCode Runtime Rules
 

--- a/docs/features/runner-providers.md
+++ b/docs/features/runner-providers.md
@@ -185,11 +185,23 @@ OpenCode adapter should map:
 - `step_finish.part.tokens` -> `done.usage`
 - `tool_use.part` -> `tool`, using `part.tool`, `part.state.status`, and
   `part.state.input`
+- `error` -> captured on `mapper.error` (there is no error-shaped
+  `RunnerEvent`); the spawner prefers `mapper.error` when the process exits
+  non-zero. Native shape:
+  `{"type":"error","sessionID":"ses_...","error":{"name":"UnknownError","data":{"message":"...","ref":"..."}}}`
 
 **Status (2026-05-15):** init/message/tool/done are mapped. Tool fixtures have
 been captured for the observed OpenCode `tool_use` shape and now emit
 `RunnerEventTool` for Slack status updates. Unknown future event types still log
 at INFO (`opencode-parser`) so operators can capture additional fixtures.
+
+**Status (2026-07-08):** native `error` events are now recognized (previously
+dropped as unmapped and truncated in the log), and their message + `ref` are
+surfaced through `mapper.error` so Slack shows the real failure instead of a
+generic `Process exited with code 1`. The `--model` flag now receives a value
+resolved by `resolveOpenCodeModel`: only `provider/model` refs are passed
+through; runner-specific aliases (`gpt-5.5`, `opus`, `sonnet`, `haiku`) fall
+back to the configured default or are omitted so OpenCode uses its own default.
 
 Do not guess the tool event schema from docs.
 

--- a/src/opencode/model.test.ts
+++ b/src/opencode/model.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test";
+import { resolveOpenCodeModel } from "./model.ts";
+
+describe("resolveOpenCodeModel", () => {
+  it("passes through a valid provider/model session reference", () => {
+    expect(resolveOpenCodeModel("anthropic/claude-sonnet-4-5", null)).toBe(
+      "anthropic/claude-sonnet-4-5",
+    );
+    expect(
+      resolveOpenCodeModel("openai/gpt-5.5", "anthropic/claude-opus-4"),
+    ).toBe("openai/gpt-5.5");
+  });
+
+  it("ignores runner-specific aliases and falls back to a valid config default", () => {
+    // gpt-5.5 / opus / haiku / sonnet are Claude/Codex aliases, not OpenCode
+    // provider/model refs — slashless strings crash opencode's server.
+    expect(resolveOpenCodeModel("gpt-5.5", "anthropic/claude-sonnet-4-5")).toBe(
+      "anthropic/claude-sonnet-4-5",
+    );
+    expect(resolveOpenCodeModel("opus", "anthropic/claude-opus-4")).toBe(
+      "anthropic/claude-opus-4",
+    );
+    expect(resolveOpenCodeModel("sonnet", "openai/gpt-5.5")).toBe("openai/gpt-5.5");
+    expect(resolveOpenCodeModel("haiku", "anthropic/claude-haiku")).toBe(
+      "anthropic/claude-haiku",
+    );
+  });
+
+  it("returns null when the alias has no valid config default to fall back to", () => {
+    // null → omit --model so opencode uses its own configured default.
+    expect(resolveOpenCodeModel("gpt-5.5", null)).toBeNull();
+    expect(resolveOpenCodeModel("gpt-5.5", undefined)).toBeNull();
+    // Config default that is itself an invalid (slashless) ref is not usable.
+    expect(resolveOpenCodeModel("gpt-5.5", "gpt-5.5")).toBeNull();
+    expect(resolveOpenCodeModel("opus", "opus")).toBeNull();
+  });
+
+  it("returns null for null/undefined inputs with no valid default", () => {
+    expect(resolveOpenCodeModel(null, null)).toBeNull();
+    expect(resolveOpenCodeModel(undefined, undefined)).toBeNull();
+    expect(resolveOpenCodeModel(null, undefined)).toBeNull();
+  });
+
+  it("uses the config default when session model is null", () => {
+    expect(resolveOpenCodeModel(null, "anthropic/claude-sonnet-4-5")).toBe(
+      "anthropic/claude-sonnet-4-5",
+    );
+    expect(resolveOpenCodeModel(undefined, "openai/gpt-5.5")).toBe("openai/gpt-5.5");
+  });
+});

--- a/src/opencode/model.ts
+++ b/src/opencode/model.ts
@@ -1,0 +1,61 @@
+/**
+ * Resolve the model reference to hand the OpenCode runner (`--model`).
+ *
+ * Mirrors `resolveClaudeModel` in `src/claude/model.ts` and `resolveCodexModel`
+ * in `src/codex-app-server/spawner.ts`, but for OpenCode's provider/model
+ * addressing scheme.
+ *
+ * OpenCode's `--model` flag expects a `provider/model` reference (e.g.
+ * `anthropic/claude-sonnet-4-5`, `openai/gpt-5.5`). A slashless string like
+ * `gpt-5.5` parses as providerID=`gpt-5.5`, modelID=`` — no such provider
+ * exists, so OpenCode's embedded server throws "Unexpected server error" and
+ * the CLI exits 1 before producing any output.
+ *
+ * Agent frontmatter historically carried bare Claude/Codex aliases (`gpt-5.5`,
+ * `opus`, `haiku`, `sonnet`) meant for those runners. None of them is a usable
+ * OpenCode reference. Rather than invent a per-alias mapping, fall back to the
+ * configured OpenCode default (when it is itself a valid ref), else return null.
+ * null means: omit `--model` entirely so OpenCode uses its own configured
+ * default — exactly how the working default-agent turns run today.
+ */
+
+import { log } from "../logger.ts";
+
+/**
+ * A model string is a usable OpenCode reference only in `provider/model` form.
+ */
+function isOpenCodeModelRef(model: string | null | undefined): model is string {
+  return typeof model === "string" && model.includes("/");
+}
+
+/**
+ * Resolve which model reference to pass to the OpenCode runner.
+ *
+ * Precedence:
+ * 1. `sessionModel` already a valid OpenCode ref (`provider/model`) — pass through.
+ * 2. `sessionModel` set but not a valid ref (a Claude/Codex alias) — ignore it
+ *    for the OpenCode provider (warn) and fall back to `configDefaultModel`.
+ * 3. `configDefaultModel` is a valid ref → use it. Otherwise null (omit
+ *    `--model` so OpenCode uses its own configured default).
+ */
+export function resolveOpenCodeModel(
+  sessionModel: string | null | undefined,
+  configDefaultModel: string | null | undefined,
+): string | null {
+  // 1. Session model is already a valid OpenCode reference — pass through.
+  if (isOpenCodeModelRef(sessionModel)) return sessionModel;
+
+  // 2. Session model set but not a valid ref: a runner-specific alias. Ignore
+  //    it for the OpenCode provider and fall back to the configured default.
+  if (sessionModel) {
+    log.warn(
+      "opencode",
+      `Session model "${sessionModel}" is not a valid OpenCode provider/model reference; ignoring it for the opencode provider and using the configured default`,
+    );
+  }
+
+  // 3. Configured default if it is itself a valid ref, else null (omit --model).
+  if (isOpenCodeModelRef(configDefaultModel)) return configDefaultModel;
+
+  return null;
+}

--- a/src/opencode/parser.test.ts
+++ b/src/opencode/parser.test.ts
@@ -105,6 +105,26 @@ describe("createOpenCodeStreamParser", () => {
       { type: "step_start", sessionID: "ses_1" },
     ]);
   });
+
+  it("recognizes native OpenCode error events instead of dropping them", () => {
+    const parser = createOpenCodeStreamParser();
+    const events = parser.feed(
+      '{"type":"error","timestamp":123,"sessionID":"ses_err","error":{"name":"UnknownError","data":{"message":"Unexpected server error. Check server logs for details.","ref":"abc123"}}}\n',
+    );
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: "error",
+      sessionID: "ses_err",
+      error: {
+        name: "UnknownError",
+        data: {
+          message: "Unexpected server error. Check server logs for details.",
+          ref: "abc123",
+        },
+      },
+    });
+  });
 });
 
 describe("createOpenCodeEventMapper", () => {
@@ -241,5 +261,41 @@ describe("createOpenCodeEventMapper", () => {
       },
     ]);
     expect(mapper.response).toBe("*Worklog — last 24h*\n\n- shipped payout migration");
+  });
+
+  it("captures the native error message (incl. ref) on mapper.error", () => {
+    const parser = createOpenCodeStreamParser();
+    const mapper = createOpenCodeEventMapper();
+    const nativeEvents = parser.feed(
+      '{"type":"error","timestamp":123,"sessionID":"ses_err","error":{"name":"UnknownError","data":{"message":"Unexpected server error. Check server logs for details.","ref":"abc123"}}}\n',
+    );
+
+    const runnerEvents = nativeEvents.flatMap((event) => mapper.map(event));
+
+    // The error event still carries a sessionID, so init is emitted; no
+    // error-shaped RunnerEvent exists, so nothing else is emitted.
+    expect(runnerEvents).toEqual([
+      { type: "init", provider: "opencode", sessionId: "ses_err" },
+    ]);
+    expect(mapper.error).toBe(
+      "UnknownError: Unexpected server error. Check server logs for details. (ref: abc123)",
+    );
+  });
+
+  it("composes the error message without a ref when none is present", () => {
+    const parser = createOpenCodeStreamParser();
+    const mapper = createOpenCodeEventMapper();
+    const nativeEvents = parser.feed(
+      '{"type":"error","error":{"name":"ProviderError","data":{"message":"model not found"}}}\n',
+    );
+
+    nativeEvents.forEach((event) => mapper.map(event));
+
+    expect(mapper.error).toBe("ProviderError: model not found");
+  });
+
+  it("has a null error until an error event is mapped", () => {
+    const mapper = createOpenCodeEventMapper();
+    expect(mapper.error).toBeNull();
   });
 });

--- a/src/opencode/parser.ts
+++ b/src/opencode/parser.ts
@@ -55,11 +55,28 @@ export interface OpenCodeToolUseEvent {
   [key: string]: unknown;
 }
 
+export interface OpenCodeErrorEvent {
+  type: "error";
+  sessionID?: string;
+  timestamp?: number;
+  error?: {
+    name?: string;
+    data?: {
+      message?: string;
+      ref?: string;
+      [key: string]: unknown;
+    };
+    [key: string]: unknown;
+  };
+  [key: string]: unknown;
+}
+
 export type OpenCodeEvent =
   | OpenCodeStepStartEvent
   | OpenCodeTextEvent
   | OpenCodeStepFinishEvent
-  | OpenCodeToolUseEvent;
+  | OpenCodeToolUseEvent
+  | OpenCodeErrorEvent;
 
 export interface OpenCodeStreamParser {
   feed(chunk: string): OpenCodeEvent[];
@@ -69,6 +86,7 @@ export interface OpenCodeStreamParser {
 export interface OpenCodeEventMapper {
   readonly sessionId: string | null;
   readonly response: string;
+  readonly error: string | null;
   map(event: OpenCodeEvent): RunnerEvent[];
 }
 
@@ -87,6 +105,7 @@ const KNOWN_EVENT_TYPES = new Set([
   "step-finish",
   "tool_use",
   "tool",
+  "error",
 ]);
 
 function isOpenCodeEvent(value: unknown): value is OpenCodeEvent {
@@ -110,6 +129,10 @@ function isOpenCodeEvent(value: unknown): value is OpenCodeEvent {
     if (typeof value.tool === "string") return true;
     if (!isRecord(value.part)) return false;
     return value.part.type === "tool" && typeof value.part.tool === "string";
+  }
+
+  if (value.type === "error") {
+    return value.error === undefined || isRecord(value.error);
   }
 
   return false;
@@ -193,6 +216,7 @@ export function createOpenCodeEventMapper(): OpenCodeEventMapper {
   let sessionId: string | null = null;
   let response = "";
   let pendingText = "";
+  let error: string | null = null;
 
   function maybeInit(event: OpenCodeEvent): RunnerEvent[] {
     if (sessionId) return [];
@@ -210,10 +234,20 @@ export function createOpenCodeEventMapper(): OpenCodeEventMapper {
     get response(): string {
       return response;
     },
+    get error(): string | null {
+      return error;
+    },
     map(event: OpenCodeEvent): RunnerEvent[] {
       const events = maybeInit(event);
 
-      if (event.type === "text") {
+      if (event.type === "error") {
+        // OpenCode reports server-side failures as a native error event and
+        // then exits 1 with an empty stderr. Capture the real message so the
+        // spawner can surface it instead of a generic exit-code string. There
+        // is no error-shaped RunnerEvent, so this is captured on the mapper
+        // only, not emitted into the event stream.
+        error = getOpenCodeError(event);
+      } else if (event.type === "text") {
         pendingText += getOpenCodeText(event);
       } else if (event.type === "tool_use" || event.type === "tool") {
         events.push(mapOpenCodeToolUse(event));
@@ -245,6 +279,14 @@ export function createOpenCodeEventMapper(): OpenCodeEventMapper {
 
 function getOpenCodeText(event: OpenCodeTextEvent): string {
   return event.text ?? event.part?.text ?? "";
+}
+
+function getOpenCodeError(event: OpenCodeErrorEvent): string {
+  const name = event.error?.name ?? "UnknownError";
+  const message = event.error?.data?.message ?? "";
+  const ref = event.error?.data?.ref;
+  const base = message ? `${name}: ${message}` : name;
+  return ref ? `${base} (ref: ${ref})` : base;
 }
 
 function mapOpenCodeToolUse(event: OpenCodeToolUseEvent): RunnerEventTool {

--- a/src/opencode/sdk-provider.ts
+++ b/src/opencode/sdk-provider.ts
@@ -19,6 +19,7 @@ import type { RunnerEvent, SpawnHandle, SpawnResult } from "../runners/types.ts"
 import { buildRunnerRuntime } from "../runners/runtime.ts";
 import { OPENCODE_PROVIDER_AGENT, buildOpenCodeAgentPrompt } from "./prompt.ts";
 import { buildOpenCodeConfigContent } from "./config.ts";
+import { resolveOpenCodeModel } from "./model.ts";
 import { loadOpenCodeSupportSubagents } from "./support-agents.ts";
 import { log as _log } from "../logger.ts";
 
@@ -135,7 +136,7 @@ export function spawnOpenCodeSdk(
 
   // Generate config the same way the CLI provider does — embedded agent prompt,
   // MCP wiring, and subagents.
-  const model = session.model ?? config.opencode.model ?? null;
+  const model = resolveOpenCodeModel(session.model, config.opencode.model);
   const agentPrompt = buildOpenCodeAgentPrompt({
     juniorAgentName,
     juniorPrompt: session.systemPrompt ?? undefined,

--- a/src/opencode/spawner.test.ts
+++ b/src/opencode/spawner.test.ts
@@ -261,7 +261,48 @@ describe("spawnOpenCode", () => {
     }
   });
 
+  it("surfaces the native error event message when opencode exits non-zero with empty stderr", async () => {
+    const session = createSession("thread-err", "C01");
+    session.provider = "opencode";
+
+    const { command, cleanup } = createErroringOpenCodeScript();
+
+    try {
+      const handle = spawnOpenCode(session, "trigger error", { command });
+      const result = await handle.result;
+
+      expect(result.exitCode).not.toBe(0);
+      expect(result.error).toBe(
+        "UnknownError: Unexpected server error. Check server logs for details. (ref: abc123)",
+      );
+    } finally {
+      cleanup();
+    }
+  });
+
 });
+
+function createErroringOpenCodeScript(): {
+  command: string;
+  cleanup: () => void;
+} {
+  const dir = mkdtempSync(join(tmpdir(), "junior-opencode-err-"));
+  const command = join(dir, "erroring-opencode.sh");
+  // Mirrors a slashless-model crash: opencode emits a native error event on
+  // stdout and exits 1 with an empty stderr.
+  writeFileSync(
+    command,
+    `#!/bin/sh
+echo '{"type":"error","timestamp":123,"sessionID":"ses_err","error":{"name":"UnknownError","data":{"message":"Unexpected server error. Check server logs for details.","ref":"abc123"}}}'
+exit 1
+`,
+  );
+  chmodSync(command, 0o755);
+  return {
+    command,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
 
 function createHungOpenCodeScript(sessionId: string): {
   command: string;

--- a/src/opencode/spawner.ts
+++ b/src/opencode/spawner.ts
@@ -2,6 +2,7 @@ import type { AgentIdentity, ThreadSession } from "../session/types.ts";
 import type { RunnerEvent, SpawnHandle, SpawnResult } from "../runners/types.ts";
 import { buildRunnerRuntime } from "../runners/runtime.ts";
 import { buildOpenCodeArgs } from "./args.ts";
+import { resolveOpenCodeModel } from "./model.ts";
 import {
   buildOpenCodeConfigContent,
   type OpenCodeMcpConfig,
@@ -61,7 +62,7 @@ export function spawnOpenCode(
   });
   const juniorAgentName = juniorAgentNameForSession(session);
   const agentName = config.agentName ?? OPENCODE_PROVIDER_AGENT;
-  const model = session.model ?? config.defaultModel ?? null;
+  const model = resolveOpenCodeModel(session.model, config.defaultModel);
   const agentPrompt = buildOpenCodeAgentPrompt({
     juniorAgentName,
     juniorPrompt: config.agentPrompt ?? session.systemPrompt,
@@ -139,10 +140,14 @@ export function spawnOpenCode(
 
     const exitCode = await proc.exited;
     const stderr = await stderrText;
+    // Prefer OpenCode's own native error event (parsed off stdout) when present:
+    // opencode's embedded server reports failures as a `{"type":"error",...}`
+    // event and exits 1 with an empty stderr, so the generic exit-code string is
+    // useless. Fall back to the original stderr/stdout/generic chain otherwise.
     const error =
       exitCode === 0
         ? stdoutError
-        : stderr || stdoutError || `Process exited with code ${exitCode}`;
+        : (mapper.error ?? (stderr || stdoutError || `Process exited with code ${exitCode}`));
 
     return {
       provider: "opencode",


### PR DESCRIPTION
## Summary
- Every opencode-provider turn for the `review` agent (and 9 other org-overlay agents declaring `model: gpt-5.5`) crashed in Slack with a bare "Error: Process exited with code 1". Root cause: the opencode spawner passed `session.model` raw into `--model`; OpenCode expects a `provider/model` ref, so a slashless alias like `gpt-5.5` parses as `providerID="gpt-5.5"` + empty `modelID` — an unknown provider — and opencode's embedded server throws before any output. Reproduced empirically (`opencode run --model gpt-5.5 "say ok"` on opencode 1.17.13) and confirmed against the production session's stored `{"providerID":"gpt-5.5","modelID":""}` message. The claude adapter already maps `gpt-5.5 → opus` and codex accepts it natively; opencode was the only adapter with no model resolution.
- Adds `resolveOpenCodeModel()` (`src/opencode/model.ts`): only `provider/model` refs pass through; runner-specific aliases fall back to the configured default or are omitted entirely (opencode then uses its own default, matching how the working default-agent turns already run). Wired into both the CLI spawner and the SDK provider.
- The stream parser previously dropped opencode's native `{"type":"error"}` events as "unmapped" (truncated at 200 chars in logs), so the real error never reached Slack or the session DB. Errors are now recognized, captured on `mapper.error` (message + ref), and preferred over the generic exit-code fallback.

Reported in: https://teamgrowthx.slack.com/archives/C0338BCK1UL/p1783509392122899

## Test plan
- [x] `bun run typecheck` clean
- [x] New/updated unit tests: `src/opencode/model.test.ts`, `src/opencode/parser.test.ts`, `src/opencode/spawner.test.ts` (61 tests total pass)
- [x] Live smoke test reproduced the original crash and confirmed the resolver prevents it