### PR TITLE
feat(memory): automatic pre-recall hook before runner turns

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -152,6 +152,19 @@ export interface Config {
      * populates it and read sites default to "local".
      */
     embedProvider?: EmbeddingProviderKind;
+    /**
+     * Pre-recall hook: before each runner turn, a cheap LLM extracts recall
+     * queries from the incoming message and injects matching claims into the
+     * prompt. Optional so existing Config test fixtures stay valid; `loadConfig`
+     * always populates it.
+     */
+    preRecall?: {
+      enabled: boolean;
+      runner: "claude" | "opencode" | "codex";
+      /** Override the pinned cheapest model for the chosen runner. */
+      model?: string;
+      timeoutMs: number;
+    };
   };
   threadArchives: {
     dir: string;
@@ -276,6 +289,12 @@ export function loadConfig(): Config {
     memory: {
       sqlitePath: optional("MEMORY_DB_PATH", "data/memory.db"),
       embedProvider: parseEmbedProvider(optional("MEMORY_EMBED_PROVIDER", "local")),
+      preRecall: {
+        enabled: parseBooleanEnv("PRE_RECALL_ENABLED", true),
+        runner: parsePreRecallRunner(optional("PRE_RECALL_RUNNER", "claude")),
+        model: process.env.PRE_RECALL_MODEL || undefined,
+        timeoutMs: Number(optional("PRE_RECALL_TIMEOUT_MS", "15000")),
+      },
     },
     threadArchives: {
       dir: optional("THREAD_ARCHIVE_DIR", "data/thread-archives"),
@@ -368,6 +387,13 @@ function parseRunnerProvider(value: string): ImplementedRunnerProvider {
   }
   throw new Error(
     `Invalid RUNNER_PROVIDER: ${value} (expected opencode|opencode-sdk|codex-app-server|claude)`,
+  );
+}
+
+function parsePreRecallRunner(value: string): "claude" | "opencode" | "codex" {
+  if (value === "claude" || value === "opencode" || value === "codex") return value;
+  throw new Error(
+    `Invalid PRE_RECALL_RUNNER: ${value} (expected claude|opencode|codex)`,
   );
 }
 

--- a/src/memory/pre-recall.ts
+++ b/src/memory/pre-recall.ts
@@ -1,0 +1,368 @@
+// Pre-recall hook: runs BEFORE the runner spawns to inject operational memory
+// into the prompt. A cheap one-shot LLM extracts 0-3 recall queries from the
+// raw Slack message, then each query hits recallMemory() from the MCP server.
+// Results are formatted as a <pre-recall> XML block prepended to the prompt.
+//
+// The LLM call is a CLI subprocess (CLAUDE.md rule 1), not an SDK call. Same
+// timeout + process-tree SIGINT pattern as the consolidation runner. The module
+// exports a factory function returning a closure (CLAUDE.md rule 14).
+
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { readFile, rm } from "node:fs/promises";
+
+import type { Config } from "../config.ts";
+import type { MemoryToolDeps, RecallMemoryResult } from "../mcp/slack-server.ts";
+import { recallMemory } from "../mcp/slack-server.ts";
+import { createMemoryStore } from "./factory.ts";
+import { createProfileStore } from "./profiles/index.ts";
+import { signalProcessTree } from "../lifecycle/process-tree.ts";
+import { sanitizeClaudeModel } from "./consolidation/runner.ts";
+import { createOpenCodeStreamParser, createOpenCodeEventMapper } from "../opencode/parser.ts";
+import { log as _log } from "../logger.ts";
+
+// ── Runner type (same as ConsolidationRunner) ────────────────────────────────
+export type PreRecallRunner = "claude" | "opencode" | "codex";
+
+// ── Pinned cheapest models per runner ────────────────────────────────────────
+const DEFAULT_CLAUDE_MODEL = "claude-haiku-4-5-20251001";
+const DEFAULT_OPENCODE_MODEL = "opencode-go/deepseek-v4-pro";
+const DEFAULT_CODEX_MODEL = "gpt-4o-mini";
+
+// ── Extraction system prompt ─────────────────────────────────────────────────
+const EXTRACTION_SYSTEM_PROMPT = `You analyze incoming Slack messages and extract what should be recalled from long-term memory before processing.
+
+Given a message, identify 0-3 recall queries — systems, APIs, procedures, people, or domain concepts mentioned that prior operational knowledge might help with.
+
+Return ONLY a JSON array of query strings. Return [] if nothing worth recalling.
+
+Examples:
+- "shift simran's ticket from bangalore to delhi" → ["event registration city shift procedure", "admin API event registration"]
+- "can you review PR #45 on gx-backend" → ["gx-backend review conventions"]
+- "hey what's up" → []
+- "use the admin api to approve it" → ["admin API event registration approve"]
+- "onboard rahul, phone 9876543210, email rahul@test.com" → ["member onboarding procedure"]`;
+
+// ── Public types ─────────────────────────────────────────────────────────────
+export type PreRecallFn = (message: string) => Promise<string | null>;
+
+// ── Factory ──────────────────────────────────────────────────────────────────
+
+/**
+ * Create a pre-recall function that lazily initializes memory dependencies and
+ * returns a closure. The closure extracts recall queries from a raw Slack
+ * message via a cheap LLM call, runs them through recallMemory(), and returns
+ * a formatted <pre-recall> block or null.
+ */
+export function createPreRecall(config: Config): PreRecallFn {
+  const preRecallConfig = config.memory.preRecall;
+  if (!preRecallConfig?.enabled) {
+    return async () => null;
+  }
+
+  const runner = preRecallConfig.runner;
+  const model = preRecallConfig.model ?? defaultModelForRunner(runner);
+  const timeoutMs = preRecallConfig.timeoutMs;
+
+  // Lazy singleton deps for recallMemory()
+  let deps: MemoryToolDeps | null = null;
+
+  async function getDeps(): Promise<MemoryToolDeps> {
+    if (deps) return deps;
+
+    const store = createMemoryStore(config.memory.sqlitePath);
+    const { createEmbeddingProvider } = await import("./embedding/factory.ts");
+    const provider = createEmbeddingProvider(
+      config.memory.embedProvider ?? "local",
+    );
+    const profileStore = createProfileStore();
+    deps = { store, provider, profileStore };
+    return deps;
+  }
+
+  return async (message: string): Promise<string | null> => {
+    try {
+      // Step 1: Extract recall queries via cheap LLM
+      const queries = await extractRecallQueries(message, runner, model, timeoutMs);
+      if (queries.length === 0) return null;
+
+      // Step 2: Run each query through recallMemory()
+      const memDeps = await getDeps();
+      const seenClaimIds = new Set<string>();
+      const allClaims: RecallMemoryResult["claims"] = [];
+
+      for (const query of queries) {
+        const result = await recallMemory({ query, limit: 3 }, memDeps);
+        for (const claim of result.claims) {
+          if (seenClaimIds.has(claim.id)) continue;
+          seenClaimIds.add(claim.id);
+          allClaims.push(claim);
+        }
+      }
+
+      if (allClaims.length === 0) return null;
+
+      // Step 3: Format as <pre-recall> block
+      const claimLines = allClaims.map((c) => `- ${c.text}`).join("\n");
+      return [
+        "<pre-recall>",
+        "The following operational knowledge was automatically recalled from memory. Use as context.",
+        "",
+        claimLines,
+        "</pre-recall>",
+      ].join("\n");
+    } catch (err) {
+      _log.warn(
+        "pre-recall",
+        `fail err=${err instanceof Error ? err.message : String(err)}`,
+      );
+      return null;
+    }
+  };
+}
+
+// ── Query extraction ─────────────────────────────────────────────────────────
+
+/**
+ * Spawn a cheap one-shot LLM to extract recall queries from the raw message.
+ * Returns 0-3 query strings. On timeout, error, or malformed output, returns [].
+ */
+async function extractRecallQueries(
+  message: string,
+  runner: PreRecallRunner,
+  model: string,
+  timeoutMs: number,
+): Promise<string[]> {
+  const runText = runTextForRunner(runner);
+  const raw = await runText({ message, model, timeoutMs });
+  return parseQueryArray(raw);
+}
+
+/**
+ * Parse the LLM's response as a JSON array of strings. Returns [] on any
+ * parse failure — never throws.
+ */
+function parseQueryArray(raw: string): string[] {
+  const trimmed = raw.trim();
+  // Strip code fences if present
+  const unfenced = trimmed.replace(/^```(?:json)?\s*\n?/i, "").replace(/\n?```\s*$/i, "").trim();
+
+  try {
+    const parsed = JSON.parse(unfenced);
+    if (!Array.isArray(parsed)) return [];
+    const queries = parsed
+      .filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+      .slice(0, 3);
+    return queries;
+  } catch {
+    return [];
+  }
+}
+
+// ── Per-runner subprocess functions ──────────────────────────────────────────
+
+interface RunTextRequest {
+  message: string;
+  model: string;
+  timeoutMs: number;
+}
+
+type RunTextFn = (req: RunTextRequest) => Promise<string>;
+
+function defaultModelForRunner(runner: PreRecallRunner): string {
+  if (runner === "opencode") return DEFAULT_OPENCODE_MODEL;
+  if (runner === "codex") return DEFAULT_CODEX_MODEL;
+  return DEFAULT_CLAUDE_MODEL;
+}
+
+function runTextForRunner(runner: PreRecallRunner): RunTextFn {
+  if (runner === "opencode") return openCodeRunText;
+  if (runner === "codex") return codexRunText;
+  return claudeRunText;
+}
+
+// ── Claude subprocess ────────────────────────────────────────────────────────
+
+async function claudeRunText(req: RunTextRequest): Promise<string> {
+  const args = [
+    "-p", req.message,
+    "--system-prompt", EXTRACTION_SYSTEM_PROMPT,
+    "--output-format", "json",
+    "--model", sanitizeClaudeModel(req.model),
+  ];
+
+  const proc = Bun.spawn(["claude", ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+    detached: true,
+  });
+
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    signalProcessTree(proc.pid, "SIGINT");
+  }, req.timeoutMs);
+
+  try {
+    const stdout = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+    if (timedOut) {
+      throw new Error(`pre-recall: claude timed out after ${req.timeoutMs}ms`);
+    }
+    if (exitCode !== 0) {
+      let stderr = "";
+      try {
+        stderr = (await new Response(proc.stderr).text()).trim();
+      } catch {
+        // best-effort
+      }
+      throw new Error(`pre-recall: claude exited ${exitCode}${stderr ? `: ${stderr}` : ""}`);
+    }
+    return extractClaudeAssistantText(stdout);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Pull the assistant's final text out of `--output-format json` stdout.
+ * The envelope is `{ "type": "result", "result": "...", ... }`.
+ */
+function extractClaudeAssistantText(stdout: string): string {
+  const trimmed = stdout.trim();
+  try {
+    const envelope = JSON.parse(trimmed);
+    if (
+      envelope &&
+      typeof envelope === "object" &&
+      typeof (envelope as { result?: unknown }).result === "string"
+    ) {
+      return (envelope as { result: string }).result;
+    }
+  } catch {
+    // Not the json envelope — return raw
+  }
+  return trimmed;
+}
+
+// ── OpenCode subprocess ──────────────────────────────────────────────────────
+
+async function openCodeRunText(req: RunTextRequest): Promise<string> {
+  // OpenCode does not support --system-prompt, so bake the system prompt
+  // into the user prompt.
+  const combinedPrompt = `${EXTRACTION_SYSTEM_PROMPT}\n\n---\n\nMessage:\n${req.message}`;
+  const args = ["run", "--format", "json"];
+  if (req.model) args.push("--model", req.model);
+  args.push(combinedPrompt);
+
+  const proc = Bun.spawn(["opencode", ...args], {
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+    detached: true,
+  });
+
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    signalProcessTree(proc.pid, "SIGINT");
+  }, req.timeoutMs);
+
+  try {
+    const stdout = await new Response(proc.stdout).text();
+    const exitCode = await proc.exited;
+    if (timedOut) {
+      throw new Error(`pre-recall: opencode timed out after ${req.timeoutMs}ms`);
+    }
+    if (exitCode !== 0) {
+      let stderr = "";
+      try {
+        stderr = (await new Response(proc.stderr).text()).trim();
+      } catch {
+        // best-effort
+      }
+      throw new Error(`pre-recall: opencode exited ${exitCode}${stderr ? `: ${stderr}` : ""}`);
+    }
+    return extractOpenCodeAssistantText(stdout);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
+ * Extract the final assistant text from OpenCode's `--format json` NDJSON
+ * stdout using the production stream parser.
+ */
+function extractOpenCodeAssistantText(stdout: string): string {
+  const parser = createOpenCodeStreamParser();
+  const mapper = createOpenCodeEventMapper();
+  for (const event of parser.feed(stdout)) mapper.map(event);
+  for (const event of parser.flush()) mapper.map(event);
+  return mapper.response || stdout.trim();
+}
+
+// ── Codex subprocess ─────────────────────────────────────────────────────────
+
+async function codexRunText(req: RunTextRequest): Promise<string> {
+  const outFile = join(tmpdir(), `junior-pre-recall-codex-${crypto.randomUUID()}.txt`);
+  // Bake system prompt into stdin since codex exec has no --system-prompt flag.
+  const combinedPrompt = `${EXTRACTION_SYSTEM_PROMPT}\n\n---\n\nMessage:\n${req.message}`;
+
+  const args = [
+    "exec",
+    "--ephemeral",
+    "--ignore-user-config",
+    "--ignore-rules",
+    "--skip-git-repo-check",
+    "-s", "read-only",
+    "--color", "never",
+    "-m", req.model,
+    "-o", outFile,
+    "-",
+  ];
+
+  const proc = Bun.spawn(["codex", ...args], {
+    cwd: tmpdir(),
+    stdin: new TextEncoder().encode(combinedPrompt),
+    stdout: "ignore",
+    stderr: "pipe",
+    detached: true,
+  });
+
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    signalProcessTree(proc.pid, "SIGINT");
+  }, req.timeoutMs);
+
+  try {
+    const exitCode = await proc.exited;
+    if (timedOut) {
+      throw new Error(`pre-recall: codex timed out after ${req.timeoutMs}ms`);
+    }
+    if (exitCode !== 0) {
+      let stderr = "";
+      try {
+        stderr = (await new Response(proc.stderr).text()).trim();
+      } catch {
+        // best-effort
+      }
+      throw new Error(`pre-recall: codex exited ${exitCode}${stderr ? `: ${stderr}` : ""}`);
+    }
+    let text: string;
+    try {
+      text = await readFile(outFile, "utf8");
+    } catch (err) {
+      const reason = err instanceof Error ? err.message : String(err);
+      throw new Error(`pre-recall: codex output file unreadable (${reason})`);
+    }
+    if (!text.trim()) {
+      throw new Error("pre-recall: codex produced an empty output file");
+    }
+    return text;
+  } finally {
+    clearTimeout(timer);
+    await rm(outFile, { force: true }).catch(() => {});
+  }
+}

