### PR TITLE
fix: recover durable pipelines and enable review verification

### DIFF
--- a/.claude/agents/common/pipeline-start.md
+++ b/.claude/agents/common/pipeline-start.md
@@ -20,6 +20,9 @@ small work expands into coordinated work, upgrade at that point. Honor an
 explicit human request for a quick/no-pipeline path.
 
 Choose `product` with `pm` or `build`, or `bug` with `debug` or `reproducer`.
+For a product `build`, pass `required_workstreams` explicitly from the actual
+change scope: `backend`, `frontend`, or both. Do not infer full-stack work just
+because the request mentions an existing API while asking for a UI change.
 State the concrete coordination reason and use a stable idempotency key for
 this source turn. After the tool accepts the upgrade, do not also emit a legacy
 `!build`, `!debug`, or duplicate worker directive. The durable initial

--- a/.claude/agents/review.md
+++ b/.claude/agents/review.md
@@ -71,11 +71,11 @@ Use the worktree to:
 - verify whether changed function signatures break callers
 - run focused checks when they are needed to confirm a finding
 
-Verification commands are intentionally limited to test/typecheck/lint/build
-scripts for the repository's package manager (npm for most product repos, pnpm
-for gx-client-expo, Bun for Junior) plus read-only git/PR inspection. Tests may
-write caches and generated output inside the disposable worktree. Never install
-dependencies, edit source, commit, push, publish, or deploy.
+Verification commands are generated from the package manager declared by the
+active worktree's `package.json` or lockfile. They are limited to
+test/typecheck/lint/build/check scripts plus read-only git/PR inspection. Tests
+may write caches and generated output inside the disposable worktree. Never
+install dependencies, edit source, commit, push, publish, or deploy.
 
 ## Re-review behavior
 

--- a/.claude/agents/review.md
+++ b/.claude/agents/review.md
@@ -1,7 +1,7 @@
 ---
 name: review
 description: Code reviewer. Use for PR reviews, code quality checks, security audits.
-tools: Read, Grep, Glob, mcp__slack-bot__github_post_review, mcp__slack-bot__slack_send_message, mcp__slack-bot__slack_read_thread, mcp__slack-bot__register_worktree, mcp__slack-bot__memory_recall, mcp__slack-bot__memory_add
+tools: Read, Grep, Glob, mcp__slack-bot__github_read_pr_review_state, mcp__slack-bot__github_post_review, mcp__slack-bot__slack_send_message, mcp__slack-bot__slack_read_thread, mcp__slack-bot__register_worktree, mcp__slack-bot__memory_recall, mcp__slack-bot__memory_add
 permissions.intent: read-only
 common: core,merge-workflow,runtime-environment
 context.threadHistory: true
@@ -81,7 +81,7 @@ install dependencies, edit source, commit, push, publish, or deploy.
 
 When re-reviewing a PR:
 
-1. Read existing GitHub review comments and reviews with `gh api --method GET` / `gh pr view` before making new comments. Fetch and check the *current* state of the code at each prior finding's location -- never re-flag a finding that's already resolved.
+1. Read existing GitHub review comments and reviews with `mcp__slack-bot__github_read_pr_review_state` / `gh pr view` before making new comments. Fetch and check the *current* state of the code at each prior finding's location -- never re-flag a finding that's already resolved. Never use raw `gh api`; its repeatable method flags cannot be constrained safely by a shell prefix allowlist.
 2. Do not duplicate issues already raised. If a previous blocker/warning is still present, reply/update in that existing thread when possible; otherwise mention that it is still unresolved in the verdict.
 3. Review only newly pushed commits and the code paths needed to verify prior findings. Do not re-review unchanged code from scratch unless the previous review state is unavailable or the diff has been rebased so heavily that the old comments no longer map.
 4. If all previous blocker/warning items are fixed, still run the normal clean-pass approval rule: two consecutive clean passes before `approved`.
@@ -94,9 +94,13 @@ Two outputs, always -- never just one.
 **1. Inline GitHub comments** on specific lines. Post them through
 `mcp__slack-bot__github_post_review`, pinned to the full head SHA. Use a stable
 idempotency key derived from the PR number, head SHA, and review pass. The tool
-submits a COMMENT review and verifies that every inline comment landed; it is
-the review agent's only GitHub write surface. Do not use `gh` or `gh api` for
-GitHub writes. Severity:
+submits a COMMENT review and verifies that every inline comment landed; require
+its `inlineComments` to equal the number submitted. Use
+`mcp__slack-bot__github_read_pr_review_state` with the returned `reviewId` for
+an independent GET-only count of that exact review's inline comments when
+needed. The post tool is the review
+agent's only GitHub write surface. Do not use `gh` or `gh api` for GitHub writes.
+Severity:
 
 - **blocker** -- Must fix before merge. Bugs, security issues, data loss risks.
 - **warning** -- Should fix. Pattern violations, performance concerns, missing edge cases.

--- a/.claude/agents/review.md
+++ b/.claude/agents/review.md
@@ -1,7 +1,7 @@
 ---
 name: review
 description: Code reviewer. Use for PR reviews, code quality checks, security audits.
-tools: Read, Write, Grep, Glob, Bash(git *), Bash(gh *), mcp__slack-bot__github_post_review, mcp__slack-bot__slack_send_message, mcp__slack-bot__slack_read_thread, mcp__slack-bot__register_worktree, mcp__slack-bot__memory_recall, mcp__slack-bot__memory_add
+tools: Read, Grep, Glob, mcp__slack-bot__github_post_review, mcp__slack-bot__slack_send_message, mcp__slack-bot__slack_read_thread, mcp__slack-bot__register_worktree, mcp__slack-bot__memory_recall, mcp__slack-bot__memory_add
 permissions.intent: read-only
 common: core,merge-workflow,runtime-environment
 context.threadHistory: true
@@ -70,6 +70,12 @@ Use the worktree to:
 - trace imports, callers, services, middleware, schemas, and database access
 - verify whether changed function signatures break callers
 - run focused checks when they are needed to confirm a finding
+
+Verification commands are intentionally limited to test/typecheck/lint/build
+scripts for the repository's package manager (npm for most product repos, pnpm
+for gx-client-expo, Bun for Junior) plus read-only git/PR inspection. Tests may
+write caches and generated output inside the disposable worktree. Never install
+dependencies, edit source, commit, push, publish, or deploy.
 
 ## Re-review behavior
 

--- a/.claude/agents/review.md
+++ b/.claude/agents/review.md
@@ -81,7 +81,7 @@ install dependencies, edit source, commit, push, publish, or deploy.
 
 When re-reviewing a PR:
 
-1. Read existing GitHub review comments and reviews with `gh api` / `gh pr view` before making new comments. Fetch and check the *current* state of the code at each prior finding's location -- never re-flag a finding that's already resolved.
+1. Read existing GitHub review comments and reviews with `gh api --method GET` / `gh pr view` before making new comments. Fetch and check the *current* state of the code at each prior finding's location -- never re-flag a finding that's already resolved.
 2. Do not duplicate issues already raised. If a previous blocker/warning is still present, reply/update in that existing thread when possible; otherwise mention that it is still unresolved in the verdict.
 3. Review only newly pushed commits and the code paths needed to verify prior findings. Do not re-review unchanged code from scratch unless the previous review state is unavailable or the diff has been rebased so heavily that the old comments no longer map.
 4. If all previous blocker/warning items are fixed, still run the normal clean-pass approval rule: two consecutive clean passes before `approved`.

--- a/docs/features/agent-product-debugging-pipeline-implementation-plan.md
+++ b/docs/features/agent-product-debugging-pipeline-implementation-plan.md
@@ -832,6 +832,35 @@ Rollback:
 - version action payloads so old buttons fail closed with “action no longer available”;
 - keep review-triggered cleanup disabled under every rollback.
 
+## Pipeline settlement incident: Claude max-turn exit
+
+The July 20 failure in Slack thread `1784535599.540009` was not 25 separate
+errors. Claude used all 25 configured agentic turns and emitted
+`result.subtype=error_max_turns` with process exit code 0 immediately after
+discovering the PR-registration and outcome tools. Junior discarded the result
+subtype, treated exit 0 as success, posted the last intention sentence, and
+marked the builder settled even though the exact assignment had no typed
+outcome. The delivered outbox row therefore had no settlement acknowledgement
+and no restart path.
+
+The required invariant is now: a pipeline invocation is settled only when its
+exact assignment gains a new durable typed outcome after that dispatch (or the
+run/assignment becomes terminal). Each dispatch carries a trusted run id,
+assignment id, dispatch key, and outcome-count baseline. A missing outcome
+quietly resumes the same provider session up to two times; a committed outcome
+wins even if the provider reaches its turn cap immediately afterward. Exhaustion
+records one idempotent `needs-human` escalation and posts one concise Slack
+failure. Startup and periodic reconciliation re-wake delivered assignments whose
+runners disappeared, using the same bounded budget. Long pipelines remain
+unbounded across typed `continue_self` and handoff assignments; the bound is per
+assignment invocation, preventing runaway recovery chatter.
+
+Product starts also carry an optional explicit `required_workstreams` list.
+Repository identity is the fallback before objective keywords, so a frontend
+repository does not become a full-stack build merely because the request says
+the backend already supports the feature. Explicit two-stream starts create and
+dispatch both backend and frontend assignments idempotently.
+
 ## Audit-to-phase coverage
 
 | Audit finding | Owning phase(s) | Proof of completion |

--- a/src/agents/manifest.ts
+++ b/src/agents/manifest.ts
@@ -62,6 +62,7 @@ export type AgentCapability =
   | "browser-read"
   | "pipeline-artifact-write"
   | "pipeline-run-start"
+  | "worktree-verify"
   | "worktree-mutate"
   | "dispatch"
   | "orchestrate";
@@ -253,6 +254,7 @@ export const TRUSTED_AGENT_CATALOG: readonly AgentManifest[] = [
       "github-review-read",
       "github-review-comment",
       "pipeline-artifact-write",
+      "worktree-verify",
     ],
     // No product-code edits or push.
     mutationPolicy: "none",

--- a/src/agents/provider-parity.test.ts
+++ b/src/agents/provider-parity.test.ts
@@ -246,7 +246,9 @@ describe("provider parity — prompt body soft budget", () => {
 
   it("routes reviewer GitHub writes through the scoped MCP tool", async () => {
     const review = await fs.readFile(path.join(agentsDir, "review.md"), "utf-8");
+    expect(review).toContain("mcp__slack-bot__github_read_pr_review_state");
     expect(review).toContain("mcp__slack-bot__github_post_review");
+    expect(review).toMatch(/Never use raw `gh api`/);
     expect(review).toMatch(/Do not use `gh` or `gh api` for\s+GitHub writes/);
   });
 });

