### PR TITLE
fix(whatsapp): revert desktop browser signature (server rejects unpaired DESKTOP registrations)

### DIFF
--- a/src/whatsapp/client.ts
+++ b/src/whatsapp/client.ts
@@ -83,13 +83,16 @@ export class WhatsAppClient {
         keys: makeCacheableSignalKeyStore(state.keys, logger),
       },
       logger,
-      // A DESKTOP-class platform signature (browser[1] = "Desktop") is what
-      // makes WhatsApp honor syncFullHistory — web-browser-class devices only
-      // get a shallow recent window at pairing. Shows up in Linked Devices as
-      // a generic macOS desktop app rather than "Junior"; cosmetic tradeoff.
-      browser: ["Mac OS", "Desktop", "14.4.1"],
+      // Do NOT override `browser`: WhatsApp rejects unpaired DESKTOP-class
+      // registrations at handshake (endless 428 pre-QR loop — the standalone
+      // desktop app is discontinued), and custom names get the same treatment
+      // unreliably. Baileys' default macOS/Chrome web signature is the one
+      // registration path the server accepts.
       // Deep history backfill at pairing (v7 default, pinned here on purpose:
       // the buildathon groups predate pairing and we want their backlog).
+      // Depth ultimately depends on what the phone sends a web-class device —
+      // check the oldest stored message after pairing; fall back to
+      // fetchMessageHistory paging or a chat-export import if it's too shallow.
       syncFullHistory: true,
       // Read-only device: don't announce presence to the groups.
       markOnlineOnConnect: false,


### PR DESCRIPTION
Fixes the endless `428 Connection Terminated` pre-QR loop hit on first pairing attempt.

Root cause: the DESKTOP-class browser signature (added in #122 for deep history sync) is rejected by WhatsApp at registration — the standalone desktop app is discontinued and new DESKTOP registrations are refused at handshake. Confirmed by A/B tests: default macOS/Chrome web signature → QR immediately (under both Bun and Node — Bun's ws warnings were a red herring); Desktop tuple → 428 loop under both runtimes, with or without explicit Origin header, on both pinned and live-fetched protocol versions.

`syncFullHistory: true` stays pinned; actual backfill depth for a web-class device gets verified after pairing, with `fetchMessageHistory` paging or chat-export import as fallbacks if it's shallow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAVCPHF6NUooDJPAVchwTs