### PR TITLE
fix(whatsapp): disable user-level hooks in the extraction subprocess

### DIFF
--- a/src/whatsapp/extraction/runner.test.ts
+++ b/src/whatsapp/extraction/runner.test.ts
@@ -26,6 +26,12 @@ describe("buildExtractionArgs — untrusted-content lockdown", () => {
     expect(args).not.toContain("--mcp-config");
   });
 
+  test("disables user-level hooks via --settings (a Stop hook's reply would replace the model's JSON as the envelope result)", () => {
+    const settingsIdx = args.indexOf("--settings");
+    expect(settingsIdx).toBeGreaterThan(-1);
+    expect(JSON.parse(args[settingsIdx + 1]!)).toEqual({ disableAllHooks: true });
+  });
+
   test("never enables a permission-bypass or tool-allow flag", () => {
     expect(args).not.toContain("--dangerously-skip-permissions");
     expect(args).not.toContain("--allow-dangerously-skip-permissions");

--- a/src/whatsapp/extraction/runner.ts
+++ b/src/whatsapp/extraction/runner.ts
@@ -60,6 +60,11 @@ export interface ExtractionRunnerOptions {
  *   instruction has nothing to act with.
  * - `--strict-mcp-config` with no `--mcp-config` loads zero MCP servers, closing
  *   the MCP-tool vector too.
+ * - `--settings '{"disableAllHooks":true}'` blocks USER-level (~/.claude) hooks,
+ *   which the neutral cwd does NOT: a user Stop hook injects a follow-up turn
+ *   and the hook-reply becomes the envelope's `result`, replacing the model's
+ *   JSON (observed live: every sweep returned the learnings-hook's "No durable
+ *   lesson…" prose and parse-failed).
  *
  * Paired at spawn time with a neutral cwd (so no project CLAUDE.md / `.claude/`
  * settings / `.mcp.json` are inherited) this makes the run text-in / text-out
@@ -76,6 +81,8 @@ export function buildExtractionArgs(model: string): string[] {
     "--tools",
     "", // disable ALL built-in tools
     "--strict-mcp-config", // no --mcp-config -> zero MCP servers load
+    "--settings",
+    '{"disableAllHooks":true}', // user hooks would hijack the final message
   ];
 }
 


### PR DESCRIPTION
Every extraction sweep was parse-failing with "model returned no JSON object". Root cause: the user-global learnings Stop hook (~/.claude) fires inside the spawned `claude -p`, injects a follow-up turn, and the hook-reply ("No durable lesson to store…") becomes the JSON envelope's `result` — replacing the model's ops JSON. The neutral cwd blocks project settings but not user-level hooks.

Fix: `--settings '{"disableAllHooks":true}'` in `buildExtractionArgs` (verified live: result returns the actual ops JSON). Also belongs in the planned memory-consolidation runner audit — its `claude -p` spawn has the same exposure (plus argv prompt + no tool lockdown).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAVCPHF6NUooDJPAVchwTs