--- a/src/agents/registry.test.ts
+++ b/src/agents/registry.test.ts
@@ -193,6 +193,8 @@ describe("capabilities", () => {
     expect(checkCapability("build", "merge").ok).toBe(false);
     expect(hasCapability("build", "worktree-mutate")).toBe(true);
     expect(hasCapability("review", "worktree-mutate")).toBe(false);
+    expect(hasCapability("review", "worktree-verify")).toBe(true);
+    expect(hasCapability("reproducer", "worktree-verify")).toBe(false);
   });
 
   it("grants pipeline starts only to trusted orchestrators", () => {

--- a/src/agents/verification.test.ts
+++ b/src/agents/verification.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "bun:test";
+import { worktreeVerificationCommandPatterns } from "./verification.ts";
+
+describe("worktreeVerificationCommandPatterns", () => {
+  it.each(["npm", "pnpm", "bun"] as const)(
+    "emits verification commands only for detected %s",
+    (manager) => {
+      const patterns = worktreeVerificationCommandPatterns(manager);
+      expect(patterns).toContain(`${manager} test`);
+      expect(patterns).toContain(`${manager} run typecheck`);
+      expect(patterns).toContain("git diff *");
+      for (const other of ["npm", "pnpm", "bun"] as const) {
+        if (other !== manager) {
+          expect(patterns).not.toContain(`${other} test`);
+        }
+      }
+      expect(patterns.some((pattern) => pattern.includes("install"))).toBe(false);
+      expect(patterns.some((pattern) => pattern.includes("publish"))).toBe(false);
+    },
+  );
+});
+

--- a/src/agents/verification.test.ts
+++ b/src/agents/verification.test.ts
@@ -9,6 +9,11 @@ describe("worktreeVerificationCommandPatterns", () => {
       expect(patterns).toContain(`${manager} test`);
       expect(patterns).toContain(`${manager} run typecheck`);
       expect(patterns).toContain("git diff *");
+      expect(patterns).toContain("git blame *");
+      expect(patterns).toContain("gh pr list *");
+      expect(patterns).toContain("gh api --method GET *");
+      expect(patterns).not.toContain("gh api *");
+      expect(patterns).not.toContain(`${manager} run test:* *`);
       for (const other of ["npm", "pnpm", "bun"] as const) {
         if (other !== manager) {
           expect(patterns).not.toContain(`${other} test`);
@@ -19,4 +24,3 @@ describe("worktreeVerificationCommandPatterns", () => {
     },
   );
 });
-

--- a/src/agents/verification.test.ts
+++ b/src/agents/verification.test.ts
@@ -11,8 +11,8 @@ describe("worktreeVerificationCommandPatterns", () => {
       expect(patterns).toContain("git diff *");
       expect(patterns).toContain("git blame *");
       expect(patterns).toContain("gh pr list *");
-      expect(patterns).toContain("gh api --method GET *");
-      expect(patterns).not.toContain("gh api *");
+      expect(patterns.some((pattern) => pattern.startsWith("gh api"))).toBe(false);
+      expect(patterns).not.toContain("gh pr checkout *");
       expect(patterns).not.toContain(`${manager} run test:* *`);
       for (const other of ["npm", "pnpm", "bun"] as const) {
         if (other !== manager) {

--- a/src/agents/verification.ts
+++ b/src/agents/verification.ts
@@ -1,0 +1,73 @@
+/**
+ * Shell commands a read-only reviewer may execute inside a Junior-managed
+ * worktree. These are verification commands only: no dependency installation,
+ * publishing, product-code edits, commits, or pushes.
+ *
+ * Repositories currently use npm by default, pnpm for gx-client-expo, and Bun
+ * for Junior itself. Keep the patterns provider-neutral; Claude wraps them in
+ * `Bash(...)` while OpenCode uses them as granular bash permission rules.
+ */
+export const WORKTREE_VERIFICATION_COMMAND_PATTERNS = [
+  // Read-only repository and PR inspection.
+  "git status",
+  "git status *",
+  "git diff",
+  "git diff *",
+  "git show *",
+  "git log *",
+  "git rev-parse *",
+  "git merge-base *",
+  "git branch --show-current",
+  "git ls-files *",
+  "git fetch *",
+  "gh pr view *",
+  "gh pr diff *",
+  "gh pr checks *",
+  "gh pr checkout *",
+
+  // npm repositories.
+  "npm test",
+  "npm test *",
+  "npm run test",
+  "npm run test *",
+  "npm run test:*",
+  "npm run test:* *",
+  "npm run typecheck",
+  "npm run typecheck *",
+  "npm run lint",
+  "npm run lint *",
+  "npm run build",
+  "npm run build *",
+  "npm run check",
+  "npm run check *",
+  // gx-client-expo.
+  "pnpm test",
+  "pnpm test *",
+  "pnpm run test",
+  "pnpm run test *",
+  "pnpm run test:*",
+  "pnpm run test:* *",
+  "pnpm run typecheck",
+  "pnpm run typecheck *",
+  "pnpm run lint",
+  "pnpm run lint *",
+  "pnpm run build",
+  "pnpm run build *",
+  "pnpm run check",
+  "pnpm run check *",
+  // Junior.
+  "bun test",
+  "bun test *",
+  "bun run test",
+  "bun run test *",
+  "bun run test:*",
+  "bun run test:* *",
+  "bun run typecheck",
+  "bun run typecheck *",
+  "bun run lint",
+  "bun run lint *",
+  "bun run build",
+  "bun run build *",
+  "bun run check",
+  "bun run check *",
+] as const;

--- a/src/agents/verification.ts
+++ b/src/agents/verification.ts
@@ -1,14 +1,7 @@
-/**
- * Shell commands a read-only reviewer may execute inside a Junior-managed
- * worktree. These are verification commands only: no dependency installation,
- * publishing, product-code edits, commits, or pushes.
- *
- * Repositories currently use npm by default, pnpm for gx-client-expo, and Bun
- * for Junior itself. Keep the patterns provider-neutral; Claude wraps them in
- * `Bash(...)` while OpenCode uses them as granular bash permission rules.
- */
-export const WORKTREE_VERIFICATION_COMMAND_PATTERNS = [
-  // Read-only repository and PR inspection.
+import type { JavaScriptPackageManager } from "../worktree/package-manager.ts";
+
+/** Read-only repository and PR inspection available to every reviewer. */
+const REVIEW_INSPECTION_COMMAND_PATTERNS = [
   "git status",
   "git status *",
   "git diff",
@@ -24,50 +17,41 @@ export const WORKTREE_VERIFICATION_COMMAND_PATTERNS = [
   "gh pr diff *",
   "gh pr checks *",
   "gh pr checkout *",
-
-  // npm repositories.
-  "npm test",
-  "npm test *",
-  "npm run test",
-  "npm run test *",
-  "npm run test:*",
-  "npm run test:* *",
-  "npm run typecheck",
-  "npm run typecheck *",
-  "npm run lint",
-  "npm run lint *",
-  "npm run build",
-  "npm run build *",
-  "npm run check",
-  "npm run check *",
-  // gx-client-expo.
-  "pnpm test",
-  "pnpm test *",
-  "pnpm run test",
-  "pnpm run test *",
-  "pnpm run test:*",
-  "pnpm run test:* *",
-  "pnpm run typecheck",
-  "pnpm run typecheck *",
-  "pnpm run lint",
-  "pnpm run lint *",
-  "pnpm run build",
-  "pnpm run build *",
-  "pnpm run check",
-  "pnpm run check *",
-  // Junior.
-  "bun test",
-  "bun test *",
-  "bun run test",
-  "bun run test *",
-  "bun run test:*",
-  "bun run test:* *",
-  "bun run typecheck",
-  "bun run typecheck *",
-  "bun run lint",
-  "bun run lint *",
-  "bun run build",
-  "bun run build *",
-  "bun run check",
-  "bun run check *",
 ] as const;
+
+const VERIFICATION_SCRIPTS = [
+  "test",
+  "typecheck",
+  "lint",
+  "build",
+  "check",
+] as const;
+
+/**
+ * Build the shell allowlist for the package manager detected from the active
+ * worktree. No repository names or organization-specific mappings belong in
+ * this policy layer.
+ */
+export function worktreeVerificationCommandPatterns(
+  packageManager: JavaScriptPackageManager,
+): string[] {
+  const commands: string[] = [...REVIEW_INSPECTION_COMMAND_PATTERNS];
+
+  for (const script of VERIFICATION_SCRIPTS) {
+    if (script === "test") {
+      commands.push(`${packageManager} test`, `${packageManager} test *`);
+    }
+    commands.push(
+      `${packageManager} run ${script}`,
+      `${packageManager} run ${script} *`,
+    );
+    if (script === "test") {
+      commands.push(
+        `${packageManager} run test:*`,
+        `${packageManager} run test:* *`,
+      );
+    }
+  }
+
+  return commands;
+}

--- a/src/agents/verification.ts
+++ b/src/agents/verification.ts
@@ -13,8 +13,6 @@ const REVIEW_SAFE_INSPECTION_COMMAND_PATTERNS = [
   "git branch --show-current",
   "git blame *",
   "git ls-files *",
-  "gh api --method GET *",
-  "gh api -X GET *",
   "gh pr list *",
   "gh pr view *",
   "gh pr diff *",
@@ -24,7 +22,6 @@ const REVIEW_SAFE_INSPECTION_COMMAND_PATTERNS = [
 /** Commands that change refs/files and therefore require an isolated worktree. */
 const REVIEW_WORKTREE_INSPECTION_COMMAND_PATTERNS = [
   "git fetch *",
-  "gh pr checkout *",
 ] as const;
 
 const VERIFICATION_SCRIPTS = [

--- a/src/agents/verification.ts
+++ b/src/agents/verification.ts
@@ -1,7 +1,7 @@
 import type { JavaScriptPackageManager } from "../worktree/package-manager.ts";
 
-/** Read-only repository and PR inspection available to every reviewer. */
-const REVIEW_INSPECTION_COMMAND_PATTERNS = [
+/** Non-mutating repository and PR inspection safe in any reviewer cwd. */
+const REVIEW_SAFE_INSPECTION_COMMAND_PATTERNS = [
   "git status",
   "git status *",
   "git diff",
@@ -11,11 +11,19 @@ const REVIEW_INSPECTION_COMMAND_PATTERNS = [
   "git rev-parse *",
   "git merge-base *",
   "git branch --show-current",
+  "git blame *",
   "git ls-files *",
-  "git fetch *",
+  "gh api --method GET *",
+  "gh api -X GET *",
+  "gh pr list *",
   "gh pr view *",
   "gh pr diff *",
   "gh pr checks *",
+] as const;
+
+/** Commands that change refs/files and therefore require an isolated worktree. */
+const REVIEW_WORKTREE_INSPECTION_COMMAND_PATTERNS = [
+  "git fetch *",
   "gh pr checkout *",
 ] as const;
 
@@ -35,7 +43,7 @@ const VERIFICATION_SCRIPTS = [
 export function worktreeVerificationCommandPatterns(
   packageManager: JavaScriptPackageManager,
 ): string[] {
-  const commands: string[] = [...REVIEW_INSPECTION_COMMAND_PATTERNS];
+  const commands = worktreeInspectionCommandPatterns();
 
   for (const script of VERIFICATION_SCRIPTS) {
     if (script === "test") {
@@ -48,10 +56,22 @@ export function worktreeVerificationCommandPatterns(
     if (script === "test") {
       commands.push(
         `${packageManager} run test:*`,
-        `${packageManager} run test:* *`,
       );
     }
   }
 
   return commands;
+}
+
+/** Repository/PR inspection that remains useful without JS package metadata. */
+export function worktreeInspectionCommandPatterns(): string[] {
+  return [
+    ...REVIEW_SAFE_INSPECTION_COMMAND_PATTERNS,
+    ...REVIEW_WORKTREE_INSPECTION_COMMAND_PATTERNS,
+  ];
+}
+
+/** Read-only inspection for reviews without a registered worktree. */
+export function reviewInspectionCommandPatterns(): string[] {
+  return [...REVIEW_SAFE_INSPECTION_COMMAND_PATTERNS];
 }

--- a/src/claude/policy.test.ts
+++ b/src/claude/policy.test.ts
@@ -143,6 +143,48 @@ describe("mapClaudeRunPolicy", () => {
     );
   });
 
+  test("review may run allowlisted checks only in a registered worktree", () => {
+    const session = createSession("t", "c");
+    session.activeAgentName = "review";
+    session.worktreePath = "/repo/.junior-worktrees/review";
+    session.worktreePaths = {
+      backend: "/repo/.junior-worktrees/review",
+      expo: "/expo/.junior-worktrees/review",
+    };
+    session.agentPermissions = {
+      intent: "read-only",
+      mcp: [],
+      tools: ["Read", "Write", "Bash(git *)"],
+    };
+
+    const policy = mapClaudeRunPolicy({
+      config,
+      session,
+      cwd: session.worktreePath,
+    });
+
+    expect(policy.permissionMode).toBe("default");
+    expect(policy.allowedTools).toContain("Bash(npm test *)");
+    expect(policy.allowedTools).toContain("Bash(pnpm test *)");
+    expect(policy.allowedTools).toContain("Bash(bun test *)");
+    expect(policy.allowedTools).not.toContain("Bash(git *)");
+    expect(policy.allowedTools).not.toContain("Write");
+    expect(policy.disallowedTools).toContain("Write");
+    expect(policy.addDirs).toContain("/expo/.junior-worktrees/review");
+  });
+
+  test("review stays in plan mode when cwd is not a registered worktree", () => {
+    const session = createSession("t", "c");
+    session.activeAgentName = "review";
+    session.worktreePath = "/registered-worktree";
+    session.agentPermissions = { intent: "read-only", mcp: [], tools: ["Read"] };
+
+    const policy = mapClaudeRunPolicy({ config, session, cwd: "/shared-repo" });
+
+    expect(policy.permissionMode).toBe("plan");
+    expect(policy.allowedTools).not.toContain("Bash(npm test *)");
+  });
+
   test("does not grant the review-comment write surface to other read-only roles", () => {
     const session = createSession("t", "c");
     session.activeAgentName = "reproducer";

--- a/src/claude/policy.test.ts
+++ b/src/claude/policy.test.ts
@@ -207,7 +207,8 @@ describe("mapClaudeRunPolicy", () => {
     expect(policy.permissionMode).toBe("default");
     expect(policy.allowedTools).toContain("Bash(git blame *)");
     expect(policy.allowedTools).toContain("Bash(gh pr list *)");
-    expect(policy.allowedTools).toContain("Bash(gh api --method GET *)");
+    expect(policy.allowedTools.some((tool) => tool.startsWith("Bash(gh api"))).toBe(false);
+    expect(policy.allowedTools).not.toContain("Bash(gh pr checkout *)");
     expect(policy.allowedTools).not.toContain("Bash(npm test *)");
   });
 

--- a/src/claude/policy.test.ts
+++ b/src/claude/policy.test.ts
@@ -22,7 +22,7 @@ function sessionWith(
 }
 
 describe("mapClaudeRunPolicy", () => {
-  test("read-only locks down writes and uses plan mode", () => {
+  test("generic read-only locks down writes and uses plan mode", () => {
     const session = sessionWith({
       intent: "read-only",
       mcp: [],
@@ -135,12 +135,14 @@ describe("mapClaudeRunPolicy", () => {
 
     const policy = mapClaudeRunPolicy({ config, session, cwd: "/repo" });
 
-    expect(policy.permissionMode).toBe("plan");
+    expect(policy.permissionMode).toBe("default");
     expect(policy.disallowedTools).toContain("Edit");
     expect(policy.disallowedTools).toContain("Write");
     expect(policy.allowedTools).toContain(
       "mcp__slack-bot__github_post_review",
     );
+    expect(policy.allowedTools).toContain("Bash(gh pr view *)");
+    expect(policy.allowedTools).not.toContain("Bash(git fetch *)");
   });
 
   test("review may run allowlisted checks only in a registered worktree", () => {
@@ -174,7 +176,7 @@ describe("mapClaudeRunPolicy", () => {
     expect(policy.addDirs).toContain("/expo/.junior-worktrees/review");
   });
 
-  test("review stays in plan mode when cwd is not a registered worktree", () => {
+  test("review gets safe inspection only when cwd is not a registered worktree", () => {
     const session = createSession("t", "c");
     session.activeAgentName = "review";
     session.worktreePath = "/registered-worktree";
@@ -183,11 +185,14 @@ describe("mapClaudeRunPolicy", () => {
 
     const policy = mapClaudeRunPolicy({ config, session, cwd: "/shared-repo" });
 
-    expect(policy.permissionMode).toBe("plan");
+    expect(policy.permissionMode).toBe("default");
+    expect(policy.allowedTools).toContain("Bash(gh pr view *)");
+    expect(policy.allowedTools).not.toContain("Bash(git fetch *)");
+    expect(policy.allowedTools).not.toContain("Bash(gh pr checkout *)");
     expect(policy.allowedTools).not.toContain("Bash(npm test *)");
   });
 
-  test("review stays in plan mode when package-manager metadata is ambiguous", () => {
+  test("review keeps inspection tools when package-manager metadata is ambiguous", () => {
     const session = createSession("t", "c");
     session.activeAgentName = "review";
     session.worktreePath = "/registered-worktree";
@@ -199,7 +204,10 @@ describe("mapClaudeRunPolicy", () => {
       cwd: session.worktreePath,
     });
 
-    expect(policy.permissionMode).toBe("plan");
+    expect(policy.permissionMode).toBe("default");
+    expect(policy.allowedTools).toContain("Bash(git blame *)");
+    expect(policy.allowedTools).toContain("Bash(gh pr list *)");
+    expect(policy.allowedTools).toContain("Bash(gh api --method GET *)");
     expect(policy.allowedTools).not.toContain("Bash(npm test *)");
   });
 
@@ -235,7 +243,7 @@ describe("mapClaudeRunPolicy", () => {
 
     const policy = mapClaudeRunPolicy({ config, session, cwd: "/repo" });
 
-    expect(policy.permissionMode).toBe("plan");
+    expect(policy.permissionMode).toBe("default");
     expect(policy.disallowedTools).toContain("Edit");
   });
 

--- a/src/claude/policy.test.ts
+++ b/src/claude/policy.test.ts
@@ -151,6 +151,7 @@ describe("mapClaudeRunPolicy", () => {
       backend: "/repo/.junior-worktrees/review",
       expo: "/expo/.junior-worktrees/review",
     };
+    session.verificationPackageManager = "pnpm";
     session.agentPermissions = {
       intent: "read-only",
       mcp: [],
@@ -164,9 +165,9 @@ describe("mapClaudeRunPolicy", () => {
     });
 
     expect(policy.permissionMode).toBe("default");
-    expect(policy.allowedTools).toContain("Bash(npm test *)");
     expect(policy.allowedTools).toContain("Bash(pnpm test *)");
-    expect(policy.allowedTools).toContain("Bash(bun test *)");
+    expect(policy.allowedTools).not.toContain("Bash(npm test *)");
+    expect(policy.allowedTools).not.toContain("Bash(bun test *)");
     expect(policy.allowedTools).not.toContain("Bash(git *)");
     expect(policy.allowedTools).not.toContain("Write");
     expect(policy.disallowedTools).toContain("Write");
@@ -177,9 +178,26 @@ describe("mapClaudeRunPolicy", () => {
     const session = createSession("t", "c");
     session.activeAgentName = "review";
     session.worktreePath = "/registered-worktree";
+    session.verificationPackageManager = "npm";
     session.agentPermissions = { intent: "read-only", mcp: [], tools: ["Read"] };
 
     const policy = mapClaudeRunPolicy({ config, session, cwd: "/shared-repo" });
+
+    expect(policy.permissionMode).toBe("plan");
+    expect(policy.allowedTools).not.toContain("Bash(npm test *)");
+  });
+
+  test("review stays in plan mode when package-manager metadata is ambiguous", () => {
+    const session = createSession("t", "c");
+    session.activeAgentName = "review";
+    session.worktreePath = "/registered-worktree";
+    session.agentPermissions = { intent: "read-only", mcp: [], tools: ["Read"] };
+
+    const policy = mapClaudeRunPolicy({
+      config,
+      session,
+      cwd: session.worktreePath,
+    });
 
     expect(policy.permissionMode).toBe("plan");
     expect(policy.allowedTools).not.toContain("Bash(npm test *)");

--- a/src/claude/policy.ts
+++ b/src/claude/policy.ts
@@ -94,6 +94,11 @@ export function mapClaudeRunPolicy(options: {
 
   if (intent === "read-only") {
     if (mayInspect) {
+      // Review runs in `default`, not `plan`, so this allowlist is the primary
+      // shell boundary: declared Bash specs are stripped, every generated
+      // pattern comes from trusted constants, and ref/file mutations are
+      // admitted only for an exact registered-worktree cwd. Keep
+      // READ_ONLY_DISALLOWED as defense in depth, never as the sole gate.
       const readOnlyDeclaredTools = declaredTools.filter(
         (tool) => !isMutatingToolSpec(tool),
       );

--- a/src/claude/policy.ts
+++ b/src/claude/policy.ts
@@ -5,7 +5,7 @@ import {
 } from "../agents/loader.ts";
 import type { ThreadSession } from "../session/types.ts";
 import { hasCapability } from "../agents/capabilities.ts";
-import { WORKTREE_VERIFICATION_COMMAND_PATTERNS } from "../agents/verification.ts";
+import { worktreeVerificationCommandPatterns } from "../agents/verification.ts";
 import { GITHUB_POST_REVIEW_TOOL } from "../github/review-comments.ts";
 
 /**
@@ -87,16 +87,17 @@ export function mapClaudeRunPolicy(options: {
   ].filter((root): root is string => Boolean(root));
   const mayVerifyWorktree =
     hasCapability(agentName, "worktree-verify") &&
-    worktreeRoots.includes(cwd);
+    worktreeRoots.includes(cwd) &&
+    Boolean(session.verificationPackageManager);
 
   if (intent === "read-only") {
     if (mayVerifyWorktree) {
       const readOnlyDeclaredTools = declaredTools.filter(
         (tool) => !isMutatingToolSpec(tool),
       );
-      const verificationTools = WORKTREE_VERIFICATION_COMMAND_PATTERNS.map(
-        (pattern) => `Bash(${pattern})`,
-      );
+      const verificationTools = worktreeVerificationCommandPatterns(
+        session.verificationPackageManager!,
+      ).map((pattern) => `Bash(${pattern})`);
       return {
         // Headless default mode denies commands that are neither explicitly
         // allowed nor approved. Review has no approval round-trip, so this is

--- a/src/claude/policy.ts
+++ b/src/claude/policy.ts
@@ -5,6 +5,7 @@ import {
 } from "../agents/loader.ts";
 import type { ThreadSession } from "../session/types.ts";
 import { hasCapability } from "../agents/capabilities.ts";
+import { WORKTREE_VERIFICATION_COMMAND_PATTERNS } from "../agents/verification.ts";
 import { GITHUB_POST_REVIEW_TOOL } from "../github/review-comments.ts";
 
 /**
@@ -80,8 +81,43 @@ export function mapClaudeRunPolicy(options: {
   )
     ? [GITHUB_POST_REVIEW_TOOL]
     : [];
+  const worktreeRoots = [
+    session.worktreePath,
+    ...Object.values(session.worktreePaths ?? {}),
+  ].filter((root): root is string => Boolean(root));
+  const mayVerifyWorktree =
+    hasCapability(agentName, "worktree-verify") &&
+    worktreeRoots.includes(cwd);
 
   if (intent === "read-only") {
+    if (mayVerifyWorktree) {
+      const readOnlyDeclaredTools = declaredTools.filter(
+        (tool) => !isMutatingToolSpec(tool),
+      );
+      const verificationTools = WORKTREE_VERIFICATION_COMMAND_PATTERNS.map(
+        (pattern) => `Bash(${pattern})`,
+      );
+      return {
+        // Headless default mode denies commands that are neither explicitly
+        // allowed nor approved. Review has no approval round-trip, so this is
+        // a strict allowlist rather than a route to arbitrary shell.
+        permissionMode: "default",
+        allowedTools: [
+          ...new Set([
+            ...readOnlyDeclaredTools,
+            ...capabilityTools,
+            ...verificationTools,
+          ]),
+        ],
+        disallowedTools: [...READ_ONLY_DISALLOWED],
+        addDirs: [
+          ...new Set([
+            cwd,
+            ...worktreeRoots,
+          ]),
+        ],
+      };
+    }
     // Critical safety case: review / reproducer-validation agents must not
     // be able to mutate the worktree. `plan` mode is the ACTUAL gate — it
     // blocks edits and write-Bash wholesale; the deny list below is

--- a/src/claude/policy.ts
+++ b/src/claude/policy.ts
@@ -5,7 +5,11 @@ import {
 } from "../agents/loader.ts";
 import type { ThreadSession } from "../session/types.ts";
 import { hasCapability } from "../agents/capabilities.ts";
-import { worktreeVerificationCommandPatterns } from "../agents/verification.ts";
+import {
+  reviewInspectionCommandPatterns,
+  worktreeInspectionCommandPatterns,
+  worktreeVerificationCommandPatterns,
+} from "../agents/verification.ts";
 import { GITHUB_POST_REVIEW_TOOL } from "../github/review-comments.ts";
 
 /**
@@ -85,19 +89,24 @@ export function mapClaudeRunPolicy(options: {
     session.worktreePath,
     ...Object.values(session.worktreePaths ?? {}),
   ].filter((root): root is string => Boolean(root));
-  const mayVerifyWorktree =
-    hasCapability(agentName, "worktree-verify") &&
-    worktreeRoots.includes(cwd) &&
-    Boolean(session.verificationPackageManager);
+  const mayInspect = hasCapability(agentName, "worktree-verify");
+  const hasRegisteredWorktreeCwd = worktreeRoots.includes(cwd);
 
   if (intent === "read-only") {
-    if (mayVerifyWorktree) {
+    if (mayInspect) {
       const readOnlyDeclaredTools = declaredTools.filter(
         (tool) => !isMutatingToolSpec(tool),
       );
-      const verificationTools = worktreeVerificationCommandPatterns(
-        session.verificationPackageManager!,
-      ).map((pattern) => `Bash(${pattern})`);
+      const commandPatterns = hasRegisteredWorktreeCwd && session.verificationPackageManager
+        ? worktreeVerificationCommandPatterns(
+            session.verificationPackageManager,
+          )
+        : hasRegisteredWorktreeCwd
+          ? worktreeInspectionCommandPatterns()
+          : reviewInspectionCommandPatterns();
+      const verificationTools = commandPatterns.map(
+        (pattern) => `Bash(${pattern})`,
+      );
       return {
         // Headless default mode denies commands that are neither explicitly
         // allowed nor approved. Review has no approval round-trip, so this is
@@ -111,12 +120,9 @@ export function mapClaudeRunPolicy(options: {
           ]),
         ],
         disallowedTools: [...READ_ONLY_DISALLOWED],
-        addDirs: [
-          ...new Set([
-            cwd,
-            ...worktreeRoots,
-          ]),
-        ],
+        addDirs: hasRegisteredWorktreeCwd
+          ? [...new Set([cwd, ...worktreeRoots])]
+          : [],
       };
     }
     // Critical safety case: review / reproducer-validation agents must not

--- a/src/claude/spawner.test.ts
+++ b/src/claude/spawner.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "bun:test";
 import { createSession } from "../session/types.ts";
-import { shouldUseClaudeMcpConfig } from "./spawner.ts";
+import {
+  classifyClaudeCompletion,
+  shouldUseClaudeMcpConfig,
+} from "./spawner.ts";
 
 describe("shouldUseClaudeMcpConfig", () => {
   it("keeps the utility cwd carve-out even when the agent declares MCP servers", () => {
@@ -22,5 +25,48 @@ describe("shouldUseClaudeMcpConfig", () => {
     const session = createSession("thread-1", "C01");
 
     expect(shouldUseClaudeMcpConfig(session, true)).toBe(true);
+  });
+});
+
+describe("classifyClaudeCompletion", () => {
+  it("does not treat error_max_turns with exit zero as success", () => {
+    expect(
+      classifyClaudeCompletion(
+        { type: "result", subtype: "error_max_turns", num_turns: 25 },
+        0,
+        null,
+      ),
+    ).toEqual({
+      status: "incomplete",
+      reason: "max_turns",
+      retryable: true,
+      providerSubtype: "error_max_turns",
+      turns: 25,
+    });
+  });
+
+  it("fails closed when Claude exits without a terminal result", () => {
+    expect(classifyClaudeCompletion(null, 0, null)).toEqual({
+      status: "incomplete",
+      reason: "missing_result",
+      retryable: true,
+    });
+  });
+
+  it("recognizes only an explicit success subtype as success", () => {
+    expect(
+      classifyClaudeCompletion(
+        { type: "result", subtype: "success", num_turns: 3 },
+        0,
+        null,
+      ).status,
+    ).toBe("success");
+    expect(
+      classifyClaudeCompletion(
+        { type: "result", subtype: "error_during_execution" },
+        0,
+        null,
+      ).status,
+    ).toBe("failure");
   });
 });

--- a/src/claude/spawner.test.ts
+++ b/src/claude/spawner.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import { createSession } from "../session/types.ts";
 import {
   classifyClaudeCompletion,
+  selectClaudeResponse,
   shouldUseClaudeMcpConfig,
 } from "./spawner.ts";
 
@@ -25,6 +26,20 @@ describe("shouldUseClaudeMcpConfig", () => {
     const session = createSession("thread-1", "C01");
 
     expect(shouldUseClaudeMcpConfig(session, true)).toBe(true);
+  });
+});
+
+describe("selectClaudeResponse", () => {
+  it("preserves the last assistant turn when an incomplete result has no text", () => {
+    expect(selectClaudeResponse("", "I finished the diagnosis before the cap.")).toBe(
+      "I finished the diagnosis before the cap.",
+    );
+  });
+
+  it("prefers provider result text when present", () => {
+    expect(selectClaudeResponse("final result", "earlier assistant text")).toBe(
+      "final result",
+    );
   });
 });
 

--- a/src/claude/spawner.ts
+++ b/src/claude/spawner.ts
@@ -4,7 +4,12 @@ import type { Config } from "../config.ts";
 import { resolveEffectivePermissionIntent } from "../agents/loader.ts";
 import type { AgentIdentity, ThreadSession } from "../session/types.ts";
 import type { ContentBlockToolUse, StreamEvent, StreamEventResult } from "./types.ts";
-import type { RunnerEvent, SpawnHandle, SpawnResult } from "../runners/types.ts";
+import type {
+  RunnerCompletion,
+  RunnerEvent,
+  SpawnHandle,
+  SpawnResult,
+} from "../runners/types.ts";
 import { buildRunnerRuntime } from "../runners/runtime.ts";
 import { buildClaudeArgs } from "./args.ts";
 import { createStreamParser } from "./parser.ts";
@@ -63,6 +68,8 @@ export function spawnClaude(
   let sessionId: string | null = null;
   let resultText = "";
   let lastAssistantText = "";
+  let terminalResult: StreamEventResult | null = null;
+  let streamError: string | null = null;
 
   const result = (async (): Promise<SpawnResult> => {
     const parser = createStreamParser();
@@ -98,6 +105,7 @@ export function spawnClaude(
           }
 
           if (event.type === "result") {
+            terminalResult = event;
             resultText = event.result ?? event.text ?? "";
           }
 
@@ -114,27 +122,41 @@ export function spawnClaude(
         }
       }
     } catch (err) {
+      streamError = err instanceof Error ? err.message : String(err);
       console.error("[spawner] Error reading stdout:", err);
     }
 
     const exitCode = await proc.exited;
 
-    let error: string | null = null;
+    let processError: string | null = streamError;
     if (exitCode !== 0) {
       try {
-        error = await new Response(proc.stderr).text();
+        processError = await new Response(proc.stderr).text();
       } catch {
-        error = `Process exited with code ${exitCode}`;
+        processError = `Process exited with code ${exitCode}`;
       }
     }
+
+    const completion = classifyClaudeCompletion(
+      terminalResult,
+      exitCode,
+      processError,
+    );
+    const error = completion.status === "success"
+      ? null
+      : claudeCompletionError(completion, processError);
 
     return {
       provider: "claude",
       sessionId,
-      response: resultText || lastAssistantText,
+      // An incomplete terminal result often follows an intention sentence such
+      // as "Now I will report the outcome". Never publish that as completion.
+      response:
+        completion.status === "success" ? resultText || lastAssistantText : "",
       events,
       exitCode,
       error,
+      completion,
     };
   })();
 
@@ -234,11 +256,79 @@ export function mapClaudeEvent(event: StreamEvent): RunnerEvent[] {
     }
     case "result": {
       const usage = claudeDoneUsage(event);
-      return [{ type: "done", provider: "claude", ...(usage ? { usage } : {}) }];
+      const completion = classifyClaudeCompletion(event, 0, null);
+      return [{
+        type: "done",
+        provider: "claude",
+        ...(usage ? { usage } : {}),
+        completion,
+      }];
     }
     default:
       return [];
   }
+}
+
+export function classifyClaudeCompletion(
+  event: StreamEventResult | null,
+  exitCode: number | null,
+  processError: string | null,
+): RunnerCompletion {
+  if (exitCode !== 0 || processError) {
+    return {
+      status: "failure",
+      reason: "process_error",
+      retryable: false,
+      ...(event?.subtype ? { providerSubtype: event.subtype } : {}),
+      ...(event?.num_turns != null ? { turns: event.num_turns } : {}),
+    };
+  }
+  if (!event) {
+    return {
+      status: "incomplete",
+      reason: "missing_result",
+      retryable: true,
+    };
+  }
+  if (event.subtype === "success") {
+    return {
+      status: "success",
+      reason: "completed",
+      retryable: false,
+      providerSubtype: event.subtype,
+      ...(event.num_turns != null ? { turns: event.num_turns } : {}),
+    };
+  }
+  if (event.subtype === "error_max_turns") {
+    return {
+      status: "incomplete",
+      reason: "max_turns",
+      retryable: true,
+      providerSubtype: event.subtype,
+      ...(event.num_turns != null ? { turns: event.num_turns } : {}),
+    };
+  }
+  return {
+    status: "failure",
+    reason: "provider_error",
+    retryable: false,
+    providerSubtype: event.subtype,
+    ...(event.num_turns != null ? { turns: event.num_turns } : {}),
+  };
+}
+
+function claudeCompletionError(
+  completion: RunnerCompletion,
+  processError: string | null,
+): string {
+  if (processError?.trim()) return processError.trim();
+  if (completion.reason === "max_turns") {
+    return `Claude reached its ${completion.turns ?? "configured"} turn limit before completing the invocation.`;
+  }
+  if (completion.reason === "missing_result") {
+    return "Claude exited without a terminal result event.";
+  }
+  return `Claude invocation failed (${completion.providerSubtype ?? completion.reason}).`;
 }
 
 function claudeDoneUsage(

--- a/src/claude/spawner.ts
+++ b/src/claude/spawner.ts
@@ -149,10 +149,10 @@ export function spawnClaude(
     return {
       provider: "claude",
       sessionId,
-      // An incomplete terminal result often follows an intention sentence such
-      // as "Now I will report the outcome". Never publish that as completion.
-      response:
-        completion.status === "success" ? resultText || lastAssistantText : "",
+      // Pipeline invocations suppress incomplete prose in the settlement
+      // layer. Ordinary turns still need their last useful assistant text when
+      // Claude reaches a turn cap or otherwise returns an incomplete result.
+      response: selectClaudeResponse(resultText, lastAssistantText),
       events,
       exitCode,
       error,
@@ -171,6 +171,13 @@ export function spawnClaude(
     },
     pid: proc.pid,
   };
+}
+
+export function selectClaudeResponse(
+  resultText: string,
+  lastAssistantText: string,
+): string {
+  return resultText || lastAssistantText;
 }
 
 export function shouldUseClaudeMcpConfig(

--- a/src/codex-app-server/policy.test.ts
+++ b/src/codex-app-server/policy.test.ts
@@ -64,6 +64,46 @@ describe("mapCodexRunPolicy", () => {
     });
   });
 
+  it("gives review workspace-write only inside registered worktrees", () => {
+    const session = createSession("t", "c");
+    session.activeAgentName = "review";
+    session.worktreePath = "/repo.junior-worktrees/slack-t";
+    session.worktreePaths = {
+      backend: "/repo.junior-worktrees/slack-t",
+      expo: "/expo.junior-worktrees/slack-t",
+    };
+    session.agentPermissions = { intent: "read-only", mcp: [], tools: [] };
+
+    expect(
+      mapCodexRunPolicy({ config, session, cwd: session.worktreePath }),
+    ).toEqual({
+      approvalPolicy: "never",
+      sandbox: "workspace-write",
+      sandboxPolicy: {
+        type: "workspaceWrite",
+        writableRoots: [
+          "/repo.junior-worktrees/slack-t",
+          "/expo.junior-worktrees/slack-t",
+        ],
+        networkAccess: false,
+        excludeTmpdirEnvVar: false,
+        excludeSlashTmp: false,
+      },
+      mcpAllowed: true,
+    });
+  });
+
+  it("does not widen review when cwd is outside the registered worktree", () => {
+    const session = createSession("t", "c");
+    session.activeAgentName = "review";
+    session.worktreePath = "/registered-worktree";
+    session.agentPermissions = { intent: "read-only", mcp: [], tools: [] };
+
+    expect(
+      mapCodexRunPolicy({ config, session, cwd: "/shared-repo" }),
+    ).toMatchObject({ sandbox: "read-only" });
+  });
+
   it("fails closed for no-tools agents", () => {
     const session = createSession("t", "c");
     session.agentPermissions = { intent: "no-tools", mcp: [], tools: [] };

--- a/src/codex-app-server/policy.test.ts
+++ b/src/codex-app-server/policy.test.ts
@@ -72,6 +72,7 @@ describe("mapCodexRunPolicy", () => {
       backend: "/repo.junior-worktrees/slack-t",
       expo: "/expo.junior-worktrees/slack-t",
     };
+    session.verificationPackageManager = "bun";
     session.agentPermissions = { intent: "read-only", mcp: [], tools: [] };
 
     expect(
@@ -97,6 +98,7 @@ describe("mapCodexRunPolicy", () => {
     const session = createSession("t", "c");
     session.activeAgentName = "review";
     session.worktreePath = "/registered-worktree";
+    session.verificationPackageManager = "npm";
     session.agentPermissions = { intent: "read-only", mcp: [], tools: [] };
 
     expect(

--- a/src/codex-app-server/policy.ts
+++ b/src/codex-app-server/policy.ts
@@ -4,6 +4,7 @@ import {
   type AgentPermissions,
 } from "../agents/loader.ts";
 import type { ThreadSession } from "../session/types.ts";
+import { hasCapability } from "../agents/capabilities.ts";
 
 export type CodexApprovalPolicy = "untrusted" | "on-request" | "never";
 export type CodexSandbox = "read-only" | "workspace-write" | "danger-full-access";
@@ -40,8 +41,28 @@ export function mapCodexRunPolicy(options: {
     permissions,
     session.activeAgentName ?? session.agentType,
   );
+  const agentName = session.activeAgentName ?? session.agentType;
+  const worktreeRoots = [
+    session.worktreePath,
+    ...Object.values(session.worktreePaths ?? {}),
+  ].filter((root): root is string => Boolean(root));
 
   if (intent === "read-only" || intent === "no-tools") {
+    if (
+      intent === "read-only" &&
+      hasCapability(agentName, "worktree-verify") &&
+      worktreeRoots.includes(cwd)
+    ) {
+      return {
+        // Tests need to write caches, coverage, and generated output. The cwd
+        // and every additional writable root are Junior-managed worktrees.
+        // Network remains disabled, so commit/push/release stays unavailable.
+        approvalPolicy: "never",
+        sandbox: "workspace-write",
+        sandboxPolicy: workspaceWritePolicy(cwd, worktreeRoots),
+        mcpAllowed: !session.cwd,
+      };
+    }
     return {
       approvalPolicy: "on-request",
       sandbox: "read-only",
@@ -90,10 +111,13 @@ export function sandboxPolicyFor(
   return workspaceWritePolicy(cwd);
 }
 
-function workspaceWritePolicy(cwd: string): CodexSandboxPolicy {
+function workspaceWritePolicy(
+  cwd: string,
+  additionalRoots: string[] = [],
+): CodexSandboxPolicy {
   return {
     type: "workspaceWrite",
-    writableRoots: [cwd],
+    writableRoots: [...new Set([cwd, ...additionalRoots])],
     networkAccess: false,
     excludeTmpdirEnvVar: false,
     excludeSlashTmp: false,

--- a/src/codex-app-server/policy.ts
+++ b/src/codex-app-server/policy.ts
@@ -51,7 +51,8 @@ export function mapCodexRunPolicy(options: {
     if (
       intent === "read-only" &&
       hasCapability(agentName, "worktree-verify") &&
-      worktreeRoots.includes(cwd)
+      worktreeRoots.includes(cwd) &&
+      Boolean(session.verificationPackageManager)
     ) {
       return {
         // Tests need to write caches, coverage, and generated output. The cwd

--- a/src/github/review-comments.test.ts
+++ b/src/github/review-comments.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import {
   postGitHubReview,
+  readGitHubReviewState,
   type GitHubApiRequest,
   type GitHubApiRunner,
   type GitHubReviewInput,
@@ -208,5 +209,128 @@ describe("postGitHubReview", () => {
       ok: false,
       reason: expect.stringContaining("verified 0 inline comments instead of 1"),
     });
+  });
+});
+
+describe("readGitHubReviewState", () => {
+  it("uses only fixed GET endpoints and returns bounded review state", async () => {
+    const { runner, calls } = scriptedRunner([
+      { body: { head: { sha: SHA } } },
+      {
+        body: [[{
+          id: 10,
+          user: { login: "reviewer" },
+          state: "COMMENTED",
+          body: "review body",
+          commit_id: SHA,
+          submitted_at: "2026-07-20T00:00:00Z",
+          html_url: "https://example.test/review/10",
+        }]],
+      },
+      {
+        body: [[{
+          id: 20,
+          user: { login: "reviewer" },
+          body: "inline finding",
+          path: "src/index.ts",
+          line: 12,
+          commit_id: SHA,
+          created_at: "2026-07-20T00:00:00Z",
+          html_url: "https://example.test/comment/20",
+        }]],
+      },
+    ]);
+
+    await expect(readGitHubReviewState(reviewContext, {
+      owner: "GrowthX-Club",
+      repo: "gx-backend",
+      prNumber: 123,
+    }, runner)).resolves.toMatchObject({
+      ok: true,
+      headSha: SHA,
+      reviewCount: 1,
+      inlineCommentCount: 1,
+      reviewIdFilter: null,
+      reviews: [{ author: "reviewer", body: "review body" }],
+      inlineComments: [{
+        author: "reviewer",
+        body: "inline finding",
+        path: "src/index.ts",
+        line: 12,
+      }],
+    });
+
+    expect(calls).toEqual([
+      {
+        method: "GET",
+        endpoint: "repos/GrowthX-Club/gx-backend/pulls/123",
+      },
+      {
+        method: "GET",
+        endpoint: "repos/GrowthX-Club/gx-backend/pulls/123/reviews?per_page=100",
+        paginate: true,
+      },
+      {
+        method: "GET",
+        endpoint: "repos/GrowthX-Club/gx-backend/pulls/123/comments?per_page=100",
+        paginate: true,
+      },
+    ]);
+    expect(calls.every((call) => call.method === "GET")).toBe(true);
+  });
+
+  it("can verify comments for one exact review id", async () => {
+    const { runner, calls } = scriptedRunner([
+      { body: { head: { sha: SHA } } },
+      { body: [[]] },
+      { body: [[{ id: 20 }]] },
+    ]);
+
+    await expect(readGitHubReviewState(reviewContext, {
+      owner: "GrowthX-Club",
+      repo: "gx-backend",
+      prNumber: 123,
+      reviewId: 99,
+    }, runner)).resolves.toMatchObject({
+      ok: true,
+      reviewIdFilter: 99,
+      inlineCommentCount: 1,
+    });
+    expect(calls[2]?.endpoint).toBe(
+      "repos/GrowthX-Club/gx-backend/pulls/123/reviews/99/comments?per_page=100",
+    );
+    expect(calls.every((call) => call.method === "GET")).toBe(true);
+  });
+
+  it("fails closed for unsigned, unauthorized, and invalid targets", async () => {
+    const never: GitHubApiRunner = async () => {
+      throw new Error("API should not be called");
+    };
+    const target = {
+      owner: "GrowthX-Club",
+      repo: "gx-backend",
+      prNumber: 123,
+    };
+
+    await expect(readGitHubReviewState(
+      { ...reviewContext, signed: false },
+      target,
+      never,
+    )).resolves.toEqual({ ok: false, reason: "signed MCP run context required" });
+    await expect(readGitHubReviewState(
+      { ...reviewContext, agent: "reproducer" },
+      target,
+      never,
+    )).resolves.toMatchObject({ ok: false });
+    await expect(readGitHubReviewState(
+      reviewContext,
+      { ...target, repo: "gx-backend --method POST" },
+      never,
+    )).resolves.toEqual({ ok: false, reason: "invalid GitHub repository" });
+    await expect(readGitHubReviewState(
+      reviewContext,
+      { ...target, reviewId: -1 },
+      never,
+    )).resolves.toEqual({ ok: false, reason: "reviewId must be a positive integer" });
   });
 });

--- a/src/github/review-comments.ts
+++ b/src/github/review-comments.ts
@@ -9,6 +9,10 @@ const inFlightReviews = new Map<string, Promise<PostGitHubReviewResult>>();
 
 export const GITHUB_POST_REVIEW_TOOL =
   "mcp__slack-bot__github_post_review";
+export const GITHUB_READ_REVIEW_STATE_TOOL =
+  "mcp__slack-bot__github_read_pr_review_state";
+
+const MAX_READ_REVIEW_ITEMS = 100;
 
 export interface GitHubInlineReviewComment {
   path: string;
@@ -57,6 +61,120 @@ export type PostGitHubReviewResult =
       headSha: string;
     }
   | { ok: false; reason: string };
+
+export interface GitHubReviewStateInput {
+  owner: string;
+  repo: string;
+  prNumber: number;
+  reviewId?: number;
+}
+
+export type ReadGitHubReviewStateResult =
+  | {
+      ok: true;
+      headSha: string;
+      reviewCount: number;
+      inlineCommentCount: number;
+      reviewIdFilter: number | null;
+      reviews: Array<{
+        id: number | null;
+        author: string | null;
+        state: string | null;
+        body: string;
+        commitId: string | null;
+        submittedAt: string | null;
+        url: string | null;
+      }>;
+      inlineComments: Array<{
+        id: number | null;
+        author: string | null;
+        body: string;
+        path: string | null;
+        line: number | null;
+        commitId: string | null;
+        createdAt: string | null;
+        url: string | null;
+      }>;
+    }
+  | { ok: false; reason: string };
+
+/**
+ * Read bounded PR review state through fixed GET endpoints. No caller input is
+ * ever interpreted as a gh flag or HTTP method.
+ */
+export async function readGitHubReviewState(
+  runContext: SlackMcpRunContext | null,
+  input: GitHubReviewStateInput,
+  runApi: GitHubApiRunner = runGitHubApi,
+): Promise<ReadGitHubReviewStateResult> {
+  if (!runContext?.signed) {
+    return { ok: false, reason: "signed MCP run context required" };
+  }
+  const capability = checkCapability(runContext.agent, "github-review-read");
+  if (!capability.ok) return { ok: false, reason: capability.reason };
+
+  const validationError = validateReviewTarget(input);
+  if (validationError) return { ok: false, reason: validationError };
+
+  const pullEndpoint = `repos/${input.owner}/${input.repo}/pulls/${input.prNumber}`;
+  const commentsEndpoint = input.reviewId
+    ? `${pullEndpoint}/reviews/${input.reviewId}/comments?per_page=100`
+    : `${pullEndpoint}/comments?per_page=100`;
+  const [pullResult, reviewsResult, commentsResult] = await Promise.all([
+    runApi({ method: "GET", endpoint: pullEndpoint }),
+    runApi({
+      method: "GET",
+      endpoint: `${pullEndpoint}/reviews?per_page=100`,
+      paginate: true,
+    }),
+    runApi({
+      method: "GET",
+      endpoint: commentsEndpoint,
+      paginate: true,
+    }),
+  ]);
+  if (!pullResult.ok) return apiFailure("read PR head", pullResult);
+  if (!reviewsResult.ok) return apiFailure("read PR reviews", reviewsResult);
+  if (!commentsResult.ok) {
+    return apiFailure("read PR inline comments", commentsResult);
+  }
+
+  const headSha = nestedString(parseJsonObject(pullResult.stdout), "head", "sha");
+  if (!headSha) {
+    return { ok: false, reason: "GitHub response omitted pull request head SHA" };
+  }
+  const reviews = parseJsonPages(reviewsResult.stdout);
+  const inlineComments = parseJsonPages(commentsResult.stdout);
+
+  return {
+    ok: true,
+    headSha,
+    reviewCount: reviews.length,
+    inlineCommentCount: inlineComments.length,
+    reviewIdFilter: input.reviewId ?? null,
+    reviews: reviews.slice(-MAX_READ_REVIEW_ITEMS).map((review) => ({
+      id: positiveInteger(review.id),
+      author: nestedString(review, "user", "login"),
+      state: optionalString(review.state),
+      body: boundedString(review.body),
+      commitId: optionalString(review.commit_id),
+      submittedAt: optionalString(review.submitted_at),
+      url: optionalString(review.html_url),
+    })),
+    inlineComments: inlineComments
+      .slice(-MAX_READ_REVIEW_ITEMS)
+      .map((comment) => ({
+        id: positiveInteger(comment.id),
+        author: nestedString(comment, "user", "login"),
+        body: boundedString(comment.body),
+        path: optionalString(comment.path),
+        line: positiveInteger(comment.line),
+        commitId: optionalString(comment.commit_id),
+        createdAt: optionalString(comment.created_at),
+        url: optionalString(comment.html_url),
+      })),
+  };
+}
 
 /**
  * Post one COMMENT review at an exact PR head through a capability-scoped API.
@@ -211,12 +329,8 @@ async function summarizeReview(
 }
 
 function validateReviewInput(input: GitHubReviewInput): string | null {
-  const coord = /^[A-Za-z0-9_.-]+$/;
-  if (!coord.test(input.owner)) return "invalid GitHub owner";
-  if (!coord.test(input.repo)) return "invalid GitHub repository";
-  if (!Number.isInteger(input.prNumber) || input.prNumber <= 0) {
-    return "prNumber must be a positive integer";
-  }
+  const targetError = validateReviewTarget(input);
+  if (targetError) return targetError;
   if (!/^[a-f0-9]{40}$/i.test(input.headSha)) {
     return "headSha must be a full 40-character Git SHA";
   }
@@ -259,6 +373,30 @@ function validateReviewInput(input: GitHubReviewInput): string | null {
     }
   }
   return null;
+}
+
+function validateReviewTarget(input: GitHubReviewStateInput): string | null {
+  const coord = /^[A-Za-z0-9_.-]+$/;
+  if (!coord.test(input.owner)) return "invalid GitHub owner";
+  if (!coord.test(input.repo)) return "invalid GitHub repository";
+  if (!Number.isInteger(input.prNumber) || input.prNumber <= 0) {
+    return "prNumber must be a positive integer";
+  }
+  if (
+    input.reviewId !== undefined &&
+    (!Number.isInteger(input.reviewId) || input.reviewId <= 0)
+  ) {
+    return "reviewId must be a positive integer";
+  }
+  return null;
+}
+
+function optionalString(value: unknown): string | null {
+  return typeof value === "string" ? value : null;
+}
+
+function boundedString(value: unknown): string {
+  return typeof value === "string" ? value.slice(0, 10_000) : "";
 }
 
 function validRepoPath(path: string): boolean {

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,10 @@ import {
 } from "./workflows/store.ts";
 import { createPipelineStore } from "./pipelines/store/factory.ts";
 import { pumpOutbox } from "./pipelines/pump.ts";
-import { recoverPipelineRuntime } from "./pipelines/recovery.ts";
+import {
+  reconcileStalePipelineAssignments,
+  recoverPipelineRuntime,
+} from "./pipelines/recovery.ts";
 import { gcTerminalPipelineHistory } from "./pipelines/gc.ts";
 import type { PipelineToolRuntime } from "./pipelines/tools.ts";
 
@@ -363,6 +366,22 @@ const pipelineBoot = (async () => {
     );
   }
 
+  if (pipelineRuntimeMode === "active") {
+    try {
+      await reconcileStalePipelineAssignments({
+        store: pipelineStore,
+        sessionReader: store,
+        audit: ({ channelId, threadId, text }) =>
+          responder.postResponse(channelId, threadId, text).then(() => undefined),
+      });
+    } catch (err) {
+      log.warn(
+        "pipeline",
+        `boot assignment recovery failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
   // GitHub observation is independent of pipeline runtime mode, but wakes
   // still require eventWakeEnabled + active controllers in the reconciler.
   if (config.github?.reconcileEnabled) {
@@ -463,14 +482,22 @@ const pipelineBoot = (async () => {
 
   if (pipelineRuntimeMode === "active") {
     setInterval(() => {
-      pumpOutbox({
-        store: pipelineStore,
-        dispatcher: sessionManager,
-        sessionReader: store,
-      }).catch((err) => {
+      void (async () => {
+        await reconcileStalePipelineAssignments({
+          store: pipelineStore,
+          sessionReader: store,
+          audit: ({ channelId, threadId, text }) =>
+            responder.postResponse(channelId, threadId, text).then(() => undefined),
+        });
+        await pumpOutbox({
+          store: pipelineStore,
+          dispatcher: sessionManager,
+          sessionReader: store,
+        });
+      })().catch((err) => {
         log.warn(
           "pipeline",
-          `periodic outbox pump failed: ${err instanceof Error ? err.message : String(err)}`,
+          `periodic recovery/pump failed: ${err instanceof Error ? err.message : String(err)}`,
         );
       });
     }, 15_000);
@@ -513,7 +540,14 @@ setInterval(() => {
 }, 60_000);
 
 setInterval(() => {
-  cleanupStaleSessions(store, config.session.staleTimeoutMs).then((cleaned) => {
+  cleanupStaleSessions(
+    store,
+    config.session.staleTimeoutMs,
+    async (runId) => {
+      const run = await pipelineStore.getRun(runId);
+      return Boolean(run && run.status !== "terminal");
+    },
+  ).then((cleaned) => {
     if (cleaned.length > 0) {
       log.info("cleanup", `Removed ${cleaned.length} stale sessions: ${cleaned.join(", ")}`);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -543,9 +543,13 @@ setInterval(() => {
   cleanupStaleSessions(
     store,
     config.session.staleTimeoutMs,
-    async (runId) => {
+    async (runId, staleBefore) => {
       const run = await pipelineStore.getRun(runId);
-      return Boolean(run && run.status !== "terminal");
+      return Boolean(
+        run &&
+        run.status !== "terminal" &&
+        run.updatedAt >= staleBefore,
+      );
     },
   ).then((cleaned) => {
     if (cleaned.length > 0) {

--- a/src/lifecycle/cleanup.test.ts
+++ b/src/lifecycle/cleanup.test.ts
@@ -19,6 +19,43 @@ describe("cleanupStaleSessions", () => {
     expect(await store.get(session.threadId)).toBeDefined();
   });
 
+  it("deletes a stale idle session whose pipeline run is also stale", async () => {
+    const store = new InMemorySessionStore();
+    const session = createSession("wedged-pipeline-thread", "C1");
+    session.lastActivity = Date.now() - 100_000;
+    session.activePipelineRunId = "run-wedged";
+    await store.set(session.threadId, session);
+
+    const cleaned = await cleanupStaleSessions(
+      store,
+      50_000,
+      async (_runId, staleBefore) => {
+        const runUpdatedAt = Date.now() - 100_000;
+        return runUpdatedAt >= staleBefore;
+      },
+    );
+
+    expect(cleaned).toEqual([session.threadId]);
+    expect(await store.get(session.threadId)).toBeUndefined();
+  });
+
+  it("keeps a stale idle session when its pipeline run was updated recently", async () => {
+    const store = new InMemorySessionStore();
+    const session = createSession("live-pipeline-thread", "C1");
+    session.lastActivity = Date.now() - 100_000;
+    session.activePipelineRunId = "run-live";
+    await store.set(session.threadId, session);
+
+    const cleaned = await cleanupStaleSessions(
+      store,
+      50_000,
+      async (_runId, staleBefore) => Date.now() >= staleBefore,
+    );
+
+    expect(cleaned).toEqual([]);
+    expect(await store.get(session.threadId)).toBeDefined();
+  });
+
   function makeStore() {
     return new InMemorySessionStore();
   }

--- a/src/lifecycle/cleanup.test.ts
+++ b/src/lifecycle/cleanup.test.ts
@@ -8,6 +8,17 @@ import { SqliteSessionStore } from "../session/store/sqlite.ts";
 import { createSession } from "../session/types.ts";
 
 describe("cleanupStaleSessions", () => {
+  it("keeps stale idle sessions that still own a pipeline run", async () => {
+    const store = new InMemorySessionStore();
+    const session = createSession("pipeline-thread", "C1");
+    session.lastActivity = Date.now() - 100_000;
+    session.activePipelineRunId = "run-active";
+    await store.set(session.threadId, session);
+
+    expect(await cleanupStaleSessions(store, 50_000)).toEqual([]);
+    expect(await store.get(session.threadId)).toBeDefined();
+  });
+
   function makeStore() {
     return new InMemorySessionStore();
   }

--- a/src/lifecycle/cleanup.ts
+++ b/src/lifecycle/cleanup.ts
@@ -6,19 +6,27 @@ import { SqliteSessionStore } from "../session/store/sqlite.ts";
 export async function cleanupStaleSessions(
   store: SessionStore,
   staleTimeoutMs: number,
-  isPipelineRunActive?: (runId: string) => Promise<boolean>,
+  shouldPreservePipelineRun?: (
+    runId: string,
+    staleBefore: number,
+  ) => Promise<boolean>,
 ): Promise<string[]> {
   const sessions = await store.getAll();
   const cleaned: string[] = [];
+  const now = Date.now();
+  const staleBefore = now - staleTimeoutMs;
 
   for (const [threadId, session] of sessions) {
-    if (Date.now() - session.lastActivity > staleTimeoutMs) {
+    if (session.lastActivity < staleBefore) {
       // A pipeline run owns durable work beyond any individual model turn.
       // Preserve its session row so startup reconciliation can resume it.
       if (
         session.activePipelineRunId &&
-        (!isPipelineRunActive ||
-          await isPipelineRunActive(session.activePipelineRunId))
+        (!shouldPreservePipelineRun ||
+          await shouldPreservePipelineRun(
+            session.activePipelineRunId,
+            staleBefore,
+          ))
       ) continue;
       if (session.status === "busy" || session.status === "draining") {
         continue;

--- a/src/lifecycle/cleanup.ts
+++ b/src/lifecycle/cleanup.ts
@@ -6,12 +6,20 @@ import { SqliteSessionStore } from "../session/store/sqlite.ts";
 export async function cleanupStaleSessions(
   store: SessionStore,
   staleTimeoutMs: number,
+  isPipelineRunActive?: (runId: string) => Promise<boolean>,
 ): Promise<string[]> {
   const sessions = await store.getAll();
   const cleaned: string[] = [];
 
   for (const [threadId, session] of sessions) {
     if (Date.now() - session.lastActivity > staleTimeoutMs) {
+      // A pipeline run owns durable work beyond any individual model turn.
+      // Preserve its session row so startup reconciliation can resume it.
+      if (
+        session.activePipelineRunId &&
+        (!isPipelineRunActive ||
+          await isPipelineRunActive(session.activePipelineRunId))
+      ) continue;
       if (session.status === "busy" || session.status === "draining") {
         continue;
       }

--- a/src/mcp/slack-server.ts
+++ b/src/mcp/slack-server.ts
@@ -964,6 +964,14 @@ function registerTools(server: McpServer, runContext: SlackMcpRunContext | null 
         bug_mode: z
           .enum(["expected-behavior", "focused-debug", "full-investigation"])
           .optional(),
+        required_workstreams: z
+          .array(z.enum(["backend", "frontend"]))
+          .min(1)
+          .max(2)
+          .optional()
+          .describe(
+            "Product build scope chosen by the orchestrator. Prefer this over keyword inference.",
+          ),
       },
     },
     async (args) => {

--- a/src/mcp/slack-server.ts
+++ b/src/mcp/slack-server.ts
@@ -63,7 +63,10 @@ import {
   pipelineStartRun,
   pipelineWriteArtifact,
 } from "../pipelines/tools.ts";
-import { postGitHubReview } from "../github/review-comments.ts";
+import {
+  postGitHubReview,
+  readGitHubReviewState,
+} from "../github/review-comments.ts";
 
 const MCP_PORT = Number(process.env.MCP_PORT ?? "3456");
 const FALLBACK_AGENTS_DIR = ".claude/agents";
@@ -129,6 +132,34 @@ function registerTools(server: McpServer, runContext: SlackMcpRunContext | null 
         : null;
     },
   });
+  server.registerTool(
+    "github_read_pr_review_state",
+    {
+      description:
+        "Read a PR head, reviews, and inline review comments through fixed GET-only GitHub endpoints. " +
+        "Use this instead of gh api when checking prior findings or verifying review comment counts.",
+      inputSchema: {
+        owner: z.string().regex(/^[A-Za-z0-9_.-]+$/),
+        repo: z.string().regex(/^[A-Za-z0-9_.-]+$/),
+        pr_number: z.number().int().positive(),
+        review_id: z.number().int().positive().optional(),
+      },
+    },
+    async ({ owner, repo, pr_number, review_id }) => {
+      const result = await readGitHubReviewState(runContext, {
+        owner,
+        repo,
+        prNumber: pr_number,
+        ...(review_id === undefined ? {} : { reviewId: review_id }),
+      });
+      return {
+        content: [
+          { type: "text" as const, text: JSON.stringify(result, null, 2) },
+        ],
+        ...(result.ok ? {} : { isError: true }),
+      };
+    },
+  );
   server.registerTool(
     "github_post_review",
     {

--- a/src/opencode/sdk-provider.ts
+++ b/src/opencode/sdk-provider.ts
@@ -149,6 +149,7 @@ export function spawnOpenCodeSdk(
     model,
     permission: compileOpenCodePermission({
       subject: session,
+      cwd: runtime.cwd,
       fallback: config.opencode.permission,
     }),
     mcp: session.cwd ? null : undefined,

--- a/src/pipelines/dispatch.ts
+++ b/src/pipelines/dispatch.ts
@@ -4,7 +4,7 @@
  */
 
 import type { SlackMessageEvent } from "../slack/events.ts";
-import type { ThreadSession } from "../session/types.ts";
+import type { PipelineInvocationRef, ThreadSession } from "../session/types.ts";
 import type { Assignment, PipelineRun } from "./types.ts";
 import {
   buildAssignmentContext,
@@ -25,6 +25,7 @@ export type PipelineSessionDispatcher = {
 /** Optional session store for busy detection before dispatch. */
 export type PipelineSessionReader = {
   get: (threadId: string) => Promise<ThreadSession | undefined>;
+  getAll?: () => Promise<Map<string, ThreadSession>>;
 };
 
 export type SlackAuditCallback = (args: {
@@ -42,6 +43,7 @@ export type DispatchAssignmentInput = {
   userId?: string;
   /** Shared idempotency / dedupe key for the synthetic Slack event. */
   dedupeKey?: string;
+  pipelineInvocation?: PipelineInvocationRef;
 };
 
 export type DispatchAssignmentResult = {
@@ -152,6 +154,7 @@ export async function dispatchAssignment(
     isSelfBot: true,
     botUsername: "pipeline",
     dedupeKey,
+    pipelineInvocation: input.pipelineInvocation,
   };
 
   const alwaysEnqueue = deps.alwaysEnqueue !== false;

--- a/src/pipelines/product/controller.test.ts
+++ b/src/pipelines/product/controller.test.ts
@@ -228,6 +228,51 @@ describe("createProductRun", () => {
     expect(loaded.length).toBe(2);
   });
 
+  it("routes a frontend repo to frontend despite incidental backend wording", async () => {
+    const store = new InMemoryPipelineStore(fakeClock(1000));
+    const result = await createProductRun(cfg(store), {
+      channelId: "C1",
+      threadId: "T-frontend-scope",
+      objective: "The backend already supports it; add the admin UI control",
+      startKind: "build",
+      messageTs: "222.3",
+      repoRefs: ["GrowthX-Club/gx-admin-client"],
+    });
+    expect(result.assignment.targetAgent).toBe("frontend");
+    const assignments = await store.listAssignments(result.run.id);
+    expect(assignments).toHaveLength(1);
+  });
+
+  it("fans out an explicitly declared full-stack build", async () => {
+    const store = new InMemoryPipelineStore(fakeClock(1000));
+    const result = await createProductRun(cfg(store), {
+      channelId: "C1",
+      threadId: "T-explicit-fullstack",
+      objective: "Implement the POST /api/invites endpoint and React admin UI",
+      startKind: "build",
+      messageTs: "222.4",
+      requiredWorkstreams: ["backend", "frontend"],
+    });
+    expect(result.run.phase).toBe("building");
+    const assignments = await store.listAssignments(result.run.id);
+    const openTargets = assignments
+      .filter((assignment) => assignment.status === "pending")
+      .map((assignment) => assignment.targetAgent)
+      .sort();
+    expect(openTargets).toEqual(["build", "frontend"]);
+
+    const replay = await createProductRun(cfg(store), {
+      channelId: "C1",
+      threadId: "T-explicit-fullstack",
+      objective: "Implement the POST /api/invites endpoint and React admin UI",
+      startKind: "build",
+      messageTs: "222.4",
+      requiredWorkstreams: ["backend", "frontend"],
+    });
+    expect(replay.created).toBe(false);
+    expect(await store.listAssignments(result.run.id)).toHaveLength(3);
+  });
+
   it("idempotent reuse of active run on same thread", async () => {
     const store = new InMemoryPipelineStore(fakeClock(1000));
     const first = await createProductRun(cfg(store), {

--- a/src/pipelines/product/controller.test.ts
+++ b/src/pipelines/product/controller.test.ts
@@ -273,6 +273,28 @@ describe("createProductRun", () => {
     expect(await store.listAssignments(result.run.id)).toHaveLength(3);
   });
 
+  it.each([
+    ["backend first", ["GrowthX-Club/gx-backend", "GrowthX-Club/gx-client-next"]],
+    ["frontend first", ["GrowthX-Club/gx-client-next", "GrowthX-Club/gx-backend"]],
+  ])("fans out inferred multi-repo builds with %s", async (_label, repoRefs) => {
+    const store = new InMemoryPipelineStore(fakeClock(1000));
+    const result = await createProductRun(cfg(store), {
+      channelId: "C1",
+      threadId: `T-inferred-${_label}`,
+      objective: "Ship the feature across the supplied repositories",
+      startKind: "build",
+      messageTs: "222.5",
+      repoRefs,
+    });
+
+    expect(result.run.phase).toBe("building");
+    const openTargets = (await store.listAssignments(result.run.id))
+      .filter((assignment) => assignment.status === "pending")
+      .map((assignment) => assignment.targetAgent)
+      .sort();
+    expect(openTargets).toEqual(["build", "frontend"]);
+  });
+
   it("idempotent reuse of active run on same thread", async () => {
     const store = new InMemoryPipelineStore(fakeClock(1000));
     const first = await createProductRun(cfg(store), {

--- a/src/pipelines/product/controller.ts
+++ b/src/pipelines/product/controller.ts
@@ -367,9 +367,13 @@ export function inferProductWorkstreams(
   if (explicit && explicit.length > 0) {
     return [...new Set(explicit)];
   }
-  const repos = repoRefs.join(" ").toLowerCase();
-  const hasFrontendRepo = /(?:^|[-_/])(client|frontend|web|admin)(?:$|[-_/])/.test(repos);
-  const hasBackendRepo = /(?:^|[-_/])(backend|api|service|server)(?:$|[-_/])/.test(repos);
+  const repos = repoRefs.map((repoRef) => repoRef.toLowerCase());
+  const hasFrontendRepo = repos.some((repo) =>
+    /(?:^|[-_/])(client|frontend|web|admin)(?:$|[-_/])/.test(repo)
+  );
+  const hasBackendRepo = repos.some((repo) =>
+    /(?:^|[-_/])(backend|api|service|server)(?:$|[-_/])/.test(repo)
+  );
   if (hasFrontendRepo && hasBackendRepo) return ["backend", "frontend"];
   if (hasFrontendRepo) return ["frontend"];
   if (hasBackendRepo) return ["backend"];

--- a/src/pipelines/product/controller.ts
+++ b/src/pipelines/product/controller.ts
@@ -62,6 +62,8 @@ export type CreateProductRunInput = {
   targetAgent?: string;
   acceptanceCriteria?: string[];
   provenance?: PipelineStartProvenance;
+  /** Orchestrator-declared implementation scope; preferred over inference. */
+  requiredWorkstreams?: Array<"backend" | "frontend">;
 };
 
 export type CreateProductRunResult = {
@@ -95,7 +97,28 @@ export async function createProductRun(
     existing.status !== "terminal"
   ) {
     const skipReasons = await loadSkipReasons(store, existing.id);
-    const assignments = await store.listAssignments(existing.id);
+    let assignments = await store.listAssignments(existing.id);
+    const existingWorkstreams = await loadWorkstreams(store, existing.id);
+    if (input.startKind === "build" && existingWorkstreams.length > 1) {
+      const parent = assignments.find((assignment) =>
+        assignment.parentAssignmentId === null
+      );
+      if (parent) {
+        await fanOutBuilders(config, {
+          runId: existing.id,
+          parentAssignmentId: parent.id,
+          expectedRunVersion: existing.stateVersion,
+          sourceAgent: input.ownerAgent ?? existing.ownerAgent,
+          objective: input.objective,
+          idempotencyKey: `product-start-fanout:${input.threadId}:${input.messageTs}`,
+          workstreams: existingWorkstreams.map((workstream) => ({
+            agent: workstream === "frontend" ? "frontend" as const : "build" as const,
+            workstreamKey: workstream,
+          })),
+        });
+        assignments = await store.listAssignments(existing.id);
+      }
+    }
     const open =
       assignments.find(
         (a) =>
@@ -106,7 +129,9 @@ export async function createProductRun(
     if (!open) {
       throw new Error(`active product run ${existing.id} has no assignments`);
     }
-    await ensureProductStartDelivery(store, existing, open, input);
+    if (existingWorkstreams.length <= 1) {
+      await ensureProductStartDelivery(store, existing, open, input);
+    }
     return {
       run: existing,
       assignment: open,
@@ -120,16 +145,25 @@ export async function createProductRun(
     objective: input.objective,
     forceDiscovery: input.forceDiscovery,
   });
-  const targetAgent = input.targetAgent ?? start.targetAgent;
+  const requestedTargetAgent = input.targetAgent ?? start.targetAgent;
   const ownerAgent = input.ownerAgent ?? start.ownerAgent;
+  const workstreams = input.startKind === "build"
+    ? inferProductWorkstreams(
+        input.objective,
+        input.repoRefs ?? [],
+        input.requiredWorkstreams,
+      )
+    : [];
+  const fullStack = workstreams.length > 1;
+  // Multi-stream starts use a coordinator parent and fan out immediately.
+  // Single-stream starts retain the existing phase progression while routing
+  // directly to the correct specialist.
+  const targetAgent = fullStack
+    ? ownerAgent
+    : workstreams[0] === "frontend"
+      ? "frontend"
+      : requestedTargetAgent;
   const runId = input.runId ?? crypto.randomUUID();
-
-  const fullStack = detectFullStackIntent(input.objective);
-  const workstreams = fullStack
-    ? ["backend", "frontend"]
-    : input.startKind === "build"
-      ? ["backend"]
-      : [];
 
   const run: ProductRun = {
     id: runId,
@@ -286,19 +320,68 @@ export async function createProductRun(
     });
   }
 
-  await ensureProductStartDelivery(store, run, assignment, input);
+  let returnedRun = run;
+  if (input.startKind === "build" && fullStack) {
+    const fanout = await fanOutBuilders(config, {
+      runId,
+      parentAssignmentId: assignment.id,
+      expectedRunVersion: run.stateVersion,
+      sourceAgent: ownerAgent,
+      objective: input.objective,
+      idempotencyKey: `product-start-fanout:${input.threadId}:${input.messageTs}`,
+      workstreams: workstreams.map((workstream) => ({
+        agent: workstream === "frontend" ? "frontend" as const : "build" as const,
+        workstreamKey: workstream,
+      })),
+    });
+    if (fanout.receipt.status === "rejected" || fanout.assignments.length === 0) {
+      throw new Error(
+        `product build fan-out failed: ${fanout.receipt.reason ?? fanout.receipt.status}`,
+      );
+    }
+    assignment = fanout.assignments[0]!;
+    const advancedRun = await store.getRun(runId);
+    if (advancedRun?.kind === "product") returnedRun = advancedRun;
+  } else {
+    await ensureProductStartDelivery(store, run, assignment, input);
+  }
 
   log.info(
     "product-controller",
-    `created run=${runId.slice(0, 8)} start=${input.startKind} phase=${start.phase} target=${targetAgent} skip=${start.skipReasons.length}`,
+    `created run=${runId.slice(0, 8)} start=${input.startKind} phase=${returnedRun.phase} target=${assignment.targetAgent} skip=${start.skipReasons.length}`,
   );
 
   return {
-    run,
+    run: returnedRun,
     assignment,
     skipReasons: start.skipReasons,
     created: true,
   };
+}
+
+export function inferProductWorkstreams(
+  objective: string,
+  repoRefs: string[],
+  explicit?: Array<"backend" | "frontend">,
+): Array<"backend" | "frontend"> {
+  if (explicit && explicit.length > 0) {
+    return [...new Set(explicit)];
+  }
+  const repos = repoRefs.join(" ").toLowerCase();
+  const hasFrontendRepo = /(?:^|[-_/])(client|frontend|web|admin)(?:$|[-_/])/.test(repos);
+  const hasBackendRepo = /(?:^|[-_/])(backend|api|service|server)(?:$|[-_/])/.test(repos);
+  if (hasFrontendRepo && hasBackendRepo) return ["backend", "frontend"];
+  if (hasFrontendRepo) return ["frontend"];
+  if (hasBackendRepo) return ["backend"];
+
+  const text = objective.toLowerCase();
+  if (detectFullStackIntent(objective) || /\bfull[ -]?stack\b/.test(text)) {
+    return ["backend", "frontend"];
+  }
+  if (/\b(ui|ux|frontend|client|react|css|component|page|screen)\b/.test(text)) {
+    return ["frontend"];
+  }
+  return ["backend"];
 }
 
 async function ensureProductStartDelivery(
@@ -683,13 +766,21 @@ export async function fanOutBuilders(
     },
   };
 
-  const receipt = await store.recordOutcomeTransaction({
-    outcome,
-    toPhase: "building",
-    actorType: "agent",
-    actorId: input.sourceAgent,
-    idempotencyKey: input.idempotencyKey,
-  });
+  const parent = await store.getAssignment(input.parentAssignmentId);
+  const receipt: TransitionReceipt = parent?.status === "completed"
+    ? {
+        status: "duplicate",
+        runVersion: run.stateVersion,
+        assignmentId: input.parentAssignmentId,
+        reason: "fan-out parent already completed; repairing topology",
+      }
+    : await store.recordOutcomeTransaction({
+        outcome,
+        toPhase: "building",
+        actorType: "agent",
+        actorId: input.sourceAgent,
+        idempotencyKey: input.idempotencyKey,
+      });
 
   // Never spawn siblings when the parent handoff did not commit.
   if (
@@ -700,7 +791,13 @@ export async function fanOutBuilders(
   }
 
   const assignments: Assignment[] = [];
-  const firstAsg = await store.getAssignment(firstId);
+  const firstAsg =
+    (await store.getAssignment(firstId)) ??
+    (await store.listAssignments(run.id)).find(
+      (assignment) =>
+        assignment.idempotencyKey ===
+          `${input.idempotencyKey}:${first.workstreamKey}`,
+    );
   if (firstAsg) assignments.push(firstAsg);
 
   for (const stream of rest) {
@@ -738,47 +835,56 @@ export async function fanOutBuilders(
     });
   }
 
-  await store.appendEvent({
-    id: crypto.randomUUID(),
-    runId: run.id,
-    eventType: FANOUT_EVENT,
-    actorType: "agent",
-    actorId: input.sourceAgent,
-    assignmentId: input.parentAssignmentId,
-    outcomeId: null,
-    fromPhase: run.phase,
-    toPhase: "building",
-    payloadVersion: 1,
-    payload: {
-      kind: "started",
-      workstreams: streams.map((s) => s.workstreamKey),
-      agents: streams.map((s) => s.agent),
-    },
-    idempotencyKey: `fanout-start:${input.idempotencyKey}`,
-    occurredAt: clock.now(),
-    observedAt: clock.now(),
-  });
+  const existingEvents = await store.listEvents(run.id);
+  if (!existingEvents.some((event) =>
+    event.idempotencyKey === `fanout-start:${input.idempotencyKey}`
+  )) {
+    await store.appendEvent({
+      id: crypto.randomUUID(),
+      runId: run.id,
+      eventType: FANOUT_EVENT,
+      actorType: "agent",
+      actorId: input.sourceAgent,
+      assignmentId: input.parentAssignmentId,
+      outcomeId: null,
+      fromPhase: run.phase,
+      toPhase: "building",
+      payloadVersion: 1,
+      payload: {
+        kind: "started",
+        workstreams: streams.map((s) => s.workstreamKey),
+        agents: streams.map((s) => s.agent),
+      },
+      idempotencyKey: `fanout-start:${input.idempotencyKey}`,
+      occurredAt: clock.now(),
+      observedAt: clock.now(),
+    });
+  }
 
   // Persist required workstreams for rejoin.
-  await store.appendEvent({
-    id: crypto.randomUUID(),
-    runId: run.id,
-    eventType: WORKSTREAM_EVENT,
-    actorType: "agent",
-    actorId: input.sourceAgent,
-    assignmentId: input.parentAssignmentId,
-    outcomeId: null,
-    fromPhase: run.phase,
-    toPhase: "building",
-    payloadVersion: 1,
-    payload: {
-      workstreams: streams.map((s) => s.workstreamKey),
-      fullStack: true,
-    },
-    idempotencyKey: `product.workstreams.fanout:${input.idempotencyKey}`,
-    occurredAt: clock.now(),
-    observedAt: clock.now(),
-  });
+  if (!existingEvents.some((event) =>
+    event.idempotencyKey === `product.workstreams.fanout:${input.idempotencyKey}`
+  )) {
+    await store.appendEvent({
+      id: crypto.randomUUID(),
+      runId: run.id,
+      eventType: WORKSTREAM_EVENT,
+      actorType: "agent",
+      actorId: input.sourceAgent,
+      assignmentId: input.parentAssignmentId,
+      outcomeId: null,
+      fromPhase: run.phase,
+      toPhase: "building",
+      payloadVersion: 1,
+      payload: {
+        workstreams: streams.map((s) => s.workstreamKey),
+        fullStack: streams.length > 1,
+      },
+      idempotencyKey: `product.workstreams.fanout:${input.idempotencyKey}`,
+      occurredAt: clock.now(),
+      observedAt: clock.now(),
+    });
+  }
 
   return { assignments, receipt };
 }

--- a/src/pipelines/pump.ts
+++ b/src/pipelines/pump.ts
@@ -199,12 +199,22 @@ async function handleOutboxItem(
         run,
         assignment,
         // Resume from devserver.ready includes the ready URL in the prompt.
-        prompt:
-          item.eventType === "assignment.resume" &&
-          typeof item.payload.readyUrl === "string"
+        prompt: item.eventType === "assignment.resume"
+          ? typeof item.payload.readyUrl === "string"
             ? `${assignment.objective}\n\n[devserver.ready] ${item.payload.readyUrl}`
-            : undefined,
+            : `${assignment.objective}\n\n[pipeline.recovery] Resume from durable state without repeating completed mutations. Report a typed outcome before ending.`
+          : undefined,
         dedupeKey: `pipeline-outbox:${item.idempotencyKey}`,
+        pipelineInvocation: {
+          runId: run.id,
+          assignmentId: assignment.id,
+          dispatchKey: item.idempotencyKey,
+          outcomeCountAtDispatch: (await store.listOutcomes(assignment.id)).length,
+          retryCount:
+            typeof item.payload.recoveryAttempt === "number"
+              ? item.payload.recoveryAttempt
+              : 0,
+        },
       },
     );
 

--- a/src/pipelines/recovery-delivery.test.ts
+++ b/src/pipelines/recovery-delivery.test.ts
@@ -46,10 +46,12 @@ describe("outbox at-least-once delivery", () => {
     );
 
     const seenDedupeKeys: string[] = [];
+    const invocations: SlackMessageEvent["pipelineInvocation"][] = [];
     const dispatcher = {
       handleAgentMessage: mock(
         async (event: SlackMessageEvent, _agent: string) => {
           if (event.dedupeKey) seenDedupeKeys.push(event.dedupeKey);
+          invocations.push(event.pipelineInvocation);
         },
       ),
     };
@@ -109,5 +111,11 @@ describe("outbox at-least-once delivery", () => {
 
     // Consumer-facing dedupe keys stay deterministic for the original delivery.
     expect(key.startsWith("pipeline-outbox:")).toBe(true);
+    expect(invocations[0]).toMatchObject({
+      runId: "run-1",
+      assignmentId: delivered[0]!.assignmentId,
+      dispatchKey: delivered[0]!.idempotencyKey,
+      outcomeCountAtDispatch: 0,
+    });
   });
 });

--- a/src/pipelines/recovery.ts
+++ b/src/pipelines/recovery.ts
@@ -3,6 +3,10 @@ import type { Clock } from "../time/clock.ts";
 import { systemClock } from "../time/clock.ts";
 import { reclaimExpiredLeases } from "./outbox.ts";
 import { reclaimDevServerJobs } from "./dev-server-jobs.ts";
+import type {
+  PipelineSessionReader,
+  SlackAuditCallback,
+} from "./dispatch.ts";
 
 export type RecoveryReport = {
   reclaimedOutboxLeases: number;
@@ -54,4 +58,140 @@ export async function recoverPipelineRuntime(
     deadlineReleasedDevServerJobs,
     reclaimedGitHubLeases,
   };
+}
+
+export type AssignmentRecoveryReport = {
+  resumesEnqueued: number;
+  escalationsRecorded: number;
+};
+
+/**
+ * Reconcile the second half of at-least-once delivery: an outbox row may be
+ * delivered while its runner dies before recording an outcome. Re-wake idle
+ * owners with deterministic keys, then durably escalate after two attempts.
+ */
+export async function reconcileStalePipelineAssignments(input: {
+  store: PipelineStore;
+  sessionReader: PipelineSessionReader;
+  audit?: SlackAuditCallback;
+  now?: number;
+  staleMs?: number;
+  maxRetries?: number;
+}): Promise<AssignmentRecoveryReport> {
+  const sessions = await input.sessionReader.getAll?.();
+  if (!sessions) return { resumesEnqueued: 0, escalationsRecorded: 0 };
+  const now = input.now ?? Date.now();
+  const staleMs = input.staleMs ?? 5 * 60_000;
+  const maxRetries = input.maxRetries ?? 2;
+  let resumesEnqueued = 0;
+  let escalationsRecorded = 0;
+
+  for (const session of sessions.values()) {
+    if (!session.activePipelineRunId) continue;
+    const run = await input.store.getRun(session.activePipelineRunId);
+    if (!run || run.status !== "active") continue;
+    const [assignments, outbox] = await Promise.all([
+      input.store.listAssignments(run.id),
+      input.store.listOutbox(run.id),
+    ]);
+
+    for (const assignment of assignments) {
+      if (assignment.status !== "pending" && assignment.status !== "leased") {
+        continue;
+      }
+      const ownerBusy = assignment.targetAgent === "lead" ||
+          assignment.targetAgent === "default" || assignment.targetAgent === "junior"
+        ? session.status === "busy" || session.status === "draining"
+        : session.agentSessions?.[assignment.targetAgent]?.status === "busy";
+      if (ownerBusy) continue;
+      const activeInvocation =
+        assignment.targetAgent === "lead" ||
+          assignment.targetAgent === "default" || assignment.targetAgent === "junior"
+          ? session.activePipelineInvocation
+          : session.agentSessions?.[assignment.targetAgent]
+            ?.activePipelineInvocation;
+      const outcomeBaseline =
+        activeInvocation?.assignmentId === assignment.id
+          ? activeInvocation.outcomeCountAtDispatch
+          : 0;
+      if (
+        (await input.store.listOutcomes(assignment.id)).length > outcomeBaseline
+      ) continue;
+
+      const wakes = outbox
+        .filter((item) =>
+          item.assignmentId === assignment.id &&
+          ["assignment.dispatch", "assignment.continue", "assignment.resume"].includes(item.eventType)
+        )
+        .sort((a, b) => b.createdAt - a.createdAt);
+      const lastWake = wakes[0];
+      if (!lastWake || lastWake.status !== "delivered") continue;
+      const lastWakeAt = lastWake.deliveredAt ?? lastWake.createdAt;
+      if (now - lastWakeAt < staleMs) continue;
+      const outboxRecoveryAttempts = wakes.filter((item) =>
+        item.idempotencyKey.startsWith(`pipeline-recovery:${assignment.id}:`)
+      ).length;
+      const recoveryAttempts = Math.max(
+        outboxRecoveryAttempts,
+        activeInvocation?.retryCount ?? 0,
+      );
+
+      if (recoveryAttempts < maxRetries) {
+        const attempt = recoveryAttempts + 1;
+        await input.store.enqueueOutbox({
+          id: crypto.randomUUID(),
+          runId: run.id,
+          assignmentId: assignment.id,
+          eventType: "assignment.resume",
+          payload: {
+            assignmentId: assignment.id,
+            targetAgent: assignment.targetAgent,
+            recoveryAttempt: attempt,
+            recoveryReason: "delivered assignment has no durable outcome",
+          },
+          idempotencyKey: `pipeline-recovery:${assignment.id}:${attempt}`,
+        });
+        resumesEnqueued += 1;
+        continue;
+      }
+
+      const currentRun = await input.store.getRun(run.id);
+      if (!currentRun || currentRun.status === "terminal") continue;
+      const receipt = await input.store.recordOutcomeTransaction({
+        outcome: {
+          assignmentId: assignment.id,
+          expectedRunVersion: currentRun.stateVersion,
+          action: "escalate",
+          status: "blocked",
+          reason: `Assignment remained without a typed outcome after ${maxRetries} recovery wakes.`,
+          evidenceRefs: [],
+          artifactRefs: [],
+          blockers: [{
+            kind: "infra_failure",
+            detail: "runner was no longer active after a delivered dispatch",
+          }],
+          checks: [],
+          progressFingerprint: `stale-settlement:${assignment.id}`,
+        },
+        toPhase: "needs-human",
+        actorType: "system",
+        actorId: "pipeline-recovery",
+        idempotencyKey: `pipeline-recovery-exhausted:${assignment.id}`,
+      });
+      if (receipt.status !== "rejected") {
+        escalationsRecorded += 1;
+        try {
+          await input.audit?.({
+            channelId: run.channelId,
+            threadId: run.threadId,
+            text: `:warning: Pipeline assignment \`${assignment.id.slice(0, 8)}\` stopped without reporting an outcome after ${maxRetries} recovery wakes and needs human attention.`,
+          });
+        } catch {
+          // The durable escalation is authoritative; Slack audit is best-effort.
+        }
+        break;
+      }
+    }
+  }
+  return { resumesEnqueued, escalationsRecorded };
 }

--- a/src/pipelines/settlement-recovery.test.ts
+++ b/src/pipelines/settlement-recovery.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, mock } from "bun:test";
+import { createSession } from "../session/types.ts";
+import { InMemorySessionStore } from "../session/store/memory.ts";
+import { fakeClock } from "../time/clock.ts";
+import { reconcileStalePipelineAssignments } from "./recovery.ts";
+import { InMemoryPipelineStore } from "./store/memory.ts";
+import { makeAssignmentCreate, makeProductRun } from "./store/test-helpers.ts";
+
+describe("pipeline settlement recovery", () => {
+  it("re-wakes a delivered assignment twice, then records one durable escalation", async () => {
+    const clock = fakeClock(1_000);
+    const pipelineStore = new InMemoryPipelineStore(clock);
+    const sessionStore = new InMemorySessionStore();
+    await pipelineStore.createRun(makeProductRun({ phase: "building" }));
+    await pipelineStore.createAssignment(makeAssignmentCreate({
+      id: "asg-stale",
+      targetAgent: "build",
+      idempotencyKey: "asg-stale-key",
+    }));
+    await pipelineStore.enqueueOutbox({
+      id: "dispatch-stale",
+      runId: "run-1",
+      assignmentId: "asg-stale",
+      eventType: "assignment.dispatch",
+      payload: { assignmentId: "asg-stale" },
+      idempotencyKey: "dispatch-stale-key",
+    });
+    const [initial] = await pipelineStore.claimOutbox("pump", 1, 1_000);
+    await pipelineStore.markOutboxDelivered(initial!.id);
+
+    const session = createSession("T1", "C1");
+    session.activePipelineRunId = "run-1";
+    await sessionStore.set(session.threadId, session);
+    const audit = mock(async () => undefined);
+
+    for (let attempt = 1; attempt <= 2; attempt++) {
+      clock.advance(5 * 60_000 + 1);
+      const report = await reconcileStalePipelineAssignments({
+        store: pipelineStore,
+        sessionReader: sessionStore,
+        audit,
+        now: clock.now(),
+      });
+      expect(report.resumesEnqueued).toBe(1);
+      const claimed = await pipelineStore.claimOutbox(`pump-${attempt}`, 10, 1_000);
+      const recovery = claimed.find((item) =>
+        item.idempotencyKey === `pipeline-recovery:asg-stale:${attempt}`
+      );
+      expect(recovery).toBeDefined();
+      await pipelineStore.markOutboxDelivered(recovery!.id);
+    }
+
+    clock.advance(5 * 60_000 + 1);
+    const exhausted = await reconcileStalePipelineAssignments({
+      store: pipelineStore,
+      sessionReader: sessionStore,
+      audit,
+      now: clock.now(),
+    });
+    expect(exhausted.escalationsRecorded).toBe(1);
+    expect(await pipelineStore.listOutcomes("asg-stale")).toHaveLength(1);
+    expect((await pipelineStore.getRun("run-1"))?.status).toBe("needs-human");
+    expect(audit).toHaveBeenCalledTimes(1);
+
+    const repeated = await reconcileStalePipelineAssignments({
+      store: pipelineStore,
+      sessionReader: sessionStore,
+      audit,
+      now: clock.now(),
+    });
+    expect(repeated.escalationsRecorded).toBe(0);
+    expect(audit).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/pipelines/tools.ts
+++ b/src/pipelines/tools.ts
@@ -90,6 +90,7 @@ export type PipelineStartRunArgs = {
   repo_refs?: string[];
   acceptance_criteria?: string[];
   bug_mode?: BugMode;
+  required_workstreams?: Array<"backend" | "frontend">;
 };
 
 /**
@@ -206,6 +207,7 @@ export async function pipelineStartRun(
             repoRefs,
             ownerAgent: runContext.agent,
             acceptanceCriteria: args.acceptance_criteria,
+            requiredWorkstreams: args.required_workstreams,
             provenance,
           },
         )

--- a/src/runners/index.ts
+++ b/src/runners/index.ts
@@ -14,6 +14,7 @@ import {
   wantsMcp,
 } from "./mcp-config.ts";
 import { compileOpenCodePermission } from "./policy.ts";
+import { resolveRunnerCwd } from "./runtime.ts";
 
 export function sessionProvider(
   session: ThreadSession,
@@ -59,6 +60,7 @@ export function spawnRunner(
         // Prefer catalog/session intent when present; fall back to operator config.
         permission: compileOpenCodePermission({
           subject: session,
+          cwd: resolveRunnerCwd(session, targetRepoCwd),
           fallback: config.opencode.permission,
         }),
         mcp: buildOpenCodeMcpConfig(config, session),

--- a/src/runners/policy.test.ts
+++ b/src/runners/policy.test.ts
@@ -52,6 +52,26 @@ describe("compileOpenCodePermission", () => {
     });
   });
 
+  it("allows only verification bash patterns for review worktrees", () => {
+    const permission = compileOpenCodePermission({
+      subject: {
+        activeAgentName: "review",
+        worktreePath: "/repo.junior-worktrees/slack-t",
+        agentPermissions: { intent: "read-only", mcp: [], tools: [] },
+      },
+    }) as Record<string, unknown>;
+
+    expect(permission.edit).toBe("deny");
+    expect(permission.write).toBe("deny");
+    expect(permission.bash).toMatchObject({
+      "*": "deny",
+      "npm test *": "allow",
+      "pnpm test *": "allow",
+      "bun test *": "allow",
+    });
+    expect(permission.bash).not.toMatchObject({ "npm install *": "allow" });
+  });
+
   it("uses an explicit read-safe MCP allowlist for read-only roles", () => {
     const permission = compileOpenCodePermission({
       subject: {

--- a/src/runners/policy.test.ts
+++ b/src/runners/policy.test.ts
@@ -35,7 +35,7 @@ const codexConfig = {
 };
 
 describe("compileOpenCodePermission", () => {
-  it("denies edit/write/bash for read-only roles", () => {
+  it("allows only non-mutating inspection for reviewers without a worktree", () => {
     const permission = compileOpenCodePermission({
       subject: {
         activeAgentName: "review",
@@ -46,9 +46,17 @@ describe("compileOpenCodePermission", () => {
     expect(permission).toMatchObject({
       edit: "deny",
       write: "deny",
-      bash: "deny",
       task: "deny",
       read: "allow",
+    });
+    expect((permission as Record<string, unknown>).bash).toMatchObject({
+      "*": "deny",
+      "gh pr view *": "allow",
+      "git blame *": "allow",
+    });
+    expect((permission as Record<string, unknown>).bash).not.toMatchObject({
+      "git fetch *": "allow",
+      "gh pr checkout *": "allow",
     });
   });
 
@@ -60,6 +68,7 @@ describe("compileOpenCodePermission", () => {
         verificationPackageManager: "npm",
         agentPermissions: { intent: "read-only", mcp: [], tools: [] },
       },
+      cwd: "/repo.junior-worktrees/slack-t",
     }) as Record<string, unknown>;
 
     expect(permission.edit).toBe("deny");
@@ -73,16 +82,46 @@ describe("compileOpenCodePermission", () => {
     expect(permission.bash).not.toMatchObject({ "npm install *": "allow" });
   });
 
-  it("keeps bash denied when a review worktree has no detected manager", () => {
+  it("keeps read-only inspection when a review worktree has no detected manager", () => {
     const permission = compileOpenCodePermission({
       subject: {
         activeAgentName: "review",
         worktreePath: "/repo.junior-worktrees/slack-t",
         agentPermissions: { intent: "read-only", mcp: [], tools: [] },
       },
+      cwd: "/repo.junior-worktrees/slack-t",
     }) as Record<string, unknown>;
 
-    expect(permission.bash).toBe("deny");
+    expect(permission.bash).toMatchObject({
+      "*": "deny",
+      "git blame *": "allow",
+      "gh pr list *": "allow",
+      "gh api --method GET *": "allow",
+    });
+    expect(permission.bash).not.toMatchObject({ "npm test *": "allow" });
+  });
+
+  it("withholds worktree mutations and checks when cwd is outside the registered worktree", () => {
+    const permission = compileOpenCodePermission({
+      subject: {
+        activeAgentName: "review",
+        worktreePath: "/repo.junior-worktrees/slack-t",
+        verificationPackageManager: "npm",
+        agentPermissions: { intent: "read-only", mcp: [], tools: [] },
+      },
+      cwd: "/shared/repo",
+    }) as Record<string, unknown>;
+
+    expect(permission.bash).toMatchObject({
+      "*": "deny",
+      "gh pr view *": "allow",
+      "git blame *": "allow",
+    });
+    expect(permission.bash).not.toMatchObject({
+      "git fetch *": "allow",
+      "gh pr checkout *": "allow",
+      "npm test *": "allow",
+    });
   });
 
   it("uses an explicit read-safe MCP allowlist for read-only roles", () => {
@@ -167,11 +206,14 @@ describe("provider permission compilation matrix", () => {
       expect(byName.has(name)).toBe(true);
     }
 
-    // Review / reproducer: hard read-only where enforceable.
+    // Review / reproducer: hard read-only where enforceable. Review also gets
+    // a non-mutating shell inspection surface; reproducer remains in plan.
     for (const name of ["review", "reproducer"] as const) {
       const row = byName.get(name)!;
       expect(row.intent).toBe("read-only");
-      expect(row.claudePermissionMode).toBe("plan");
+      expect(row.claudePermissionMode).toBe(
+        name === "review" ? "default" : "plan",
+      );
       expect(row.codexSandbox).toBe("read-only");
       expect(row.openCode).toMatchObject({ edit: "deny", write: "deny" });
     }

--- a/src/runners/policy.test.ts
+++ b/src/runners/policy.test.ts
@@ -57,6 +57,7 @@ describe("compileOpenCodePermission", () => {
       subject: {
         activeAgentName: "review",
         worktreePath: "/repo.junior-worktrees/slack-t",
+        verificationPackageManager: "npm",
         agentPermissions: { intent: "read-only", mcp: [], tools: [] },
       },
     }) as Record<string, unknown>;
@@ -66,10 +67,22 @@ describe("compileOpenCodePermission", () => {
     expect(permission.bash).toMatchObject({
       "*": "deny",
       "npm test *": "allow",
-      "pnpm test *": "allow",
-      "bun test *": "allow",
     });
+    expect(permission.bash).not.toMatchObject({ "pnpm test *": "allow" });
+    expect(permission.bash).not.toMatchObject({ "bun test *": "allow" });
     expect(permission.bash).not.toMatchObject({ "npm install *": "allow" });
+  });
+
+  it("keeps bash denied when a review worktree has no detected manager", () => {
+    const permission = compileOpenCodePermission({
+      subject: {
+        activeAgentName: "review",
+        worktreePath: "/repo.junior-worktrees/slack-t",
+        agentPermissions: { intent: "read-only", mcp: [], tools: [] },
+      },
+    }) as Record<string, unknown>;
+
+    expect(permission.bash).toBe("deny");
   });
 
   it("uses an explicit read-safe MCP allowlist for read-only roles", () => {

--- a/src/runners/policy.test.ts
+++ b/src/runners/policy.test.ts
@@ -76,7 +76,9 @@ describe("compileOpenCodePermission", () => {
     expect(permission.bash).toMatchObject({
       "*": "deny",
       "npm test *": "allow",
+      "git fetch *": "allow",
     });
+    expect(permission.bash).not.toMatchObject({ "gh pr checkout *": "allow" });
     expect(permission.bash).not.toMatchObject({ "pnpm test *": "allow" });
     expect(permission.bash).not.toMatchObject({ "bun test *": "allow" });
     expect(permission.bash).not.toMatchObject({ "npm install *": "allow" });
@@ -96,8 +98,12 @@ describe("compileOpenCodePermission", () => {
       "*": "deny",
       "git blame *": "allow",
       "gh pr list *": "allow",
-      "gh api --method GET *": "allow",
     });
+    expect(
+      Object.keys(permission.bash as Record<string, string>).some((pattern) =>
+        pattern.startsWith("gh api")
+      ),
+    ).toBe(false);
     expect(permission.bash).not.toMatchObject({ "npm test *": "allow" });
   });
 
@@ -134,6 +140,7 @@ describe("compileOpenCodePermission", () => {
     expect(permission["mcp__*"]).toBe("deny");
     expect(permission["mcp__slack-bot__memory_recall"]).toBe("allow");
     expect(permission["mcp__slack-bot__slack_read_thread"]).toBe("allow");
+    expect(permission["mcp__slack-bot__github_read_pr_review_state"]).toBe("allow");
     expect(permission["mcp__slack-bot__github_post_review"]).toBe("allow");
     // Mutating MCP tools must not ride a blanket allow.
     expect(permission["mcp__slack-bot__agent_dispatch"]).not.toBe("allow");

--- a/src/runners/policy.ts
+++ b/src/runners/policy.ts
@@ -35,11 +35,14 @@ import {
 import type { OpenCodePermissionConfig } from "../opencode/config.ts";
 import { hasCapability } from "../agents/capabilities.ts";
 import { GITHUB_POST_REVIEW_TOOL } from "../github/review-comments.ts";
+import { WORKTREE_VERIFICATION_COMMAND_PATTERNS } from "../agents/verification.ts";
 
 export interface PermissionSubject {
   agentPermissions?: AgentPermissions;
   activeAgentName?: string | null;
   agentType?: string | null;
+  worktreePath?: string | null;
+  worktreePaths?: Record<string, string>;
 }
 
 /**
@@ -77,8 +80,8 @@ export const READ_SAFE_MCP_PERMISSIONS: Record<string, string> = {
  * - human-gated: ask on mutating tools
  * - normal / utility / null: use the configured fallback (typically "allow")
  *
- * Reviewers do not receive arbitrary Bash merely to run tests — verification
- * should go through a pipeline-owned allowlisted runner (Phase 4+).
+ * Reviewers receive granular verification commands only when a managed
+ * worktree is registered; arbitrary Bash remains denied.
  */
 export function compileOpenCodePermission(options: {
   subject: PermissionSubject;
@@ -94,6 +97,12 @@ export function compileOpenCodePermission(options: {
   )
     ? { [GITHUB_POST_REVIEW_TOOL]: "allow" }
     : {};
+  const mayVerifyWorktree =
+    hasCapability(agentName, "worktree-verify") &&
+    Boolean(
+      options.subject.worktreePath ||
+        Object.keys(options.subject.worktreePaths ?? {}).length > 0,
+    );
 
   if (intent === "no-tools") {
     return {
@@ -117,9 +126,14 @@ export function compileOpenCodePermission(options: {
       list: "allow",
       edit: "deny",
       write: "deny",
-      // Best-effort: deny shell. Review uses git/gh via provider-specific
-      // allowlists on Claude; OpenCode has no equivalent command patterns here.
-      bash: "deny",
+      bash: mayVerifyWorktree
+        ? Object.fromEntries([
+            ["*", "deny"],
+            ...WORKTREE_VERIFICATION_COMMAND_PATTERNS.map(
+              (pattern) => [pattern, "allow"],
+            ),
+          ])
+        : "deny",
       task: "deny",
       // Explicit read-safe MCP surface only — never blanket mcp__*.
       ...READ_SAFE_MCP_PERMISSIONS,

--- a/src/runners/policy.ts
+++ b/src/runners/policy.ts
@@ -34,7 +34,10 @@ import {
 } from "../codex-app-server/policy.ts";
 import type { OpenCodePermissionConfig } from "../opencode/config.ts";
 import { hasCapability } from "../agents/capabilities.ts";
-import { GITHUB_POST_REVIEW_TOOL } from "../github/review-comments.ts";
+import {
+  GITHUB_POST_REVIEW_TOOL,
+  GITHUB_READ_REVIEW_STATE_TOOL,
+} from "../github/review-comments.ts";
 import {
   reviewInspectionCommandPatterns,
   worktreeInspectionCommandPatterns,
@@ -75,6 +78,7 @@ export const READ_SAFE_MCP_PERMISSIONS: Record<string, string> = {
   "mcp__slack-bot__memory_recall": "allow",
   "mcp__slack-bot__register_worktree": "allow",
   "mcp__slack-bot__pipeline_get_state": "allow",
+  [GITHUB_READ_REVIEW_STATE_TOOL]: "allow",
   "mcp__playwright__*": "allow",
 };
 

--- a/src/runners/policy.ts
+++ b/src/runners/policy.ts
@@ -35,7 +35,11 @@ import {
 import type { OpenCodePermissionConfig } from "../opencode/config.ts";
 import { hasCapability } from "../agents/capabilities.ts";
 import { GITHUB_POST_REVIEW_TOOL } from "../github/review-comments.ts";
-import { worktreeVerificationCommandPatterns } from "../agents/verification.ts";
+import {
+  reviewInspectionCommandPatterns,
+  worktreeInspectionCommandPatterns,
+  worktreeVerificationCommandPatterns,
+} from "../agents/verification.ts";
 
 export interface PermissionSubject {
   agentPermissions?: AgentPermissions;
@@ -87,6 +91,7 @@ export const READ_SAFE_MCP_PERMISSIONS: Record<string, string> = {
  */
 export function compileOpenCodePermission(options: {
   subject: PermissionSubject;
+  cwd?: string;
   fallback?: OpenCodePermissionConfig;
 }): OpenCodePermissionConfig {
   const intent = resolveRunPermissionIntent(options.subject);
@@ -99,13 +104,14 @@ export function compileOpenCodePermission(options: {
   )
     ? { [GITHUB_POST_REVIEW_TOOL]: "allow" }
     : {};
-  const mayVerifyWorktree =
-    hasCapability(agentName, "worktree-verify") &&
-    Boolean(
-      options.subject.worktreePath ||
-        Object.keys(options.subject.worktreePaths ?? {}).length > 0,
-    ) &&
-    Boolean(options.subject.verificationPackageManager);
+  const worktreeRoots = [
+    options.subject.worktreePath,
+    ...Object.values(options.subject.worktreePaths ?? {}),
+  ].filter((root): root is string => Boolean(root));
+  const mayInspect = hasCapability(agentName, "worktree-verify");
+  const hasRegisteredWorktreeCwd =
+    Boolean(options.cwd) &&
+    worktreeRoots.includes(options.cwd!);
 
   if (intent === "no-tools") {
     return {
@@ -129,11 +135,16 @@ export function compileOpenCodePermission(options: {
       list: "allow",
       edit: "deny",
       write: "deny",
-      bash: mayVerifyWorktree
+      bash: mayInspect
         ? Object.fromEntries([
             ["*", "deny"],
-            ...worktreeVerificationCommandPatterns(
-              options.subject.verificationPackageManager!,
+            ...(hasRegisteredWorktreeCwd && options.subject.verificationPackageManager
+              ? worktreeVerificationCommandPatterns(
+                  options.subject.verificationPackageManager,
+                )
+              : hasRegisteredWorktreeCwd
+                ? worktreeInspectionCommandPatterns()
+                : reviewInspectionCommandPatterns()
             ).map(
               (pattern) => [pattern, "allow"],
             ),
@@ -238,6 +249,7 @@ export function buildPermissionMatrix(options: {
     });
     const openCode = compileOpenCodePermission({
       subject: threadSession,
+      cwd,
       fallback: options.openCodeFallback ?? "allow",
     });
 

--- a/src/runners/policy.ts
+++ b/src/runners/policy.ts
@@ -35,7 +35,7 @@ import {
 import type { OpenCodePermissionConfig } from "../opencode/config.ts";
 import { hasCapability } from "../agents/capabilities.ts";
 import { GITHUB_POST_REVIEW_TOOL } from "../github/review-comments.ts";
-import { WORKTREE_VERIFICATION_COMMAND_PATTERNS } from "../agents/verification.ts";
+import { worktreeVerificationCommandPatterns } from "../agents/verification.ts";
 
 export interface PermissionSubject {
   agentPermissions?: AgentPermissions;
@@ -43,6 +43,7 @@ export interface PermissionSubject {
   agentType?: string | null;
   worktreePath?: string | null;
   worktreePaths?: Record<string, string>;
+  verificationPackageManager?: ThreadSession["verificationPackageManager"];
 }
 
 /**
@@ -81,7 +82,8 @@ export const READ_SAFE_MCP_PERMISSIONS: Record<string, string> = {
  * - normal / utility / null: use the configured fallback (typically "allow")
  *
  * Reviewers receive granular verification commands only when a managed
- * worktree is registered; arbitrary Bash remains denied.
+ * worktree is registered and its package manager is unambiguous; arbitrary
+ * Bash remains denied.
  */
 export function compileOpenCodePermission(options: {
   subject: PermissionSubject;
@@ -102,7 +104,8 @@ export function compileOpenCodePermission(options: {
     Boolean(
       options.subject.worktreePath ||
         Object.keys(options.subject.worktreePaths ?? {}).length > 0,
-    );
+    ) &&
+    Boolean(options.subject.verificationPackageManager);
 
   if (intent === "no-tools") {
     return {
@@ -129,7 +132,9 @@ export function compileOpenCodePermission(options: {
       bash: mayVerifyWorktree
         ? Object.fromEntries([
             ["*", "deny"],
-            ...WORKTREE_VERIFICATION_COMMAND_PATTERNS.map(
+            ...worktreeVerificationCommandPatterns(
+              options.subject.verificationPackageManager!,
+            ).map(
               (pattern) => [pattern, "allow"],
             ),
           ])

--- a/src/runners/types.ts
+++ b/src/runners/types.ts
@@ -31,6 +31,26 @@ export interface RunnerEventDone {
   type: "done";
   provider: RunnerProvider;
   usage?: Record<string, unknown>;
+  completion?: RunnerCompletion;
+}
+
+export type RunnerCompletionStatus = "success" | "incomplete" | "failure";
+
+export type RunnerCompletionReason =
+  | "completed"
+  | "max_turns"
+  | "missing_result"
+  | "provider_error"
+  | "process_error"
+  | "timeout";
+
+/** Provider-neutral terminal semantics. Process exit code alone is not completion. */
+export interface RunnerCompletion {
+  status: RunnerCompletionStatus;
+  reason: RunnerCompletionReason;
+  retryable: boolean;
+  providerSubtype?: string;
+  turns?: number;
 }
 
 export type RunnerEvent =
@@ -46,6 +66,7 @@ export interface SpawnResult {
   events: RunnerEvent[];
   exitCode: number | null;
   error: string | null;
+  completion?: RunnerCompletion;
 }
 
 export type RunnerKillSignal = "SIGINT" | "SIGTERM" | "SIGKILL";

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach, mock } from "bun:test";
 import type {
+  RunnerCompletion,
   RunnerEvent,
   SpawnHandle,
   SpawnResult,
@@ -12,11 +13,22 @@ import type { App } from "@slack/bolt";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { InMemoryPipelineStore } from "../pipelines/store/memory.ts";
+import {
+  makeAssignmentCreate,
+  makeProductRun,
+} from "../pipelines/store/test-helpers.ts";
+import { fakeClock } from "../time/clock.ts";
 
 // --- Mock setup ---
 
 interface MockHandle extends SpawnHandle {
-  _complete: (response?: string, sessionId?: string, events?: RunnerEvent[]) => void;
+  _complete: (
+    response?: string,
+    sessionId?: string,
+    events?: RunnerEvent[],
+    completion?: RunnerCompletion,
+  ) => void;
   _error: (errorMsg: string) => void;
 }
 
@@ -36,7 +48,12 @@ function createMockHandle(
     onEvent: (cb) => listeners.push(cb),
     kill: mock(() => {}),
     pid: 12345,
-    _complete: (resp?: string, sid?: string, resultEvents?: RunnerEvent[]) => {
+    _complete: (
+      resp?: string,
+      sid?: string,
+      resultEvents?: RunnerEvent[],
+      completion?: RunnerCompletion,
+    ) => {
       const finalResponse = resp ?? response;
       const finalSessionId = sid ?? sessionId;
       for (const l of listeners)
@@ -50,10 +67,13 @@ function createMockHandle(
       resolveResult({
         provider: "claude",
         sessionId: finalSessionId,
-        response: finalResponse,
+        response: completion && completion.status !== "success" ? "" : finalResponse,
         events: resultEvents ?? [],
         exitCode: 0,
-        error: null,
+        error: completion && completion.status !== "success"
+          ? "Claude reached the turn limit"
+          : null,
+        completion,
       });
     },
     _error: (errorMsg: string) => {
@@ -2161,5 +2181,146 @@ describe("SessionManager", () => {
       expect(after.dormant).toBe(false);
       expect(after.humanParticipants).toEqual(["U-A"]);
     });
+  });
+});
+
+describe("typed pipeline settlement", () => {
+  it("quietly resumes a max-turn Claude session and trusts its later durable outcome", async () => {
+    const sessionStore = new InMemorySessionStore();
+    const pipelineStore = new InMemoryPipelineStore(fakeClock(1_000));
+    await pipelineStore.createRun(makeProductRun({ phase: "building" }));
+    await pipelineStore.createAssignment(makeAssignmentCreate({
+      id: "asg-settlement",
+      targetAgent: "build",
+      idempotencyKey: "asg-settlement-key",
+    }));
+    const handles: MockHandle[] = [];
+    const prompts: string[] = [];
+    const localSpawn: SpawnRunnerFn = (_session, prompt) => {
+      const handle = createMockHandle();
+      handles.push(handle);
+      prompts.push(prompt);
+      return handle;
+    };
+    const manager = new SessionManager(sessionStore, testConfig, localSpawn);
+    manager.pipelineStore = pipelineStore;
+    const errors = mock((_session, _error) => undefined);
+    manager.onError = errors;
+
+    await manager.handleAgentMessage(makeEvent({
+      text: "implement the assignment",
+      dedupeKey: "pipeline-outbox:dispatch-settlement",
+      pipelineInvocation: {
+        runId: "run-1",
+        assignmentId: "asg-settlement",
+        dispatchKey: "dispatch-settlement",
+        outcomeCountAtDispatch: 0,
+        retryCount: 0,
+      },
+    }), "build");
+    await waitFor(() => handles.length === 1);
+    const first = handles[0]!;
+    first._complete("about to report", "claude-settlement", [], {
+      status: "incomplete",
+      reason: "max_turns",
+      retryable: true,
+      providerSubtype: "error_max_turns",
+      turns: 25,
+    });
+
+    await waitFor(() => handles.length === 2);
+    expect(prompts[1]).toContain("pipeline_report_outcome");
+    expect(errors).not.toHaveBeenCalled();
+    const storedDuringRetry = await sessionStore.get("thread-1");
+    expect(
+      storedDuringRetry?.agentSessions.build?.activePipelineInvocation?.retryCount,
+    ).toBe(1);
+
+    const run = (await pipelineStore.getRun("run-1"))!;
+    const receipt = await pipelineStore.recordOutcomeTransaction({
+      outcome: {
+        assignmentId: "asg-settlement",
+        expectedRunVersion: run.stateVersion,
+        action: "escalate",
+        status: "blocked",
+        reason: "waiting for a human-only credential",
+        evidenceRefs: [],
+        artifactRefs: [],
+        blockers: [{ kind: "missing_authority", detail: "credential required" }],
+        checks: [],
+        progressFingerprint: "settled-after-resume",
+      },
+      toPhase: "needs-human",
+      actorType: "system",
+      actorId: "test",
+      idempotencyKey: "settled-after-resume",
+    });
+    expect(receipt.status).not.toBe("rejected");
+
+    const second = handles[1]!;
+    second._complete("", "claude-settlement", [], {
+      status: "incomplete",
+      reason: "max_turns",
+      retryable: true,
+      providerSubtype: "error_max_turns",
+      turns: 25,
+    });
+    await waitFor(async () =>
+      (await sessionStore.get("thread-1"))?.agentSessions.build?.status === "done"
+    );
+    expect(errors).not.toHaveBeenCalled();
+    expect(
+      (await sessionStore.get("thread-1"))?.agentSessions.build
+        ?.activePipelineInvocation,
+    ).toBeNull();
+  });
+
+  it("posts one failure only after the bounded recovery budget is exhausted", async () => {
+    const sessionStore = new InMemorySessionStore();
+    const pipelineStore = new InMemoryPipelineStore(fakeClock(1_000));
+    await pipelineStore.createRun(makeProductRun({ phase: "building" }));
+    await pipelineStore.createAssignment(makeAssignmentCreate({
+      id: "asg-exhausted",
+      targetAgent: "build",
+      idempotencyKey: "asg-exhausted-key",
+    }));
+    const handles: MockHandle[] = [];
+    const manager = new SessionManager(sessionStore, testConfig, () => {
+      const handle = createMockHandle();
+      handles.push(handle);
+      return handle;
+    });
+    manager.pipelineStore = pipelineStore;
+    const errors = mock((_session, _error) => undefined);
+    manager.onError = errors;
+
+    await manager.handleAgentMessage(makeEvent({
+      text: "implement the assignment",
+      dedupeKey: "pipeline-outbox:dispatch-exhausted",
+      pipelineInvocation: {
+        runId: "run-1",
+        assignmentId: "asg-exhausted",
+        dispatchKey: "dispatch-exhausted",
+        outcomeCountAtDispatch: 0,
+        retryCount: 0,
+      },
+    }), "build");
+
+    for (let index = 0; index < 3; index++) {
+      await waitFor(() => handles.length === index + 1);
+      handles[index]!._complete("", "claude-exhausted", [], {
+        status: "incomplete",
+        reason: "max_turns",
+        retryable: true,
+        providerSubtype: "error_max_turns",
+        turns: 25,
+      });
+      if (index < 2) expect(errors).not.toHaveBeenCalled();
+    }
+
+    await waitFor(() => errors.mock.calls.length === 1);
+    expect(errors).toHaveBeenCalledTimes(1);
+    expect(await pipelineStore.listOutcomes("asg-exhausted")).toHaveLength(1);
+    expect((await pipelineStore.getRun("run-1"))?.status).toBe("needs-human");
   });
 });

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -26,7 +26,7 @@ import type { WorktreeManager } from "../worktree/manager.ts";
 interface MockHandle extends SpawnHandle {
   _complete: (
     response?: string,
-    sessionId?: string,
+    sessionId?: string | null,
     events?: RunnerEvent[],
     completion?: RunnerCompletion,
   ) => void;
@@ -51,24 +51,26 @@ function createMockHandle(
     pid: 12345,
     _complete: (
       resp?: string,
-      sid?: string,
+      sid?: string | null,
       resultEvents?: RunnerEvent[],
       completion?: RunnerCompletion,
     ) => {
       const finalResponse = resp ?? response;
-      const finalSessionId = sid ?? sessionId;
+      const finalSessionId = sid === undefined ? sessionId : sid;
       for (const l of listeners)
-        l({
-          type: "init",
-          provider: "claude",
-          sessionId: finalSessionId,
-        });
+        if (finalSessionId) {
+          l({
+            type: "init",
+            provider: "claude",
+            sessionId: finalSessionId,
+          });
+        }
       for (const l of listeners)
         l({ type: "done", provider: "claude" });
       resolveResult({
         provider: "claude",
         sessionId: finalSessionId,
-        response: completion && completion.status !== "success" ? "" : finalResponse,
+        response: finalResponse,
         events: resultEvents ?? [],
         exitCode: 0,
         error: completion && completion.status !== "success"
@@ -294,10 +296,12 @@ function createCompletingOpencodeHandle(
     onEvent: (cb) => listeners.push(cb),
     kill: mock(() => {}),
     pid,
-    _complete: (resp?: string, sid?: string, resultEvents?: RunnerEvent[]) => {
-      const finalSessionId = sid ?? sessionId;
+    _complete: (resp?: string, sid?: string | null, resultEvents?: RunnerEvent[]) => {
+      const finalSessionId = sid === undefined ? sessionId : sid;
       for (const l of listeners) {
-        l({ type: "init", provider: "opencode", sessionId: finalSessionId });
+        if (finalSessionId) {
+          l({ type: "init", provider: "opencode", sessionId: finalSessionId });
+        }
         l({ type: "done", provider: "opencode" });
       }
       resolveResult({
@@ -1725,6 +1729,33 @@ describe("SessionManager", () => {
     expect(errors).toEqual(["Claude crashed"]);
   });
 
+  it("publishes useful partial output from a non-pipeline turn-limit result", async () => {
+    const errors: string[] = [];
+    const responses: string[] = [];
+    manager.onError = (_session, error) => {
+      if (error) errors.push(error);
+    };
+    manager.onResponse = (_session, response) => responses.push(response);
+
+    await manager.handleMessage(makeEvent({ text: "Do a long investigation" }));
+    currentHandle._complete(
+      "I traced the failure to the queue lease.",
+      "claude-partial",
+      [],
+      {
+        status: "incomplete",
+        reason: "max_turns",
+        retryable: true,
+        providerSubtype: "error_max_turns",
+        turns: 25,
+      },
+    );
+
+    await waitFor(() => errors.length === 1 && responses.length === 1);
+    expect(errors[0]).toContain("turn limit");
+    expect(responses).toEqual(["I traced the failure to the queue lease."]);
+  });
+
   // --- onEvent forwarding ---
 
   it("forwards stream events via onEvent", async () => {
@@ -2363,5 +2394,51 @@ describe("typed pipeline settlement", () => {
     expect(errors).toHaveBeenCalledTimes(1);
     expect(await pipelineStore.listOutcomes("asg-exhausted")).toHaveLength(1);
     expect((await pipelineStore.getRun("run-1"))?.status).toBe("needs-human");
+  });
+
+  it("reports zero recovery continuations when no provider session can resume", async () => {
+    const sessionStore = new InMemorySessionStore();
+    const pipelineStore = new InMemoryPipelineStore(fakeClock(1_000));
+    await pipelineStore.createRun(makeProductRun({ phase: "building" }));
+    await pipelineStore.createAssignment(makeAssignmentCreate({
+      id: "asg-no-session",
+      targetAgent: "build",
+      idempotencyKey: "asg-no-session-key",
+    }));
+    const handle = createMockHandle();
+    const manager = new SessionManager(sessionStore, testConfig, () => handle);
+    manager.pipelineStore = pipelineStore;
+    const errors = mock((_session, _error) => undefined);
+    const responses = mock((_session, _response) => undefined);
+    manager.onError = errors;
+    manager.onResponse = responses;
+
+    await manager.handleAgentMessage(makeEvent({
+      text: "implement the assignment",
+      dedupeKey: "pipeline-outbox:dispatch-no-session",
+      pipelineInvocation: {
+        runId: "run-1",
+        assignmentId: "asg-no-session",
+        dispatchKey: "dispatch-no-session",
+        outcomeCountAtDispatch: 0,
+        retryCount: 0,
+      },
+    }), "build");
+
+    handle._complete("about to report", null, [], {
+      status: "incomplete",
+      reason: "max_turns",
+      retryable: true,
+      providerSubtype: "error_max_turns",
+      turns: 25,
+    });
+
+    await waitFor(() => errors.mock.calls.length === 1);
+    expect(errors.mock.calls[0]![1]).toContain("without a recovery continuation");
+    expect(errors.mock.calls[0]![1]).not.toContain("after 2");
+    expect(responses).not.toHaveBeenCalled();
+    const outcomes = await pipelineStore.listOutcomes("asg-no-session");
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0]!.reason).toContain("without a recovery continuation");
   });
 });

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -19,6 +19,7 @@ import {
   makeProductRun,
 } from "../pipelines/store/test-helpers.ts";
 import { fakeClock } from "../time/clock.ts";
+import type { WorktreeManager } from "../worktree/manager.ts";
 
 // --- Mock setup ---
 
@@ -363,6 +364,44 @@ describe("SessionManager", () => {
     const callArgs = mockSpawnFn.mock.calls[0];
     // Second arg is the prompt
     expect(callArgs[1]).toBe("Build me a feature");
+  });
+
+  it("switches to and registers the PR repo worktree before starting review", async () => {
+    const createWorktree = mock(async () => "/tmp/frontend.junior-worktrees/slack-thread-1");
+    manager.worktreeManager = {
+      createWorktree,
+      getBranchName: () => "slack/thread-1",
+    } as unknown as WorktreeManager;
+    const existing = createSession("thread-1", "C123");
+    existing.targetRepo = "junior";
+    existing.worktreePath = "/tmp/junior.junior-worktrees/slack-thread-1";
+    existing.worktreePaths = {
+      junior: "/tmp/junior.junior-worktrees/slack-thread-1",
+    };
+    await store.set(existing.threadId, existing);
+
+    await manager.handleAgentMessage(
+      makeEvent({
+        text: "review https://github.com/GrowthX-Club/frontend/pull/127",
+      }),
+      "review",
+    );
+    await waitFor(() => createWorktree.mock.calls.length === 1);
+
+    expect(createWorktree).toHaveBeenCalledWith(
+      "frontend",
+      "thread-1",
+      undefined,
+    );
+    const runSession = mockSpawnFn.mock.calls[0][0];
+    expect(runSession.worktreePath).toBe(
+      "/tmp/frontend.junior-worktrees/slack-thread-1",
+    );
+    expect(runSession.worktreePaths).toEqual({
+      junior: "/tmp/junior.junior-worktrees/slack-thread-1",
+      frontend: "/tmp/frontend.junior-worktrees/slack-thread-1",
+    });
+    expect(runSession.targetRepo).toBe("frontend");
   });
 
   it("adds downloaded non-image Slack file paths to the prompt", async () => {

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -238,7 +238,7 @@ function cloneConfig(overrides: Partial<Config> = {}): Config {
 
 async function waitFor(
   predicate: () => boolean | Promise<boolean>,
-  timeoutMs: number = 100,
+  timeoutMs: number = 1000,
 ): Promise<void> {
   const started = Date.now();
   while (!(await predicate())) {
@@ -367,7 +367,9 @@ describe("SessionManager", () => {
   });
 
   it("switches to and registers the PR repo worktree before starting review", async () => {
-    const createWorktree = mock(async () => "/tmp/frontend.junior-worktrees/slack-thread-1");
+    const reviewWorktree = mkdtempSync(join(tmpdir(), "junior-review-worktree-"));
+    writeFileSync(join(reviewWorktree, "package-lock.json"), "{}");
+    const createWorktree = mock(async () => reviewWorktree);
     manager.worktreeManager = {
       createWorktree,
       getBranchName: () => "slack/thread-1",
@@ -386,7 +388,7 @@ describe("SessionManager", () => {
       }),
       "review",
     );
-    await waitFor(() => createWorktree.mock.calls.length === 1);
+    await waitFor(() => mockSpawnFn.mock.calls.length === 1);
 
     expect(createWorktree).toHaveBeenCalledWith(
       "frontend",
@@ -394,14 +396,14 @@ describe("SessionManager", () => {
       undefined,
     );
     const runSession = mockSpawnFn.mock.calls[0][0];
-    expect(runSession.worktreePath).toBe(
-      "/tmp/frontend.junior-worktrees/slack-thread-1",
-    );
+    expect(runSession.worktreePath).toBe(reviewWorktree);
     expect(runSession.worktreePaths).toEqual({
       junior: "/tmp/junior.junior-worktrees/slack-thread-1",
-      frontend: "/tmp/frontend.junior-worktrees/slack-thread-1",
+      frontend: reviewWorktree,
     });
     expect(runSession.targetRepo).toBe("frontend");
+    expect(runSession.verificationPackageManager).toBe("npm");
+    rmSync(reviewWorktree, { recursive: true, force: true });
   });
 
   it("adds downloaded non-image Slack file paths to the prompt", async () => {

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -1882,6 +1882,9 @@ export class SessionManager {
     }
 
     const latestRun = await this.pipelineStore.getRun(invocation.runId);
+    const recoverySummary = invocation.retryCount === 0
+      ? "without a recovery continuation"
+      : `after ${invocation.retryCount} recovery continuation${invocation.retryCount === 1 ? "" : "s"}`;
     if (latestRun && latestRun.status !== "terminal") {
       await this.pipelineStore.recordOutcomeTransaction({
         outcome: {
@@ -1889,7 +1892,7 @@ export class SessionManager {
           expectedRunVersion: latestRun.stateVersion,
           action: "escalate",
           status: "blocked",
-          reason: `Pipeline invocation ended without a typed outcome after ${maxRetries} recovery continuations.`,
+          reason: `Pipeline invocation ended without a typed outcome ${recoverySummary}.`,
           evidenceRefs: [],
           artifactRefs: [],
           blockers: [{
@@ -1908,7 +1911,7 @@ export class SessionManager {
     return {
       ...result,
       response: "",
-      error: `Pipeline assignment ${invocation.assignmentId.slice(0, 8)} stopped without reporting a typed outcome after ${maxRetries} recovery continuations. The run was escalated for human attention.`,
+      error: `Pipeline assignment ${invocation.assignmentId.slice(0, 8)} stopped without reporting a typed outcome ${recoverySummary}. The run was escalated for human attention.`,
       completion: {
         status: "failure",
         reason: result.completion?.reason ?? "provider_error",

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -55,6 +55,7 @@ import { DEFAULT_CONTEXT_PROFILE, type AgentContextProfile } from "../agents/loa
 import { downloadSlackFiles } from "../slack/files.ts";
 import { log as _log } from "../logger.ts";
 import { inferReviewRepo } from "../worktree/review-routing.ts";
+import { detectJavaScriptPackageManager } from "../worktree/package-manager.ts";
 import type { MemoryIngestor } from "../memory/ingestion.ts";
 import { createPreRecall, type PreRecallFn } from "../memory/pre-recall.ts";
 import { clearThreadJuniorMessages } from "../slack/thread-archive.ts";
@@ -1321,6 +1322,7 @@ export class SessionManager {
       // the newly registered isolated checkout on this same turn.
       const runSession = this.buildRunSession(session, agentName, agentIdentity);
       runSession.currentMessageTs = latestTs ?? null;
+      await this.attachReviewVerificationPolicy(runSession, agentName);
 
       // Resolve the agent definition early so its declared context profile
       // gates the preamble. Default agent (no .md) and missing-flag cases
@@ -1653,6 +1655,7 @@ export class SessionManager {
             "Continue from the last completed step.",
           ].join("\n");
           const retryRunSession = this.buildRunSession(session, agentName, agentIdentity);
+          await this.attachReviewVerificationPolicy(retryRunSession, agentName);
 
           // Re-spawn with the continue prompt. Reuse the same rawHandle
           // creation path (driver.send for tmux, spawnRunner otherwise).
@@ -2448,6 +2451,21 @@ export class SessionManager {
       activeAgentName: agentName,
       slackIdentity: agentIdentity,
     };
+  }
+
+  private async attachReviewVerificationPolicy(
+    runSession: ThreadSession,
+    agentName: string,
+  ): Promise<void> {
+    if (agentName !== "review" || !runSession.worktreePath) return;
+    runSession.verificationPackageManager =
+      await detectJavaScriptPackageManager(runSession.worktreePath);
+    if (!runSession.verificationPackageManager) {
+      _log.warn(
+        "manager",
+        `review verification disabled: package manager is absent or ambiguous in ${runSession.worktreePath}`,
+      );
+    }
   }
 
   private withAgentIdentityPrompt(

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -418,6 +418,7 @@ export class SessionManager {
         return;
       }
       agentSession.status = "busy";
+      agentSession.activePipelineInvocation = event.pipelineInvocation ?? null;
       agentSession.lastActivity = Date.now();
       s.lastActivity = agentSession.lastActivity;
       outcome.action = "run";
@@ -481,6 +482,7 @@ export class SessionManager {
         return;
       }
       s.status = "busy";
+      s.activePipelineInvocation = event.pipelineInvocation ?? null;
       s.activeAgentName = agentName;
       s.activeTopLevelMessageTs = event.ts;
       s.slackIdentity = identityForAgent(agentName);
@@ -650,6 +652,7 @@ export class SessionManager {
         s.sessionId = null;
         s.leadSessionId = null;
         s.pendingMessages = [];
+        s.activePipelineInvocation = null;
         s.status = "idle";
         s.pid = null;
         s.tmuxSessionName = null;
@@ -1684,6 +1687,15 @@ export class SessionManager {
           continue;
         }
 
+        const pipelineResolution = await this.resolvePipelineInvocation(
+          session,
+          agentName,
+          result,
+          attemptHandle,
+        );
+        if (pipelineResolution === null) return;
+        result = pipelineResolution;
+
         // Normal completion (or idle-interrupted but out of retries).
         const exhaustedRetries = idleInterrupted && session.idleInterruptCount >= maxIdleInterrupts;
         // Reset idle interrupt count so the next turn starts fresh.
@@ -1713,6 +1725,155 @@ export class SessionManager {
         session.lastError.message,
       );
     }
+  }
+
+  /**
+   * A pipeline invocation is complete only after its exact assignment gains a
+   * new durable outcome. Claude/process completion is merely a transport
+   * signal. Missing outcomes resume quietly; exhaustion records one durable
+   * escalation and lets the normal error path post one concise failure.
+   */
+  private async resolvePipelineInvocation(
+    session: ThreadSession,
+    agentName: string,
+    result: SpawnResult,
+    ownHandle: SpawnHandle,
+  ): Promise<SpawnResult | null> {
+    if (!this.pipelineStore) return result;
+    const fresh = (await this.store.get(session.threadId)) ?? session;
+    const isTopLevel = agentName === "lead" || agentName === "default";
+    const invocation = isTopLevel
+      ? fresh.activePipelineInvocation
+      : fresh.agentSessions?.[agentName]?.activePipelineInvocation;
+    if (!invocation) return result;
+
+    const [run, assignment, outcomes] = await Promise.all([
+      this.pipelineStore.getRun(invocation.runId),
+      this.pipelineStore.getAssignment(invocation.assignmentId),
+      this.pipelineStore.listOutcomes(invocation.assignmentId),
+    ]);
+    if (!run || !assignment) {
+      return {
+        ...result,
+        response: "",
+        error: `Pipeline settlement state is missing for run ${invocation.runId.slice(0, 8)} / assignment ${invocation.assignmentId.slice(0, 8)}.`,
+        completion: {
+          status: "failure",
+          reason: "provider_error",
+          retryable: false,
+        },
+      };
+    }
+    const durable =
+      run.status === "terminal" ||
+      !["pending", "leased"].includes(assignment.status) ||
+      outcomes.length > invocation.outcomeCountAtDispatch;
+
+    if (durable) {
+      // The typed outcome is authoritative. A provider may hit its turn cap
+      // immediately after committing it; that must not become a Slack error.
+      return result.error
+        ? {
+            ...result,
+            response: "",
+            error: null,
+            completion: {
+              status: "success",
+              reason: "completed",
+              retryable: false,
+              providerSubtype: result.completion?.providerSubtype,
+              turns: result.completion?.turns,
+            },
+          }
+        : result;
+    }
+
+    const sessionId = isTopLevel
+      ? fresh.sessionId
+      : fresh.agentSessions?.[agentName]?.sessionId;
+    const maxRetries = 2;
+    if (invocation.retryCount < maxRetries && (result.sessionId || sessionId)) {
+      const retryCount = invocation.retryCount + 1;
+      const continued = await this.mutateSession(fresh.threadId, (current) => {
+        const owner = isTopLevel
+          ? current
+          : this.getOrCreateAgentSession(current, agentName);
+        const active = owner.activePipelineInvocation;
+        if (!active || active.dispatchKey !== invocation.dispatchKey) {
+          throw new Error("pipeline invocation ownership changed");
+        }
+        owner.activePipelineInvocation = { ...active, retryCount };
+        if (result.sessionId) {
+          owner.sessionId = result.sessionId;
+          owner.provider = result.provider;
+          if (isTopLevel) current.leadSessionId = result.sessionId;
+        }
+        owner.status = "busy";
+        owner.pid = null;
+      });
+      if (this.handles.get(this.handleKey(fresh.threadId, agentName)) === ownHandle) {
+        this.handles.delete(this.handleKey(fresh.threadId, agentName));
+      }
+      const continuation = [
+        "The pipeline assignment has not recorded a typed outcome yet.",
+        `Recovery continuation ${retryCount} of ${maxRetries}. Resume this same session from durable state; do not repeat completed mutations.`,
+        "Finish any remaining work, then call pipeline_report_outcome for the active assignment before ending this invocation.",
+      ].join("\n");
+      _log.warn(
+        "pipeline",
+        `settlement.resume thread=${fresh.threadId} agent=${agentName} assignment=${invocation.assignmentId} attempt=${retryCount}/${maxRetries} reason=${result.completion?.reason ?? (result.error ? "runner-error" : "missing-outcome")}`,
+      );
+      this.runRunnerWithAgent(
+        continued,
+        continuation,
+        undefined,
+        undefined,
+        agentName,
+      ).catch((err) => {
+        _log.error(
+          "pipeline",
+          `settlement.resume.fail thread=${fresh.threadId} assignment=${invocation.assignmentId} err=${err instanceof Error ? err.message : String(err)}`,
+        );
+      });
+      return null;
+    }
+
+    const latestRun = await this.pipelineStore.getRun(invocation.runId);
+    if (latestRun && latestRun.status !== "terminal") {
+      await this.pipelineStore.recordOutcomeTransaction({
+        outcome: {
+          assignmentId: invocation.assignmentId,
+          expectedRunVersion: latestRun.stateVersion,
+          action: "escalate",
+          status: "blocked",
+          reason: `Pipeline invocation ended without a typed outcome after ${maxRetries} recovery continuations.`,
+          evidenceRefs: [],
+          artifactRefs: [],
+          blockers: [{
+            kind: "infra_failure",
+            detail: result.error ?? "runner completed without reporting an outcome",
+          }],
+          checks: [],
+          progressFingerprint: `settlement-exhausted:${invocation.dispatchKey}`,
+        },
+        toPhase: "needs-human",
+        actorType: "system",
+        actorId: "pipeline-settlement",
+        idempotencyKey: `pipeline-settlement-exhausted:${invocation.dispatchKey}`,
+      });
+    }
+    return {
+      ...result,
+      response: "",
+      error: `Pipeline assignment ${invocation.assignmentId.slice(0, 8)} stopped without reporting a typed outcome after ${maxRetries} recovery continuations. The run was escalated for human attention.`,
+      completion: {
+        status: "failure",
+        reason: result.completion?.reason ?? "provider_error",
+        retryable: false,
+        providerSubtype: result.completion?.providerSubtype,
+        turns: result.completion?.turns,
+      },
+    };
   }
 
   private async persistRunProcessDetails(
@@ -1930,20 +2091,24 @@ export class SessionManager {
           const pendingMessages = s.pendingMessages;
           if (pendingMessages.length > 0 && s.muted) {
             s.pendingMessages = [];
+            s.activePipelineInvocation = null;
             s.status = "idle";
             settle.action = "muted-discard";
           } else if (pendingMessages.length > 0) {
+            const drained = this.takePendingBatch(pendingMessages);
             s.activeTopLevelMessageTs =
-              pendingMessages[pendingMessages.length - 1]?.ts ??
+              drained.messages[drained.messages.length - 1]?.ts ??
               s.activeTopLevelMessageTs ??
               null;
-            settle.drainPrompt = pendingMessages
+            settle.drainPrompt = drained.messages
               .map((m) => `<@${m.user}>: ${m.text}`)
               .join("\n");
-            s.pendingMessages = [];
+            s.pendingMessages = drained.remaining;
+            s.activePipelineInvocation = drained.pipelineInvocation;
             s.status = "draining";
             settle.action = "drain";
           } else {
+            s.activePipelineInvocation = null;
             s.status = "idle";
             settle.action = "settle";
           }
@@ -1965,16 +2130,20 @@ export class SessionManager {
           const pendingMessages = agentSession.pendingMessages;
           if (pendingMessages.length > 0 && s.muted) {
             agentSession.pendingMessages = [];
+            agentSession.activePipelineInvocation = null;
             agentSession.status = "idle";
             settle.action = "muted-discard";
           } else if (pendingMessages.length > 0) {
-            settle.drainPrompt = pendingMessages
+            const drained = this.takePendingBatch(pendingMessages);
+            settle.drainPrompt = drained.messages
               .map((m) => `<@${m.user}>: ${m.text}`)
               .join("\n");
-            agentSession.pendingMessages = [];
+            agentSession.pendingMessages = drained.remaining;
+            agentSession.activePipelineInvocation = drained.pipelineInvocation;
             agentSession.status = "busy";
             settle.action = "drain";
           } else {
+            agentSession.activePipelineInvocation = null;
             agentSession.status = result.error ? "failed" : "done";
             agentSession.lastActivity = Date.now();
             settle.action = "settle";
@@ -2025,6 +2194,32 @@ export class SessionManager {
         internalDispatchDirectives,
       );
     }
+  }
+
+  /** Keep control-plane dispatches individually attributable while retaining
+   * legacy batching for ordinary chat messages. */
+  private takePendingBatch(messages: PendingMessage[]): {
+    messages: PendingMessage[];
+    remaining: PendingMessage[];
+    pipelineInvocation: PendingMessage["pipelineInvocation"] | null;
+  } {
+    const firstPipeline = messages.findIndex((m) => m.pipelineInvocation);
+    if (firstPipeline === 0) {
+      const [first, ...remaining] = messages;
+      return {
+        messages: first ? [first] : [],
+        remaining,
+        pipelineInvocation: first?.pipelineInvocation ?? null,
+      };
+    }
+    if (firstPipeline > 0) {
+      return {
+        messages: messages.slice(0, firstPipeline),
+        remaining: messages.slice(firstPipeline),
+        pipelineInvocation: null,
+      };
+    }
+    return { messages: [...messages], remaining: [], pipelineInvocation: null };
   }
 
   private allowedInternalDirectivesForResponse(
@@ -2254,6 +2449,7 @@ export class SessionManager {
       ts: event.ts,
       command: event.command ?? undefined,
       dedupeKey: event.dedupeKey,
+      pipelineInvocation: event.pipelineInvocation,
     };
   }
 

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -54,6 +54,7 @@ import { isDuplicateSlackToolResponse } from "../slack/formatting.ts";
 import { DEFAULT_CONTEXT_PROFILE, type AgentContextProfile } from "../agents/loader.ts";
 import { downloadSlackFiles } from "../slack/files.ts";
 import { log as _log } from "../logger.ts";
+import { inferReviewRepo } from "../worktree/review-routing.ts";
 import type { MemoryIngestor } from "../memory/ingestion.ts";
 import { createPreRecall, type PreRecallFn } from "../memory/pre-recall.ts";
 import { clearThreadJuniorMessages } from "../slack/thread-archive.ts";
@@ -1225,9 +1226,39 @@ export class SessionManager {
         ? null
         : this.getOrCreateAgentSession(session, agentName);
       const agentIdentity = identityForAgent(agentName);
-      const runSession = this.buildRunSession(session, agentName, agentIdentity);
-      runSession.currentMessageTs = latestTs ?? null;
       const rawMessage = prompt;
+
+      // Reviewers run checks only in Junior-managed worktrees. Route each PR
+      // URL to its repo-specific worktree, and fall back to a pipeline repo ref
+      // only when the run names exactly one configured repo. This also lets one
+      // Slack session review PRs across different repositories without reusing
+      // the wrong checkout.
+      if (agentName === "review" && this.worktreeManager) {
+        let pipelineRepoRefs: string[] = [];
+        if (session.activePipelineRunId && this.pipelineStore) {
+          try {
+            const activeRun = await this.pipelineStore.getRun(
+              session.activePipelineRunId,
+            );
+            pipelineRepoRefs = activeRun?.repoRefs ?? [];
+          } catch (err) {
+            _log.warn(
+              "manager",
+              `review repo inference failed for pipeline ${session.activePipelineRunId}: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
+        }
+        const inferredRepo = inferReviewRepo(
+          this.config.repos,
+          prompt,
+          pipelineRepoRefs,
+        );
+        if (inferredRepo && session.targetRepo !== inferredRepo.name) {
+          session.targetRepo = inferredRepo.name;
+          session.worktreePath = session.worktreePaths[inferredRepo.name] ?? null;
+          await this.store.set(session.threadId, session);
+        }
+      }
 
       // Resolve target repo before building the preamble so workspace info can be injected.
       let targetRepo: { name: string; path: string } | undefined;
@@ -1253,6 +1284,10 @@ export class SessionManager {
             session.threadId,
             session.baseRef ?? undefined,
           );
+          session.worktreePaths = {
+            ...session.worktreePaths,
+            [targetRepo.name]: session.worktreePath,
+          };
           await this.store.set(session.threadId, session);
         } catch (err) {
           _log.warn(
@@ -1281,6 +1316,11 @@ export class SessionManager {
         session.worktreePaths && Object.keys(session.worktreePaths).length > 0
           ? session.worktreePaths
           : undefined;
+
+      // Build after worktree routing/creation so provider policy and cwd see
+      // the newly registered isolated checkout on this same turn.
+      const runSession = this.buildRunSession(session, agentName, agentIdentity);
+      runSession.currentMessageTs = latestTs ?? null;
 
       // Resolve the agent definition early so its declared context profile
       // gates the preamble. Default agent (no .md) and missing-flag cases

--- a/src/session/store/sqlite.test.ts
+++ b/src/session/store/sqlite.test.ts
@@ -78,6 +78,36 @@ describe("SqliteSessionStore", () => {
     );
   });
 
+  it("round-trips active pipeline invocations through parent JSON and agent rows", async () => {
+    const session = createSession("pipeline-thread", "channel-1");
+    session.activePipelineInvocation = {
+      runId: "run-top",
+      assignmentId: "asg-top",
+      dispatchKey: "dispatch-top",
+      outcomeCountAtDispatch: 2,
+      retryCount: 1,
+    };
+    session.agentSessions.build = makeAgent("build", {
+      activePipelineInvocation: {
+        runId: "run-agent",
+        assignmentId: "asg-agent",
+        dispatchKey: "dispatch-agent",
+        outcomeCountAtDispatch: 4,
+        retryCount: 2,
+      },
+    });
+
+    await store.set(session.threadId, session);
+
+    const retrieved = await store.get(session.threadId);
+    expect(retrieved?.activePipelineInvocation).toEqual(
+      session.activePipelineInvocation,
+    );
+    expect(retrieved?.agentSessions.build?.activePipelineInvocation).toEqual(
+      session.agentSessions.build.activePipelineInvocation,
+    );
+  });
+
   it("persists provider beside thread and agent session ids", async () => {
     const session = createSession("thread-1", "channel-1");
     session.provider = "opencode";

--- a/src/session/store/sqlite.ts
+++ b/src/session/store/sqlite.ts
@@ -370,6 +370,9 @@ export class SqliteSessionStore implements SessionStore {
         pid: row.pid ?? existing?.pid ?? null,
         stateVersion: row.state_version ?? existing?.stateVersion ?? 0,
       };
+      // Fields without dedicated dual-write columns remain durable in the
+      // authoritative parent-session JSON. Preserve the exact dispatch while
+      // overlaying the independently queryable agent row.
       if (existing?.activePipelineInvocation !== undefined) {
         agent.activePipelineInvocation = existing.activePipelineInvocation;
       }

--- a/src/session/store/sqlite.ts
+++ b/src/session/store/sqlite.ts
@@ -370,6 +370,9 @@ export class SqliteSessionStore implements SessionStore {
         pid: row.pid ?? existing?.pid ?? null,
         stateVersion: row.state_version ?? existing?.stateVersion ?? 0,
       };
+      if (existing?.activePipelineInvocation !== undefined) {
+        agent.activePipelineInvocation = existing.activePipelineInvocation;
+      }
       // Keep tmuxSessionName optional when never set (matches AgentSession shape
       // and round-trip equality for pre-tmux rows).
       const tmuxSessionName =

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -103,6 +103,11 @@ export interface ThreadSession {
   worktreePath: string | null;
   /** Per-repo worktree paths for bug-pipeline threads. Keys are repo names (from RepoConfig.name). */
   worktreePaths: Record<string, string>;
+  /**
+   * Ephemeral package manager detected from the active review worktree.
+   * Set only on the run-session copy; never treated as durable repo metadata.
+   */
+  verificationPackageManager?: import("../worktree/package-manager.ts").JavaScriptPackageManager | null;
   targetRepo: string | null;
   baseRef: string | null;
   agentType: string | null;

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -4,6 +4,16 @@ export interface PendingMessage {
   ts: string;
   command?: string;
   dedupeKey?: string;
+  pipelineInvocation?: PipelineInvocationRef;
+}
+
+/** Trusted control-plane identity attached by the outbox pump, never by a model. */
+export interface PipelineInvocationRef {
+  runId: string;
+  assignmentId: string;
+  dispatchKey: string;
+  outcomeCountAtDispatch: number;
+  retryCount: number;
 }
 
 export type AgentSessionStatus = "idle" | "busy" | "done" | "failed";
@@ -64,6 +74,7 @@ export interface AgentSession {
   tmuxSessionName?: string | null;
   /** Compare-and-set version for concurrent agent-row updates. Missing → 0. */
   stateVersion?: number;
+  activePipelineInvocation?: PipelineInvocationRef | null;
 }
 
 export interface AgentIdentity {
@@ -183,6 +194,8 @@ export interface ThreadSession {
    */
   activePipelineRunId?: string | null;
   activePipelineKind?: "product" | "bug" | null;
+  /** Exact assignment dispatch currently owned by the top-level runner. */
+  activePipelineInvocation?: PipelineInvocationRef | null;
   /** Authoritative Slack source turn for the active top-level invocation. */
   activeTopLevelMessageTs?: string | null;
   /**

--- a/src/slack/events.ts
+++ b/src/slack/events.ts
@@ -1,5 +1,6 @@
 import type { App } from "@slack/bolt";
 import type { SessionStore } from "../session/store/interface.ts";
+import type { PipelineInvocationRef } from "../session/types.ts";
 import { parseCommand } from "./commands.ts";
 import { isPersistentAgent } from "../support/agents.ts";
 import { log } from "../logger.ts";
@@ -65,6 +66,8 @@ export interface SlackMessageEvent {
   /** True when raw Slack text contained `<@selfUserId>` before mention stripping. */
   mentionsJunior?: boolean;
   dedupeKey?: string;
+  /** Internal-only trusted assignment correlation from the pipeline outbox. */
+  pipelineInvocation?: PipelineInvocationRef;
 }
 
 export type OnMessageCallback = (event: SlackMessageEvent) => void;

--- a/src/worktree/package-manager.test.ts
+++ b/src/worktree/package-manager.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { detectJavaScriptPackageManager } from "./package-manager.ts";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true })));
+});
+
+async function workspace(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "junior-package-manager-"));
+  roots.push(root);
+  return root;
+}
+
+describe("detectJavaScriptPackageManager", () => {
+  it("prefers the packageManager field over lockfiles", async () => {
+    const root = await workspace();
+    await writeFile(
+      join(root, "package.json"),
+      JSON.stringify({ packageManager: "pnpm@10.0.0" }),
+    );
+    await writeFile(join(root, "package-lock.json"), "{}");
+
+    expect(await detectJavaScriptPackageManager(root)).toBe("pnpm");
+  });
+
+  it.each([
+    ["bun.lock", "bun"],
+    ["pnpm-lock.yaml", "pnpm"],
+    ["package-lock.json", "npm"],
+  ] as const)("detects %s", async (filename, expected) => {
+    const root = await workspace();
+    await writeFile(join(root, filename), "");
+
+    expect(await detectJavaScriptPackageManager(root)).toBe(expected);
+  });
+
+  it("fails closed for conflicting lockfile families", async () => {
+    const root = await workspace();
+    await writeFile(join(root, "bun.lock"), "");
+    await writeFile(join(root, "package-lock.json"), "{}");
+
+    expect(await detectJavaScriptPackageManager(root)).toBeNull();
+  });
+
+  it("does not reinterpret an explicitly unsupported manager", async () => {
+    const root = await workspace();
+    await writeFile(
+      join(root, "package.json"),
+      JSON.stringify({ packageManager: "yarn@4.0.0" }),
+    );
+    await writeFile(join(root, "package-lock.json"), "{}");
+
+    expect(await detectJavaScriptPackageManager(root)).toBeNull();
+  });
+
+  it("fails closed when repository metadata declares no manager", async () => {
+    expect(await detectJavaScriptPackageManager(await workspace())).toBeNull();
+  });
+});

--- a/src/worktree/package-manager.ts
+++ b/src/worktree/package-manager.ts
@@ -1,0 +1,50 @@
+import { readFile, readdir } from "node:fs/promises";
+import { join } from "node:path";
+
+export type JavaScriptPackageManager = "npm" | "pnpm" | "bun";
+
+const LOCKFILE_FAMILIES: ReadonlyArray<{
+  manager: JavaScriptPackageManager;
+  files: readonly string[];
+}> = [
+  { manager: "pnpm", files: ["pnpm-lock.yaml", "pnpm-workspace.yaml"] },
+  { manager: "bun", files: ["bun.lock", "bun.lockb"] },
+  { manager: "npm", files: ["package-lock.json", "npm-shrinkwrap.json"] },
+];
+
+/**
+ * Discover the JavaScript package manager declared by a worktree. Prefer the
+ * standard package.json `packageManager` field; otherwise accept exactly one
+ * lockfile family. Conflicting or absent metadata fails closed.
+ */
+export async function detectJavaScriptPackageManager(
+  worktreePath: string,
+): Promise<JavaScriptPackageManager | null> {
+  const declared = await packageManagerFromPackageJson(worktreePath);
+  if (declared !== undefined) return declared;
+
+  let entries: Set<string>;
+  try {
+    entries = new Set(await readdir(worktreePath));
+  } catch {
+    return null;
+  }
+  const detected = LOCKFILE_FAMILIES.filter((family) =>
+    family.files.some((filename) => entries.has(filename)),
+  ).map((family) => family.manager);
+  return detected.length === 1 ? detected[0]! : null;
+}
+
+async function packageManagerFromPackageJson(
+  worktreePath: string,
+): Promise<JavaScriptPackageManager | null | undefined> {
+  try {
+    const raw = await readFile(join(worktreePath, "package.json"), "utf8");
+    const value = (JSON.parse(raw) as { packageManager?: unknown }).packageManager;
+    if (typeof value !== "string") return undefined;
+    const name = value.trim().split("@")[0];
+    return name === "npm" || name === "pnpm" || name === "bun" ? name : null;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/worktree/review-routing.test.ts
+++ b/src/worktree/review-routing.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "bun:test";
+import type { RepoConfig } from "../config.ts";
+import { inferReviewRepo } from "./review-routing.ts";
+
+const repos: RepoConfig[] = [
+  { name: "gx-backend", path: "/repos/backend", defaultBase: "origin/main" },
+  { name: "gx-client-expo", path: "/repos/expo", defaultBase: "origin/main" },
+];
+
+describe("inferReviewRepo", () => {
+  it("routes an explicit PR URL to its configured repository", () => {
+    expect(
+      inferReviewRepo(
+        repos,
+        "review https://github.com/GrowthX-Club/gx-client-expo/pull/42",
+        ["GrowthX-Club/gx-backend"],
+      )?.name,
+    ).toBe("gx-client-expo");
+  });
+
+  it("uses a single pipeline repo ref when the prompt has no PR URL", () => {
+    expect(
+      inferReviewRepo(repos, "run aggregate checks", ["GrowthX-Club/gx-backend"])
+        ?.name,
+    ).toBe("gx-backend");
+  });
+
+  it("does not guess when a pipeline spans multiple repositories", () => {
+    expect(
+      inferReviewRepo(repos, "review the aggregate", [
+        "GrowthX-Club/gx-backend",
+        "GrowthX-Club/gx-client-expo",
+      ]),
+    ).toBeUndefined();
+  });
+});
+

--- a/src/worktree/review-routing.ts
+++ b/src/worktree/review-routing.ts
@@ -1,0 +1,39 @@
+import type { RepoConfig } from "../config.ts";
+
+/**
+ * Resolve the repository a review turn is about without guessing from ordinary
+ * prose. An explicit GitHub URL wins; a pipeline repo ref is used only when it
+ * resolves to exactly one configured repository.
+ */
+export function inferReviewRepo(
+  repos: RepoConfig[],
+  prompt: string,
+  pipelineRepoRefs: string[] = [],
+): RepoConfig | undefined {
+  const urlMatches = repos.filter((repo) => {
+    const escaped = escapeRegExp(repo.name);
+    return new RegExp(
+      `github\\.com/[^/\\s]+/${escaped}(?:\\.git)?(?:/|\\s|$)`,
+      "i",
+    ).test(prompt);
+  });
+  if (urlMatches.length === 1) return urlMatches[0];
+
+  const refMatches = repos.filter((repo) =>
+    pipelineRepoRefs.some((ref) => repoMatchesRef(repo.name, ref)),
+  );
+  return refMatches.length === 1 ? refMatches[0] : undefined;
+}
+
+function repoMatchesRef(repoName: string, ref: string): boolean {
+  const normalized = ref.trim().replace(/\.git$/i, "").replace(/\/+$/, "");
+  return (
+    normalized.toLowerCase() === repoName.toLowerCase() ||
+    normalized.toLowerCase().endsWith(`/${repoName.toLowerCase()}`)
+  );
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+


### PR DESCRIPTION
## Summary

- preserve Claude completion semantics and recover pipeline assignments that finish without a durable typed outcome
- infer multi-repo product workstreams per repository so array order cannot drop a builder
- route PR reviews into repository-specific worktrees, including sessions that move across repositories
- retain safe git and GitHub inspection without package metadata while gating fetch and tests on the actual registered worktree cwd
- derive the active package manager from package.json metadata or an unambiguous lockfile family instead of hardcoding repository mappings
- reclaim stale session rows when their non-terminal pipeline run has also stopped updating

## Reviewer permission invariant

Review intentionally moves from plan mode to default mode so a headless reviewer can use a strict, generated Bash allowlist. Declared Bash specs are stripped; only trusted inspection constants are admitted; ref mutations and verification commands require an exact registered-worktree cwd; Edit, Write, NotebookEdit, and unlisted Bash remain denied. The deny list is defense in depth, while the generated allowlist is the primary shell boundary.

Raw gh api and agent-driven gh pr checkout are not allowed. Review state and exact inline-comment counts are read through the signed, capability-checked github_read_pr_review_state MCP tool, which invokes only fixed GET endpoints. github_post_review remains the only GitHub write surface.

## Follow-up review fixes

- preserve useful partial assistant output for ordinary max-turn runs
- report the actual number of recovery continuations, including zero when no provider session exists
- prove active pipeline invocations survive SQLite parent-JSON and agent-row reloads
- add git blame and gh pr list inspection
- remove persistent reviewer branch checkout and replace raw GitHub API reads with a fixed-endpoint read tool

## Dependency

- GrowthX-Club/junior-private-agents#15 updates the private reviewer playbook and is pinned by this PR

## Verification

- TypeScript typecheck passed twice
- Full Bun suite passed twice: 1,243 passed, 2 intentionally skipped, 0 failed