### PR TITLE
fix(session): only auto-dormant on humans who never engaged Junior

### DIFF
--- a/docs/features/thread-commands.md
+++ b/docs/features/thread-commands.md
@@ -123,7 +123,7 @@ The problem this solves: a thread that started with Junior often turns into a hu
 
 - `!aside [text]` — drop the current message before it reaches any agent. React with 👀 so the user knows it landed; do not spawn Claude. Anyone in the thread. Cheap, no state change.
 
-- **Auto-dormant trigger** — when a human posts a message that does NOT @mention Junior AND at least one other human has already posted in the thread, set `session.dormant = true`, post a single notice to the thread:
+- **Auto-dormant trigger** — when a human who has never directly engaged Junior in this thread posts a message that does NOT @mention Junior AND at least one other human has already posted in the thread, set `session.dormant = true`, post a single notice to the thread:
   > Two people are interacting here, so I’ll stop replying. @ me or use !listen to bring me back.
 
   After that, drop every message in the thread except:
@@ -131,17 +131,19 @@ The problem this solves: a thread that started with Junior often turns into a hu
     - `!aside` (still works — it's a no-op anyway)
     - any message that @mentions Junior (wake)
 
-  Track `humanParticipants: string[]` on the session — append on every human message (not Junior, not its agents, not other bots). Decision rule: if the set already contains a user other than the current sender AND the current message doesn't @mention Junior → go dormant.
+  Track `humanParticipants: string[]` on the session — append on every human message (not Junior, not its agents, not other bots). Also track `engagedHumans: string[]` — the subset who have directly engaged Junior: their message @mentioned it, routed to a runner turn, or they summoned it with `!listen`. Decision rule: if the set already contains a user other than the current sender AND the current message doesn't @mention Junior AND the sender has never engaged Junior → go dormant.
+
+  The engagement check is what keeps a genuinely mixed conversation alive: once a second human @mentions Junior (or Junior has been replying to them), their plain follow-ups — and the first human's — are continuation of a conversation *with* Junior, not a sidebar. Without it the very next untagged message after Junior replies would falsely trip the trigger. `!aside` posters and the sender whose sidebar message fired the trigger are participants but never engaged, so a lurker who only whispered asides still trips the gate with their first real message.
 
 - `!listen` — set `session.dormant = false`, react with 👂 (or post a short ack). Anyone in the thread.
 
 - **Bot identity rule** — Junior and its agents (lead, reproducer, thinker, scotty, uhura, bones, etc.) share the same Slack `bot_id` and are never participants. Other bots (Friday, Doraemon, CI webhooks, foreign assistants) are not counted either — they're not conversation partners.
 
-**Persistence:** `dormant: boolean` and `humanParticipants: string[]` are columns on the `sessions` table in SQLite. Survives restart so a dormant thread doesn't auto-resume on bot bounce.
+**Persistence:** `dormant: boolean`, `humanParticipants: string[]`, and `engagedHumans: string[]` persist on the session row in SQLite. Survives restart so a dormant thread doesn't auto-resume on bot bounce.
 
 **Wake by @mention:** `app_mention` events always wake the thread before routing. The mention itself is the explicit "I'm talking to you again" signal.
 
-**Test:** Thread with one human + Junior — chats freely, never goes dormant. Second human joins and @mentions Junior — wakes (no-op, wasn't dormant). Second human posts without mention while first human is also present — dormant, notice posted once. Subsequent messages dropped silently. `!listen` from either human — wakes, next message routes normally. `!aside fyi I have to step out` — dropped, 👀 reaction, thread state unchanged.
+**Test:** Thread with one human + Junior — chats freely, never goes dormant. Second human joins and @mentions Junior — wakes (no-op, wasn't dormant), and their untagged follow-ups keep routing (engaged) — as do the first human's. Second never-engaged human posts without mention while first human is also present — dormant, notice posted once. Subsequent messages dropped silently. `!listen` from either human — wakes, next message routes normally. `!aside fyi I have to step out` — dropped, 👀 reaction, thread state unchanged.
 
 **Defers:** Per-user wake (only the thread owner can `!listen`), time-based auto-wake, configurable trigger threshold.
 

--- a/src/claude/args.test.ts
+++ b/src/claude/args.test.ts
@@ -27,6 +27,7 @@ function makeSession(overrides: Partial<ThreadSession> = {}): ThreadSession {
     needsThreadCatchup: false,
     dormantAnnounced: false,
     humanParticipants: [],
+    engagedHumans: [],
     model: null,
     cwd: null,
     pid: null,

--- a/src/claude/tmux-driver.test.ts
+++ b/src/claude/tmux-driver.test.ts
@@ -37,6 +37,7 @@ function makeSession(overrides: Partial<ThreadSession> = {}): ThreadSession {
     needsThreadCatchup: false,
     dormantAnnounced: false,
     humanParticipants: [],
+    engagedHumans: [],
     ...overrides,
   };
 }

--- a/src/runners/runtime.test.ts
+++ b/src/runners/runtime.test.ts
@@ -28,6 +28,7 @@ function makeSession(overrides: Partial<ThreadSession> = {}): ThreadSession {
     needsThreadCatchup: false,
     dormantAnnounced: false,
     humanParticipants: [],
+    engagedHumans: [],
     model: null,
     cwd: null,
     pid: null,

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -2009,6 +2009,97 @@ describe("SessionManager", () => {
       expect(drop).toBe(false);
       const after = (await store.get("thread-1"))!;
       expect(after.dormant).toBe(false);
+      // The mention passing the gate marks U-B engaged
+      expect(after.engagedHumans).toContain("U-B");
+    });
+
+    it("does not trigger on follow-ups from a second human who @mentioned Junior", async () => {
+      // U-A starts the thread, U-B joins by @mentioning Junior
+      await manager.handleMessage(makeEvent({ user: "U-A" }));
+      currentHandle._complete("done");
+      await new Promise((r) => setTimeout(r, 5));
+      await manager.gateAttention(
+        makeEvent({
+          user: "U-B",
+          mentionsJunior: true,
+          text: "addressing junior",
+          ts: "ts-mention-b",
+        }),
+      );
+
+      const responses: string[] = [];
+      manager.onCommandResponse = (_e, r) => responses.push(r);
+
+      // U-B's plain follow-up — engaged, must NOT trip the sidebar trigger
+      const drop = await manager.gateAttention(
+        makeEvent({ user: "U-B", text: "and one more thing", ts: "ts-b-followup" }),
+      );
+      expect(drop).toBe(false);
+      expect(responses).toEqual([]);
+      const after = (await store.get("thread-1"))!;
+      expect(after.dormant).toBe(false);
+      expect(after.dormantAnnounced).toBe(false);
+    });
+
+    it("does not trigger on the first human's follow-up after a second human engages", async () => {
+      // U-A starts the thread (routed message → engaged via getOrCreateSession)
+      await manager.handleMessage(makeEvent({ user: "U-A" }));
+      currentHandle._complete("done");
+      await new Promise((r) => setTimeout(r, 5));
+      expect((await store.get("thread-1"))!.engagedHumans).toContain("U-A");
+      // U-B joins by @mentioning Junior
+      await manager.gateAttention(
+        makeEvent({
+          user: "U-B",
+          mentionsJunior: true,
+          text: "addressing junior",
+          ts: "ts-mention-b",
+        }),
+      );
+
+      // U-A's plain follow-up — Junior was already talking to them
+      const drop = await manager.gateAttention(
+        makeEvent({ user: "U-A", text: "yes do that", ts: "ts-a-followup" }),
+      );
+      expect(drop).toBe(false);
+      const after = (await store.get("thread-1"))!;
+      expect(after.dormant).toBe(false);
+    });
+
+    it("still triggers for an aside-only human's first real message", async () => {
+      // U-A starts the thread; U-B has only posted !aside (participant, NOT engaged)
+      await manager.handleMessage(makeEvent({ user: "U-A" }));
+      currentHandle._complete("done");
+      await new Promise((r) => setTimeout(r, 5));
+      await manager.gateAttention(
+        makeEvent({ command: "aside", user: "U-B", text: "side note", ts: "ts-aside-b" }),
+      );
+
+      const drop = await manager.gateAttention(
+        makeEvent({ user: "U-B", text: "anyway, as I was saying", ts: "ts-b-real" }),
+      );
+      expect(drop).toBe(true);
+      const after = (await store.get("thread-1"))!;
+      expect(after.dormant).toBe(true);
+      expect(after.engagedHumans).not.toContain("U-B");
+    });
+
+    it("marks the sender engaged on !listen", async () => {
+      await manager.handleMessage(makeEvent({ user: "U-A" }));
+      currentHandle._complete("done");
+      await new Promise((r) => setTimeout(r, 5));
+
+      await manager.gateAttention(
+        makeEvent({ command: "listen", user: "U-B", text: "", ts: "ts-listen-b" }),
+      );
+      expect((await store.get("thread-1"))!.engagedHumans).toContain("U-B");
+
+      // U-B's plain follow-up after summoning Junior does not trip the trigger
+      const drop = await manager.gateAttention(
+        makeEvent({ user: "U-B", text: "so about that bug", ts: "ts-b-after-listen" }),
+      );
+      expect(drop).toBe(false);
+      expect((await store.get("thread-1"))!.dormant).toBe(false);
     });
 
     it("does not re-trigger after manual !listen (sticky dormantAnnounced)", async () => {

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -304,10 +304,14 @@ export class SessionManager {
     // engaged — an aside is side-talk, not engagement.
     if (event.command === "aside") {
       if (isHuman && event.user) {
+        const user = event.user;
         const session = await this.store.get(event.threadId);
-        if (session && !session.humanParticipants.includes(event.user)) {
-          session.humanParticipants.push(event.user);
-          await this.store.set(event.threadId, session);
+        if (session && !session.humanParticipants.includes(user)) {
+          await this.mutateSession(event.threadId, (s) => {
+            if (!s.humanParticipants.includes(user)) {
+              s.humanParticipants.push(user);
+            }
+          });
         }
       }
       this.onReaction?.(event, "eyes");
@@ -331,36 +335,36 @@ export class SessionManager {
     // summon — the sender is engaging Junior, so mark them engaged too.
     if (event.command === "listen") {
       if (session) {
-        let changed = false;
-        if (session.dormant) {
-          session.dormant = false;
-          session.needsThreadCatchup = true;
-          changed = true;
+        const user = isHuman ? event.user : undefined;
+        if (
+          session.dormant ||
+          (user && !session.engagedHumans.includes(user))
+        ) {
+          await this.mutateSession(event.threadId, (s) => {
+            if (s.dormant) {
+              s.dormant = false;
+              s.needsThreadCatchup = true;
+            }
+            if (user && !s.engagedHumans.includes(user)) {
+              s.engagedHumans.push(user);
+            }
+          });
         }
-        if (isHuman && event.user) {
-          session.engagedHumans ??= [];
-          if (!session.engagedHumans.includes(event.user)) {
-            session.engagedHumans.push(event.user);
-            changed = true;
-          }
-        }
-        if (changed) await this.store.set(event.threadId, session);
       }
       this.onReaction?.(event, "ear");
       return true;
     }
 
-    // @mention wakes a dormant thread, then falls through so the mention is
-    // processed normally.
-    if (event.mentionsJunior && session?.dormant) {
-      session.dormant = false;
-      session.needsThreadCatchup = true;
-      await this.store.set(event.threadId, session);
-    }
-
-    // Dormant after the wake check → drop silently. No state change.
+    // Dormant: an @mention wakes the thread and falls through so the mention
+    // is processed normally; anything else drops silently.
     if (session?.dormant) {
-      return true;
+      if (!event.mentionsJunior) return true;
+      await this.mutateSession(event.threadId, (s) => {
+        if (s.dormant) {
+          s.dormant = false;
+          s.needsThreadCatchup = true;
+        }
+      });
     }
 
     if (isAutoTrigger) return false;
@@ -377,18 +381,20 @@ export class SessionManager {
       session &&
       !session.dormantAnnounced &&
       !event.mentionsJunior &&
-      !(event.user && session.engagedHumans?.includes(event.user))
+      !(event.user && session.engagedHumans.includes(event.user))
     ) {
       const otherHumans = session.humanParticipants.filter(
         (u) => u !== event.user,
       );
       if (otherHumans.length > 0) {
-        session.dormant = true;
-        session.dormantAnnounced = true;
-        if (event.user && !session.humanParticipants.includes(event.user)) {
-          session.humanParticipants.push(event.user);
-        }
-        await this.store.set(event.threadId, session);
+        const user = event.user;
+        await this.mutateSession(event.threadId, (s) => {
+          s.dormant = true;
+          s.dormantAnnounced = true;
+          if (user && !s.humanParticipants.includes(user)) {
+            s.humanParticipants.push(user);
+          }
+        });
         this.onCommandResponse?.(
           event,
           "Two people are interacting here, so I’ll stop replying. @ me or use !listen to bring me back.",
@@ -401,12 +407,18 @@ export class SessionManager {
     // engaging it. Engaged humans never fire the sidebar trigger again
     // (the thread opener's first message has no session yet; that case is
     // covered by getOrCreateSession marking engagement on routed messages).
-    if (isHuman && event.user && session) {
-      session.engagedHumans ??= [];
-      if (!session.engagedHumans.includes(event.user)) {
-        session.engagedHumans.push(event.user);
-        await this.store.set(event.threadId, session);
-      }
+    if (
+      isHuman &&
+      event.user &&
+      session &&
+      !session.engagedHumans.includes(event.user)
+    ) {
+      const user = event.user;
+      await this.mutateSession(event.threadId, (s) => {
+        if (!s.engagedHumans.includes(user)) {
+          s.engagedHumans.push(user);
+        }
+      });
     }
 
     return false;
@@ -2133,32 +2145,38 @@ export class SessionManager {
       await this.store.set(event.threadId, session);
     }
 
+    // Track human participants for the attention gate. Bots — Junior, its
+    // agents, and foreign bots — are excluded by design (see gateAttention).
+    // A message reaching here routed to Junior, so the sender is also
+    // engaged — their later plain follow-ups must not trip the sidebar
+    // trigger. This covers the thread opener, whose first message passes
+    // the gate before any session row exists. Goes through mutateSession —
+    // a new participant can post while a runner turn is mid-flight, and a
+    // whole-row get→set here would revert status/sessionId.
+    const isHuman = !event.isSelfBot && !event.botId;
+    if (
+      isHuman &&
+      event.user &&
+      (!session.humanParticipants.includes(event.user) ||
+        !session.engagedHumans.includes(event.user))
+    ) {
+      const user = event.user;
+      session = await this.mutateSession(event.threadId, (s) => {
+        if (!s.humanParticipants.includes(user)) {
+          s.humanParticipants.push(user);
+        }
+        if (!s.engagedHumans.includes(user)) {
+          s.engagedHumans.push(user);
+        }
+      });
+    }
+
     session.leadSessionId ??= session.sessionId;
     session.agentSessions ??= {};
     session.provider ??= "claude";
     session.humanParticipants ??= [];
     session.engagedHumans ??= [];
     session.needsThreadCatchup ??= false;
-
-    // Track human participants for the attention gate. Bots — Junior, its
-    // agents, and foreign bots — are excluded by design (see gateAttention).
-    // A message reaching here routed to Junior, so the sender is also
-    // engaged — their later plain follow-ups must not trip the sidebar
-    // trigger. This covers the thread opener, whose first message passes
-    // the gate before any session row exists.
-    const isHuman = !event.isSelfBot && !event.botId;
-    if (isHuman && event.user) {
-      let changed = false;
-      if (!session.humanParticipants.includes(event.user)) {
-        session.humanParticipants.push(event.user);
-        changed = true;
-      }
-      if (!session.engagedHumans.includes(event.user)) {
-        session.engagedHumans.push(event.user);
-        changed = true;
-      }
-      if (changed) await this.store.set(event.threadId, session);
-    }
 
     return session;
   }

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -281,7 +281,10 @@ export class SessionManager {
    * - Drop everything while muted, except `!unmute`.
    * - Drop everything while dormant.
    * - One-shot auto-dormant trigger when a second human posts without
-   *   mentioning Junior. Announcement only fires once per thread (sticky
+   *   mentioning Junior AND has never directly engaged it in this thread.
+   *   Humans who have engaged Junior (@mention, a routed message, `!listen`)
+   *   never trip the trigger — their follow-ups are conversation with Junior,
+   *   not a sidebar. Announcement only fires once per thread (sticky
    *   `dormantAnnounced` flag), so manual `!listen` is respected — re-silence
    *   is `!aside` or `!mute`.
    *
@@ -290,13 +293,16 @@ export class SessionManager {
    * input there, not a sidebar.
    */
   async gateAttention(event: SlackMessageEvent): Promise<boolean> {
+    // Junior, its agents, and foreign bots never trip or feed the gate.
+    const isHuman = !event.isSelfBot && !event.botId;
+
     // !aside: drop the message but still record the sender as a participant —
     // they're a human in the room even if this message isn't for Junior. The
     // alternative (skip tracking) creates a corner where U-B posts only
     // asides, then a real non-mention message, and the gate fails to fire
-    // because U-B was never registered as present.
+    // because U-B was never registered as present. Deliberately NOT marked
+    // engaged — an aside is side-talk, not engagement.
     if (event.command === "aside") {
-      const isHuman = !event.isSelfBot && !event.botId;
       if (isHuman && event.user) {
         const session = await this.store.get(event.threadId);
         if (session && !session.humanParticipants.includes(event.user)) {
@@ -321,12 +327,24 @@ export class SessionManager {
       return true;
     }
 
-    // !listen: wake from dormant if needed. Anyone in the thread.
+    // !listen: wake from dormant if needed. Anyone in the thread. An explicit
+    // summon — the sender is engaging Junior, so mark them engaged too.
     if (event.command === "listen") {
-      if (session && session.dormant) {
-        session.dormant = false;
-        session.needsThreadCatchup = true;
-        await this.store.set(event.threadId, session);
+      if (session) {
+        let changed = false;
+        if (session.dormant) {
+          session.dormant = false;
+          session.needsThreadCatchup = true;
+          changed = true;
+        }
+        if (isHuman && event.user) {
+          session.engagedHumans ??= [];
+          if (!session.engagedHumans.includes(event.user)) {
+            session.engagedHumans.push(event.user);
+            changed = true;
+          }
+        }
+        if (changed) await this.store.set(event.threadId, session);
       }
       this.onReaction?.(event, "ear");
       return true;
@@ -349,14 +367,17 @@ export class SessionManager {
 
     // Trigger: actor must be human (not Junior, not its agents, not any
     // foreign bot). Session must exist with another human already recorded.
-    // Message must not @mention Junior. And the gate fires at most once per
-    // thread — once announced, dormancy is the human's call (`!aside` / `!mute`).
-    const isHuman = !event.isSelfBot && !event.botId;
+    // Message must not @mention Junior, and the sender must never have
+    // directly engaged Junior in this thread — someone already conversing
+    // with Junior posting a plain follow-up is continuation, not a sidebar.
+    // And the gate fires at most once per thread — once announced, dormancy
+    // is the human's call (`!aside` / `!mute`).
     if (
       isHuman &&
       session &&
       !session.dormantAnnounced &&
-      !event.mentionsJunior
+      !event.mentionsJunior &&
+      !(event.user && session.engagedHumans?.includes(event.user))
     ) {
       const otherHumans = session.humanParticipants.filter(
         (u) => u !== event.user,
@@ -364,7 +385,7 @@ export class SessionManager {
       if (otherHumans.length > 0) {
         session.dormant = true;
         session.dormantAnnounced = true;
-        if (!session.humanParticipants.includes(event.user)) {
+        if (event.user && !session.humanParticipants.includes(event.user)) {
           session.humanParticipants.push(event.user);
         }
         await this.store.set(event.threadId, session);
@@ -373,6 +394,18 @@ export class SessionManager {
           "Two people are interacting here, so I’ll stop replying. @ me or use !listen to bring me back.",
         );
         return true;
+      }
+    }
+
+    // The message is about to route to Junior — the sender is directly
+    // engaging it. Engaged humans never fire the sidebar trigger again
+    // (the thread opener's first message has no session yet; that case is
+    // covered by getOrCreateSession marking engagement on routed messages).
+    if (isHuman && event.user && session) {
+      session.engagedHumans ??= [];
+      if (!session.engagedHumans.includes(event.user)) {
+        session.engagedHumans.push(event.user);
+        await this.store.set(event.threadId, session);
       }
     }
 
@@ -2104,14 +2137,27 @@ export class SessionManager {
     session.agentSessions ??= {};
     session.provider ??= "claude";
     session.humanParticipants ??= [];
+    session.engagedHumans ??= [];
     session.needsThreadCatchup ??= false;
 
     // Track human participants for the attention gate. Bots — Junior, its
     // agents, and foreign bots — are excluded by design (see gateAttention).
+    // A message reaching here routed to Junior, so the sender is also
+    // engaged — their later plain follow-ups must not trip the sidebar
+    // trigger. This covers the thread opener, whose first message passes
+    // the gate before any session row exists.
     const isHuman = !event.isSelfBot && !event.botId;
-    if (isHuman && event.user && !session.humanParticipants.includes(event.user)) {
-      session.humanParticipants.push(event.user);
-      await this.store.set(event.threadId, session);
+    if (isHuman && event.user) {
+      let changed = false;
+      if (!session.humanParticipants.includes(event.user)) {
+        session.humanParticipants.push(event.user);
+        changed = true;
+      }
+      if (!session.engagedHumans.includes(event.user)) {
+        session.engagedHumans.push(event.user);
+        changed = true;
+      }
+      if (changed) await this.store.set(event.threadId, session);
     }
 
     return session;

--- a/src/session/store/sqlite.ts
+++ b/src/session/store/sqlite.ts
@@ -554,13 +554,14 @@ function normalizeSession(session: ThreadSession): ThreadSession {
   session.driverMode ??= "headless";
   session.tmuxSessionName ??= null;
   session.topLevelTmuxAgent ??= null;
-  // Migration: dormant / dormantAnnounced / humanParticipants added for the
-  // attention gate. Pre-existing sessions default to "awake, never announced,
-  // no recorded participants" — they re-accumulate naturally as new messages
-  // arrive.
+  // Migration: dormant / dormantAnnounced / humanParticipants /
+  // engagedHumans added for the attention gate. Pre-existing sessions
+  // default to "awake, never announced, no recorded participants" — they
+  // re-accumulate naturally as new messages arrive.
   session.dormant ??= false;
   session.dormantAnnounced ??= false;
   session.humanParticipants ??= [];
+  session.engagedHumans ??= [];
   session.pipelineGuardRetryCount ??= 0;
   session.stateVersion ??= 0;
   // Pipeline substrate (Phase 2): pre-existing rows default to no active run.

--- a/src/session/types.test.ts
+++ b/src/session/types.test.ts
@@ -119,6 +119,7 @@ describe("createSession", () => {
       "dormant",
       "dormantAnnounced",
       "driverMode",
+      "engagedHumans",
       "humanParticipants",
       "idleInterruptCount",
       "lastActivity",
@@ -168,6 +169,11 @@ describe("createSession", () => {
   it("has humanParticipants as empty array by default", () => {
     const session = createSession("t1", "C01");
     expect(session.humanParticipants).toEqual([]);
+  });
+
+  it("has engagedHumans as empty array by default", () => {
+    const session = createSession("t1", "C01");
+    expect(session.engagedHumans).toEqual([]);
   });
 });
 

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -136,6 +136,17 @@ export interface ThreadSession {
    * for the thread opener) without a data-shape migration.
    */
   humanParticipants: string[];
+  /**
+   * Slack user IDs of humans who have directly engaged Junior in this
+   * thread: their message @mentioned it, routed to a runner turn, or they
+   * summoned it with `!listen`. Subset of `humanParticipants` — `!aside`
+   * posters and the sender whose sidebar message fired the auto-dormant
+   * trigger are participants but not engaged. The attention gate only
+   * auto-dormants on a message from a non-engaged human: once someone is
+   * talking to Junior directly, their plain follow-ups are conversation,
+   * not a sidebar.
+   */
+  engagedHumans: string[];
   model: string | null;
   /**
    * Explicit Claude-runner model override, sourced from the active agent's
@@ -229,6 +240,7 @@ export function createSession(
     needsThreadCatchup: false,
     dormantAnnounced: false,
     humanParticipants: [],
+    engagedHumans: [],
     model: null,
     cwd: null,
     pid: null,


### PR DESCRIPTION
## Problem

Two bugs in threads where a second person joins a conversation with Junior:

1. The second person @mentions Junior directly — the sidebar mute correctly doesn't apply and Junior replies, but the **next** untagged message (from either person) makes Junior mute himself.
2. Junior is mid-conversation with someone, and as soon as a second human is recorded in the thread, the next untagged message mutes him.

Both come from the same root cause: the attention gate's auto-dormant trigger fired on *any* non-mention human message once two humans existed in `humanParticipants`, with no notion of whether the sender was already talking **to Junior**.

## Fix

Track `engagedHumans` on the session — users who have directly engaged Junior in the thread:
- their message @mentioned Junior,
- their message routed to a runner turn (covers the thread opener), or
- they summoned Junior with `!listen`.

The sidebar trigger now only fires for a human who has **never** engaged Junior. Once someone is conversing with Junior, their plain follow-ups are continuation, not a sidebar.

Deliberately *not* engaged (preserves existing corners):
- `!aside` posters — an aside is side-talk, so a lurker who only posted asides still trips the gate with their first real message.
- The sender whose sidebar message fired the trigger.

`dormantAnnounced` stickiness and the auto-trigger-channel exemption are unchanged.

## Concurrency (review follow-up)

All attention-gate session writes (`!aside` participant tracking, `!listen` wake+engage, @mention wake, the sidebar trigger, engagement marking) and `getOrCreateSession`'s participant/engagement write now go through `mutateSession` instead of whole-row get→set, so a write racing a completing runner turn cannot revert `status`/`sessionId`. Snapshot pre-checks keep the hot path write-free once a sender is already engaged.

## Testing

- 4 new `gateAttention` tests (mention-then-follow-up, first human's follow-up after second human engages, aside-only corner still triggers, `!listen` marks engaged) plus an engagement assertion in an existing test; `createSession` expected-keys and default-value coverage for `engagedHumans` in `types.test.ts`.
- Full suite: 1204 pass / 0 fail (`bun test`, verified on raw unfiltered output), `bun run typecheck` clean — two consecutive green runs.
- `engagedHumans` defaults to `[]` for pre-existing SQLite rows via `normalizeSession`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VVzTPvBp7NRg33afpHRzkg