### PR TITLE
Fix Claude pipeline session recovery

### DIFF
--- a/src/claude/args.test.ts
+++ b/src/claude/args.test.ts
@@ -81,10 +81,26 @@ describe("buildClaudeArgs", () => {
   });
 
   it("includes --resume when sessionId is present", () => {
-    const session = makeSession({ sessionId: "sess-abc" });
+    const session = makeSession({ sessionId: "sess-abc", sessionCwd: CWD });
     const args = buildClaudeArgs(session, "continue", makeConfig(), CWD);
     expect(args).toContain("--resume");
     expect(args).toContain("sess-abc");
+  });
+
+  it("does not resume a session created under another cwd", () => {
+    const session = makeSession({
+      sessionId: "sess-abc",
+      sessionCwd: "/work/other-repo",
+    });
+    const args = buildClaudeArgs(session, "continue", makeConfig(), CWD);
+    expect(args).not.toContain("--resume");
+    expect(args).not.toContain("sess-abc");
+  });
+
+  it("does not assume legacy sessions without cwd affinity are resumable", () => {
+    const session = makeSession({ sessionId: "sess-legacy" });
+    const args = buildClaudeArgs(session, "continue", makeConfig(), CWD);
+    expect(args).not.toContain("--resume");
   });
 
   it("does not include --resume when sessionId is null", () => {
@@ -124,6 +140,7 @@ describe("buildClaudeArgs", () => {
   it("includes both --resume and --append-system-prompt when both are set", () => {
     const session = makeSession({
       sessionId: "sess-xyz",
+      sessionCwd: CWD,
       systemPrompt: "Be concise.",
     });
     const args = buildClaudeArgs(session, "go", makeConfig(), CWD);

--- a/src/claude/args.ts
+++ b/src/claude/args.ts
@@ -3,6 +3,7 @@ import { resolveEffectivePermissionIntent } from "../agents/loader.ts";
 import type { ThreadSession } from "../session/types.ts";
 import { mapClaudeRunPolicy } from "./policy.ts";
 import { resolveClaudeModel } from "./model.ts";
+import { providerSessionMatchesCwd } from "../runners/runtime.ts";
 
 /** Fully-qualified name of the slack-bot MCP approval tool (see src/mcp/approval.ts). */
 export const APPROVAL_PERMISSION_TOOL = "mcp__slack-bot__request_permission";
@@ -50,7 +51,15 @@ export function buildClaudeArgs(
     String(config.maxTurns),
   ];
 
-  if (session.sessionId) {
+  if (
+    session.sessionId &&
+    providerSessionMatchesCwd({
+      provider: "claude",
+      sessionId: session.sessionId,
+      sessionCwd: session.sessionCwd,
+      cwd,
+    })
+  ) {
     args.push("--resume", session.sessionId);
   }
 

--- a/src/claude/driver.ts
+++ b/src/claude/driver.ts
@@ -58,4 +58,11 @@ export interface ClaudeDriver {
    * Tmux: `tmux kill-session` for the corresponding session name.
    */
   close(threadId: string, agentName: string): Promise<void>;
+
+  /** Close only when the live driver state still belongs to the expected provider session. */
+  closeIfSessionId(
+    threadId: string,
+    agentName: string,
+    expectedSessionId: string,
+  ): Promise<boolean>;
 }

--- a/src/claude/headless-driver.ts
+++ b/src/claude/headless-driver.ts
@@ -38,4 +38,12 @@ export class HeadlessDriver implements ClaudeDriver {
   async close(_threadId: string, _agentName: string): Promise<void> {
     // No persistent state between turns; nothing to tear down.
   }
+
+  async closeIfSessionId(
+    _threadId: string,
+    _agentName: string,
+    _expectedSessionId: string,
+  ): Promise<boolean> {
+    return false;
+  }
 }

--- a/src/claude/tmux-driver.test.ts
+++ b/src/claude/tmux-driver.test.ts
@@ -156,6 +156,102 @@ describe("TmuxDriver with stubbed exec", () => {
     expect(calls.filter((c) => c.args[0] === "new-session").length).toBe(1);
   });
 
+  it("recreates a live tmux session when routing changes cwd", async () => {
+    const { driver, calls, projectsRoot } = setup();
+    const firstCwd = mkdtempSync(join(tmpdir(), "junior-cwd-a-"));
+    const secondCwd = mkdtempSync(join(tmpdir(), "junior-cwd-b-"));
+    const session = makeSession({
+      worktreePath: firstCwd,
+      sessionId: "old-repo-session",
+      sessionCwd: firstCwd,
+    });
+    const transcriptDir = join(projectsRoot, firstCwd.replace(/\//g, "-"));
+    mkdirSync(transcriptDir, { recursive: true });
+    writeFileSync(join(transcriptDir, "old-repo-session.jsonl"), "");
+
+    const first = driver.send({
+      session,
+      prompt: "first repo",
+      config: claudeConfig(),
+      threadId: session.threadId,
+      agentName: "review",
+    });
+    await new Promise((r) => setTimeout(r, 50));
+    first.kill();
+
+    session.worktreePath = secondCwd;
+    const second = driver.send({
+      session,
+      prompt: "second repo",
+      config: claudeConfig(),
+      threadId: session.threadId,
+      agentName: "review",
+    });
+    await new Promise((r) => setTimeout(r, 50));
+    second.kill();
+
+    expect(calls.filter((c) => c.args[0] === "kill-session")).toHaveLength(1);
+    const starts = calls.filter((c) => c.args[0] === "new-session");
+    expect(starts).toHaveLength(2);
+    expect(starts[0]?.args).toContain("old-repo-session");
+    expect(starts[1]?.args).not.toContain("old-repo-session");
+    expect(driver.listSessions()[0]?.sessionId).toBeNull();
+  });
+
+  it("cold-starts tmux when the cwd matches but the transcript is missing", async () => {
+    const { driver, calls } = setup();
+    const cwd = mkdtempSync(join(tmpdir(), "junior-cwd-missing-transcript-"));
+    const session = makeSession({
+      worktreePath: cwd,
+      sessionId: "missing-transcript-session",
+      sessionCwd: cwd,
+    });
+
+    const handle = driver.send({
+      session,
+      prompt: "continue",
+      config: claudeConfig(),
+      threadId: session.threadId,
+      agentName: "review",
+    });
+    await new Promise((r) => setTimeout(r, 50));
+    handle.kill();
+
+    const start = calls.find((c) => c.args[0] === "new-session");
+    expect(start?.args).not.toContain("missing-transcript-session");
+    expect(driver.listSessions()[0]?.sessionId).toBeNull();
+  });
+
+  it("resumes against targetRepoCwd when no worktree path is set", async () => {
+    const { driver, calls, projectsRoot } = setup();
+    const targetRepoCwd = mkdtempSync(join(tmpdir(), "junior-target-repo-"));
+    const session = makeSession({
+      sessionId: "target-repo-session",
+      sessionCwd: targetRepoCwd,
+    });
+    const transcriptDir = join(
+      projectsRoot,
+      targetRepoCwd.replace(/\//g, "-"),
+    );
+    mkdirSync(transcriptDir, { recursive: true });
+    writeFileSync(join(transcriptDir, "target-repo-session.jsonl"), "");
+
+    const handle = driver.send({
+      session,
+      prompt: "continue",
+      config: claudeConfig(),
+      targetRepoCwd,
+      threadId: session.threadId,
+      agentName: "review",
+    });
+    await new Promise((r) => setTimeout(r, 50));
+    handle.kill();
+
+    const start = calls.find((c) => c.args[0] === "new-session");
+    expect(start?.args).toContain("target-repo-session");
+    expect(start?.args[start.args.indexOf("-c") + 1]).toBe(targetRepoCwd);
+  });
+
   it("starts Claude tmux with a per-run contextual MCP config", async () => {
     const { driver, calls } = setup();
     const cwd = mkdtempSync(join(tmpdir(), "junior-cwd-"));

--- a/src/claude/tmux-driver.ts
+++ b/src/claude/tmux-driver.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, resolve } from "node:path";
 import { mkdirSync, existsSync, readdirSync, statSync, watch as fsWatch } from "node:fs";
 import type { FSWatcher } from "node:fs";
 import { open } from "node:fs/promises";
@@ -9,7 +9,10 @@ import type { RunnerEvent, SpawnHandle, SpawnResult } from "../runners/types.ts"
 import { buildClaudeArgs } from "./args.ts";
 import { mapClaudeEvent, writeClaudeMcpConfig } from "./spawner.ts";
 import { adaptTranscriptLine } from "./transcript-adapter.ts";
-import { buildRunnerRuntime } from "../runners/runtime.ts";
+import {
+  buildRunnerRuntime,
+  providerSessionMatchesCwd,
+} from "../runners/runtime.ts";
 
 /**
  * Test seam — let unit tests inject a fake tmux invoker and override the
@@ -192,7 +195,25 @@ export class TmuxDriver implements ClaudeDriver {
     if (sess.pollTimer) clearInterval(sess.pollTimer);
     sess.activeTurn = null;
     await this.killTmuxSession(sess.name).catch(() => undefined);
-    this.sessions.delete(key);
+    if (this.sessions.get(key) === sess) {
+      this.sessions.delete(key);
+    }
+  }
+
+  async closeIfSessionId(
+    threadId: string,
+    agentName: string,
+    expectedSessionId: string,
+  ): Promise<boolean> {
+    const session = this.sessions.get(handleKey(threadId, agentName));
+    if (!session || session.sessionId !== expectedSessionId) return false;
+    await this.close(threadId, agentName);
+    return true;
+  }
+
+  /** Kill an unadopted persisted tmux session during fail-closed reconciliation. */
+  async discardPersistedSession(tmuxSessionName: string): Promise<void> {
+    await this.killTmuxSession(tmuxSessionName).catch(() => undefined);
   }
 
   /**
@@ -293,9 +314,30 @@ export class TmuxDriver implements ClaudeDriver {
   private async ensureSession(input: DriverSendInput): Promise<void> {
     const key = handleKey(input.threadId, input.agentName);
     const existing = this.sessions.get(key);
+    const runtime = buildRunnerRuntime(input);
+    const cwd = runtime.cwd;
+    const affinityResumeId = providerSessionMatchesCwd({
+      provider: "claude",
+      sessionId: input.session.sessionId,
+      sessionCwd: input.session.sessionCwd,
+      cwd,
+    })
+      ? input.session.sessionId
+      : null;
+    // Interactive Claude can fall back to a shell without exposing the
+    // headless "No conversation found" stderr. Only cold-resume a tmux process
+    // when the cwd-scoped transcript actually exists; otherwise start fresh.
+    const effectiveResumeId = affinityResumeId &&
+      existsSync(this.transcriptPathFor(cwd, affinityResumeId))
+      ? affinityResumeId
+      : null;
     // tmuxSessionUsable rejects panes where claude has exited and the pane is
     // sitting at a shell — keeps us from pasting into a dead shell each turn.
-    if (existing && (await this.tmuxSessionUsable(existing.name))) {
+    if (
+      existing &&
+      resolve(existing.cwd) === resolve(cwd) &&
+      (await this.tmuxSessionUsable(existing.name))
+    ) {
       return;
     }
     if (existing) {
@@ -307,14 +349,22 @@ export class TmuxDriver implements ClaudeDriver {
       this.sessions.delete(key);
     }
 
-    const runtime = buildRunnerRuntime(input);
-    const cwd = runtime.cwd;
     mkdirSync(cwd, { recursive: true });
 
     const sessionName = computeSessionName(input.threadId, input.agentName);
     const startedAt = Date.now();
 
-    const claudeArgs = buildInteractiveClaudeArgs(input, runtime.needsProjectMcp);
+    const effectiveInput = effectiveResumeId === input.session.sessionId
+      ? input
+      : {
+          ...input,
+          session: { ...input.session, sessionId: effectiveResumeId },
+        };
+    const claudeArgs = buildInteractiveClaudeArgs(
+      effectiveInput,
+      runtime.needsProjectMcp,
+      cwd,
+    );
     await this.execImpl(this.tmuxBin, [
       "new-session",
       "-d",
@@ -329,9 +379,9 @@ export class TmuxDriver implements ClaudeDriver {
     const sess: TmuxSession = {
       name: sessionName,
       cwd,
-      sessionId: input.session.sessionId,
-      transcriptPath: input.session.sessionId
-        ? this.transcriptPathFor(cwd, input.session.sessionId)
+      sessionId: effectiveResumeId,
+      transcriptPath: effectiveResumeId
+        ? this.transcriptPathFor(cwd, effectiveResumeId)
         : null,
       transcriptOffset: 0,
       watcher: null,
@@ -577,11 +627,13 @@ function encodeCwd(cwd: string): string {
   return cwd.replace(/\//g, "-");
 }
 
-function buildInteractiveClaudeArgs(input: DriverSendInput, needsProjectMcp: boolean): string[] {
+function buildInteractiveClaudeArgs(
+  input: DriverSendInput,
+  needsProjectMcp: boolean,
+  cwd: string,
+): string[] {
   // Lean on the existing arg builder but strip the `-p <prompt>` and
   // `--output-format` flags — those are headless-only.
-  const cwd =
-    input.session.cwd ?? input.session.worktreePath ?? process.cwd();
   const all = buildClaudeArgs(
     input.session,
     /*prompt*/ "",

--- a/src/lifecycle/tmux-reconcile.test.ts
+++ b/src/lifecycle/tmux-reconcile.test.ts
@@ -20,15 +20,21 @@ interface AdoptCall {
 function fakeDriver(liveTmux: Set<string>): {
   driver: TmuxDriver;
   adoptCalls: AdoptCall[];
+  discardCalls: string[];
 } {
   const adoptCalls: AdoptCall[] = [];
+  const discardCalls: string[] = [];
   const driver = {
     tmuxHasSession: async (name: string) => liveTmux.has(name),
     adoptExistingSession: async (input: AdoptCall) => {
       adoptCalls.push(input);
     },
+    discardPersistedSession: async (name: string) => {
+      discardCalls.push(name);
+      liveTmux.delete(name);
+    },
   } as unknown as TmuxDriver;
-  return { driver, adoptCalls };
+  return { driver, adoptCalls, discardCalls };
 }
 
 describe("reconcileTmuxSessions", () => {
@@ -38,6 +44,7 @@ describe("reconcileTmuxSessions", () => {
     session.tmuxSessionName = "junior-T1-default";
     session.topLevelTmuxAgent = "default";
     session.worktreePath = "/tmp/T1";
+    session.sessionCwd = "/tmp/T1";
     await store.set("T1", session);
 
     const { driver, adoptCalls } = fakeDriver(new Set(["junior-T1-default"]));
@@ -61,6 +68,7 @@ describe("reconcileTmuxSessions", () => {
     session.tmuxSessionName = "junior-T1-default";
     session.topLevelTmuxAgent = "default";
     session.worktreePath = "/tmp/T1";
+    session.sessionCwd = "/tmp/T1";
     session.status = "busy";
     await store.set("T1", session);
 
@@ -81,6 +89,7 @@ describe("reconcileTmuxSessions", () => {
     session.tmuxSessionName = "junior-T1-lead";
     session.topLevelTmuxAgent = "lead";
     session.worktreePath = "/tmp/T1";
+    session.sessionCwd = "/tmp/T1";
     session.status = "busy";
     await store.set("T1", session);
 
@@ -97,6 +106,7 @@ describe("reconcileTmuxSessions", () => {
     const store = new InMemorySessionStore();
     const session = createSession("T1", "C1", "quiet", "headless");
     session.worktreePath = "/tmp/T1";
+    session.sessionCwd = "/tmp/T1";
     await store.set("T1", session);
 
     const { driver, adoptCalls } = fakeDriver(new Set());
@@ -112,10 +122,12 @@ describe("reconcileTmuxSessions", () => {
     session.tmuxSessionName = "junior-T1-default";
     session.topLevelTmuxAgent = "default";
     session.worktreePath = "/tmp/T1";
+    session.sessionCwd = "/tmp/T1";
     session.agentSessions = {
       reviewer: {
         agentName: "reviewer",
         sessionId: "rev-1",
+        sessionCwd: "/tmp/reviewer-T1",
         status: "idle",
         pendingMessages: [],
         lastActivity: Date.now(),
@@ -133,5 +145,33 @@ describe("reconcileTmuxSessions", () => {
     expect(result.adopted).toBe(2);
     const adoptedAgents = adoptCalls.map((c) => c.agentName).sort();
     expect(adoptedAgents).toEqual(["default", "reviewer"]);
+    expect(adoptCalls.find((c) => c.agentName === "reviewer")?.cwd).toBe(
+      "/tmp/reviewer-T1",
+    );
+  });
+
+  it("discards legacy tmux state without recorded cwd affinity", async () => {
+    const store = new InMemorySessionStore();
+    const session = createSession("T1", "C1", "quiet", "tmux");
+    session.tmuxSessionName = "junior-T1-default";
+    session.topLevelTmuxAgent = "default";
+    session.sessionId = "legacy-session";
+    session.leadSessionId = "legacy-session";
+    session.worktreePath = "/tmp/current-worktree";
+    session.sessionCwd = null;
+    await store.set("T1", session);
+
+    const { driver, adoptCalls, discardCalls } = fakeDriver(
+      new Set(["junior-T1-default"]),
+    );
+    const result = await reconcileTmuxSessions(store, driver);
+
+    expect(result).toEqual({ adopted: 0, downgraded: 1 });
+    expect(adoptCalls).toEqual([]);
+    expect(discardCalls).toEqual(["junior-T1-default"]);
+    const after = (await store.get("T1"))!;
+    expect(after.tmuxSessionName).toBeNull();
+    expect(after.sessionId).toBeNull();
+    expect(after.leadSessionId).toBeNull();
   });
 });

--- a/src/lifecycle/tmux-reconcile.ts
+++ b/src/lifecycle/tmux-reconcile.ts
@@ -23,63 +23,80 @@ export async function reconcileTmuxSessions(
   for (const [threadId, session] of sessions) {
     if (session.driverMode !== "tmux") continue;
 
-    // tmux sessions were always launched with a concrete cwd; reuse the
-    // session's recorded worktreePath. If the worktree is gone the
-    // session can't be safely adopted — leave it for the next send to
-    // cold-start.
-    const cwd = session.cwd ?? session.worktreePath;
-    if (!cwd) continue;
-
     if (session.tmuxSessionName) {
-      const live = await driver.tmuxHasSession(session.tmuxSessionName);
-      if (live) {
-        await driver.adoptExistingSession({
-          threadId,
-          agentName: session.topLevelTmuxAgent ?? "lead",
-          cwd,
-          tmuxSessionName: session.tmuxSessionName,
-          sessionId: session.sessionId,
-        });
-        // The bot died mid-turn but tmux survived. We have no activeTurn to
-        // resolve, so the next `turn_duration` event would be silently dropped
-        // and the row stays busy forever — flip back to idle so new messages
-        // can drain. Symmetric to the dead-tmux branch below.
-        if (session.status === "busy") {
-          session.status = "idle";
-          session.lastError = {
-            type: "tmux-adopted-mid-turn",
-            message: "bot restarted mid-turn; tmux session adopted, in-flight turn dropped",
-            timestamp: Date.now(),
-          };
-          await store.set(threadId, session);
-        }
-        adopted++;
-      } else {
-        // The tmux session is gone but we kept the transcript — next send()
-        // will cold-start a fresh tmux with --resume <sessionId>.
+      const cwd = session.sessionCwd;
+      if (!cwd) {
+        await driver.discardPersistedSession(session.tmuxSessionName);
         session.tmuxSessionName = null;
-        if (session.status === "busy") {
-          session.status = "idle";
-          session.lastError = {
-            type: "tmux-lost",
-            message: "tmux session died while bot was down",
-            timestamp: Date.now(),
-          };
-        }
+        session.topLevelTmuxAgent = null;
+        session.sessionId = null;
+        session.leadSessionId = null;
+        session.sessionCwd = null;
+        if (session.status === "busy") session.status = "idle";
         await store.set(threadId, session);
         downgraded++;
+      } else {
+        const live = await driver.tmuxHasSession(session.tmuxSessionName);
+        if (live) {
+          await driver.adoptExistingSession({
+            threadId,
+            agentName: session.topLevelTmuxAgent ?? "lead",
+            cwd,
+            tmuxSessionName: session.tmuxSessionName,
+            sessionId: session.sessionId,
+          });
+          // The bot died mid-turn but tmux survived. We have no activeTurn to
+          // resolve, so the next `turn_duration` event would be silently dropped
+          // and the row stays busy forever — flip back to idle so new messages
+          // can drain. Symmetric to the dead-tmux branch below.
+          if (session.status === "busy") {
+            session.status = "idle";
+            session.lastError = {
+              type: "tmux-adopted-mid-turn",
+              message: "bot restarted mid-turn; tmux session adopted, in-flight turn dropped",
+              timestamp: Date.now(),
+            };
+            await store.set(threadId, session);
+          }
+          adopted++;
+        } else {
+          // The tmux session is gone but we kept the transcript — next send()
+          // will cold-start a fresh tmux with --resume <sessionId>.
+          session.tmuxSessionName = null;
+          if (session.status === "busy") {
+            session.status = "idle";
+            session.lastError = {
+              type: "tmux-lost",
+              message: "tmux session died while bot was down",
+              timestamp: Date.now(),
+            };
+          }
+          await store.set(threadId, session);
+          downgraded++;
+        }
       }
     }
 
     // Per-agent persistent agents
     for (const agentSession of Object.values(session.agentSessions ?? {})) {
       if (!agentSession.tmuxSessionName) continue;
+      const agentCwd = agentSession.sessionCwd;
+      if (!agentCwd) {
+        await driver.discardPersistedSession(agentSession.tmuxSessionName);
+        agentSession.tmuxSessionName = null;
+        agentSession.sessionId = null;
+        agentSession.sessionCwd = null;
+        if (agentSession.status === "busy") agentSession.status = "idle";
+        await store.set(threadId, session);
+        downgraded++;
+        continue;
+      }
       const live = await driver.tmuxHasSession(agentSession.tmuxSessionName);
       if (live) {
         await driver.adoptExistingSession({
           threadId,
           agentName: agentSession.agentName,
-          cwd,
+          cwd: agentCwd,
           tmuxSessionName: agentSession.tmuxSessionName,
           sessionId: agentSession.sessionId,
         });

--- a/src/runners/runtime.test.ts
+++ b/src/runners/runtime.test.ts
@@ -3,6 +3,9 @@ import type { ThreadSession } from "../session/types.ts";
 import {
   buildRunnerEnv,
   needsProjectMcp,
+  isProviderSessionUnavailable,
+  normalizeProviderSessionCwd,
+  providerSessionMatchesCwd,
   resolveRunnerCwd,
   willResume,
 } from "./runtime.ts";
@@ -93,6 +96,39 @@ describe("willResume", () => {
 });
 
 describe("runner runtime", () => {
+  it("matches Claude sessions only to their creation cwd", () => {
+    expect(providerSessionMatchesCwd({
+      provider: "claude",
+      sessionId: "ses_1",
+      sessionCwd: "/tmp/repo/.",
+      cwd: "/tmp/repo",
+    })).toBe(true);
+    expect(providerSessionMatchesCwd({
+      provider: "claude",
+      sessionId: "ses_1",
+      sessionCwd: "/tmp/repo-a",
+      cwd: "/tmp/repo-b",
+    })).toBe(false);
+    expect(providerSessionMatchesCwd({
+      provider: "claude",
+      sessionId: "ses_1",
+      sessionCwd: null,
+      cwd: "/tmp/repo",
+    })).toBe(false);
+  });
+
+  it("recognizes only provider-originated missing Claude conversations", () => {
+    expect(isProviderSessionUnavailable(
+      "claude",
+      "No conversation found with session ID: ses_1",
+    )).toBe(true);
+    expect(isProviderSessionUnavailable(
+      "opencode",
+      "No conversation found with session ID: ses_1",
+    )).toBe(false);
+    expect(normalizeProviderSessionCwd("/tmp/repo/.")).toBe("/tmp/repo");
+  });
+
   it("resolves cwd using session override first", () => {
     const session = makeSession({
       cwd: "/tmp/junior-utility",

--- a/src/runners/runtime.ts
+++ b/src/runners/runtime.ts
@@ -1,4 +1,5 @@
-import { mkdirSync } from "node:fs";
+import { mkdirSync, realpathSync } from "node:fs";
+import { resolve } from "node:path";
 import type { AgentIdentity, RunnerProvider, ThreadSession } from "../session/types.ts";
 
 export interface RunnerRuntimeOptions {
@@ -61,6 +62,43 @@ export function resolveRunnerCwd(
   targetRepoCwd?: string,
 ): string {
   return session.cwd ?? session.worktreePath ?? targetRepoCwd ?? process.cwd();
+}
+
+/**
+ * Claude stores conversations under a cwd-derived project directory. A
+ * session id that exists under one checkout is not resumable from another.
+ * Unknown legacy affinity fails closed so the next turn establishes a fresh,
+ * correctly-scoped provider session.
+ */
+export function providerSessionMatchesCwd(options: {
+  provider: RunnerProvider;
+  sessionId: string | null | undefined;
+  sessionCwd: string | null | undefined;
+  cwd: string;
+}): boolean {
+  if (!options.sessionId?.trim()) return true;
+  if (options.provider !== "claude") return true;
+  if (!options.sessionCwd?.trim()) return false;
+  return normalizeProviderSessionCwd(options.sessionCwd) ===
+    normalizeProviderSessionCwd(options.cwd);
+}
+
+export function normalizeProviderSessionCwd(cwd: string): string {
+  const absolute = resolve(cwd);
+  try {
+    return realpathSync.native(absolute);
+  } catch {
+    return absolute;
+  }
+}
+
+export function isProviderSessionUnavailable(
+  provider: RunnerProvider,
+  error: string | null | undefined,
+): boolean {
+  const normalized = (error ?? "").replace(/\x1B\[[0-?]*[ -/]*[@-~]/g, "");
+  return provider === "claude" &&
+    /No conversation found with session ID\b\s*:?/i.test(normalized);
 }
 
 export function needsProjectMcp(session: ThreadSession, cwd: string): boolean {

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -8,7 +8,7 @@ import type {
 } from "../runners/types.ts";
 import type { SlackMessageEvent } from "../slack/events.ts";
 import type { Config } from "../config.ts";
-import { createSession } from "./types.ts";
+import { createSession, type ThreadSession } from "./types.ts";
 import type { App } from "@slack/bolt";
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -149,6 +149,7 @@ function makeFakeDrivers(): {
     close: async (threadId: string, agentName: string) => {
       closeCalls.push({ mode, threadId, agentName });
     },
+    closeIfSessionId: async () => false,
   });
   return { drivers: { headless: stub("headless"), tmux: stub("tmux") }, closeCalls };
 }
@@ -410,6 +411,166 @@ describe("SessionManager", () => {
     rmSync(reviewWorktree, { recursive: true, force: true });
   });
 
+  it("cold-starts a reviewer when its provider session belongs to another cwd", async () => {
+    const reviewWorktree = mkdtempSync(join(tmpdir(), "junior-review-worktree-"));
+    writeFileSync(join(reviewWorktree, "package-lock.json"), "{}");
+    manager.worktreeManager = {
+      createWorktree: mock(async () => reviewWorktree),
+      getBranchName: () => "slack/thread-1",
+    } as unknown as WorktreeManager;
+    const existing = createSession("thread-1", "C123");
+    existing.agentSessions.review = {
+      agentName: "review",
+      provider: "claude",
+      sessionId: "review-from-junior-root",
+      sessionCwd: "/Users/psbakre/Projects/junior",
+      status: "idle",
+      pendingMessages: [],
+      lastActivity: Date.now(),
+      pid: null,
+    };
+    await store.set(existing.threadId, existing);
+
+    await manager.handleAgentMessage(
+      makeEvent({
+        text: "review https://github.com/GrowthX-Club/frontend/pull/127",
+      }),
+      "review",
+    );
+    await waitFor(() => mockSpawnFn.mock.calls.length === 1);
+
+    const runSession = mockSpawnFn.mock.calls[0][0];
+    expect(runSession.sessionId).toBeNull();
+    expect(runSession.sessionCwd).toBeNull();
+    const stored = await store.get("thread-1");
+    expect(stored?.agentSessions.review.sessionId).toBeNull();
+    expect(stored?.agentSessions.review.sessionCwd).toBeNull();
+    rmSync(reviewWorktree, { recursive: true, force: true });
+  });
+
+  it("resumes a reviewer when its provider session cwd matches the worktree", async () => {
+    const reviewWorktree = mkdtempSync(join(tmpdir(), "junior-review-worktree-"));
+    writeFileSync(join(reviewWorktree, "package-lock.json"), "{}");
+    manager.worktreeManager = {
+      createWorktree: mock(async () => reviewWorktree),
+      getBranchName: () => "slack/thread-1",
+    } as unknown as WorktreeManager;
+    const existing = createSession("thread-1", "C123");
+    existing.targetRepo = "frontend";
+    existing.worktreePath = reviewWorktree;
+    existing.worktreePaths = { frontend: reviewWorktree };
+    existing.agentSessions.review = {
+      agentName: "review",
+      provider: "claude",
+      sessionId: "review-in-worktree",
+      sessionCwd: reviewWorktree,
+      status: "idle",
+      pendingMessages: [],
+      lastActivity: Date.now(),
+      pid: null,
+    };
+    await store.set(existing.threadId, existing);
+
+    await manager.handleAgentMessage(
+      makeEvent({
+        text: "review https://github.com/GrowthX-Club/frontend/pull/127",
+      }),
+      "review",
+    );
+    await waitFor(() => mockSpawnFn.mock.calls.length === 1);
+
+    expect(mockSpawnFn.mock.calls[0][0].sessionId).toBe("review-in-worktree");
+    expect(mockSpawnFn.mock.calls[0][0].sessionCwd).toBe(reviewWorktree);
+    rmSync(reviewWorktree, { recursive: true, force: true });
+  });
+
+  it("retries an unavailable Claude conversation once as a fresh session", async () => {
+    const localStore = new InMemorySessionStore();
+    const handles: MockHandle[] = [];
+    const spawnedSessions: ThreadSession[] = [];
+    const localSpawn: SpawnRunnerFn = (runSession) => {
+      spawnedSessions.push(structuredClone(runSession));
+      const handle = createMockHandle();
+      handles.push(handle);
+      return handle;
+    };
+    const localManager = new SessionManager(localStore, testConfig, localSpawn);
+    const existing = createSession("thread-1", "C123");
+    existing.sessionId = "missing-session";
+    existing.leadSessionId = "missing-session";
+    existing.sessionCwd = process.cwd();
+    await localStore.set(existing.threadId, existing);
+    const errors = mock((_session, _error) => undefined);
+    localManager.onError = errors;
+
+    await localManager.handleMessage(makeEvent({ text: "continue the work" }));
+    await waitFor(() => handles.length === 1);
+    handles[0]!._error(
+      "No conversation found with session ID: missing-session",
+    );
+    await waitFor(() => handles.length === 2);
+
+    expect(spawnedSessions[0]!.sessionId).toBe("missing-session");
+    expect(spawnedSessions[1]!.sessionId).toBeNull();
+    expect(errors).not.toHaveBeenCalled();
+
+    handles[1]!._complete("recovered", "fresh-session");
+    await waitFor(async () => (await localStore.get("thread-1"))?.status === "idle");
+    const recovered = await localStore.get("thread-1");
+    expect(recovered?.sessionId).toBe("fresh-session");
+    expect(recovered?.sessionCwd).toBe(process.cwd());
+  });
+
+  it("does not clear a newer session when an old unavailable result arrives", async () => {
+    const localStore = new InMemorySessionStore();
+    const handles: MockHandle[] = [];
+    const localManager = new SessionManager(localStore, testConfig, () => {
+      const handle = createMockHandle();
+      handles.push(handle);
+      return handle;
+    });
+    const existing = createSession("thread-1", "C123");
+    existing.sessionId = "old-session";
+    existing.leadSessionId = "old-session";
+    existing.sessionCwd = process.cwd();
+    await localStore.set(existing.threadId, existing);
+    const errors = mock((_session, _error) => undefined);
+    localManager.onError = errors;
+
+    await localManager.handleMessage(makeEvent({ text: "continue the work" }));
+    await waitFor(() => handles.length === 1);
+    // Force invalidateProviderSession's mutator to run once against the old
+    // id, then retry after a concurrent writer installs a newer id. Its result
+    // flag must describe the committed retry, not the discarded first attempt.
+    const originalMutate = localStore.mutateThread.bind(localStore);
+    let forcedRetry = false;
+    localStore.mutateThread = async (threadId, mutator) => {
+      if (!forcedRetry) {
+        forcedRetry = true;
+        const discardedDraft = structuredClone((await localStore.get(threadId))!);
+        await mutator(discardedDraft);
+        await originalMutate(threadId, (session) => {
+          session.sessionId = "newer-session";
+          session.leadSessionId = "newer-session";
+          session.sessionCwd = process.cwd();
+        });
+      }
+      return originalMutate(threadId, mutator);
+    };
+    handles[0]!._error("No conversation found with session ID old-session");
+    await waitFor(async () => (await localStore.get("thread-1"))?.status === "idle");
+
+    expect(handles).toHaveLength(1);
+    const stored = await localStore.get("thread-1");
+    expect(stored?.sessionId).toBe("newer-session");
+    expect(stored?.sessionCwd).toBe(process.cwd());
+    expect(stored?.status).toBe("idle");
+    expect(errors).toHaveBeenCalledTimes(1);
+
+    await localManager.handleMessage(makeEvent({ text: "next message", ts: "2.0" }));
+    await waitFor(() => handles.length === 2);
+  });
+
   it("adds downloaded non-image Slack file paths to the prompt", async () => {
     const originalFetch = globalThis.fetch;
     globalThis.fetch = mock(async () => new Response("a,b\n1,2\n", { status: 200 })) as unknown as typeof fetch;
@@ -488,6 +649,35 @@ describe("SessionManager", () => {
     expect(responses).toEqual([
       { agentName: "echo", username: "Echo", response: "echo response" },
     ]);
+  });
+
+  it("does not spawn an initial worker reset during dispatch notification", async () => {
+    const localStore = new InMemorySessionStore();
+    const localSpawn = mock<SpawnRunnerFn>(() => createMockHandle());
+    const localManager = new SessionManager(localStore, testConfig, localSpawn);
+    let releaseDispatch!: () => void;
+    let markEntered!: () => void;
+    const entered = new Promise<void>((resolve) => { markEntered = resolve; });
+    const dispatchGate = new Promise<void>((resolve) => { releaseDispatch = resolve; });
+    localManager.onAgentDispatched = async () => {
+      markEntered();
+      await dispatchGate;
+    };
+
+    const dispatch = localManager.handleAgentMessage(
+      makeEvent({ text: "start worker" }),
+      "echo",
+    );
+    await entered;
+    await localManager.handleMessage(
+      makeEvent({ command: "reset", text: "echo", ts: "reset-dispatch" }),
+    );
+    releaseDispatch();
+    await dispatch;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+
+    expect(localSpawn).not.toHaveBeenCalled();
+    expect((await localStore.get("thread-1"))?.agentSessions.echo).toBeUndefined();
   });
 
   it("internalizes pure persistent-agent directive responses instead of posting them", async () => {
@@ -747,6 +937,64 @@ describe("SessionManager", () => {
     }
   });
 
+  it("does not spawn a guard continuation after the thread is reset during setup", async () => {
+    const bugRoot = mkdtempSync(join(tmpdir(), "junior-guard-reset-"));
+    const previousBugRoot = process.env.JUNIOR_BUG_ROOT;
+    process.env.JUNIOR_BUG_ROOT = bugRoot;
+    try {
+      const bugDir = join(bugRoot, "growthx", "6a167cfb");
+      mkdirSync(bugDir, { recursive: true });
+      writeFileSync(join(bugDir, "state.json"), JSON.stringify({
+        bugId: "6a167cfb",
+        product: "growthx",
+        status: "researching",
+        slackChannel: "C-BUGS",
+        slackThread: "thread-1",
+      }));
+      const localStore = new InMemorySessionStore();
+      const handles: MockHandle[] = [];
+      const localManager = new SessionManager(
+        localStore,
+        cloneConfig({ channelDefaults: { "C-BUGS": { agentType: "lead" } } }),
+        () => {
+          const handle = createMockHandle();
+          handles.push(handle);
+          return handle;
+        },
+      );
+      let releaseRecall!: () => void;
+      const recallGate = new Promise<void>((resolve) => { releaseRecall = resolve; });
+      let recallCalls = 0;
+      (localManager as unknown as { preRecall: (message: string, context: { repo: string | null }) => Promise<string | null> }).preRecall = async () => {
+        recallCalls++;
+        if (recallCalls === 2) await recallGate;
+        return null;
+      };
+
+      await localManager.handleLeadMessage(
+        makeEvent({ channel: "C-BUGS", text: "bug report" }),
+      );
+      await waitFor(() => handles.length === 1);
+      handles[0]!._complete(
+        "DONE: New Relic findings written to research.md.",
+        "lead-guard-session",
+      );
+      await waitFor(() => recallCalls === 2);
+      await localManager.handleMessage(
+        makeEvent({ channel: "C-BUGS", command: "reset", text: "all", ts: "reset-guard" }),
+      );
+      releaseRecall();
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      expect(await localStore.get("thread-1")).toBeUndefined();
+      expect(handles).toHaveLength(1);
+    } finally {
+      if (previousBugRoot === undefined) delete process.env.JUNIOR_BUG_ROOT;
+      else process.env.JUNIOR_BUG_ROOT = previousBugRoot;
+      rmSync(bugRoot, { recursive: true, force: true });
+    }
+  });
+
   it("captures sessionId from init event", async () => {
     await manager.handleMessage(makeEvent());
     currentHandle._complete("response", "claude-session-42");
@@ -954,6 +1202,41 @@ describe("SessionManager", () => {
     // Session should be in draining/busy
     const session = await store.get("thread-1");
     expect(session!.pendingMessages.length).toBe(0);
+  });
+
+  it("does not spawn a worker drain after that agent is reset during setup", async () => {
+    const localStore = new InMemorySessionStore();
+    const handles: MockHandle[] = [];
+    const localManager = new SessionManager(localStore, testConfig, () => {
+      const handle = createMockHandle();
+      handles.push(handle);
+      return handle;
+    });
+    let releaseRecall!: () => void;
+    const recallGate = new Promise<void>((resolve) => { releaseRecall = resolve; });
+    let recallCalls = 0;
+    (localManager as unknown as { preRecall: (message: string, context: { repo: string | null }) => Promise<string | null> }).preRecall = async () => {
+      recallCalls++;
+      if (recallCalls === 2) await recallGate;
+      return null;
+    };
+
+    await localManager.handleAgentMessage(makeEvent({ text: "first" }), "echo");
+    await waitFor(() => handles.length === 1);
+    await localManager.handleAgentMessage(
+      makeEvent({ text: "second", ts: "drain-second" }),
+      "echo",
+    );
+    handles[0]!._complete("first done", "echo-session");
+    await waitFor(() => recallCalls === 2);
+    await localManager.handleMessage(
+      makeEvent({ command: "reset", text: "echo", ts: "reset-drain" }),
+    );
+    releaseRecall();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect((await localStore.get("thread-1"))?.agentSessions.echo).toBeUndefined();
+    expect(handles).toHaveLength(1);
   });
 
   // --- Commands ---
@@ -1236,6 +1519,8 @@ describe("SessionManager", () => {
       adminManager.onClearThreadStatus = onClear;
 
       await adminManager.handleMessage(makeEvent({ user: "U-ADMIN", text: "go" }));
+      currentHandle._complete("done");
+      await waitFor(async () => (await store.get("thread-1"))?.status === "idle");
       await adminManager.handleMessage(
         makeEvent({ user: "U-ADMIN", command: "clear", text: "", ts: "ts-clear" }),
       );
@@ -1262,6 +1547,8 @@ describe("SessionManager", () => {
       adminManager.onCommandResponse = onCmd;
 
       await adminManager.handleMessage(makeEvent({ user: "U-ADMIN", text: "go" }));
+      currentHandle._complete("done");
+      await waitFor(async () => (await store.get("thread-1"))?.status === "idle");
       await adminManager.handleMessage(
         makeEvent({ user: "U-ADMIN", command: "clear", text: "", ts: "ts-clear" }),
       );
@@ -2485,6 +2772,359 @@ describe("SessionManager", () => {
 });
 
 describe("typed pipeline settlement", () => {
+  it("repairs an unavailable Claude session without consuming pipeline retries", async () => {
+    const sessionStore = new InMemorySessionStore();
+    const pipelineStore = new InMemoryPipelineStore(fakeClock(1_000));
+    await pipelineStore.createRun(makeProductRun({ phase: "building" }));
+    await pipelineStore.createAssignment(makeAssignmentCreate({
+      id: "asg-invalid-session",
+      targetAgent: "build",
+      idempotencyKey: "asg-invalid-session-key",
+    }));
+    const seeded = createSession("thread-1", "C123");
+    seeded.agentSessions.build = {
+      agentName: "build",
+      provider: "claude",
+      sessionId: "missing-build-session",
+      sessionCwd: process.cwd(),
+      status: "idle",
+      pendingMessages: [],
+      lastActivity: Date.now(),
+      pid: null,
+    };
+    await sessionStore.set(seeded.threadId, seeded);
+    const handles: MockHandle[] = [];
+    const spawnedSessions: ThreadSession[] = [];
+    const manager = new SessionManager(sessionStore, testConfig, (runSession) => {
+      spawnedSessions.push(structuredClone(runSession));
+      const handle = createMockHandle();
+      handles.push(handle);
+      return handle;
+    });
+    manager.pipelineStore = pipelineStore;
+    const errors = mock((_session, _error) => undefined);
+    manager.onError = errors;
+
+    await manager.handleAgentMessage(makeEvent({
+      text: "<pipeline-assignment>repair me</pipeline-assignment>",
+      dedupeKey: "pipeline-outbox:dispatch-invalid-session",
+      pipelineInvocation: {
+        runId: "run-1",
+        assignmentId: "asg-invalid-session",
+        dispatchKey: "dispatch-invalid-session",
+        outcomeCountAtDispatch: 0,
+        retryCount: 0,
+      },
+    }), "build");
+    await waitFor(() => handles.length === 1);
+    handles[0]!._error(
+      "No conversation found with session ID: missing-build-session",
+    );
+    await waitFor(() => handles.length === 2);
+
+    expect(spawnedSessions[0]?.sessionId).toBe("missing-build-session");
+    expect(spawnedSessions[1]?.sessionId).toBeNull();
+    expect(
+      (await sessionStore.get("thread-1"))?.agentSessions.build
+        ?.activePipelineInvocation?.retryCount,
+    ).toBe(0);
+    expect(await pipelineStore.listOutcomes("asg-invalid-session")).toEqual([]);
+    expect(errors).not.toHaveBeenCalled();
+
+    const run = (await pipelineStore.getRun("run-1"))!;
+    await pipelineStore.recordOutcomeTransaction({
+      outcome: {
+        assignmentId: "asg-invalid-session",
+        expectedRunVersion: run.stateVersion,
+        action: "complete",
+        status: "succeeded",
+        reason: "fresh provider session recovered",
+        evidenceRefs: [],
+        artifactRefs: [],
+        blockers: [],
+        checks: [],
+        progressFingerprint: "invalid-session-recovered",
+      },
+      toPhase: "aggregate-verification",
+      actorType: "system",
+      actorId: "test",
+      idempotencyKey: "invalid-session-recovered",
+    });
+    handles[1]!._complete("recovered", "fresh-build-session");
+    await waitFor(async () =>
+      (await sessionStore.get("thread-1"))?.agentSessions.build?.status === "done"
+    );
+  });
+
+  it("rebuilds exact assignment context when a settlement resume is unavailable", async () => {
+    const sessionStore = new InMemorySessionStore();
+    const pipelineStore = new InMemoryPipelineStore(fakeClock(1_000));
+    await pipelineStore.createRun(makeProductRun({ phase: "building" }));
+    await pipelineStore.createAssignment(makeAssignmentCreate({
+      id: "asg-resume-context",
+      targetAgent: "build",
+      objective: "implement the durable checkout fix",
+      acceptanceCriteria: ["resume from the correct worktree"],
+      idempotencyKey: "asg-resume-context-key",
+    }));
+    const handles: MockHandle[] = [];
+    const prompts: string[] = [];
+    const manager = new SessionManager(sessionStore, testConfig, (_session, prompt) => {
+      prompts.push(prompt);
+      const handle = createMockHandle();
+      handles.push(handle);
+      return handle;
+    });
+    manager.pipelineStore = pipelineStore;
+
+    await manager.handleAgentMessage(makeEvent({
+      text: "initial assignment dispatch",
+      dedupeKey: "pipeline-outbox:dispatch-resume-context",
+      pipelineInvocation: {
+        runId: "run-1",
+        assignmentId: "asg-resume-context",
+        dispatchKey: "dispatch-resume-context",
+        outcomeCountAtDispatch: 0,
+        retryCount: 0,
+      },
+    }), "build");
+    await waitFor(() => handles.length === 1);
+    handles[0]!._complete("about to report", "resume-context-session", [], {
+      status: "incomplete",
+      reason: "max_turns",
+      retryable: true,
+      providerSubtype: "error_max_turns",
+      turns: 25,
+    });
+    await waitFor(() => handles.length === 2);
+    handles[1]!._error(
+      "No conversation found with session ID: resume-context-session",
+    );
+    await waitFor(() => handles.length === 3);
+
+    expect(prompts[2]).toContain("<pipeline-assignment>");
+    expect(prompts[2]).toContain("assignment_id: asg-resume-context");
+    expect(prompts[2]).toContain("objective: implement the durable checkout fix");
+    expect(prompts[2]).toContain("resume from the correct worktree");
+    expect(
+      (await sessionStore.get("thread-1"))?.agentSessions.build
+        ?.activePipelineInvocation?.retryCount,
+    ).toBe(1);
+
+    const run = (await pipelineStore.getRun("run-1"))!;
+    await pipelineStore.recordOutcomeTransaction({
+      outcome: {
+        assignmentId: "asg-resume-context",
+        expectedRunVersion: run.stateVersion,
+        action: "complete",
+        status: "succeeded",
+        reason: "recovered with durable context",
+        evidenceRefs: [],
+        artifactRefs: [],
+        blockers: [],
+        checks: [],
+        progressFingerprint: "resume-context-recovered",
+      },
+      toPhase: "aggregate-verification",
+      actorType: "system",
+      actorId: "test",
+      idempotencyKey: "resume-context-recovered",
+    });
+    handles[2]!._complete("recovered", "fresh-resume-context-session");
+    await waitFor(async () =>
+      (await sessionStore.get("thread-1"))?.agentSessions.build?.status === "done"
+    );
+  });
+
+  it("escalates a non-retryable provider failure without wasting continuations", async () => {
+    const sessionStore = new InMemorySessionStore();
+    const pipelineStore = new InMemoryPipelineStore(fakeClock(1_000));
+    await pipelineStore.createRun(makeProductRun({ phase: "building" }));
+    await pipelineStore.createAssignment(makeAssignmentCreate({
+      id: "asg-provider-failure",
+      targetAgent: "build",
+      idempotencyKey: "asg-provider-failure-key",
+    }));
+    await pipelineStore.createAssignment(makeAssignmentCreate({
+      id: "asg-concurrent-progress",
+      idempotencyKey: "asg-concurrent-progress-key",
+    }));
+    const originalRecordOutcome = pipelineStore.recordOutcomeTransaction.bind(
+      pipelineStore,
+    );
+    let settlementAttempts = 0;
+    pipelineStore.recordOutcomeTransaction = async (input) => {
+      if (
+        input.actorId === "pipeline-settlement" &&
+        settlementAttempts++ === 0
+      ) {
+        const run = (await pipelineStore.getRun("run-1"))!;
+        const concurrent = await originalRecordOutcome({
+          outcome: {
+            assignmentId: "asg-concurrent-progress",
+            expectedRunVersion: run.stateVersion,
+            action: "continue_self",
+            status: "progress",
+            reason: "another assignment advanced the run",
+            evidenceRefs: ["concurrent-progress"],
+            artifactRefs: [],
+            blockers: [],
+            checks: [],
+            progressFingerprint: "concurrent-progress",
+          },
+          toPhase: "building",
+          actorType: "system",
+          actorId: "test",
+          idempotencyKey: "concurrent-progress",
+        });
+        expect(concurrent.status).toBe("accepted");
+      }
+      return originalRecordOutcome(input);
+    };
+    const handles: MockHandle[] = [];
+    const manager = new SessionManager(sessionStore, testConfig, () => {
+      const handle = createMockHandle();
+      handles.push(handle);
+      return handle;
+    });
+    manager.pipelineStore = pipelineStore;
+    const errors = mock((_session, _error) => undefined);
+    manager.onError = errors;
+
+    await manager.handleAgentMessage(makeEvent({
+      text: "implement the assignment",
+      dedupeKey: "pipeline-outbox:dispatch-provider-failure",
+      pipelineInvocation: {
+        runId: "run-1",
+        assignmentId: "asg-provider-failure",
+        dispatchKey: "dispatch-provider-failure",
+        outcomeCountAtDispatch: 0,
+        retryCount: 0,
+      },
+    }), "build");
+    await waitFor(() => handles.length === 1);
+    handles[0]!._error("Claude process crashed before init");
+
+    await waitFor(() => errors.mock.calls.length === 1);
+    expect(handles).toHaveLength(1);
+    expect(errors.mock.calls[0]![1]).toContain(
+      "Provider error: Claude process crashed before init",
+    );
+    expect((await pipelineStore.getRun("run-1"))?.status).toBe("needs-human");
+    expect(settlementAttempts).toBe(2);
+    const outcomes = await pipelineStore.listOutcomes("asg-provider-failure");
+    expect(outcomes).toHaveLength(1);
+    expect(outcomes[0]?.blockers[0]?.detail).toBe(
+      "Claude process crashed before init",
+    );
+  });
+
+  it("does not resurrect a worker reset during continuation setup", async () => {
+    const sessionStore = new InMemorySessionStore();
+    const pipelineStore = new InMemoryPipelineStore(fakeClock(1_000));
+    await pipelineStore.createRun(makeProductRun({ phase: "building" }));
+    await pipelineStore.createAssignment(makeAssignmentCreate({
+      id: "asg-reset-worker",
+      targetAgent: "build",
+      idempotencyKey: "asg-reset-worker-key",
+    }));
+    const handles: MockHandle[] = [];
+    const manager = new SessionManager(sessionStore, testConfig, () => {
+      const handle = createMockHandle();
+      handles.push(handle);
+      return handle;
+    });
+    manager.pipelineStore = pipelineStore;
+    let releaseRecall!: () => void;
+    const recallGate = new Promise<void>((resolve) => { releaseRecall = resolve; });
+    let recallCalls = 0;
+    (manager as unknown as { preRecall: (message: string, context: { repo: string | null }) => Promise<string | null> }).preRecall = async () => {
+      recallCalls++;
+      if (recallCalls === 2) await recallGate;
+      return null;
+    };
+
+    await manager.handleAgentMessage(makeEvent({
+      text: "implement",
+      dedupeKey: "pipeline-outbox:reset-worker",
+      pipelineInvocation: {
+        runId: "run-1",
+        assignmentId: "asg-reset-worker",
+        dispatchKey: "reset-worker",
+        outcomeCountAtDispatch: 0,
+        retryCount: 0,
+      },
+    }), "build");
+    await waitFor(() => handles.length === 1);
+    handles[0]!._complete("", "worker-session", [], {
+      status: "incomplete",
+      reason: "max_turns",
+      retryable: true,
+    });
+    await waitFor(() => recallCalls === 2);
+    await manager.handleMessage(
+      makeEvent({ command: "reset", text: "build", ts: "reset-worker" }),
+    );
+    releaseRecall();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect((await sessionStore.get("thread-1"))?.agentSessions.build).toBeUndefined();
+    expect(handles).toHaveLength(1);
+  });
+
+  it("does not resurrect a thread reset during continuation setup", async () => {
+    const sessionStore = new InMemorySessionStore();
+    const pipelineStore = new InMemoryPipelineStore(fakeClock(1_000));
+    await pipelineStore.createRun(makeProductRun({ phase: "building" }));
+    await pipelineStore.createAssignment(makeAssignmentCreate({
+      id: "asg-reset-lead",
+      targetAgent: "lead",
+      idempotencyKey: "asg-reset-lead-key",
+    }));
+    const handles: MockHandle[] = [];
+    const manager = new SessionManager(sessionStore, testConfig, () => {
+      const handle = createMockHandle();
+      handles.push(handle);
+      return handle;
+    });
+    manager.pipelineStore = pipelineStore;
+    let releaseRecall!: () => void;
+    const recallGate = new Promise<void>((resolve) => { releaseRecall = resolve; });
+    let recallCalls = 0;
+    (manager as unknown as { preRecall: (message: string, context: { repo: string | null }) => Promise<string | null> }).preRecall = async () => {
+      recallCalls++;
+      if (recallCalls === 2) await recallGate;
+      return null;
+    };
+
+    await manager.handleAgentMessage(makeEvent({
+      text: "implement",
+      dedupeKey: "pipeline-outbox:reset-lead",
+      pipelineInvocation: {
+        runId: "run-1",
+        assignmentId: "asg-reset-lead",
+        dispatchKey: "reset-lead",
+        outcomeCountAtDispatch: 0,
+        retryCount: 0,
+      },
+    }), "lead");
+    await waitFor(() => handles.length === 1);
+    handles[0]!._complete("", "lead-session", [], {
+      status: "incomplete",
+      reason: "max_turns",
+      retryable: true,
+    });
+    await waitFor(() => recallCalls === 2);
+    await manager.handleMessage(
+      makeEvent({ command: "reset", text: "all", ts: "reset-lead" }),
+    );
+    releaseRecall();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(await sessionStore.get("thread-1")).toBeUndefined();
+    expect(handles).toHaveLength(1);
+  });
+
   it("quietly resumes a max-turn Claude session and trusts its later durable outcome", async () => {
     const sessionStore = new InMemorySessionStore();
     const pipelineStore = new InMemoryPipelineStore(fakeClock(1_000));

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -30,7 +30,12 @@ import {
   sessionProvider,
   spawnRunner as defaultSpawnRunner,
 } from "../runners/index.ts";
-import { willResume } from "../runners/runtime.ts";
+import {
+  isProviderSessionUnavailable,
+  providerSessionMatchesCwd,
+  resolveRunnerCwd,
+  willResume,
+} from "../runners/runtime.ts";
 import { createDrivers, type DriverMap } from "../claude/factory.ts";
 import { tmuxSessionNameFor } from "../claude/tmux-driver.ts";
 import {
@@ -64,6 +69,11 @@ import {
   formatPipelineStatusLines,
   projectRunSummary,
 } from "../pipelines/projection.ts";
+import { buildAssignmentContext } from "../pipelines/context.ts";
+import { bugContextForAssignment } from "../pipelines/bug/controller.ts";
+import { composeBugDispatchPrompt } from "../pipelines/bug/context.ts";
+import { productContextForAssignment } from "../pipelines/product/controller.ts";
+import { composeProductDispatchPrompt } from "../pipelines/product/context.ts";
 
 export class SessionManager {
   private store: SessionStore;
@@ -474,13 +484,16 @@ export class SessionManager {
 
     if (outcome.action === "muted") return;
 
-    await this.onAgentDispatched?.(session, agentName);
-
     if (outcome.action === "buffer") {
       this.onMessageBuffered?.(event);
       return;
     }
 
+    const reservation = createRunSetupReservation(
+      sessionProvider(this.buildRunSession(session, agentName), this.config),
+    );
+    this.handles.set(this.handleKey(session.threadId, agentName), reservation);
+    await this.onAgentDispatched?.(session, agentName);
     this.runRunnerWithAgent(
       session,
       event.text,
@@ -488,6 +501,7 @@ export class SessionManager {
       event.files,
       agentName,
       event.user,
+      reservation,
     );
   }
 
@@ -543,6 +557,10 @@ export class SessionManager {
       return;
     }
 
+    const reservation = createRunSetupReservation(
+      sessionProvider(this.buildRunSession(session, agentName), this.config),
+    );
+    this.handles.set(this.handleKey(session.threadId, agentName), reservation);
     this.runRunnerWithAgent(
       session,
       event.text,
@@ -550,6 +568,7 @@ export class SessionManager {
       event.files,
       agentName,
       event.user,
+      reservation,
     );
   }
 
@@ -699,6 +718,7 @@ export class SessionManager {
       await this.mutateSession(threadId, (s) => {
         s.sessionId = null;
         s.leadSessionId = null;
+        s.sessionCwd = null;
         s.pendingMessages = [];
         s.activePipelineInvocation = null;
         s.status = "idle";
@@ -1266,10 +1286,18 @@ export class SessionManager {
     files: SlackFileAttachment[] | undefined,
     agentName: string,
     senderUserId?: string,
+    expectedHandle?: SpawnHandle,
   ): Promise<void> {
     const isTopLevel = agentName === "lead" || agentName === "default";
+    const reservationKey = this.handleKey(session.threadId, agentName);
+    const assertRunOwnership = () => {
+      if (expectedHandle && this.handles.get(reservationKey) !== expectedHandle) {
+        throw new RunOwnershipChangedError();
+      }
+    };
     try {
-      const agentSession = isTopLevel
+      assertRunOwnership();
+      let agentSession = isTopLevel
         ? null
         : this.getOrCreateAgentSession(session, agentName);
       const agentIdentity = identityForAgent(agentName);
@@ -1295,15 +1323,18 @@ export class SessionManager {
             );
           }
         }
+        assertRunOwnership();
         const inferredRepo = inferReviewRepo(
           this.config.repos,
           prompt,
           pipelineRepoRefs,
         );
         if (inferredRepo && session.targetRepo !== inferredRepo.name) {
-          session.targetRepo = inferredRepo.name;
-          session.worktreePath = session.worktreePaths[inferredRepo.name] ?? null;
-          await this.store.set(session.threadId, session);
+          session = await this.mutateSession(session.threadId, (fresh) => {
+            assertRunOwnership();
+            fresh.targetRepo = inferredRepo.name;
+            fresh.worktreePath = fresh.worktreePaths[inferredRepo.name] ?? null;
+          });
         }
       }
 
@@ -1326,16 +1357,22 @@ export class SessionManager {
         !session.worktreePath
       ) {
         try {
+          const targetRepoName = targetRepo.name;
           session.worktreePath = await this.worktreeManager.createWorktree(
-            targetRepo.name,
+            targetRepoName,
             session.threadId,
             session.baseRef ?? undefined,
           );
-          session.worktreePaths = {
-            ...session.worktreePaths,
-            [targetRepo.name]: session.worktreePath,
-          };
-          await this.store.set(session.threadId, session);
+          assertRunOwnership();
+          const createdPath = session.worktreePath;
+          session = await this.mutateSession(session.threadId, (fresh) => {
+            assertRunOwnership();
+            fresh.worktreePath = createdPath;
+            fresh.worktreePaths = {
+              ...fresh.worktreePaths,
+              [targetRepoName]: createdPath,
+            };
+          });
         } catch (err) {
           _log.warn(
             "manager",
@@ -1364,11 +1401,56 @@ export class SessionManager {
           ? session.worktreePaths
           : undefined;
 
+      // cwd fallback: only used when no worktree exists. With the always-worktree
+      // policy above, this only fires for read-only/discussion threads with no
+      // targetRepo — never inside the shared origin repo.
+      const targetRepoCwd: string | undefined = session.worktreePath
+        ? undefined
+        : targetRepo?.path;
+
       // Build after worktree routing/creation so provider policy and cwd see
       // the newly registered isolated checkout on this same turn.
-      const runSession = this.buildRunSession(session, agentName, agentIdentity);
+      let runSession = this.buildRunSession(session, agentName, agentIdentity);
+      let provider = sessionProvider(runSession, this.config);
+      const invocationCwd = resolveRunnerCwd(runSession, targetRepoCwd);
+      if (
+        runSession.sessionId &&
+        !providerSessionMatchesCwd({
+          provider,
+          sessionId: runSession.sessionId,
+          sessionCwd: runSession.sessionCwd,
+          cwd: invocationCwd,
+        })
+      ) {
+        const staleSessionId = runSession.sessionId;
+        const invalidation = await this.invalidateProviderSession(
+          session.threadId,
+          agentName,
+          staleSessionId,
+        );
+        session = invalidation.session;
+        agentSession = isTopLevel
+          ? null
+          : this.getOrCreateAgentSession(session, agentName);
+        runSession = this.buildRunSession(session, agentName, agentIdentity);
+        provider = sessionProvider(runSession, this.config);
+        if (invalidation.invalidated) {
+          _log.warn(
+            "session",
+            `provider-session.cold-start thread=${session.threadId} agent=${agentName} provider=${provider} reason=cwd-affinity`,
+          );
+          if (!latestTs) {
+            prompt = await this.buildProviderColdStartPrompt(
+              session,
+              agentName,
+              rawMessage,
+            );
+          }
+        }
+      }
       runSession.currentMessageTs = latestTs ?? null;
       await this.attachReviewVerificationPolicy(runSession, agentName);
+      assertRunOwnership();
 
       // Resolve the agent definition early so its declared context profile
       // gates the preamble. Default agent (no .md) and missing-flag cases
@@ -1376,6 +1458,7 @@ export class SessionManager {
       const agentDefinition = this.agentRouter
         ? await this.agentRouter.resolveAgent(runSession)
         : null;
+      assertRunOwnership();
       const contextProfile: AgentContextProfile =
         agentDefinition?.context ?? DEFAULT_CONTEXT_PROFILE;
 
@@ -1387,16 +1470,20 @@ export class SessionManager {
       if (agentDefinition?.model) {
         runSession.model = agentDefinition.model;
         if (isTopLevel) {
-          session.model = agentDefinition.model;
-          await this.store.set(session.threadId, session);
+          session = await this.mutateSession(session.threadId, (fresh) => {
+            assertRunOwnership();
+            fresh.model = agentDefinition.model ?? null;
+          });
         }
       }
       // Per-agent Claude-runner model override (`model.claude` frontmatter).
       // Resolved by resolveClaudeModel at spawn; carried the same way as `model`.
       runSession.modelClaude = agentDefinition?.modelClaude ?? null;
       if (isTopLevel && agentDefinition?.modelClaude) {
-        session.modelClaude = agentDefinition.modelClaude;
-        await this.store.set(session.threadId, session);
+        session = await this.mutateSession(session.threadId, (fresh) => {
+          assertRunOwnership();
+          fresh.modelClaude = agentDefinition.modelClaude ?? null;
+        });
       }
       runSession.agentPermissions = agentDefinition?.permissions;
 
@@ -1433,6 +1520,11 @@ export class SessionManager {
             provider,
             sessionId: runSession.sessionId,
             opencodeContinuityEnabled: this.config.opencode.continuityEnabled,
+          }) && providerSessionMatchesCwd({
+            provider,
+            sessionId: runSession.sessionId,
+            sessionCwd: runSession.sessionCwd,
+            cwd: invocationCwd,
           });
           const isFirstTurn = !resumes;
           const needsThreadCatchup = !!session.needsThreadCatchup;
@@ -1460,10 +1552,13 @@ export class SessionManager {
               this.config.repos,
               preambleProfile,
             );
+            assertRunOwnership();
             prompt = preamble ? `${preamble}\n\n${readablePrompt}` : readablePrompt;
             if (needsThreadCatchup) {
-              session.needsThreadCatchup = false;
-              await this.store.set(session.threadId, session);
+              session = await this.mutateSession(session.threadId, (fresh) => {
+                assertRunOwnership();
+                fresh.needsThreadCatchup = false;
+              });
             }
           } else if (contextProfile.workspace) {
             const workspaceBlock = buildWorkspaceBlock(
@@ -1520,18 +1615,16 @@ export class SessionManager {
           agentName,
           agentIdentity,
         );
+        assertRunOwnership();
         if (isTopLevel) {
-          session.systemPrompt = runSession.systemPrompt;
+          session = await this.mutateSession(session.threadId, (fresh) => {
+            assertRunOwnership();
+            fresh.systemPrompt = runSession.systemPrompt;
+          });
+        } else {
+          assertRunOwnership();
         }
-        await this.store.set(session.threadId, session);
       }
-
-      // cwd fallback: only used when no worktree exists. With the always-worktree
-      // policy above, this only fires for read-only/discussion threads with no
-      // targetRepo — never inside the shared origin repo.
-      const targetRepoCwd: string | undefined = session.worktreePath
-        ? undefined
-        : targetRepo?.path;
 
       if (contextProfile.agentState) {
         const agentStateBlock = this.buildAgentStateBlock(session);
@@ -1546,6 +1639,7 @@ export class SessionManager {
         const preRecallBlock = await this.preRecall(rawMessage, {
           repo: session.targetRepo,
         });
+        assertRunOwnership();
         if (preRecallBlock) {
           prompt = `${preRecallBlock}\n\n${prompt}`;
         }
@@ -1554,7 +1648,6 @@ export class SessionManager {
       // We don't log the prompt to avoid spamming the logs. unless we are debugging it
       // log.info("prompt", `thread=${session.threadId} cwd=${targetRepoCwd ?? session.worktreePath ?? "junior"}\n--- PROMPT START ---\n${prompt}\n--- PROMPT END ---`);
 
-      const provider = sessionProvider(runSession, this.config);
       let rawHandle: SpawnHandle;
       if (provider === "claude") {
         const driver = this.driverFor(session.driverMode);
@@ -1563,14 +1656,17 @@ export class SessionManager {
         // same name; storing it here lets reconciliation find it later.
         if (session.driverMode === "tmux") {
           const tmuxName = tmuxSessionNameFor(session.threadId, agentName);
-          if (isTopLevel) {
-            session.tmuxSessionName = tmuxName;
-            session.topLevelTmuxAgent = agentName;
-          } else if (agentSession) {
-            agentSession.tmuxSessionName = tmuxName;
-          }
-          await this.store.set(session.threadId, session);
+          session = await this.mutateSession(session.threadId, (fresh) => {
+            assertRunOwnership();
+            if (isTopLevel) {
+              fresh.tmuxSessionName = tmuxName;
+              fresh.topLevelTmuxAgent = agentName;
+            } else {
+              this.getOrCreateAgentSession(fresh, agentName).tmuxSessionName = tmuxName;
+            }
+          });
         }
+        assertRunOwnership();
         rawHandle = driver.send({
           session: runSession,
           prompt,
@@ -1582,6 +1678,7 @@ export class SessionManager {
           agentName,
         });
       } else {
+        assertRunOwnership();
         rawHandle = this.spawnRunner(
           runSession,
           prompt,
@@ -1592,6 +1689,7 @@ export class SessionManager {
           imagePaths,
         );
       }
+      let attemptedResumeId = runSession.sessionId;
       const handle = withTimeout(
         rawHandle,
         runnerTimeoutMs(this.config, provider),
@@ -1602,6 +1700,7 @@ export class SessionManager {
         },
       );
       const handleKey = this.handleKey(session.threadId, agentName);
+      assertRunOwnership();
       this.handles.set(handleKey, handle);
       if (isTopLevel) {
         session.pid = handle.pid;
@@ -1650,9 +1749,11 @@ export class SessionManager {
           if (isTopLevel) {
             session.sessionId = event.sessionId;
             session.leadSessionId = event.sessionId;
+            session.sessionCwd = invocationCwd;
             session.provider = event.provider;
           } else if (agentSession) {
             agentSession.sessionId = event.sessionId;
+            agentSession.sessionCwd = invocationCwd;
             agentSession.provider = event.provider;
           }
           void this.persistRunSessionId(
@@ -1660,6 +1761,7 @@ export class SessionManager {
             agentName,
             event.provider,
             event.sessionId,
+            invocationCwd,
           );
         }
         this.onEvent?.(this.buildRunSession(session, agentName, agentIdentity), event);
@@ -1686,6 +1788,77 @@ export class SessionManager {
           clearIdleTimers();
         }
 
+        // Claude can lose an otherwise persisted conversation (most commonly
+        // after cwd/worktree routing changes). Repair that transport failure
+        // once as a fresh provider session before pipeline settlement sees it;
+        // this retry must not consume an assignment recovery continuation.
+        if (
+          attemptedResumeId &&
+          isProviderSessionUnavailable(provider, result.error)
+        ) {
+          if (this.handles.get(handleKey) !== attemptHandle) return;
+          let invalidation: { session: ThreadSession; invalidated: boolean };
+          try {
+            invalidation = await this.invalidateProviderSession(
+              session.threadId,
+              agentName,
+              attemptedResumeId,
+            );
+          } catch (err) {
+            if (err instanceof Error && err.message.startsWith("session not found:")) {
+              return;
+            }
+            throw err;
+          }
+          // A reset or newer dispatch can take ownership while invalidation is
+          // awaiting storage/tmux. Never spawn from the old result afterward.
+          if (this.handles.get(handleKey) !== attemptHandle) return;
+          if (!invalidation.invalidated) {
+            // The persisted provider id moved forward independently. Settle
+            // this old owning invocation without writing its stale id back.
+            result = { ...result, sessionId: null };
+          } else {
+            _log.warn(
+              "session",
+              `provider-session.cold-start thread=${session.threadId} agent=${agentName} provider=${provider} reason=session-unavailable`,
+            );
+            const coldStartPrompt = await this.buildProviderColdStartPrompt(
+              invalidation.session,
+              agentName,
+              rawMessage,
+            );
+            // Prompt reconstruction may await pipeline context. Re-check the
+            // slot before launching so a concurrent reset cannot be replaced.
+            if (this.handles.get(handleKey) !== attemptHandle) return;
+            const restartSession = await this.store.get(session.threadId);
+            if (!restartSession || this.handles.get(handleKey) !== attemptHandle) return;
+            const restartOwner = this.buildRunSession(
+              restartSession,
+              agentName,
+              agentIdentity,
+            );
+            if (restartOwner.sessionId) {
+              result = { ...result, sessionId: null };
+            } else {
+              this.runRunnerWithAgent(
+                restartSession,
+                coldStartPrompt,
+                latestTs ?? restartSession.activeTopLevelMessageTs ?? restartSession.threadId,
+                files,
+                agentName,
+                senderUserId,
+                attemptHandle,
+              ).catch((err) => {
+                _log.error(
+                  "session",
+                  `provider-session.cold-start.fail thread=${session.threadId} agent=${agentName} err=${err instanceof Error ? err.message : String(err)}`,
+                );
+              });
+              return;
+            }
+          }
+        }
+
         if (
           idleInterrupted &&
           this.idleResumeEnabled(provider) &&
@@ -1706,6 +1879,7 @@ export class SessionManager {
           ].join("\n");
           const retryRunSession = this.buildRunSession(session, agentName, agentIdentity);
           await this.attachReviewVerificationPolicy(retryRunSession, agentName);
+          attemptedResumeId = retryRunSession.sessionId;
 
           // Re-spawn with the continue prompt. Reuse the same rawHandle
           // creation path (driver.send for tmux, spawnRunner otherwise).
@@ -1757,9 +1931,11 @@ export class SessionManager {
               if (isTopLevel) {
                 session.sessionId = event.sessionId;
                 session.leadSessionId = event.sessionId;
+                session.sessionCwd = invocationCwd;
                 session.provider = event.provider;
               } else if (agentSession) {
                 agentSession.sessionId = event.sessionId;
+                agentSession.sessionCwd = invocationCwd;
                 agentSession.provider = event.provider;
               }
               void this.persistRunSessionId(
@@ -1767,6 +1943,7 @@ export class SessionManager {
                 agentName,
                 event.provider,
                 event.sessionId,
+                invocationCwd,
               );
             }
             this.onEvent?.(this.buildRunSession(session, agentName, agentIdentity), event);
@@ -1785,6 +1962,7 @@ export class SessionManager {
           agentName,
           result,
           attemptHandle,
+          invocationCwd,
         );
         if (pipelineResolution === null) return;
         result = pipelineResolution;
@@ -1796,26 +1974,46 @@ export class SessionManager {
         if (result.error && exhaustedRetries) {
           result.error = `Idle interrupts exhausted after ${maxIdleInterrupts} attempts. ${result.error}`;
         }
-        return this.onRunComplete(session, result, agentName, attemptHandle);
+        return this.onRunComplete(
+          session,
+          result,
+          agentName,
+          attemptHandle,
+          invocationCwd,
+        );
       }
     } catch (err) {
-      // Agent prompt composition or worktree creation failed fatally
-      if (isTopLevel) {
-        session.status = "idle";
-      } else {
-        const agentSession = this.getOrCreateAgentSession(session, agentName);
-        agentSession.status = "failed";
-        agentSession.pid = null;
+      if (err instanceof RunOwnershipChangedError) return;
+      if (expectedHandle && this.handles.get(reservationKey) !== expectedHandle) {
+        return;
       }
-      session.lastError = {
-        type: "setup",
-        message: err instanceof Error ? err.message : String(err),
-        timestamp: Date.now(),
-      };
-      await this.store.set(session.threadId, session);
+      if (expectedHandle) this.handles.delete(reservationKey);
+      // Agent prompt composition or worktree creation failed fatally
+      try {
+        session = await this.mutateSession(session.threadId, (fresh) => {
+          if (isTopLevel) {
+            fresh.status = "idle";
+          } else {
+            const failedAgent = this.getOrCreateAgentSession(fresh, agentName);
+            failedAgent.status = "failed";
+            failedAgent.pid = null;
+          }
+          fresh.lastError = {
+            type: "setup",
+            message: err instanceof Error ? err.message : String(err),
+            timestamp: Date.now(),
+          };
+        });
+      } catch (persistErr) {
+        if (
+          persistErr instanceof Error &&
+          persistErr.message.startsWith("session not found:")
+        ) return;
+        throw persistErr;
+      }
       this.onError?.(
         this.buildRunSession(session, agentName, identityForAgent(agentName)),
-        session.lastError.message,
+        session.lastError?.message ?? "runner setup failed",
       );
     }
   }
@@ -1831,9 +2029,13 @@ export class SessionManager {
     agentName: string,
     result: SpawnResult,
     ownHandle: SpawnHandle,
+    invocationCwd: string,
   ): Promise<SpawnResult | null> {
     if (!this.pipelineStore) return result;
-    const fresh = (await this.store.get(session.threadId)) ?? session;
+    const handleKey = this.handleKey(session.threadId, agentName);
+    if (this.handles.get(handleKey) !== ownHandle) return null;
+    const fresh = await this.store.get(session.threadId);
+    if (!fresh) return null;
     const isTopLevel = agentName === "lead" || agentName === "default";
     const invocation = isTopLevel
       ? fresh.activePipelineInvocation
@@ -1885,28 +2087,46 @@ export class SessionManager {
       ? fresh.sessionId
       : fresh.agentSessions?.[agentName]?.sessionId;
     const maxRetries = 2;
-    if (invocation.retryCount < maxRetries && (result.sessionId || sessionId)) {
+    const canContinueProviderSession =
+      !result.error || result.completion?.retryable === true;
+    if (
+      invocation.retryCount < maxRetries &&
+      (result.sessionId || sessionId) &&
+      canContinueProviderSession
+    ) {
+      if (this.handles.get(handleKey) !== ownHandle) return null;
       const retryCount = invocation.retryCount + 1;
-      const continued = await this.mutateSession(fresh.threadId, (current) => {
-        const owner = isTopLevel
-          ? current
-          : this.getOrCreateAgentSession(current, agentName);
-        const active = owner.activePipelineInvocation;
-        if (!active || active.dispatchKey !== invocation.dispatchKey) {
-          throw new Error("pipeline invocation ownership changed");
+      let continued: ThreadSession;
+      try {
+        continued = await this.mutateSession(fresh.threadId, (current) => {
+          const owner = isTopLevel
+            ? current
+            : this.getOrCreateAgentSession(current, agentName);
+          const active = owner.activePipelineInvocation;
+          if (!active || active.dispatchKey !== invocation.dispatchKey) {
+            throw new Error("pipeline invocation ownership changed");
+          }
+          owner.activePipelineInvocation = { ...active, retryCount };
+          if (result.sessionId) {
+            owner.sessionId = result.sessionId;
+            owner.sessionCwd = invocationCwd;
+            owner.provider = result.provider;
+            if (isTopLevel) current.leadSessionId = result.sessionId;
+          }
+          owner.status = "busy";
+          owner.pid = null;
+        });
+      } catch (err) {
+        if (
+          err instanceof Error &&
+          (err.message === "pipeline invocation ownership changed" ||
+            err.message.startsWith("session not found:"))
+        ) {
+          return null;
         }
-        owner.activePipelineInvocation = { ...active, retryCount };
-        if (result.sessionId) {
-          owner.sessionId = result.sessionId;
-          owner.provider = result.provider;
-          if (isTopLevel) current.leadSessionId = result.sessionId;
-        }
-        owner.status = "busy";
-        owner.pid = null;
-      });
-      if (this.handles.get(this.handleKey(fresh.threadId, agentName)) === ownHandle) {
-        this.handles.delete(this.handleKey(fresh.threadId, agentName));
+        throw err;
       }
+      if (this.handles.get(handleKey) !== ownHandle) return null;
       const continuation = [
         "The pipeline assignment has not recorded a typed outcome yet.",
         `Recovery continuation ${retryCount} of ${maxRetries}. Resume this same session from durable state; do not repeat completed mutations.`,
@@ -1922,6 +2142,8 @@ export class SessionManager {
         undefined,
         undefined,
         agentName,
+        undefined,
+        ownHandle,
       ).catch((err) => {
         _log.error(
           "pipeline",
@@ -1931,12 +2153,42 @@ export class SessionManager {
       return null;
     }
 
-    const latestRun = await this.pipelineStore.getRun(invocation.runId);
     const recoverySummary = invocation.retryCount === 0
       ? "without a recovery continuation"
       : `after ${invocation.retryCount} recovery continuation${invocation.retryCount === 1 ? "" : "s"}`;
-    if (latestRun && latestRun.status !== "terminal") {
-      await this.pipelineStore.recordOutcomeTransaction({
+    let escalationPersisted = false;
+    for (let attempt = 0; attempt < 3; attempt++) {
+      if (this.handles.get(handleKey) !== ownHandle) return null;
+      const [latestRun, latestAssignment, latestOutcomes] = await Promise.all([
+        this.pipelineStore.getRun(invocation.runId),
+        this.pipelineStore.getAssignment(invocation.assignmentId),
+        this.pipelineStore.listOutcomes(invocation.assignmentId),
+      ]);
+      if (
+        !latestRun ||
+        !latestAssignment ||
+        latestRun.status === "terminal" ||
+        !["pending", "leased"].includes(latestAssignment.status) ||
+        latestOutcomes.length > invocation.outcomeCountAtDispatch
+      ) {
+        // Another actor durably settled or advanced this assignment while the
+        // exhausted invocation was finishing. Trust that durable state.
+        return result.error
+          ? {
+              ...result,
+              response: "",
+              error: null,
+              completion: {
+                status: "success",
+                reason: "completed",
+                retryable: false,
+                providerSubtype: result.completion?.providerSubtype,
+                turns: result.completion?.turns,
+              },
+            }
+          : result;
+      }
+      const receipt = await this.pipelineStore.recordOutcomeTransaction({
         outcome: {
           assignmentId: invocation.assignmentId,
           expectedRunVersion: latestRun.stateVersion,
@@ -1957,11 +2209,57 @@ export class SessionManager {
         actorId: "pipeline-settlement",
         idempotencyKey: `pipeline-settlement-exhausted:${invocation.dispatchKey}`,
       });
+      if (
+        receipt.status === "accepted" ||
+        receipt.status === "escalated" ||
+        receipt.status === "duplicate"
+      ) {
+        escalationPersisted = true;
+        break;
+      }
+      if (!/state version conflict/i.test(receipt.reason ?? "")) break;
+    }
+    if (!escalationPersisted) {
+      if (this.handles.get(handleKey) !== ownHandle) return null;
+      this.handles.delete(handleKey);
+      const persistenceError =
+        `Pipeline assignment ${invocation.assignmentId.slice(0, 8)} exhausted recovery, but its escalation could not be persisted. The assignment remains active for retry.`;
+      let preserved: ThreadSession;
+      try {
+        preserved = await this.mutateSession(fresh.threadId, (current) => {
+          const owner = isTopLevel
+            ? current
+            : this.getOrCreateAgentSession(current, agentName);
+          const active = owner.activePipelineInvocation;
+          if (!active || active.dispatchKey !== invocation.dispatchKey) return;
+          owner.status = isTopLevel ? "idle" : "failed";
+          owner.pid = null;
+          current.lastError = {
+            type: "pipeline-settlement",
+            message: persistenceError,
+            timestamp: Date.now(),
+          };
+        });
+      } catch (err) {
+        if (err instanceof Error && err.message.startsWith("session not found:")) {
+          return null;
+        }
+        throw err;
+      }
+      this.onError?.(
+        this.buildRunSession(preserved, agentName, identityForAgent(agentName)),
+        persistenceError,
+      );
+      return null;
     }
     return {
       ...result,
       response: "",
-      error: `Pipeline assignment ${invocation.assignmentId.slice(0, 8)} stopped without reporting a typed outcome ${recoverySummary}. The run was escalated for human attention.`,
+      error: formatPipelineSettlementError(
+        invocation.assignmentId,
+        recoverySummary,
+        result.error,
+      ),
       completion: {
         status: "failure",
         reason: result.completion?.reason ?? "provider_error",
@@ -2003,6 +2301,7 @@ export class SessionManager {
     agentName: string,
     provider: RunnerProvider,
     sessionId: string,
+    sessionCwd: string,
   ): Promise<void> {
     try {
       await this.mutateSession(threadId, (fresh) => {
@@ -2010,12 +2309,14 @@ export class SessionManager {
           if (fresh.status === "busy" || fresh.status === "draining") {
             fresh.sessionId = sessionId;
             fresh.leadSessionId = sessionId;
+            fresh.sessionCwd = sessionCwd;
             fresh.provider = provider;
           }
         } else {
           const agentSession = fresh.agentSessions?.[agentName];
           if (agentSession?.status === "busy") {
             agentSession.sessionId = sessionId;
+            agentSession.sessionCwd = sessionCwd;
             agentSession.provider = provider;
           }
         }
@@ -2028,11 +2329,104 @@ export class SessionManager {
     }
   }
 
+  private async invalidateProviderSession(
+    threadId: string,
+    agentName: string,
+    expectedSessionId: string,
+  ): Promise<{ session: ThreadSession; invalidated: boolean }> {
+    const before = await this.store.get(threadId);
+    let invalidated = false;
+    const session = await this.mutateSession(threadId, (fresh) => {
+      // mutateThread may re-run this callback after a CAS conflict.
+      invalidated = false;
+      if (agentName === "lead" || agentName === "default") {
+        const currentSessionId = fresh.leadSessionId ?? fresh.sessionId;
+        if (currentSessionId !== expectedSessionId) return;
+        invalidated = true;
+        fresh.sessionId = null;
+        fresh.leadSessionId = null;
+        fresh.sessionCwd = null;
+        fresh.tmuxSessionName = null;
+        fresh.topLevelTmuxAgent = null;
+        return;
+      }
+
+      const agentSession = fresh.agentSessions?.[agentName];
+      if (!agentSession || agentSession.sessionId !== expectedSessionId) return;
+      invalidated = true;
+      agentSession.sessionId = null;
+      agentSession.sessionCwd = null;
+      agentSession.tmuxSessionName = null;
+    });
+    if (invalidated && before?.driverMode === "tmux") {
+      await this.driverFor("tmux")
+        .closeIfSessionId(threadId, agentName, expectedSessionId)
+        .catch(() => false);
+    }
+    return { session, invalidated };
+  }
+
+  private async buildProviderColdStartPrompt(
+    session: ThreadSession,
+    agentName: string,
+    fallbackPrompt: string,
+  ): Promise<string> {
+    if (!this.pipelineStore) return fallbackPrompt;
+    const invocation = agentName === "lead" || agentName === "default"
+      ? session.activePipelineInvocation
+      : session.agentSessions?.[agentName]?.activePipelineInvocation;
+    if (!invocation) return fallbackPrompt;
+
+    const [run, assignment] = await Promise.all([
+      this.pipelineStore.getRun(invocation.runId),
+      this.pipelineStore.getAssignment(invocation.assignmentId),
+    ]);
+    if (!run || !assignment) return fallbackPrompt;
+
+    const assignmentContext = buildAssignmentContext({ run, assignment });
+    const objective = [
+      assignment.objective,
+      "[provider-session-recovery]",
+      fallbackPrompt,
+    ].join("\n\n");
+    try {
+      if (run.kind === "bug") {
+        const bugContext = await bugContextForAssignment(
+          { store: this.pipelineStore, workspaceRoot: process.cwd() },
+          run,
+          assignment,
+        );
+        return composeBugDispatchPrompt({
+          bugContext,
+          assignmentContext,
+          objective,
+        });
+      }
+      const productContext = await productContextForAssignment(
+        { store: this.pipelineStore, workspaceRoot: process.cwd() },
+        run,
+        assignment,
+      );
+      return composeProductDispatchPrompt({
+        productContext,
+        assignmentContext,
+        objective,
+      });
+    } catch (err) {
+      _log.warn(
+        "session",
+        `provider-session.context-rebuild.fail thread=${session.threadId} agent=${agentName} run=${run.id} assignment=${assignment.id} err=${err instanceof Error ? err.message : String(err)}`,
+      );
+      return `${assignmentContext}\n\n${objective}`;
+    }
+  }
+
   private async onRunComplete(
     session: ThreadSession,
     result: SpawnResult,
     agentName: string,
     ownHandle?: SpawnHandle,
+    invocationCwd?: string,
   ): Promise<void> {
     const isTopLevel = agentName === "lead" || agentName === "default";
     const agentIdentity = identityForAgent(agentName);
@@ -2046,13 +2440,16 @@ export class SessionManager {
     if (ownHandle && this.handles.get(handleKey) !== ownHandle) {
       return;
     }
-    this.handles.delete(handleKey);
+    const stillOwnsRun = () =>
+      !ownHandle || this.handles.get(handleKey) === ownHandle;
 
     // Snapshot for read-only side effects (validation, onResponse). All
     // durable mutations go through mutateSession so parallel agents cannot
     // clobber each other via a stale full-row write.
-    const snapshot = (await this.store.get(session.threadId)) ?? session;
+    const snapshot = await this.store.get(session.threadId);
+    if (!snapshot || !stillOwnsRun()) return;
     await this.captureRunnerMemory(snapshot.threadId, agentName, result);
+    if (!stillOwnsRun()) return;
     let internalDispatchDirectives: AgentDirective[] = [];
     let pipelineGuardRetryReset = false;
 
@@ -2076,12 +2473,15 @@ export class SessionManager {
         snapshot.pipelineGuardRetryCount ?? 0,
       );
       if (validation.action === "continue") {
+        if (!stillOwnsRun()) return;
         let continued: ThreadSession;
         try {
           continued = await this.mutateSession(snapshot.threadId, (s) => {
+            if (!stillOwnsRun()) throw new RunOwnershipChangedError();
             if (result.sessionId) {
               s.sessionId = result.sessionId;
               s.leadSessionId = result.sessionId;
+              s.sessionCwd = invocationCwd ?? s.sessionCwd ?? null;
               s.provider = result.provider;
             }
             s.pipelineGuardRetryCount = (s.pipelineGuardRetryCount ?? 0) + 1;
@@ -2090,8 +2490,8 @@ export class SessionManager {
           });
         } catch (err) {
           if (
-            err instanceof Error &&
-            err.message.startsWith("session not found:")
+            err instanceof RunOwnershipChangedError ||
+            (err instanceof Error && err.message.startsWith("session not found:"))
           ) {
             return;
           }
@@ -2107,6 +2507,8 @@ export class SessionManager {
           undefined,
           undefined,
           agentName,
+          undefined,
+          ownHandle,
         ).catch(async (err) => {
           _log.error(
             "pipeline",
@@ -2153,6 +2555,7 @@ export class SessionManager {
           this.buildRunSession(snapshot, agentName, agentIdentity),
           result.response,
         );
+        if (!stillOwnsRun()) return;
       }
     }
 
@@ -2164,7 +2567,9 @@ export class SessionManager {
 
     let settled: ThreadSession;
     try {
+      if (!stillOwnsRun()) return;
       settled = await this.mutateSession(snapshot.threadId, (s) => {
+        if (!stillOwnsRun()) throw new RunOwnershipChangedError();
         if (pipelineGuardRetryReset) {
           s.pipelineGuardRetryCount = 0;
         }
@@ -2174,6 +2579,7 @@ export class SessionManager {
           if (result.sessionId) {
             s.sessionId = result.sessionId;
             s.leadSessionId = result.sessionId;
+            s.sessionCwd = invocationCwd ?? s.sessionCwd ?? null;
             s.provider = result.provider;
           }
           if (result.error) {
@@ -2211,6 +2617,7 @@ export class SessionManager {
           agentSession.pid = null;
           if (result.sessionId) {
             agentSession.sessionId = result.sessionId;
+            agentSession.sessionCwd = invocationCwd ?? agentSession.sessionCwd ?? null;
             agentSession.provider = result.provider;
           }
           if (result.error) {
@@ -2244,8 +2651,8 @@ export class SessionManager {
       });
     } catch (err) {
       if (
-        err instanceof Error &&
-        err.message.startsWith("session not found:")
+        err instanceof RunOwnershipChangedError ||
+        (err instanceof Error && err.message.startsWith("session not found:"))
       ) {
         // Row deleted (e.g. !reset) — nothing left to settle.
         return;
@@ -2260,6 +2667,8 @@ export class SessionManager {
         undefined,
         undefined,
         agentName,
+        undefined,
+        ownHandle,
       ).catch(async (err) => {
         console.error("[manager] Drain failed:", err);
         try {
@@ -2275,7 +2684,12 @@ export class SessionManager {
           // Session may have been reset during the failed drain.
         }
       });
-    } else if (settle.action === "settle") {
+    } else {
+      if (ownHandle && this.handles.get(handleKey) === ownHandle) {
+        this.handles.delete(handleKey);
+      }
+    }
+    if (settle.action === "settle") {
       await this.onAgentSettled?.(settled, agentName, result.response ?? null);
     }
 
@@ -2442,6 +2856,7 @@ export class SessionManager {
     }
 
     session.leadSessionId ??= session.sessionId;
+    session.sessionCwd ??= null;
     session.agentSessions ??= {};
     session.provider ??= "claude";
     session.humanParticipants ??= [];
@@ -2460,6 +2875,7 @@ export class SessionManager {
       agentName,
       provider: session.provider ?? this.config.runner.provider,
       sessionId: null,
+      sessionCwd: null,
       status: "idle",
       pendingMessages: [],
       lastActivity: Date.now(),
@@ -2509,6 +2925,7 @@ export class SessionManager {
     return {
       ...session,
       sessionId: agentSession.sessionId,
+      sessionCwd: agentSession.sessionCwd ?? null,
       provider: agentSession.provider ?? session.provider ?? this.config.runner.provider,
       agentType: agentName,
       systemPrompt: null,
@@ -2654,3 +3071,32 @@ const defaultSpawnRunnerForRuntime: SpawnRunnerFn =
         );
       }
     : defaultSpawnRunner;
+
+function formatPipelineSettlementError(
+  assignmentId: string,
+  recoverySummary: string,
+  providerError: string | null,
+): string {
+  const base =
+    `Pipeline assignment ${assignmentId.slice(0, 8)} stopped without reporting a typed outcome ${recoverySummary}. The run was escalated for human attention.`;
+  const detail = providerError?.replace(/\s+/g, " ").trim();
+  if (!detail) return base;
+  return `${base} Provider error: ${detail.slice(0, 500)}`;
+}
+
+class RunOwnershipChangedError extends Error {
+  constructor() {
+    super("runner ownership changed during setup");
+    this.name = "RunOwnershipChangedError";
+  }
+}
+
+function createRunSetupReservation(provider: RunnerProvider): SpawnHandle {
+  return {
+    provider,
+    result: new Promise<SpawnResult>(() => undefined),
+    onEvent: () => undefined,
+    kill: () => undefined,
+    pid: null,
+  };
+}

--- a/src/session/store/sqlite.test.ts
+++ b/src/session/store/sqlite.test.ts
@@ -64,6 +64,7 @@ describe("SqliteSessionStore", () => {
       agentName: "echo",
       provider: "opencode",
       sessionId: "echo-session",
+      sessionCwd: "/tmp/echo-worktree",
       status: "busy",
       pendingMessages: [{ user: "U1", text: "next", ts: "2.3" }],
       lastActivity: 12345,
@@ -75,6 +76,25 @@ describe("SqliteSessionStore", () => {
     const retrieved = await store.get("thread-1");
     expect(retrieved!.agentSessions.echo).toEqual(
       session.agentSessions.echo,
+    );
+  });
+
+  it("round-trips distinct top-level and per-agent session cwd affinity", async () => {
+    const session = createSession("cwd-thread", "channel-1");
+    session.sessionId = "lead-session";
+    session.leadSessionId = "lead-session";
+    session.sessionCwd = "/tmp/lead-worktree";
+    session.agentSessions.review = makeAgent("review", {
+      sessionId: "review-session",
+      sessionCwd: "/tmp/review-worktree",
+    });
+
+    await store.set(session.threadId, session);
+
+    const retrieved = await store.get(session.threadId);
+    expect(retrieved?.sessionCwd).toBe("/tmp/lead-worktree");
+    expect(retrieved?.agentSessions.review.sessionCwd).toBe(
+      "/tmp/review-worktree",
     );
   });
 
@@ -200,6 +220,7 @@ describe("SqliteSessionStore", () => {
     const retrieved = await store.get("legacy-thread");
     expect(retrieved!.provider).toBe("claude");
     expect(retrieved!.agentSessions.worker.provider).toBe("claude");
+    expect(retrieved!.agentSessions.worker.sessionCwd).toBeNull();
   });
 
   it("set on existing threadId upserts", async () => {

--- a/src/session/store/sqlite.ts
+++ b/src/session/store/sqlite.ts
@@ -19,6 +19,7 @@ type AgentSessionRow = {
   agent_name: string;
   provider: string | null;
   session_id: string | null;
+  session_cwd: string | null;
   status: AgentSession["status"];
   last_activity: number | null;
   state_version: number | null;
@@ -57,6 +58,7 @@ export class SqliteSessionStore implements SessionStore {
         agent_name TEXT NOT NULL,
         provider TEXT DEFAULT 'claude',
         session_id TEXT,
+        session_cwd TEXT,
         status TEXT DEFAULT 'idle',
         last_activity INTEGER,
         state_version INTEGER NOT NULL DEFAULT 0,
@@ -339,7 +341,7 @@ export class SqliteSessionStore implements SessionStore {
   private loadAgentSessions(session: ThreadSession): void {
     const rows = this.db
       .query<AgentSessionRow, [string]>(
-        `SELECT agent_name, provider, session_id, status, last_activity,
+        `SELECT agent_name, provider, session_id, session_cwd, status, last_activity,
                 state_version, pending_json, pid, tmux_session_name
          FROM agent_sessions WHERE thread_id = ?`,
       )
@@ -364,6 +366,7 @@ export class SqliteSessionStore implements SessionStore {
           row.provider ?? existing?.provider,
         ),
         sessionId: row.session_id,
+        sessionCwd: row.session_cwd ?? existing?.sessionCwd ?? null,
         status: row.status,
         pendingMessages: pendingFromRow ?? existing?.pendingMessages ?? [],
         lastActivity: row.last_activity ?? existing?.lastActivity ?? Date.now(),
@@ -402,12 +405,13 @@ export class SqliteSessionStore implements SessionStore {
   ): void {
     const upsert = this.db.query(
       `INSERT INTO agent_sessions
-         (thread_id, agent_name, provider, session_id, status, last_activity,
+         (thread_id, agent_name, provider, session_id, session_cwd, status, last_activity,
           state_version, pending_json, pid, tmux_session_name)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
        ON CONFLICT(thread_id, agent_name) DO UPDATE SET
          provider = excluded.provider,
          session_id = excluded.session_id,
+         session_cwd = excluded.session_cwd,
          status = excluded.status,
          last_activity = excluded.last_activity,
          state_version = excluded.state_version,
@@ -425,6 +429,7 @@ export class SqliteSessionStore implements SessionStore {
         agentSession.agentName,
         normalizePersistedRunnerProvider(agentSession.provider),
         agentSession.sessionId,
+        agentSession.sessionCwd ?? null,
         agentSession.status,
         agentSession.lastActivity,
         nextAgentVersion,
@@ -525,6 +530,7 @@ export class SqliteSessionStore implements SessionStore {
     this.ensureColumn("agent_sessions", "pending_json", "TEXT");
     this.ensureColumn("agent_sessions", "pid", "INTEGER");
     this.ensureColumn("agent_sessions", "tmux_session_name", "TEXT");
+    this.ensureColumn("agent_sessions", "session_cwd", "TEXT");
   }
 
   private ensureColumn(
@@ -543,11 +549,13 @@ export class SqliteSessionStore implements SessionStore {
 function normalizeSession(session: ThreadSession): ThreadSession {
   session.provider = normalizePersistedRunnerProvider(session.provider);
   session.leadSessionId ??= session.sessionId;
+  session.sessionCwd ??= null;
   session.agentSessions ??= {};
   for (const agentSession of Object.values(session.agentSessions)) {
     agentSession.provider = normalizePersistedRunnerProvider(
       agentSession.provider,
     );
+    agentSession.sessionCwd ??= null;
     agentSession.stateVersion ??= 0;
     agentSession.pendingMessages ??= [];
     agentSession.pid ??= null;

--- a/src/session/types.test.ts
+++ b/src/session/types.test.ts
@@ -132,6 +132,7 @@ describe("createSession", () => {
       "pid",
       "pipelineGuardRetryCount",
       "provider",
+      "sessionCwd",
       "sessionId",
       "stateVersion",
       "status",

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -63,6 +63,8 @@ export interface AgentSession {
   agentName: string;
   provider?: RunnerProvider;
   sessionId: string | null;
+  /** Working directory in which the native provider session was created. */
+  sessionCwd?: string | null;
   status: AgentSessionStatus;
   pendingMessages: PendingMessage[];
   lastActivity: number;
@@ -99,6 +101,8 @@ export interface ThreadSession {
   provider?: RunnerProvider;
   sessionId: string | null;
   leadSessionId: string | null;
+  /** Working directory in which sessionId / leadSessionId was created. */
+  sessionCwd?: string | null;
   agentSessions: Record<string, AgentSession>;
   worktreePath: string | null;
   /** Per-repo worktree paths for bug-pipeline threads. Keys are repo names (from RepoConfig.name). */
@@ -243,6 +247,7 @@ export function createSession(
     provider,
     sessionId: null,
     leadSessionId: null,
+    sessionCwd: null,
     agentSessions: {},
     worktreePath: null,
     worktreePaths: {},


### PR DESCRIPTION
## Summary
- bind Claude sessions to their working directories and cold-start invalid resumes safely
- recover tmux sessions only from valid transcripts
- make pipeline recovery, escalation, and dispatch ownership durable and race-safe

## Verification
- independent review agent: APPROVED
- two consecutive clean passes of `git diff --check`, `bun run typecheck`, and `bun test`
- full suite: 1277 passed, 2 expected skips, 0 failed