--- a/src/memory/pre-recall.ts
+++ b/src/memory/pre-recall.ts
@@ -27,7 +27,7 @@ export type PreRecallRunner = "claude" | "opencode" | "codex";
 // ── Pinned cheapest models per runner ────────────────────────────────────────
 const DEFAULT_CLAUDE_MODEL = "claude-haiku-4-5-20251001";
 const DEFAULT_OPENCODE_MODEL = "opencode-go/deepseek-v4-pro";
-const DEFAULT_CODEX_MODEL = "gpt-4o-mini";
+const DEFAULT_CODEX_MODEL = "gpt-5.4-nano";
 
 // ── Extraction system prompt ─────────────────────────────────────────────────
 const EXTRACTION_SYSTEM_PROMPT = `You analyze incoming Slack messages and extract what should be recalled from long-term memory before processing.

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -49,6 +49,7 @@ import { DEFAULT_CONTEXT_PROFILE, type AgentContextProfile } from "../agents/loa
 import { downloadSlackFiles } from "../slack/files.ts";
 import { log as _log } from "../logger.ts";
 import type { MemoryIngestor } from "../memory/ingestion.ts";
+import { createPreRecall, type PreRecallFn } from "../memory/pre-recall.ts";
 import { clearThreadJuniorMessages } from "../slack/thread-archive.ts";
 
 export class SessionManager {
@@ -59,6 +60,7 @@ export class SessionManager {
   private spawnRunner: SpawnRunnerFn;
   private drivers: DriverMap;
   private memoryIngestor?: MemoryIngestor;
+  private preRecall: PreRecallFn | null;
 
   slackApp?: App;
   botUserId?: string;
@@ -104,6 +106,9 @@ export class SessionManager {
         ),
     });
     this.memoryIngestor = memoryIngestor;
+    this.preRecall = config.memory.preRecall?.enabled
+      ? createPreRecall(config)
+      : null;
   }
 
   setMemoryIngestor(memoryIngestor: MemoryIngestor): void {
@@ -985,6 +990,7 @@ export class SessionManager {
         : this.getOrCreateAgentSession(session, agentName);
       const agentIdentity = identityForAgent(agentName);
       const runSession = this.buildRunSession(session, agentName, agentIdentity);
+      const rawMessage = prompt;
 
       // Resolve target repo before building the preamble so workspace info can be injected.
       let targetRepo: { name: string; path: string } | undefined;
@@ -1181,6 +1187,13 @@ export class SessionManager {
         const agentStateBlock = this.buildAgentStateBlock(session);
         if (agentStateBlock) {
           prompt = `${agentStateBlock}\n\n${prompt}`;
+        }
+      }
+
+      if (this.preRecall) {
+        const preRecallBlock = await this.preRecall(rawMessage);
+        if (preRecallBlock) {
+          prompt = `${preRecallBlock}\n\n${prompt}`;
         }
       }
 


### PR DESCRIPTION
## Summary
- Adds a pre-recall hook that runs before every runner turn: a cheap LLM (haiku/deepseek/gpt-4o-mini) extracts 0-3 recall queries from the incoming Slack message, then calls `recallMemory()` and injects matching claims as a `<pre-recall>` block into the prompt
- Supports all three CLI runners (claude, opencode, codex) via `PRE_RECALL_RUNNER` env var; defaults to claude/haiku
- Solves the chicken-and-egg problem where agents skip `memory_recall` and waste tokens re-discovering knowledge that's already stored

## Changes
- **`src/memory/pre-recall.ts`** (new) — factory function, per-runner subprocess spawning, query extraction prompt, recall + dedup + formatting
- **`src/config.ts`** — `preRecall` section in memory config (`PRE_RECALL_ENABLED`, `PRE_RECALL_RUNNER`, `PRE_RECALL_MODEL`, `PRE_RECALL_TIMEOUT_MS`)
- **`src/session/manager.ts`** — captures raw message early, runs pre-recall, prepends results before runner spawn

## Config
| Env var | Default | Description |
|---------|---------|-------------|
| `PRE_RECALL_ENABLED` | `true` | Enable/disable the hook |
| `PRE_RECALL_RUNNER` | `claude` | Which CLI to use (claude/opencode/codex) |
| `PRE_RECALL_MODEL` | per-runner cheapest | Override model |
| `PRE_RECALL_TIMEOUT_MS` | `15000` | Timeout for the LLM extraction call |

## Test plan
- [ ] Verify typecheck passes (done locally)
- [ ] Test with `PRE_RECALL_ENABLED=true` — send a message mentioning a known memory topic, confirm `<pre-recall>` block appears in the prompt
- [ ] Test with `PRE_RECALL_ENABLED=false` — confirm no pre-recall block
- [ ] Test timeout handling — set `PRE_RECALL_TIMEOUT_MS=1` and confirm graceful fallback (no block, warning logged)
- [ ] Test each runner (claude, opencode, codex) extracts queries correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)