### PR TITLE
docs: audit and refresh repository documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,7 +88,8 @@ MEMORY_EMBED_PROVIDER=local
 
 # Automatic recall before every incoming Slack runner turn. This costs one
 # cheap model subprocess per turn; failures and timeouts fail open without recall.
-PRE_RECALL_ENABLED=true
+# Disabled by default; enable only after verifying the extra process/latency cost.
+PRE_RECALL_ENABLED=false
 PRE_RECALL_RUNNER=claude
 PRE_RECALL_TIMEOUT_MS=15000
 # Leave unset to use the pinned cheap model for the selected runner.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,13 @@
 
 ## Project Overview
 
-junior is a Slack bot that acts as the control plane for coding agent sessions. OpenCode is the default runner provider for automated Slack turns; Claude Code remains available through the Claude adapter and tmux driver. It's the successor to the OpenClaw-based agent system (PranavBakre/openclaw-agents).
+junior is a Slack bot that acts as the control plane for coding-agent sessions. OpenCode is the default runner provider; OpenCode SDK, Claude Code, and Codex app-server are also implemented. Claude tmux is an opt-in interactive driver. It's the successor to the OpenClaw-based agent system (PranavBakre/openclaw-agents).
 
 The server owns the lifecycle. When a Slack message arrives in a thread, the bot spawns a runner turn through the selected provider. Headless OpenCode/Claude turns are short-lived subprocesses; Claude tmux mode keeps an interactive process alive behind a per-thread driver flag. Each thread gets its own isolated session and optional target-repo worktree.
 
-**Stack:** Node.js / Bun, TypeScript, Slack Event API, OpenCode (default) / Claude Code CLI.
+**Stack:** Bun, TypeScript, Slack Event API, OpenCode CLI/SDK, Claude Code CLI, Codex app-server, SQLite, dynamic workflows, and durable product/bug pipeline state.
 
-**Key architectural choice:** CLI subprocess, not SDK. Headless turns spawn one provider CLI process per Slack turn; provider-native resume (`--session` for OpenCode, `--resume` for Claude) carries conversation context.
+**Key architectural choice:** providers are behind one normalized runner boundary. Headless CLI turns spawn one short-lived process per turn; server-attached providers keep their own runtime connection. Provider-native resume carries conversation context, but durable session/pipeline/artifact state remains authoritative after restart or recovery.
 
 ## Where to Look
 
@@ -36,11 +36,14 @@ The server owns the lifecycle. When a Slack message arrives in a thread, the bot
 | How are bug-pipeline worktrees laid out? | [docs/features/bug-pipeline-worktrees.md](docs/features/bug-pipeline-worktrees.md) |
 | How do sessions persist across restarts? | [docs/features/session-persistence.md](docs/features/session-persistence.md) |
 | How does the localhost HTTP dashboard work? | [docs/features/http-dashboard.md](docs/features/http-dashboard.md) |
+| How do dynamic workflows load, schedule, and run? | [docs/features/dynamic-workflows.md](docs/features/dynamic-workflows.md) |
+| How do durable product/bug pipelines dispatch and recover? | [docs/features/agent-product-debugging-pipeline-implementation-plan.md](docs/features/agent-product-debugging-pipeline-implementation-plan.md) |
+| How does GitHub PR/resource reconciliation work? | [docs/code_index/github-reconciliation.md](docs/code_index/github-reconciliation.md) |
+| How do provider-neutral agent capabilities and handoffs work? | [docs/code_index/agent-catalog.md](docs/code_index/agent-catalog.md) |
 | Project setup, config, directory structure? | [docs/features/project-setup.md](docs/features/project-setup.md) |
 | Known limitations and open questions? | [docs/features/v2-backlog.md](docs/features/v2-backlog.md) |
 | Code index for a specific module? | `docs/code_index/<module>.md` (matches feature doc names) |
-| Ideation and planning workflow? | [docs/workflows/ideation.md](docs/workflows/ideation.md) |
-| Building and iteration workflow? | [docs/workflows/building.md](docs/workflows/building.md) |
+| Current workflow definitions and docs map? | [docs/README.md](docs/README.md) and [`workflows/`](workflows/) |
 
 ## Architecture
 
@@ -48,10 +51,10 @@ The server owns the lifecycle. When a Slack message arrives in a thread, the bot
 Slack Event API (message.channels, app_mention)
     |
     v
-Slack Bot Server (Node.js / Bun)
+Slack Bot Server (Bun)
     |
-    +-- Session Manager: Map<thread_id, session>
-    |     session = { sessionId, worktreePath, status, pendingMessages, skillSet }
+    +-- Session Manager: durable ThreadSession per thread
+    |     session = { sessionId, worktreePaths, status, pendingMessages, pipeline state }
     |
     +-- On message:
     |     1. Look up thread_id
@@ -59,9 +62,12 @@ Slack Bot Server (Node.js / Bun)
     |     3. If idle -> spawn selected runner provider
     |     4. On exit -> post response to Slack, drain buffer
     |
-    +-- Runner CLI Process (short-lived, one per message turn)
-          opencode run --format json --dir "<worktree>" --session <id> --agent build "<prompt>"
-          claude -p "<prompt>" --output-format stream-json --resume <id> --mcp-config .mcp.json
+    +-- Runner provider boundary
+          OpenCode CLI / OpenCode SDK / Claude CLI / Codex app-server
+          normalized events + provider-native resume
+    +-- Durable workflows and product/bug pipelines
+          markdown definitions → scheduler/executor
+          typed runs → assignments → outbox → agent sessions
 ```
 
 ## Prerequisites
@@ -69,25 +75,46 @@ Slack Bot Server (Node.js / Bun)
 Install and authenticate the tools required by the provider and agents you enable:
 - **OpenCode** (default runner provider)
 - **Claude Code CLI** (Claude provider and tmux driver)
-- **Vercel CLI** (required by `vercel-status`)
-- **New Relic CLI** (required by `nr-research`)
-- **Sentry CLI** (required by `sentry-fetch`)
+- **Codex CLI/app-server** (Codex provider)
+- Observability CLIs such as Vercel, New Relic, or Sentry only when the
+  private overlay agents that use them are enabled.
 - **tmux 3.4+** (required only for `DEFAULT_CLAUDE_DRIVER=tmux`)
 
 ## Critical Rules
 
-1. **CLI subprocess, not SDK.** Spawn `opencode` or `claude -p` as a child process. Never use `@anthropic-ai/claude-code` as a library — that requires API keys.
-2. **One process per message turn.** Each Slack message spawns a short-lived runner process. The process exits after responding. No long-lived processes between messages (except in experimental TMUX mode).
-3. **Native resume for continuity.** Use `--session` (OpenCode) or `--resume` (Claude) to pick up conversation context. Session IDs are extracted from the first stream event on stdout.
+1. **Use the provider boundary.** OpenCode CLI is the default; OpenCode SDK,
+   Claude, and Codex app-server are implemented adapters. Keep provider-specific
+   arguments, parsing, and policy inside their adapter modules.
+2. **Match lifecycle to the provider.** Headless CLI turns are short-lived
+   processes; server-attached OpenCode SDK/Codex providers own their connection;
+   Claude tmux is an explicit interactive exception.
+3. **Use native resume when enabled.** Provider-native continuity uses
+   OpenCode sessions, Claude `--resume`, or Codex app-server thread state.
+   Durable session and pipeline state remains authoritative.
 4. **Buffer, don't interrupt.** If a runner is mid-execution and new messages arrive, buffer them. Do not kill the running turn except through the explicit stop/driver interrupt path. Drain the buffer as a combined prompt after the current turn exits.
 5. **Worktrees for target repos only.** Junior's workspace is shared across all threads (learnings accumulate). Worktrees are created in TARGET repos (example-backend, example-frontend) when threads need code isolation. Threads that only read or discuss don't need worktrees.
-6. **Stream events for status.** Parse provider-native JSON streams (`opencode run --format json`, Claude `--output-format stream-json`) into normalized runner events and post incremental Slack updates.
-7. **Session state is authoritative.** The session map (thread_id -> session) is the single source of truth for whether a thread is idle/busy, what its session ID is, and what messages are pending.
+6. **Stream events for status.** Parse provider-native streams from OpenCode,
+   Claude, and Codex into normalized runner events and post incremental Slack
+   updates. `SpawnHandle.onEvent` is the in-process callback boundary.
+7. **Durable state is authoritative.** Session, action, workflow, pipeline, and
+   artifact stores are the source of truth for restart/recovery. In-memory maps
+   are caches or test implementations, not the production contract.
 8. **Cleanup stale sessions.** The cleanup job deletes stale idle/draining session rows (24h default). Worktree removal is separate and must dirty-check before destructive cleanup.
-9. **Runner MCP contract.** Worktree-backed target-repo runs get Junior's local MCP wiring. Claude receives the project `.mcp.json` via `--mcp-config`; OpenCode receives generated MCP config through `OPENCODE_CONFIG_CONTENT`. Runs with an explicit `session.cwd` skip Junior's project MCP wiring because utility commands need their own cloud integrations. Keep this aligned with [docs/features/runner-providers.md](docs/features/runner-providers.md).
+9. **Runner MCP contract.** Worktree-backed target-repo runs get Junior's local
+   MCP wiring. Claude receives the project `.mcp.json` via `--mcp-config`; OpenCode
+   and Codex receive generated MCP config. Runs with an explicit `session.cwd`
+   skip Junior's project MCP wiring because utility commands need their own cloud
+   integrations. Run context is signed and scoped per spawn.
 10. **No `--input-format stream-json` in production.** The bidirectional streaming flag exists but is undocumented and unstable. Use `--resume` for multi-turn until the protocol is specified.
-11. **SQLite for persistence.** Sessions persist in a SQLite file via `bun:sqlite` (`data/sessions.db` by default, `SESSION_DB_PATH` to override). Single-writer, no extra service, survives restarts. `SESSION_STORE=memory` switches to the in-memory store for tests/dev. The home tab shows only sessions active in the last `HOME_WINDOW_MS` (2 days default); cleanup and health still scan all rows. Pending messages are persisted but treated as stale on restart — the Claude process they were queued behind is dead.
-12. **Always handle zombie processes.** Set a timeout guard (5 min default). Kill with SIGINT on timeout. Handle process errors. Clear the timeout on exit.
+11. **SQLite for persistence.** Sessions, actions, workflow runs, pipeline state,
+   and memory use SQLite-backed stores by default. `SESSION_STORE=memory` is for
+   tests/dev. The home tab shows only sessions active in `HOME_WINDOW_MS`; cleanup
+   and health still scan all rows. Pending messages are persisted but stale after
+   restart because the process they were queued behind is dead.
+12. **Handle stalled processes and recovery.** Keep a hard timeout guard, use
+   provider-specific idle recovery where supported, handle process errors, and
+   clear timers/handles on exit. Server-attached providers manage their own
+   connection lifecycle.
 13. **Design for swappability.** When adding infrastructure that could have multiple implementations (persistence, message queue, notification), use a provider/factory pattern. Each provider gets its own file, a factory selects the right one.
 14. **Pure functions over framework ceremony.** If a library's core value is bypassed, replace it with the simplest implementation. A 20-line function beats a dependency you're working around.
 15. **Test against real infrastructure, mock at boundaries.** Mock Slack API and runner CLIs at system boundaries. Don't mock internal session management or message routing.
@@ -121,22 +148,28 @@ junior/
         memory.ts         -- InMemorySessionStore (tests, dev)
         sqlite.ts         -- SqliteSessionStore (production)
     runners/
-      index.ts            -- select OpenCode/Claude provider
+      index.ts            -- select the normalized runner provider
       runtime.ts          -- shared cwd/env/MCP runtime contract
+      mcp-config.ts       -- generated OpenCode/Codex MCP configuration
     opencode/
-      spawner.ts          -- spawn opencode run, parse JSON events
+      spawner.ts          -- spawn OpenCode CLI, parse JSON events
+      sdk-provider.ts     -- OpenCode SDK provider
     claude/
       spawner.ts          -- spawn claude -p for headless mode
       tmux-driver.ts      -- interactive Claude driver behind tmux
       args.ts             -- build CLI args from session state
       parser.ts           -- stream-json line parser
       types.ts            -- stream-json event types
+    codex-app-server/     -- Codex app-server adapter, parser, policy, config
     worktree/
       manager.ts          -- create/remove/check worktrees in target repos
       types.ts            -- RepoConfig
     agents/
-      router.ts           -- load agent definitions, pick agent type
-      loader.ts           -- read .md files, parse frontmatter
+      router.ts           -- load definitions and build prompts
+      loader.ts           -- read .md files and parse frontmatter
+      manifest.ts         -- catalog capabilities and handoff policy
+      registry.ts         -- reloadable public/private definition registry
+      verification.ts     -- definition and policy checks
     memory/               -- v3 long-term memory (see docs/features/memory-system-v3.md)
       sqlite.ts           -- SqliteMemoryStore: source records, claims, episodes, decay
       store.ts            -- MemoryStore interface
@@ -151,6 +184,13 @@ junior/
       timeout.ts          -- process timeout guard
       health.ts           -- orphan detection
       shutdown.ts         -- graceful bot shutdown
+      dev-server.ts       -- per-repo dev-server manager
+      dev-server-queue.ts -- single-flight dev-server activation
+    pipelines/             -- durable product/bug runs, outbox, recovery, GC
+    workflows/             -- markdown workflow registry, scheduler, executor
+    github/                -- optional GitHub reconciliation and review writes
+    whatsapp/              -- optional passive WhatsApp archive
+    time/                  -- injectable clock for deterministic behavior
   .claude/
     agents/               -- agent definitions (junior's own, not target repo's)
       common/
@@ -167,17 +207,17 @@ junior/
   docs/
     features/             -- feature design docs with iteration plans
     code_index/           -- code indexes per module
-    workflows/            -- ideation and building workflows
+  workflows/              -- executable workflow definitions (worklog, release notes, memory consolidation, worktree prune)
   CLAUDE.md
   learnings.md
 ```
 
 ## Origin: OpenClaw Agent System
 
-This project replaces the OpenClaw-based agent workspace at PranavBakre/openclaw-agents. Key things that carry over:
+This project replaces the OpenClaw-based agent workspace at PranavBakre/openclaw-agents. The older identity names are historical context, not the current Junior dispatch contract. Current public identities are `default`, `lead`, `reproducer`, `review`, and `echo`; private/org identities are loaded from `agents-org`.
 
-- **Agent squad:** Junior (orchestrator), Scotty (backend builder), Uhura (frontend builder), Bones (code reviewer) — Star Trek naming.
-- **Junior's role:** Architect, orchestrator, rubber duck. Plans, reviews, coordinates — agents code. Does not write production code directly for non-trivial work.
+- **Agent roles:** The trusted catalog includes orchestrators plus `build`, `frontend`, `architect`, `pm`, `review`, and `reproducer` capabilities. It is separate from Slack persona identities.
+- **Junior's role:** Orchestrator, architect, and coordinator. It plans, reviews, and dispatches implementation work; non-trivial product edits are delegated to the appropriate trusted role.
 - **Sub-agent dispatch pattern:** Share relevant conventions and past mistakes in the prompt when spawning sub-agents. They don't have memory — if you don't share it, they repeat mistakes.
 - **Build -> Review loop:** Build via agent -> push -> Bones reviews -> fix -> re-review -> ship. 3-round escalation to Pranav if Bones keeps finding blockers.
 
@@ -187,7 +227,11 @@ What changes:
 - Agent dispatch uses Claude Code's `--resume` and worktrees in target repos instead of OpenClaw's agent workspace system.
 - Agent definitions live in target repos' `.claude/agents/` — don't duplicate them in junior.
 
-## Build Order
+## Historical build order
+
+The original feature-first build order is retained below as project history;
+the runtime now includes additional provider, workflow, pipeline, and
+reconciliation surfaces.
 
 Features depend on each other. Build in this order:
 
@@ -209,11 +253,14 @@ Items 3-5 can partially parallelize. Items 6-9 can be built in any order once se
 ```bash
 # Development
 bun run dev                     # Start bot server with hot reload (--watch)
+bun run start                   # Start the production entry point
 bun run build                   # Build for production
 bun run typecheck               # Type checking without emit
+bun test                        # Run the Bun test suite
 
 # Slack bot management
 bun run cleanup                 # Delete stale idle/draining session rows
+bun run migrate:prune-routing-logs # One-shot memory routing-log cleanup
 
 # Upload files/screenshots to the current Slack thread
 bin/slack-upload.sh <file-path> [comment]  # Uses SLACK_BOT_TOKEN, SLACK_CHANNEL, SLACK_THREAD_TS env vars (auto-set)

--- a/README.md
+++ b/README.md
@@ -1,22 +1,20 @@
 # junior
 
-A Slack bot that acts as the control plane for headless coding-agent sessions. OpenCode is the default runner provider; Claude Code remains available as a fallback provider. Each Slack thread maps to its own short-lived runner subprocess, and continuity comes from the provider's native resume session ID rather than a long-lived process.
+A Slack bot that acts as the control plane for coding-agent sessions. OpenCode is the default runner provider; Claude Code, OpenCode SDK, and Codex app-server are also supported. Headless CLI turns are short-lived, while Claude tmux mode is an opt-in interactive driver. Each Slack thread has durable session state and provider-native resume continuity.
 
 Successor to the OpenClaw-based agent system at [PranavBakre/openclaw-agents](https://github.com/PranavBakre/openclaw-agents) — same role (orchestrator + sub-agent dispatcher), rebuilt on top of coding-agent CLIs.
 
-**Stack:** Bun, TypeScript, [@slack/bolt](https://github.com/slackapi/bolt-js) (Socket Mode), OpenCode by default with Claude Code as an alternate provider, native session-resume for cross-turn continuity, SQLite for session + long-term memory persistence, and on-device vector embeddings (local ONNX model — no remote embedding API).
+**Stack:** Bun, TypeScript, [@slack/bolt](https://github.com/slackapi/bolt-js) (Socket Mode), provider adapters for OpenCode/Claude/Codex, SQLite persistence, dynamic markdown workflows, durable product/bug pipeline state, and on-device vector embeddings (local ONNX model — no remote embedding API).
 
 For deep architecture and the canonical "critical rules" list, see [CLAUDE.md](./CLAUDE.md). This README is the on-ramp.
 
 ## Prerequisites
 
-Junior orchestrates external coding agents and observability tools. Ensure the following are installed and authenticated on your host:
+Junior orchestrates external coding agents and optional observability integrations. Install the tools required by the providers, workflows, and private `agents-org` overlay you enable:
 
 - **[OpenCode](https://opencode.ai)** (default runner provider)
 - **[Claude Code CLI](https://anthropic.com)** (Claude provider and tmux driver)
-- **[Vercel CLI](https://vercel.com/docs/cli)** (required by `vercel-status`)
-- **[New Relic CLI](https://github.com/newrelic/newrelic-cli)** (required by `nr-research`)
-- **[Sentry CLI](https://docs.sentry.io/product/cli/)** (required by `sentry-fetch`)
+- **Vercel, New Relic, and Sentry CLIs** only if the private overlay's support agents use them
 - **tmux 3.4+** (required only for `DEFAULT_CLAUDE_DRIVER=tmux`)
 
 ---
@@ -25,7 +23,7 @@ Junior orchestrates external coding agents and observability tools. Ensure the f
 
 A Slack message in a configured channel triggers one of three things:
 
-1. **A persistent-agent dispatch** — `!review`, `!reproducer`, `!thinker`, `!echo`, or (implicit, in support channels) `!lead`. Each persistent agent gets its own `sessionId`, its own Slack username + emoji, and runs as a logically separate Claude conversation in the same thread.
+1. **A persistent-agent dispatch** — `!review`, `!reproducer`, `!echo`, or (implicit, in support channels) `!lead`. `default`/`lead` are orchestrators; `review` and `reproducer` are core workers. `thinker` is a legacy session alias, not a current directive. Each persistent agent gets its own `sessionId`, Slack identity, and logically separate conversation in the same thread.
 2. **A built-in directive** — e.g. `!devserver <branch>`, `!build`, `!status`, `!mute`. Directives are handled by junior itself or routed to a one-shot agent; they don't spawn a persistent agent.
 3. **A plain message** — buffered to the active session in that thread (or starts a new one). If a turn is in progress, the message is queued and drained as a combined prompt after the current turn exits — junior never interrupts a running process.
 
@@ -35,11 +33,13 @@ A single Slack thread can host multiple agents at once. The dispatcher is in [`s
 
 | Agent | Username | Emoji | Use |
 | --- | --- | --- | --- |
-| `lead` | Junior | 🤠 | Default in support channels — orchestrator / rubber duck |
+| `default` | Junior | app profile | Default orchestrator for ordinary channels |
+| `lead` | Junior (Lead) | :face_with_cowboy_hat: | Orchestrator marker for support channels |
 | `reproducer` | Reproducer | :mag: | Reproduce a reported bug deterministically |
-| `thinker` | Thinker | :wrench: | Form and mock-test a hypothesis |
 | `review` | Reviewer | :eyes: | Code review |
 | `echo` | Echo | :speech_balloon: | Reads/writes back — used as a coordination test bed |
+
+The trusted catalog also defines internal `pm`, `architect`, `build`, and `frontend` roles. They are selected by commands or pipeline assignments and do not need public Slack identities. See [agent routing](docs/features/agent-routing.md).
 
 Each agent stores its own row in the `agent_sessions` SQLite table so threading can fan out without losing per-agent `--resume` continuity.
 
@@ -47,10 +47,14 @@ Each agent stores its own row in the `agent_sessions` SQLite table so threading 
 
 While a runner is active, it can post to and read from Slack autonomously through an in-process HTTP MCP server ([`src/mcp/slack-server.ts`](src/mcp/slack-server.ts)). Tools exposed:
 
-- `slack_send_message`, `slack_read_channel`, `slack_read_thread`
-- `slack_search`, `slack_search_users`
-- `slack_upload_file`
+- Slack read/post/search/upload tools
 - `register_worktree` — let an agent claim a worktree path mid-turn
+- agent dispatch and definition search
+- memory recall/add/consolidation
+- pipeline start/state/assignment/outcome/check tools when pipeline mode is active
+- optional MongoDB and WhatsApp read tools
+
+The authoritative list and capability gates live in [the MCP server docs](docs/features/mcp-server.md).
 
 This is what enables agents to talk back to other agents (or to the human) within a single turn instead of waiting for the turn to end.
 
@@ -60,7 +64,7 @@ Junior keeps a long-term memory in `data/memory.db` (separate from the session D
 
 - **Capture (hot path).** Slack messages, routing decisions, and runner outputs are appended as raw **source records** by `MemoryIngestor` — cheap provenance, not yet recallable.
 - **Consolidate (offline).** A `claude -p` pass reads the unconsolidated source records and derives durable memory: **episodes** (affect-tagged raw log), keyed entity **profiles** (person/repo/situation, stored as markdown under `data/profiles/`, gitignored), and atomic **claims** (lessons/facts) embedded for semantic recall. Run it via the `consolidate-v3` CLI, the `memory-consolidation` workflow, or the `memory_consolidate` MCP tool — all share `runConsolidationSweep`.
-- **Recall (two channels).** `memory_recall` fetches keyed profiles verbatim by `entity_ref` and cosine-ranks the atomic claim store against a locally embedded query. Recall is **cosine-only** — there is no FTS channel.
+- **Recall (two surfaces).** `memory_recall` fetches keyed profiles verbatim by `entity_ref` and cosine-ranks the atomic claim store against a locally embedded query. Recall is **cosine-only** — there is no FTS channel. Optional pre-recall is off by default and must be enabled explicitly.
 - **Local embeddings.** Claims and queries are embedded in-process with `onnx-community/harrier-oss-v1-270m-ONNX` (640-dim, last-token pooling), co-located with the text in SQLite as a Float32 BLOB. Nothing leaves for a remote API.
 - **Decay.** Claims/episodes/profiles track `last_used_at`; an offline pass archives stale **and** low-value claims (`active = 0`, never hard-deleted). `memoryHealth` reports the fade candidates.
 
@@ -85,7 +89,7 @@ Each thread that touches a target repo gets its own git worktree at `<repo>.juni
 
 ### SQLite persistence
 
-Sessions and per-agent sessions persist in `data/sessions.db` (`bun:sqlite`, single-writer). The schema is created on boot — no migration tooling needed yet. `SESSION_STORE=memory` switches to the in-memory store for tests.
+Sessions, per-agent sessions, action records, workflow state, and pipeline state use SQLite stores under `data/` (`bun:sqlite`, single-writer). Each store creates or extends its tables on boot; there is no standalone migration CLI for session/workflow/pipeline state. `SESSION_STORE=memory` switches the session/workflow/pipeline stores to in-memory implementations for tests.
 
 ### Slack home tab
 
@@ -111,8 +115,11 @@ Binds `127.0.0.1` only. Junior is intentionally insecure as a networked product:
 | `GET /api/sessions` | All threads with their agent sessions |
 | `GET /api/sessions/:threadId` | Full session detail |
 | `GET /api/dev-server` | Per-repo manager state + queue depth |
+| `GET /api/workflows` | Loaded workflow definitions, runtime state, and recent runs |
 | `GET /api/logs?date=&tail=&tag=&level=` | Tail of structured logs |
 | `GET /api/memory` / `GET /api/memory/<path>` | Browse `docs/**/*.md` |
+| `GET /api/memory/recall` | Read-only claim/profile recall for the dashboard |
+| `GET /api/memory/projection` | Read-only memory-cloud projection data |
 
 Ported from [Friday](https://github.com/anmolm-growthx/Friday)'s `src/http/`. Junior-specific extensions: `/api/dev-server` exposes `DevServerQueue` state, and `/api/sessions` joins `agent_sessions` so the UI can render multi-agent threads.
 
@@ -149,7 +156,7 @@ All config is loaded from environment variables in [`src/config.ts`](src/config.
 | `SESSION_DB_PATH` | `data/sessions.db` | SQLite file path |
 | `HTTP_DASHBOARD_PORT` | *(unset)* | If set, starts the localhost dashboard |
 | `MCP_PORT` | `3456` | Port for the in-process Slack MCP server |
-| `RUNNER_PROVIDER` | `opencode` | Default runner provider: `opencode`, `opencode-sdk`, `codex-app-server`, or `claude` (`codex` is reserved for a future CLI fallback) |
+| `RUNNER_PROVIDER` | `opencode` | Default runner provider: `opencode`, `opencode-sdk`, `codex-app-server`, or `claude` |
 | `CLAUDE_MAX_TURNS` | `25` | Max turns per `claude -p` invocation |
 | `CLAUDE_TIMEOUT_MS` | `300000` | Per-turn timeout before SIGINT |
 | `CLAUDE_MODEL` | *(unset)* | Override default Claude model |
@@ -159,12 +166,21 @@ All config is loaded from environment variables in [`src/config.ts`](src/config.
 | `JUNIOR_OPENCODE_PERMISSION` | `allow` | OpenCode permission mode for generated agent config |
 | `OPENCODE_MCP_ENABLED` | `true` | Enables generated OpenCode MCP config for normal non-utility runs |
 | `OPENCODE_PLAYWRIGHT_MCP_ENABLED` | `true` | Include Playwright MCP in generated OpenCode config; set `false` to disable |
+| `OPENCODE_SLACK_MCP_ENABLED` | `true` | Include Slack MCP in generated OpenCode config |
+| `OPENCODE_MIXPANEL_MCP_ENABLED` | `true` | Include Mixpanel MCP when configured |
+| `OPENCODE_MONGODB_MCP_ENABLED` | `true` | Include MongoDB MCP when configured |
+| `CODEX_MODE` | `app-server` | Codex transport: `app-server` or the isolated `cli` fallback |
 | `CODEX_MODEL` | *(unset)* | Override default Codex app-server model |
 | `CODEX_TIMEOUT_MS` | `300000` | Per-turn Codex timeout before SIGINT |
 | `CODEX_SANDBOX` | `workspace-write` | Codex app-server sandbox. Set `danger-full-access` for YOLO-style full filesystem/network access. |
 | `CODEX_ASK_FOR_APPROVAL` | `never` | Codex app-server approval policy |
 | `CODEX_APP_SERVER_CONTINUITY_ENABLED` | `false` | Enables Codex app-server idle-timeout recovery: native `turn/interrupt` plus automatic continue turn. Normal `thread/resume` across app restarts stays enabled. |
 | `CODEX_ISOLATED_HOME_PATH` | `data/codex-home` | Junior-owned Codex home with generated config and symlinked auth |
+| `PRE_RECALL_ENABLED` | `false` | Run the optional cheap-model recall query extractor before runner turns |
+| `WHATSAPP_ENABLED` | `false` | Enable the read-only WhatsApp archive and MCP tools |
+| `PIPELINE_RUNTIME_MODE` | `off` | Durable pipeline mode: `off`, `shadow`, or `active` |
+| `BUG_PIPELINE_ENABLED` / `PRODUCT_PIPELINE_ENABLED` | `false` | Enable typed bug/product starts; requires `PIPELINE_RUNTIME_MODE=active` |
+| `GITHUB_RECONCILE_ENABLED` | `false` | Enable outbound PR/resource reconciliation |
 
 `REPOS` example:
 
@@ -192,8 +208,9 @@ Slash-style commands are parsed in [`src/slack/commands.ts`](src/slack/commands.
 !build [prompt]            -- spawn the build one-shot agent
 !frontend [prompt]         -- spawn the frontend one-shot agent
 !architect [prompt]        -- spawn the architect one-shot agent
+!pm [prompt]               -- spawn the PM one-shot agent
 !review                    -- dispatch to the review persistent agent
-!reproducer / !thinker     -- ditto
+!reproducer                -- dispatch to the reproducer persistent agent
 !echo / !lead              -- ditto
 
 !cancel                    -- cancel the in-flight turn
@@ -205,7 +222,12 @@ Slash-style commands are parsed in [`src/slack/commands.ts`](src/slack/commands.
 !provider <name>           -- switch this thread's runner provider
 !quiet | !normal | !verbose -- per-thread verbosity
 !mute | !unmute            -- silence/unsilence this thread
+!aside [text]              -- discard one message without waking a runner
+!listen                    -- wake an auto-dormant thread
 !adhoc / !bugs / !help     -- channel-specific entry points
+
+!workflow <show|run|start|stop|logs|reload> [name]
+!workflows                 -- list workflow definitions and state
 
 !devserver <branch> [repo] -- acquire dev-server slot
 !devserver status          -- queue depth
@@ -241,7 +263,8 @@ AgentDispatcher (src/support/router.ts)
                           |
                           v
                   Spawn runner provider
-                    claude -p / opencode run      (per-thread provider)
+                    claude -p / opencode run / Codex app-server
+                    (per-thread provider)
                     native resume id              (continuity)
                     normalized runner events      (tool/text/result events)
                     project MCP config            (worktree-backed runs)
@@ -275,13 +298,17 @@ src/
   agents/               agent loader (.md frontmatter)
   support/              AgentDispatcher, persistent-agent identities
   lifecycle/            dev-server manager + queue, timeouts, shutdown, health
-  mcp/                  in-process Slack MCP server
-  http/                 localhost dashboard (this PR)
+  mcp/                  in-process Slack/MongoDB/WhatsApp MCP server + approvals
+  pipelines/             durable product/bug runs, assignments, outcomes, outbox
+  github/                read-only PR/resource reconciliation
+  workflows/             markdown workflow registry, scheduler, executor, store
+  time/                  injectable clock seams for durable state tests
+  http/                  localhost dashboard
 public/                 static dashboard assets
 docs/                   feature design docs, code indexes, workflows
 ```
 
-For per-feature deep dives, see the [`docs/`](docs/) tree — `docs/architecture.md` and `docs/features/<name>.md`.
+For per-feature deep dives and source maps, start with [`docs/README.md`](docs/README.md), then use `docs/features/<name>.md` and `docs/code_index/<name>.md`.
 
 ---
 
@@ -299,4 +326,4 @@ bun run cleanup     # delete stale idle/draining session rows
 
 ## Origin and naming
 
-Junior is the orchestrator in a Star-Trek-named agent squad: Scotty (backend), Uhura (frontend), Bones (reviewer). Sub-agent dispatch is shared-context — agents don't have memory across runs, so the dispatcher passes relevant conventions and prior mistakes in the prompt. See the "Origin: OpenClaw Agent System" section in [CLAUDE.md](./CLAUDE.md) for what carried over from the previous incarnation and what changed.
+Junior is the orchestrator in a Star-Trek-named agent squad. The current public runtime uses `default`/`lead`, `reproducer`, and `review`; private overlays may add organization-specific identities. Agent dispatch is shared-context — agents don't have memory across runs, so the dispatcher passes relevant conventions and prior mistakes in the prompt. See the "Origin: OpenClaw Agent System" section in [CLAUDE.md](./CLAUDE.md) for historical context.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,77 @@
+# Junior documentation
+
+This directory describes the current Junior runtime and preserves older design
+records where they explain why a decision was made. For current behavior,
+prefer the root [README](../README.md), [CLAUDE.md](../CLAUDE.md), the code
+indexes, and the source links in those documents.
+
+## Start here
+
+| Need | Document |
+|---|---|
+| Run Junior and configure providers | [README](../README.md) |
+| Work on the repository safely | [CLAUDE.md](../CLAUDE.md) |
+| Understand the runtime boundaries | [Architecture](architecture.md) |
+| Check security assumptions | [Security](security.md) |
+| Find a module quickly | [Code indexes](#code-indexes) |
+
+## Current runtime surfaces
+
+- [Runner providers](features/runner-providers.md): OpenCode CLI (default),
+  OpenCode SDK, Claude headless/tmux, and Codex app-server.
+- [Session management](features/session-management.md) and
+  [session persistence](features/session-persistence.md): buffering, resume,
+  SQLite state, cleanup, and provider-specific recovery.
+- [Thread commands](features/thread-commands.md) and
+  [Slack event handling](features/slack-event-handler.md): command parsing,
+  persistent-agent directives, approvals, and App Home actions.
+- [MCP server](features/mcp-server.md): loopback Slack, agent, memory,
+  pipeline, GitHub, MongoDB, and WhatsApp tool surfaces.
+- [Dynamic workflows](features/dynamic-workflows.md): markdown definitions,
+  registry overlays, scheduler, executor, and dashboard state.
+- [Pipeline implementation](features/agent-product-debugging-pipeline-implementation-plan.md):
+  typed product/bug runs, assignments, outbox delivery, recovery, and GC.
+- [GitHub reconciliation](code_index/github-reconciliation.md): review-state
+  reads, idempotent comments, and optional polling/event wake-up.
+- [Memory v3](features/memory-system-v3.md): source records, claims, profiles,
+  local embeddings, recall, and consolidation.
+- [Worktrees and dev servers](features/bug-pipeline-worktrees.md) plus
+  [worktree runtime](features/worktree-manager.md): target-repo isolation and
+  the serialized dev-server slot.
+- [WhatsApp archive](features/whatsapp-tools.md): optional ingestion and
+  admin-gated read/search tools.
+
+## Code indexes
+
+Indexes map current symbols to source files. The most recently added runtime
+surfaces have dedicated indexes:
+
+- [Agent catalog](code_index/agent-catalog.md)
+- [Codex app-server](code_index/codex-app-server.md)
+- [GitHub reconciliation](code_index/github-reconciliation.md)
+- [HTTP dashboard](code_index/http-dashboard.md)
+- [MCP server](code_index/mcp-server.md)
+- [Pipelines](code_index/pipelines.md)
+- [Project setup and boot](code_index/project-setup.md)
+- [Runner providers](code_index/runner-providers.md)
+- [Support router](code_index/support-router.md)
+- [Workflows](code_index/workflows.md)
+
+The remaining indexes are listed by module in `docs/code_index/`.
+
+## Historical and proposal documents
+
+Feature files with an explicit `Historical`, `Proposal`, `Future`, or
+`Superseded` status are retained as design history. In particular, the older
+Codex runner plans, associative-memory designs, and pre-v3 memory plans are
+not implementation contracts. When a historical document names a path or
+agent that no longer exists, use its status banner and follow the linked
+current index instead.
+
+## Updating docs
+
+When changing a runtime surface, update its code index and feature document,
+then update [CLAUDE.md](../CLAUDE.md) or [README](../README.md) only when the
+change affects operator behavior, configuration, commands, or architecture.
+Run `git diff --check`, `bun run typecheck`, `bun test`, and an internal-link
+check before handing off a documentation change.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -10,7 +10,7 @@ System architecture for junior — the Slack bot that orchestrates coding-agent 
 | Slack SDK | @slack/bolt (Socket Mode) | Official SDK. Socket Mode = no public URL needed, works from a laptop. |
 | Language | TypeScript (strict, ESM) | Type safety across the session state machine and stream parser. |
 | Persistence | SQLite (`bun:sqlite`) | Survives restarts without an external service; memory store remains available for tests/dev. |
-| Runner providers | OpenCode by default, Claude as fallback | Provider adapters normalize CLI args, events, resume semantics, cwd, env, and MCP wiring. |
+| Runner providers | OpenCode CLI by default; OpenCode SDK, Claude, and Codex app-server | Provider adapters normalize args, events, resume semantics, cwd, env, policy, and MCP wiring. |
 | Driver modes | Headless by default, Claude tmux opt-in | Headless uses one subprocess per turn; tmux keeps an interactive Claude session alive behind a flag. |
 
 ## System Diagram
@@ -30,7 +30,7 @@ Slack (Socket Mode)
 │  Session Manager                                  │
 │  (manager.ts)                                     │
 │                                                   │
-│  Map<threadId, ThreadSession>                     │
+│  Durable ThreadSession + store                    │
 │                                                   │
 │  States: idle ──► busy ──► draining ──► idle     │
 │                   ▲  buffer    │  drain           │
@@ -43,11 +43,12 @@ Slack (Socket Mode)
 │   Agent    │  │  Worktree  │  │  Runner    │
 │   Router   │  │  Manager   │  │ Providers   │
 │            │  │            │  │            │
-│ Load .md   │  │ git work-  │  │ spawn      │
-│ from target│  │ tree in    │  │ opencode /│
-│ repo's     │  │ TARGET     │  │ claude     │
-│ .claude/   │  │ repos      │  │ parse JSON │
-│ agents/    │  │ (not here) │  │            │
+│ Load .md   │  │ git work-  │  │ normalized │
+│ from target│  │ tree in    │  │ OpenCode / │
+│ repo's     │  │ TARGET     │  │ Claude /   │
+│ .claude/   │  │ repos      │  │ Codex      │
+│ agents/    │  │ (not here) │  │ parse JSON │
+│            │  │            │  │            │
 └─────┬──────┘  └─────┬──────┘  └──────┬─────┘
       │               │                │
       │   systemPrompt│   cwd          │  runner events
@@ -87,11 +88,13 @@ Every feature touches `ThreadSession`. It's the shared entity, like `jobs` in in
 | `status` | Session Manager | All (guards behavior) |
 | `sessionId` | Runner provider (from provider event stream) | Runner provider (for native resume) |
 | `worktreePath` | Worktree Manager | Runner provider (for cwd) |
+| `worktreePaths` | Worktree Manager / pipeline intake | Runner providers and workspace prompt |
 | `agentType` | Thread Commands / Agent Router | Agent Router (to load definition) |
 | `systemPrompt` | Agent Router | Runner provider (Claude append-system-prompt or generated OpenCode config) |
 | `pendingMessages` | Session Manager (buffer) | Session Manager (drain) |
 | `verbosity` | Thread Commands | Stream-to-Slack |
 | `targetRepo` | Thread Commands | Worktree Manager, Agent Router |
+| `pipeline` / workflow state | Pipeline/workflow controllers | Dispatch, dashboard, recovery |
 
 **Implication:** `ThreadSession` is the integration contract. Changes to its shape affect every module. Keep it stable early.
 
@@ -143,7 +146,7 @@ Four boundaries need swappable implementations:
 |---|---|---|
 | Session persistence | `SessionStore` | `InMemorySessionStore`, `SqliteSessionStore` |
 | Slack posting | `SlackClient` | Real Bolt client, mock for tests |
-| Runner spawning | `spawnRunner` / driver interfaces | OpenCode adapter, Claude headless adapter, Claude tmux driver |
+| Runner spawning | `spawnRunner` / driver interfaces | OpenCode CLI/SDK adapters, Claude headless/tmux drivers, Codex app-server adapter |
 | Worktree operations | `WorktreeManager` | Real git commands, mock for tests |
 
 Factory selects the implementation at startup based on config. Consumer code only sees the interface.
@@ -161,9 +164,11 @@ draining          → busy     (spawn with combined buffer)
 
 This is simple enough for a pure `validateTransition()` function — no XState needed. Hiring-platform learned this: XState was removed because pure validation functions did the same thing without the ceremony. Same applies here.
 
-### 8. Event-driven internal flow (EventEmitter, not queue)
+### 8. Event-driven internal flow (callbacks, not a queue)
 
-The runner handle emits normalized events as it parses provider output. Stream-to-Slack subscribes to these events. This is in-process pub/sub, not RabbitMQ.
+The runner handle invokes `onEvent` callbacks as it parses provider output.
+Stream-to-Slack subscribes through that callback boundary. This is in-process
+delivery, not RabbitMQ or a Node `EventEmitter`.
 
 ```typescript
 // runner emits

--- a/docs/audits/2026-07-19-agent-product-debugging-pipeline.md
+++ b/docs/audits/2026-07-19-agent-product-debugging-pipeline.md
@@ -404,3 +404,9 @@ The tracked bug-state snapshot contains 44 `state.json` files: 7 `done` and 37 n
 9. Port adaptive bug modes into the active orchestrator.
 10. Make generic workflow docs repository-neutral.
 11. Consolidate prompts and add end-to-end pipeline simulations for restart recovery, duplicate handoffs, busy-agent buffering, review-to-fix loops, dev-server readiness, GitHub changes during laptop sleep, revision-matched gates, timeout escalation, multi-PR action anchoring, and terminal-only cleanup.
+# Historical snapshot
+
+> This audit predates the 2026-07-21 documentation and agent-catalog updates.
+> It records findings from that point in time; follow the current code indexes
+> and [`2026-07-21-documentation.md`](2026-07-21-documentation.md) for live
+> behavior.

--- a/docs/audits/2026-07-21-documentation.md
+++ b/docs/audits/2026-07-21-documentation.md
@@ -1,0 +1,62 @@
+# Documentation audit — 2026-07-21
+
+## Scope
+
+Audited the operator entry points (`README.md`, `CLAUDE.md`, `.env.example`),
+architecture/security docs, feature pages, code indexes, executable workflow
+definitions, and the current `src/` module inventory. The audit covered runner
+providers, sessions/persistence, agent routing, MCP/HTTP surfaces, worktrees,
+memory, workflows, pipelines, GitHub reconciliation, and WhatsApp archive tools.
+
+## Agent audit
+
+Three read-only audit agents ran in parallel. They inspected the repository and
+reported findings without modifying files:
+
+1. Runtime/source inventory and missing code indexes.
+2. Feature-document claims versus current implementation.
+3. README/CLAUDE/config/operator-surface drift and stale references.
+
+The audits converged on the same high-impact drift: provider support was
+understated, the default agent catalog still named retired roles, persistence
+was described as an in-memory map, MCP and dashboard routes were incomplete,
+and several shipped features were still framed as proposals.
+
+## Updates made
+
+- Documented all four implemented runner paths: OpenCode CLI, OpenCode SDK,
+  Claude headless/tmux, and Codex app-server.
+- Corrected the SQLite/session, pipeline/workflow, memory, GitHub, WhatsApp,
+  and MCP/HTTP descriptions and configuration references.
+- Added current code indexes for the agent catalog, Codex app-server, GitHub
+  reconciliation, pipelines, support router, and workflows.
+- Added `docs/README.md` as the canonical documentation map and marked older
+  plans/design records as historical where their paths or roles are no longer
+  current.
+- Corrected worktree/dev-server paths and the delegated setup-command contract.
+- Updated command, driver, thread archive, security, and agent-action-button
+  documentation to match shipped behavior.
+- Corrected `.env.example` so `PRE_RECALL_ENABLED=false` matches the source
+  default.
+
+## Deliberate non-changes
+
+The audit found an unrelated current UI-label issue in
+`public/index.html` around provider resume labels. It was not changed because
+this task is a documentation audit and the issue does not make the docs more
+accurate. Historical design records remain in place when they provide useful
+decision context, but current-status banners point readers to the live indexes.
+
+## Verification (first pass)
+
+- `git diff --check`: passed.
+- Internal Markdown link check: passed for 111 tracked/current Markdown files.
+- `bun test`: passed — 1,277 tests, 2 model-download skips, 0 failures.
+- `bun run typecheck`: still fails on pre-existing MCP/Zod schema typing errors
+  in `src/mcp/slack-server.ts`, `src/mcp/mongodb-proxy.ts`, and
+  `src/mcp/whatsapp-tools.ts`. No source files in those modules were changed by
+  this audit; dependency refresh from the committed lockfile removed unrelated
+  duplicate-package errors but not the existing MCP typing mismatch.
+
+The same formatting, link, test, and typecheck checks are repeated after the
+first clean documentation pass and before the commit/PR handoff.

--- a/docs/code_index/agent-catalog.md
+++ b/docs/code_index/agent-catalog.md
@@ -1,0 +1,43 @@
+# Code Index: Agent Catalog and Verification
+
+The agent catalog is the provider-neutral source of truth for which agent
+roles may be selected, what they are allowed to do, and which handoffs are
+valid. Markdown definitions provide prompts; the catalog adds capabilities,
+policy, and verification metadata.
+
+## Sources
+
+| Symbol | File | Purpose |
+|---|---|---|
+| `AGENT_CATALOG` | `src/agents/manifest.ts` | Declares role metadata, capabilities, and handoff policy. |
+| `AGENT_IDENTITIES` | `src/support/agents.ts` | Public Slack identities and dispatch aliases. Core identities are `default`, `lead`, `reproducer`, `review`, and `echo`; support-channel `lead` sessions resolve to the `default` definition. |
+| `loadOverlayIdentities()` | `src/support/agents.ts` | Loads private `agents-org` identities from frontmatter without replacing existing public entries. |
+| `AgentRegistry` | `src/agents/registry.ts` | Loads/reloads definitions and resolves dispatchable agents. |
+| `AgentRouter` | `src/agents/router.ts` | Chooses a definition and builds the prompt for a turn. |
+| `getAgentCapabilities()` | `src/agents/capabilities.ts` | Returns capability metadata for policy checks and prompts. |
+| `verifyAgentDefinition()` | `src/agents/verification.ts` | Checks definition frontmatter, required sections, tools, and policy constraints. |
+| `loadAgentDefinition()` | `src/agents/loader.ts` | Parses markdown frontmatter and materializes a definition. |
+
+## Current roles
+
+- `default`: the general orchestrator; support-channel `lead` markers resolve
+  here and layer the bug-pipeline playbook when appropriate.
+- `reproducer`: read-only reproduction and later validation of a local fix.
+- `review`: review and merge-readiness checks.
+- `pm`, `architect`, `build`, and `frontend`: catalog roles for planning and
+  implementation handoffs. They are not interchangeable persistent Slack
+  identities.
+- Private overlay roles are dispatchable only after their identity metadata is
+  loaded from `agents-org`.
+
+The old standalone `thinker` and public `lead.md` definitions are retired.
+References in older feature plans describe the former two-phase design; the
+current orchestrator performs that reasoning and dispatches implementation to
+the catalog roles.
+
+## Safety boundary
+
+Catalog verification must run before dispatch. A role may narrow its declared
+permissions but cannot widen the target repository, MCP scope, or handoff
+policy supplied by the runtime. Keep changes to role metadata and prompt
+content covered by `src/agents/*.test.ts` and the provider-parity tests.

--- a/docs/code_index/agent-definitions.md
+++ b/docs/code_index/agent-definitions.md
@@ -16,11 +16,15 @@ This module handles loading, parsing, and routing of agent definitions from mark
 | Symbol | File | Purpose |
 |---|---|---|
 | `loadAgentDefinition(filePath)` | `src/agents/loader.ts` | Reads an agent markdown file, parses flat frontmatter, strips quotes, and returns the body prompt. |
-| `parseAgentFrontmatter(...)` | `src/agents/loader.ts` | Parses `name`, `description`, `tools`, `model`, `common`, `username`, `iconEmoji`, and `context.*` flags. |
+| `loadAgentDefinition(...)` (private `parseFrontmatter`) | `src/agents/loader.ts` | Parses `name`, `description`, `tools`, `model`, `model.claude`, `common`, `permissions.*`, identity fields, and context profile flags. |
 | `AgentRouter.resolveAgent(session)` | `src/agents/router.ts` | Resolves target repo -> org overlay -> public fallback, first match wins. |
 | `AgentRouter.composeSystemPrompt(session)` | `src/agents/router.ts` | Prepends selected common prompt files and appends the resolved agent body. |
 | `loadOverlayIdentities(...)` | `src/support/agents.ts` | Loads Slack identity frontmatter for overlay/private persistent agents. |
 | `loadOpenCodeSupportSubagents()` | `src/opencode/support-agents.ts` | Loads stateless support prompts into generated OpenCode config. |
+
+The trusted operational catalog is separate from prompt content. See
+[`agent-catalog.md`](agent-catalog.md) for capabilities, mutation policy, and
+handoff rules; target-repo frontmatter cannot widen those catalog ceilings.
 
 ## Data Flow
 

--- a/docs/code_index/claude-spawner.md
+++ b/docs/code_index/claude-spawner.md
@@ -18,8 +18,11 @@ Spawns `claude -p` as a child process, parses stream-json output, and collects s
 |---|---|---|
 | `StreamEvent` | `types.ts` | Union: `StreamEventInit \| StreamEventAssistant \| StreamEventResult \| StreamEventUser \| StreamEventRateLimit` |
 | `ContentBlock` | `types.ts` | Union: `ContentBlockText \| ContentBlockToolUse \| ContentBlockThinking` |
-| `SpawnResult` | `types.ts` | `{ sessionId, response, events, exitCode, error }` |
-| `SpawnHandle` | `types.ts` | `{ result: Promise<SpawnResult>, onEvent(cb), kill(), pid }` |
+| `SpawnResult` | `src/runners/types.ts` | Provider-neutral `{ provider, sessionId, response, events, exitCode, error }` |
+| `SpawnHandle` | `src/runners/types.ts` | Provider-neutral `{ result: Promise<SpawnResult>, onEvent(cb), kill(), pid }` |
+
+`src/claude/types.ts` contains Claude-native stream-json event/content types;
+the app-facing result and handle types live in `src/runners/types.ts`.
 
 ## Data Flow
 

--- a/docs/code_index/codex-app-server.md
+++ b/docs/code_index/codex-app-server.md
@@ -1,0 +1,27 @@
+# Code Index: Codex App-Server Provider
+
+The Codex provider adapts the Codex app-server protocol to Junior's normalized
+runner boundary. It is selected with `RUNNER_PROVIDER=codex-app-server` and is
+not the same as the historical standalone `src/codex` runner plan.
+
+## Sources
+
+| Area | Files | Purpose |
+|---|---|---|
+| Spawning and lifecycle | `src/codex-app-server/spawner.ts` | Starts the isolated Codex app-server process and exposes a runner handle. |
+| Protocol parsing | `src/codex-app-server/parser.ts` | Parses JSONL app-server messages into normalized events. |
+| Configuration | `src/codex-app-server/config.ts` | Builds app-server launch and MCP configuration. |
+| Policy | `src/codex-app-server/policy.ts` | Maps sandbox, approval, search, and agent policy to Codex options. |
+| Shared boundary | `src/runners/types.ts`, `src/runners/index.ts` | Provider-neutral `SpawnHandle`, events, resume, and provider selection. |
+
+## Configuration
+
+`CODEX_MODE` defaults to `app-server`; sandbox and approval are controlled by
+`CODEX_SANDBOX` and `CODEX_ASK_FOR_APPROVAL`. MCP, search, continuity,
+isolated-home, model, and timeout flags are listed in [`.env.example`](../../.env.example).
+The provider receives the same scoped Junior MCP contract as other normal
+worktree-backed runs, subject to per-agent permissions.
+
+Codex continuity is provider-native and optional. Durable session, workflow,
+pipeline, and artifact state remains authoritative when a process or provider
+connection is restarted.

--- a/docs/code_index/github-reconciliation.md
+++ b/docs/code_index/github-reconciliation.md
@@ -1,0 +1,28 @@
+# Code Index: GitHub Reconciliation
+
+GitHub integration is an outbound read/reconcile surface. It is optional and
+disabled unless `GITHUB_RECONCILE_ENABLED=true`; it does not require an inbound
+webhook to keep pipeline state correct.
+
+## Sources
+
+| Symbol/area | File | Purpose |
+|---|---|---|
+| GitHub client | `src/github/client.ts` | Authenticated, bounded GitHub API operations. |
+| Query builders | `src/github/queries.ts` | Resource/review queries used by reconciliation. |
+| `reconcile*` | `src/github/reconciler.ts` | Fetches external state and applies idempotent internal updates. |
+| Diffing | `src/github/diff.ts` | Compares observed and projected review/resource state. |
+| Review comments | `src/github/review-comments.ts` | Scopes comments to an exact head SHA and avoids duplicate writes. |
+| Types | `src/github/types.ts` | GitHub resource, review, and reconciliation contracts. |
+
+## Configuration
+
+`GITHUB_RECONCILE_TOKEN`, `GITHUB_RECONCILE_INTERVAL_MS`,
+`GITHUB_RECONCILE_USE_CLI`, and the event-wake flag are documented in
+[`.env.example](../../.env.example). Event wake requires reconciliation to be
+enabled. MCP review tools are limited to the fixed read-state and idempotent
+comment operations; arbitrary GitHub mutation is not part of the contract.
+
+The pipeline layer consumes reconciled state through typed resources and
+outcomes. Failures are recoverable and must not be treated as proof that the
+external review state changed.

--- a/docs/code_index/http-dashboard.md
+++ b/docs/code_index/http-dashboard.md
@@ -1,6 +1,6 @@
 # Code Index: HTTP Dashboard
 
-Localhost-only HTTP server for operator inspection (sessions, dev-servers, logs, docs). Off by default; enabled via `HTTP_DASHBOARD_PORT`. Binds 127.0.0.1 and intentionally has no auth; do not expose it beyond a trusted local operator environment.
+Localhost-only HTTP server for operator inspection (sessions, dev-servers, workflows, logs, docs, and memory projections). Off by default; enabled via `HTTP_DASHBOARD_PORT`. Binds 127.0.0.1 and intentionally has no auth; do not expose it beyond a trusted local operator environment.
 
 ## Code Index
 
@@ -9,14 +9,17 @@ Localhost-only HTTP server for operator inspection (sessions, dev-servers, logs,
 | Symbol | File | Purpose |
 |---|---|---|
 | `startHttpServer(deps)` | `server.ts` | Bun.serve on 127.0.0.1:port; routes API + serves `public/index.html` |
-| `HttpServerDeps` | `server.ts` | `{ store, config, devServerManager, devServerQueue, repos }` |
+| `HttpServerDeps` | `server.ts` | `{ store, config, devServerManager, devServerQueue, repos, workflowRegistry, workflowStore, memoryStore? }` |
 | `handleHealth(store, config, startedAt)` | `routes/health.ts` | `GET /api/health` — uptime, session counts, agent counts, repo list |
 | `handleSessions(store)` | `routes/sessions.ts` | `GET /api/sessions` — list (strips worktreePath, systemPrompt, cwd, pid, slackIdentity, pendingMessages flattened to count) |
 | `handleSessionDetail(store, threadId)` | `routes/sessions.ts` | `GET /api/sessions/:threadId` — full session JSON |
 | `handleDevServers(manager, queue, repos)` | `routes/dev-server.ts` | `GET /api/dev-server` — per-repo state, idle TTL remaining, queue depth |
+| `handleWorkflows(registry, store)` | `routes/workflows.ts` | `GET /api/workflows` — workflow definitions, persisted state, recent runs, registry errors |
 | `handleLogs(searchParams)` | `routes/logs.ts` | `GET /api/logs?date=YYYY-MM-DD` — parses daily log file (strict date regex prevents path traversal) |
 | `handleMemoryList()` | `routes/memory.ts` | `GET /api/memory` — list files under `docs/` |
 | `handleMemoryRead(filePath)` | `routes/memory.ts` | `GET /api/memory/:path` — read a doc file (path-traversal guarded) |
+| `handleMemoryRecall(store, params)` | `routes/memory.ts` | `GET /api/memory/recall` — semantic claim recall without recording dashboard usage |
+| `handleMemoryProjection(store)` | `routes/memory.ts` | `GET /api/memory/projection` — PCA/KNN projection for the memory cloud view |
 
 ## Routes
 
@@ -26,16 +29,19 @@ GET /api/health             → handleHealth
 GET /api/sessions           → handleSessions
 GET /api/sessions/<id>      → handleSessionDetail
 GET /api/dev-server         → handleDevServers
+GET /api/workflows          → handleWorkflows
 GET /api/logs?date=...      → handleLogs
 GET /api/memory             → handleMemoryList
 GET /api/memory/<path>      → handleMemoryRead
+GET /api/memory/recall      → handleMemoryRecall (503 if unavailable)
+GET /api/memory/projection  → handleMemoryProjection (503 if unavailable)
 ```
 
 ## Key Concepts
 
 ### Loopback-only threat model
 
-Binds `127.0.0.1`. No CORS headers — same-origin from `public/index.html`. Don't expose this port. No auth.
+Binds `127.0.0.1`. No CORS headers — same-origin from `public/index.html`. Don't expose this port. No auth. The internal MCP server is a separate loopback-only service.
 
 ### Path traversal guards
 
@@ -48,5 +54,5 @@ Binds `127.0.0.1`. No CORS headers — same-origin from `public/index.html`. Don
 
 ## Dependencies
 
-- **Uses**: `Bun.serve`, `SessionStore`, `DevServerManager`, `DevServerQueue`, `RepoConfig`, `logger`
+- **Uses**: `Bun.serve`, `SessionStore`, `DevServerManager`, `DevServerQueue`, `WorkflowRegistry`, `WorkflowStore`, optional `MemoryStore`, `RepoConfig`, `logger`
 - **Used by**: `src/index.ts` (gated on `config.http.enabled`)

--- a/docs/code_index/mcp-server.md
+++ b/docs/code_index/mcp-server.md
@@ -1,6 +1,8 @@
-# Code Index: Bot Slack MCP Server
+# Code Index: Bot MCP Server
 
-Shared HTTP MCP server running inside Junior's process. All spawned Claude instances connect to it for Slack operations using the bot token.
+Shared loopback HTTP MCP server running inside Junior's process. All spawned
+runners connect to it for Slack, memory, agent, and (when enabled) pipeline
+operations using the bot token and signed run context.
 
 ## Code Index
 
@@ -8,7 +10,7 @@ Shared HTTP MCP server running inside Junior's process. All spawned Claude insta
 
 | Symbol | File | Purpose |
 |---|---|---|
-| `startMcpServer(botToken, store?, worktreeManager?)` | `slack-server.ts` | Starts HTTP server on `MCP_PORT` (default 3456). Called once from `index.ts`. |
+| `startMcpServer(deps)` | `slack-server.ts` | Starts HTTP server on `MCP_PORT` (default 3456), binding `127.0.0.1` and best-effort `::1`. Optional dependencies wire stores and pipeline services. |
 | `registerTools(server)` (internal) | `slack-server.ts` | Registers Slack, worktree, and agent-registry tools on a fresh `McpServer` per request. |
 | `handleMongoMcpRequest(req, res)` | `mongodb-proxy.ts` | Serves `/mcp/mongodb` as a stateless HTTP MCP proxy to one shared read-only MongoDB stdio backend. |
 | `closeMongoMcpBackend()` | `mongodb-proxy.ts` | Closes the shared backend immediately; also used by the idle TTL. |
@@ -27,12 +29,18 @@ Shared HTTP MCP server running inside Junior's process. All spawned Claude insta
 | `register_worktree` | Junior internal | `thread_id`, `repo` | `branch` (branch-name override) |
 | `agent_search` | Junior internal | — | `query`, `include_public`, `include_private`, `limit` |
 | `reload_agent_registry` | Junior internal | — | — |
+| `slack_send_dm` | Slack Web API | `user_id`, `text` | identity fields |
+| `agent_dispatch` | Junior internal | agent, prompt, thread context | synthetic user/timestamp |
+| `memory_recall` / `memory_add` / `memory_consolidate` | Memory v3 | tool-specific | filters/options |
+| `github_read_pr_review_state` / `github_post_review` | Fixed GitHub API surface | review-specific | inline comments |
+| `pipeline_*` | Durable pipeline store | tool-specific | artifact/check fields |
+| `whatsapp_*` | Read-only archive | tool-specific | time/group filters |
 
 ### Configuration
 
 | File | What |
 |---|---|
-| `.mcp.json` | Root Claude config contains only Junior's `slack-bot` HTTP MCP. Per-agent generated configs add Playwright/MongoDB as needed. |
+| `.mcp.json` | Root config contains `slack-bot`, Figma, and Notion servers. Per-agent generated configs add Playwright/MongoDB as needed. |
 | `.claude/settings.json` | `permissions.allow: ["mcp__slack-bot__*"]` |
 | `src/claude/spawner.ts` | Passes `--mcp-config` for worktree spawns |
 
@@ -40,7 +48,7 @@ Shared HTTP MCP server running inside Junior's process. All spawned Claude insta
 
 ### Stateless per request
 
-Each HTTP request creates a fresh `McpServer` + `StreamableHTTPServerTransport` (`sessionIdGenerator: undefined`). No sessions, no state between HTTP requests. Slack requests share the same `WebClient` (module-level singleton). MongoDB proxy requests share one lazily started wrapped stdio backend and close it after an idle TTL.
+Each HTTP request creates a fresh `McpServer` + `StreamableHTTPServerTransport` (`sessionIdGenerator: undefined`). No MCP session state is kept between requests. Slack requests share the same `WebClient` (module-level singleton). MongoDB proxy requests share one lazily started wrapped stdio backend and close it after an idle TTL. Run context is HMAC-signed per spawn and validated before thread/agent-sensitive tools execute.
 
 ### Identity model
 
@@ -56,5 +64,5 @@ Called by lead/intake to create a per-thread worktree for a repo and persist its
 
 ## Dependencies
 
-- **Uses**: `@modelcontextprotocol/sdk` (`McpServer`, `StreamableHTTPServerTransport`), `@slack/web-api`, `zod`, `SessionStore`, `WorktreeManager`
-- **Used by**: spawned Claude instances (HTTP), `src/index.ts` (startup)
+- **Uses**: `@modelcontextprotocol/sdk` (`McpServer`, `StreamableHTTPServerTransport`), `@slack/web-api`, `zod`, session/worktree/action/memory/pipeline stores
+- **Used by**: spawned Claude/OpenCode/Codex instances (HTTP), `src/index.ts` (startup)

--- a/docs/code_index/persistent-agents.md
+++ b/docs/code_index/persistent-agents.md
@@ -1,6 +1,8 @@
 # Code Index: Persistent Agents & Dispatch
 
-Multi-agent dispatch layer: registry of agent slack identities, orchestrator/worker classification, dispatch-allow rules, and the universal message router that parses `!<agent>` and `!devserver` directives and routes each to the right session slice.
+Multi-agent dispatch layer: registry of agent Slack identities, trusted catalog/orchestrator-worker classification, legacy compatibility rules, and the universal message router that parses `!<agent>` and `!devserver` directives and routes each to the right session slice.
+
+> **Current status (2026-07-21):** Core identities are `default`, `lead`, `reproducer`, `review`, and `echo`; private overlay agents are loaded from `agents-org`. `thinker` is retained only for compatibility with old sessions. See [`agent-catalog.md`](agent-catalog.md) for the trusted role registry.
 
 ## Code Index
 
@@ -8,14 +10,14 @@ Multi-agent dispatch layer: registry of agent slack identities, orchestrator/wor
 
 | Symbol | File | Purpose |
 |---|---|---|
-| `AGENT_IDENTITIES` | `agents.ts` | Mutable registry of `agentName → { username, iconEmoji }`. Core agents (`default`, `lead`, `reproducer`, `thinker`, `review`, `echo`) seeded in code. |
+| `AGENT_IDENTITIES` | `agents.ts` | Mutable registry of `agentName → { username, iconEmoji }`. Core agents (`default`, `lead`, `reproducer`, `review`, `echo`) seeded in code; overlays add private identities. |
 | `registerAgentIdentity(name, identity)` | `agents.ts` | Add an overlay agent identity. Refuses to overwrite existing entries. |
 | `loadOverlayIdentities(dirPath)` | `agents.ts` | Scan `agents-org/*.md` and register identities for agents with both `username` + `iconEmoji` frontmatter. |
 | `isOrchestratorAgent(name)` | `agents.ts` | `name ∈ {lead, default, junior}`. Orchestrators may dispatch any worker. |
 | `isPersistentAgent(name)` | `agents.ts` | Membership check in `AGENT_IDENTITIES`. |
 | `identityForAgent(name)` | `agents.ts` | Lookup; undefined if not registered. |
 | `agentForUsername(username)` | `agents.ts` | Reverse lookup, used to classify self-bot posts. |
-| `WORKER_DISPATCH_ALLOW` | `agents.ts` | Worker → worker dispatch exceptions. Empty after the 3-way merge retired thinker — the orchestrator emits `!reproducer`/`!review` itself; no worker→worker chain remains. |
+| `WORKER_DISPATCH_ALLOW` | `agents.ts` | Legacy worker → worker compatibility map. Its `thinker` entry supports resumed pre-merge sessions; live routing uses the trusted catalog and orchestrator. |
 | `workerMayDispatch(src, target)` | `agents.ts` | Gate for worker self-bot directives. |
 | `dispatchableAgentsFor(name)` | `agents.ts` | Returns allowed dispatch targets for an agent. |
 | `buildDispatchAllowBlock(name)` | `agents.ts` | `<dispatch-allow>` system-prompt block injected into every agent. |
@@ -54,7 +56,7 @@ AgentDispatcher.handleMessage(event)
 
 ### Orchestrator vs Worker
 
-Orchestrators (`lead`, `default`, `junior`) may emit any `!<agent>` directive. Workers may emit only entries in `WORKER_DISPATCH_ALLOW` (currently `thinker → {review, reproducer}`). Disallowed worker directives are stripped and the message is re-routed to lead as plain text.
+Orchestrators (`lead`, `default`, `junior`) may emit any registered worker directive. Workers are constrained by the trusted catalog; the legacy `WORKER_DISPATCH_ALLOW` entry (`thinker → {review, reproducer}`) exists only for resumed pre-merge sessions. Disallowed worker directives are stripped and the message is re-routed to the orchestrator as plain text.
 
 ### Self-bot routing
 

--- a/docs/code_index/pipelines.md
+++ b/docs/code_index/pipelines.md
@@ -1,0 +1,35 @@
+# Code Index: Durable Product and Bug Pipelines
+
+Pipelines are the typed control plane for product and bug work. They remain
+disabled by default (`PIPELINE_RUNTIME_MODE=off`) and can run in `shadow` or
+`active` mode after the corresponding product/bug flag is enabled.
+
+## Sources
+
+| Area | Files | Purpose |
+|---|---|---|
+| Types and definitions | `src/pipelines/types.ts`, `src/pipelines/bug/definition.ts`, `src/pipelines/product/definition.ts` | Run, assignment, outcome, artifact, transition, and pipeline-specific state. |
+| Controllers | `src/pipelines/bug/controller.ts`, `src/pipelines/product/controller.ts` | Start typed runs, apply transitions, and enqueue work. |
+| Dispatch | `src/pipelines/dispatch.ts`, `src/pipelines/pump.ts` | Claim assignments and deliver them to agent sessions. |
+| Persistence | `src/pipelines/store/*` | Memory and SQLite stores, versioned writes, and transactional outcome handling. |
+| Reliability | `src/pipelines/outbox.ts`, `recovery.ts`, `settlement-recovery` paths | At-least-once outbox delivery, lease recovery, and settlement repair. |
+| Outcomes | `src/pipelines/outcomes.ts`, `revision.ts`, `artifacts.ts` | Idempotent agent outcomes, revisions, artifacts, and handoffs. |
+| Projection and cleanup | `src/pipelines/projection.ts`, `src/pipelines/gc.ts` | Dashboard projections and retention cleanup. |
+| Legacy bridge | `src/pipelines/legacy-directives.ts`, `src/support/pipeline-guard.ts` | Safely maps selected legacy directives while preserving existing routing. |
+| MCP tools | `src/pipelines/tools.ts` | Runner-facing pipeline read/write tools with scope and idempotency checks. |
+
+## Runtime contract
+
+`off` leaves legacy Slack routing unchanged. `shadow` records eligible starts
+without dispatching or mutating legacy ownership. `active` enables typed
+controllers, assignments, recovery, and optional GitHub reconciliation. The
+config loader rejects product/bug flags unless the mode is `active`.
+
+Assignments use leases and idempotency keys. The outbox is at-least-once, so
+consumers and outcome writes must remain idempotent; version/CAS checks prevent
+stale workers from overwriting newer state. Retention is controlled by
+`PIPELINE_RETENTION_DAYS`.
+
+See [the implementation plan](../features/agent-product-debugging-pipeline-implementation-plan.md)
+for design history and [GitHub reconciliation](github-reconciliation.md) for
+the external review boundary.

--- a/docs/code_index/project-setup.md
+++ b/docs/code_index/project-setup.md
@@ -1,6 +1,6 @@
 # Code Index: Project Setup
 
-Entry point, configuration, logging, persona loading, and boot sequence.
+Entry point, configuration, logging, persona loading, and boot sequence. The project foundation is shipped; this index is the current source map, while older setup prose remains useful as design history.
 
 ## Code Index
 
@@ -16,7 +16,7 @@ Entry point, configuration, logging, persona loading, and boot sequence.
 
 | Type | File | Shape |
 |---|---|---|
-| `Config` | `config.ts` | `{ slack, claude, repos, session, channelDefaults, adminSlackUserId, http }` |
+| `Config` | `config.ts` | `{ slack, claude, runner, opencode, codex, repos, session, memory, threadArchives, channelDefaults, adminSlackUserId, http, whatsapp?, pipeline?, github? }` |
 | `RepoConfig` | `config.ts` | `{ name, path, defaultBase, worktreeSetupCommand?, devCommand?, devPort?, readyUrl? }` |
 | `SessionStoreKind` | `config.ts` | `"memory" \| "sqlite"` |
 
@@ -27,6 +27,7 @@ Entry point, configuration, logging, persona loading, and boot sequence.
 | `SLACK_BOT_TOKEN` | yes | — | Bolt + MCP server + file uploads |
 | `SLACK_APP_TOKEN` | yes | — | Socket Mode |
 | `SLACK_SIGNING_SECRET` | no | `""` | Bolt request verification |
+| `RUNNER_PROVIDER` | no | `opencode` | `claude` \| `opencode` \| `opencode-sdk` \| `codex-app-server` |
 | `CLAUDE_MAX_TURNS` | no | `25` | `--max-turns` |
 | `CLAUDE_TIMEOUT_MS` | no | `300000` | Process timeout guard |
 | `CLAUDE_PERMISSION_MODE` | no | `bypassPermissions` | `--permission-mode` |
@@ -42,6 +43,14 @@ Entry point, configuration, logging, persona loading, and boot sequence.
 | `ADMIN_SLACK_USER_ID` | no | unset | Bootstrap admin (rest in `admins` table) |
 | `HTTP_DASHBOARD_PORT` | no | unset (disabled) | Strict positive int 1-65535; throws on invalid |
 | `MCP_PORT` | no | `3456` | Bot Slack MCP server port (read in `src/mcp/slack-server.ts`) |
+| `MEMORY_DB_PATH` | no | `data/memory.db` | Semantic claim store |
+| `MEMORY_EMBED_PROVIDER` | no | `local` | Embedding provider (`local` or `hashing`) |
+| `PRE_RECALL_ENABLED` | no | `false` | Optional pre-recall hook |
+| `WHATSAPP_ENABLED` | no | `false` | Read-only archive ingestion/tools |
+| `PIPELINE_RUNTIME_MODE` | no | `off` | Typed pipeline mode (`off`, `shadow`, `active`) |
+| `PRODUCT_PIPELINE_ENABLED` | no | `false` | Product pipeline starts; requires active mode |
+| `BUG_PIPELINE_ENABLED` | no | `false` | Bug pipeline starts; requires active mode |
+| `GITHUB_RECONCILE_ENABLED` | no | `false` | PR reconciliation |
 
 ## Boot Sequence (`index.ts`)
 
@@ -54,7 +63,7 @@ Entry point, configuration, logging, persona loading, and boot sequence.
  6. WorktreeManager(repos)
  7. DevServerManager(repos, worktreeManager)
  8. DevServerQueue(devServerManager, repos)
- 9. startMcpServer(botToken, store, worktreeManager)   ← HTTP MCP on MCP_PORT
+ 9. startMcpServer(deps)                              ← loopback MCP on MCP_PORT
 10. Wire: sessionManager.{agentRouter, worktreeManager, slackApp}
 11. SlackResponder(app)
 12. AgentDispatcher(sessionManager, supportChannels, { devServerQueue, sessionStore, slackClient, repos })
@@ -67,7 +76,7 @@ Entry point, configuration, logging, persona loading, and boot sequence.
 19. await app.start()                                   ← Socket Mode connect
 20. auth.test()  → sessionManager.botUserId, selfBotId
 21. registerEventHandlers(app, dispatcher.handleMessage, store, selfBotId, botUserId, autoTriggerChannels)
-22. if (http.enabled) startHttpServer(...)              ← non-fatal
+22. if (http.enabled) startHttpServer(...)              ← workflows + memory routes; non-fatal
 ```
 
 ## Logger
@@ -80,5 +89,5 @@ Daily file rotation; format: `<ISO> [LEVEL] [tag] message`. Writes go to both st
 
 ## Dependencies
 
-- **Uses**: every module (composition root)
+- **Uses**: every module (composition root), including runners, memory, workflows, pipelines, GitHub reconciliation, WhatsApp archive, and HTTP dashboard wiring
 - **Used by**: nothing

--- a/docs/code_index/runner-providers.md
+++ b/docs/code_index/runner-providers.md
@@ -1,6 +1,6 @@
 # Code Index: Runner Providers
 
-Provider boundary for Claude/OpenCode spawning. App code talks to normalized
+Provider boundary for Claude/OpenCode/Codex spawning. App code talks to normalized
 runner events; provider adapters own CLI args, config, parsing, resume, cwd, env,
 and MCP wiring.
 
@@ -10,7 +10,7 @@ and MCP wiring.
 
 | Symbol | File | Purpose |
 |---|---|---|
-| `spawnRunner(session, prompt, config, ...)` | `index.ts` | Selects Claude/OpenCode provider and dispatches to the adapter. |
+| `spawnRunner(session, prompt, config, ...)` | `index.ts` | Selects `claude`, `opencode`, `opencode-sdk`, or `codex-app-server` and dispatches to the adapter. |
 | `buildOpenCodeMcpConfig(config)` | `index.ts` | Builds OpenCode MCP entries (`slack-bot`, `playwright` by default unless disabled). |
 | `buildRunnerRuntime(options)` | `runtime.ts` | Shared cwd/env contract for provider adapters. |
 | `resolveRunnerCwd(session, targetRepoCwd?)` | `runtime.ts` | Cwd priority: `session.cwd` → `worktreePath` → target repo → Junior root. |
@@ -40,7 +40,6 @@ and MCP wiring.
   `session.cwd` runs and use a constrained read/search/MCP permission surface.
 - Persistent workers (`reproducer`, `review`) are not generated as
   OpenCode Task subagents; they are Slack-dispatched persistent sessions.
-- Future OpenCode SDK/server support should be added as a separate provider or
-  driver. Its interrupt path should call OpenCode's `session.abort` API and then
-  prompt the same session to continue, rather than sending Escape bytes or
-  changing the current CLI adapter's stdin policy.
+- `opencode-sdk` is the separate OpenCode server/SDK provider. It uses the
+  native session abort/attach path and is tested independently from the CLI
+  adapter.

--- a/docs/code_index/support-router.md
+++ b/docs/code_index/support-router.md
@@ -1,0 +1,19 @@
+# Code Index: Support Router and Agent Dispatch
+
+The support router is the Slack-facing dispatch boundary for persistent agent
+directives and pipeline-aware routing.
+
+## Sources
+
+| Symbol | File | Purpose |
+|---|---|---|
+| `SupportRouter` / `AgentDispatcher` | `src/support/router.ts` | Routes messages, resolves persistent agents, starts turns, and coordinates pipeline mode. |
+| Directive parsing | `src/support/directives.ts` | Parses persistent-agent directives and their arguments. |
+| Pipeline guard | `src/support/pipeline-guard.ts` | Keeps legacy routing and typed pipeline ownership consistent. |
+| Agent identities | `src/support/agents.ts` | Public identity catalog and private overlay reload. |
+| Pipeline controllers | `src/pipelines/*/controller.ts` | Typed product/bug starts when active. |
+
+Normal commands are parsed by `src/slack/commands.ts`; persistent directives
+are handled by the support router. This distinction matters for `!review`,
+`!reproducer`, `!pm`, and `!build`: they may be pipeline-aware directives,
+not ordinary one-shot session controls.

--- a/docs/code_index/thread-commands.md
+++ b/docs/code_index/thread-commands.md
@@ -6,9 +6,9 @@
 
 | Symbol | File | Purpose |
 |---|---|---|
-| `KNOWN_COMMANDS` (private set) | `slack/commands.ts` | `build, frontend, architect, cancel, reset, clear, status, repo, branch, agent, quiet, verbose, normal, help, adhoc, bugs, mute, unmute, aside, listen` |
+| `KNOWN_COMMANDS` | `slack/commands.ts` | `build, frontend, architect, pm, cancel, clear, reset, status, repo, branch, agent, provider, quiet, verbose, normal, help, workflow, workflows, adhoc, bugs, mute, unmute, stop, driver, aside, listen` |
 | `parseCommand(text)` | `slack/commands.ts` | Splits `!build fix auth` → `{ command: "build", text: "fix auth" }`. Returns `{ command: null, text }` for unknown or non-`!` input. |
-| `SessionManager.handleCommand(session, event)` | `session/manager.ts` | Dispatches by `event.command`; returns true if the command consumed the message (no Claude spawn), false if it should fall through |
+| `SessionManager.handleCommand(session, event)` | `session/manager.ts` | Dispatches by `event.command`; runner-selection commands (`build`, `frontend`, `architect`, `pm`) fall through to a run, while control commands are consumed |
 | `SessionManager.gateAttention(event)` | `session/manager.ts` | Runs before any routing in `index.ts`. Consumes `!aside` and `!listen`, drops everything while `session.dormant`, and fires the one-shot auto-dormant trigger when a second human posts without `@`-mentioning Junior. Returns `true` when the message is consumed. Auto-trigger channels (`channelDefaults[channel]`) are exempt. |
 
 ## Supported Commands
@@ -18,6 +18,7 @@
 | `!build <text>` | Sets `agentType = "build"` | Yes |
 | `!frontend <text>` | Sets `agentType = "frontend"` | Yes |
 | `!architect <text>` | Sets `agentType = "architect"` | Yes |
+| `!pm <text>` | Sets `agentType = "pm"` | Yes |
 | `!repo <name>` | Sets `targetRepo` (validates against `config.repos`) | No |
 | `!branch <ref>` | Sets `baseRef` for next worktree creation | No |
 | `!agent <junior\|lead>` | Sets thread-level `defaultAgent` override (used by `AgentDispatcher`) | No |
@@ -26,6 +27,10 @@
 | `!clear` | **Admin-gated**. Archives full thread to `data/thread-archives/`, deletes Junior bot messages only, clears status-pill cache | No |
 | `!status` | Posts thread/agent/repo/worktree/pending/last-activity summary | No |
 | `!quiet` / `!normal` / `!verbose` | Sets `session.verbosity` | No |
+| `!provider <name>` | Sets the thread runner provider | No |
+| `!stop` | Stops the active runner/driver | No |
+| `!driver <headless\|tmux>` | Sets Claude's driver mode | No |
+| `!workflow ...` / `!workflows` | Lists or controls dynamic workflows | No |
 | `!help` | Posts command reference | No |
 | `!adhoc <text>` / `!bugs <text>` | Calendar item via haiku model + `cwd = /tmp/junior-utility`; accepts `today\|tomorrow` prefix; reshapes `event.text` into a structured GCal task | Yes |
 | `!mute` / `!unmute` | **Admin-gated**. Toggles `session.muted`. Muted sessions discard buffered messages on drain. | No |

--- a/docs/code_index/workflows.md
+++ b/docs/code_index/workflows.md
@@ -1,0 +1,34 @@
+# Code Index: Dynamic Workflows
+
+Dynamic workflows are markdown-defined, typed runs scheduled and executed by
+Junior. Definitions are data; the runtime owns validation, scheduling,
+execution, persistence, and dashboard projection.
+
+## Sources
+
+| Symbol/area | File | Purpose |
+|---|---|---|
+| `WorkflowRegistry` | `src/workflows/registry.ts` | Loads definitions, applies overlay precedence, and watches for changes. |
+| Definition parser | `src/workflows/definition.ts` | Parses and validates frontmatter/body workflow definitions. |
+| `WorkflowScheduler` | `src/workflows/scheduler.ts` | Computes due work and persists scheduler state. |
+| `WorkflowExecutor` | `src/workflows/executor.ts` | Runs a validated workflow step through the configured runner boundary. |
+| Controller | `src/workflows/controller.ts` | Coordinates registry, scheduler, executor, and store. |
+| Store | `src/workflows/store.ts` | Persists workflow definitions/runs and their state. |
+| Types | `src/workflows/types.ts` | Workflow definition, run, step, and execution contracts. |
+
+## Definitions
+
+The current repository definitions are:
+
+- `workflows/memory-consolidation.workflow.md`
+- `workflows/release-notes.workflow.md`
+- `workflows/worklog.workflow.md`
+- `workflows/worktree-prune.workflow.md`
+
+Private overlay definitions may be loaded from `agents-org/workflows/` when
+that directory exists. Overlay precedence and file-watch reload behavior are
+implemented in the registry, not in individual workflow files.
+
+The localhost dashboard exposes workflow state at `/api/workflows`; see
+[the HTTP index](http-dashboard.md). Workflow utility runs with an explicit
+cwd intentionally do not inherit Junior's project MCP wiring.

--- a/docs/features/agent-action-buttons.md
+++ b/docs/features/agent-action-buttons.md
@@ -1,6 +1,8 @@
 # Agent Action Buttons
 
-Status: **implemented in progress**.
+Status: **implemented**.
+
+> **Current routing note:** The `Make fix` action is resolved to the `lead` session in support channels and `default` elsewhere. The payload's legacy `agent` value is not used as the final target for this action, so the merged orchestrator owns scoping and dispatches `build`/`frontend` as needed.
 
 Persistent agents can attach safe Slack action buttons to final responses. The first consumer is the review agent: `Re-review`, `Make fix`, and `Cleanup worktree`.
 
@@ -24,7 +26,7 @@ Agents append a stripped sentinel block to the final response:
     "label": "Make fix",
     "style": "danger",
     "type": "dispatch_agent",
-    "agent": "thinker",
+    "agent": "default",
     "prompt": "Address the blockers from the latest review. Read thread history first."
   },
   {
@@ -43,7 +45,7 @@ Junior validates the JSON, strips it from the Slack-visible text, renders Slack 
 - Action records are stored in SQLite.
 - Buttons expire when the same source agent receives a new message or posts a newer response in the same thread.
 - Clicked buttons are disabled by updating the original Slack message and removing the actions block.
-- `Make fix` dispatches `thinker`; thinker reads Slack thread history instead of relying on copied review text.
+- `Make fix` dispatches the support `lead` marker or the default Junior session; the orchestrator reads Slack thread history instead of relying on copied review text.
 - `cleanup_worktree` may be clicked by any thread participant.
 - Worktree cleanup refuses tracked changes and unknown untracked files.
 - Cleanup may proceed when the only untracked paths are `learnings.md`, `.codex/`, `.claude/`, or `.DS_Store`.

--- a/docs/features/agent-product-debugging-pipeline-implementation-plan.md
+++ b/docs/features/agent-product-debugging-pipeline-implementation-plan.md
@@ -1,5 +1,11 @@
 # Agent Product-Building and Bug-Debugging Pipeline Implementation Plan
 
+> **Historical implementation plan:** This plan predates the current SQLite
+> bootstrapping and workflow layout. Its migration paths and `docs/workflows/*`
+> references are preserved as design history; follow [`../README.md`](../README.md),
+> [`../code_index/pipelines.md`](../code_index/pipelines.md), and
+> [`../code_index/workflows.md`](../code_index/workflows.md) for live behavior.
+
 > Status: Phases 0–9 landed (shadow/off by default)
 >
 > Source audit: [Agent Product-Building and Bug-Debugging Pipeline Audit](../audits/2026-07-19-agent-product-debugging-pipeline.md)

--- a/docs/features/bug-pipeline-worktrees.md
+++ b/docs/features/bug-pipeline-worktrees.md
@@ -2,6 +2,8 @@
 
 Status: **landed (Scopes 1, 2a, 2b)**. Step 4 (this doc sync) shipped 2026-04-30.
 
+> **Current implementation note (2026-07-21):** The implementation is live, but several sections below retain the original design discussion. The dev-server slot is a sibling worktree at `<repo>.junior-worktrees/slack-dev-server`; it is not under `<repo>/.claude/dev-server`. Current source: [`src/lifecycle/dev-server.ts`](../../src/lifecycle/dev-server.ts), [`src/lifecycle/dev-server-queue.ts`](../../src/lifecycle/dev-server-queue.ts), and [`docs/code_index/worktree-manager.md`](../code_index/worktree-manager.md).
+
 Implementation history:
 - Scope-1 (PR #3, merged 2026-04-29): per-thread worktrees + `register_worktree` MCP tool. Code: `WorktreeManager.createWorktree(repo, threadId, baseRef?, branchOverride?)`, `ThreadSession.worktreePaths`, multi-repo `<workspace>` block in `buildWorkspaceBlock`.
 - Scope-2a (PR #4, merged 2026-04-30): `DevServerManager` (`src/lifecycle/dev-server.ts`) — owns dev-server PID/branch tracking, idle TTL sweeper, shutdown teardown, startup orphan check. Independently fixed the leaked-`pnpm dev` bug.
@@ -48,7 +50,7 @@ This alone stops the cross-branch corruption from edits and `git checkout`.
 
 The dev server can't trivially live in N concurrent worktrees on fixed ports. The cleanest answer is queueing rather than per-thread ports.
 
-- Each repo gets a **dedicated dev-server worktree** at a fixed path (e.g. `<repo>/.claude/dev-server`). Dev servers always run from there. The bare repo is never touched by junior.
+- Each repo gets a **dedicated dev-server worktree** at `<repo>.junior-worktrees/slack-dev-server`. Dev servers always run from there. The bare repo is never touched by junior.
 - Junior holds an in-process **per-repo mutex** (or `p-queue` with concurrency=1). `reproducer` phase-2 acquires the lock for each repo it needs → `git fetch && git checkout <fix-branch>` in the dev-server worktree → restart dev server → walk → release. Other threads wait.
 - `thinker` keeps writing in its own per-thread worktree (so concurrent thinking is fine); only the validation slot is serialised.
 
@@ -85,11 +87,11 @@ This bumps the dev-server worktree from a passive checkout location to an active
 
 ## Queue implementation — filesystem lock
 
-**Decided: filesystem lock via `proper-lockfile` on `<repo>/.claude/dev-server/.lock`.** Picked for durability under heavy usage and to leave the door open for multiple junior instances or long-lived background processes coordinating on the same host. In-process primitives (`async-mutex`, `p-queue`) were considered and rejected because they don't survive a junior restart mid-validation — a crash with the lock held leaves no on-disk record, and the next junior boot has no way to know whether the dev server it spawns is fighting another instance.
+**Decided: filesystem lock via `proper-lockfile` on `<repo>.junior-worktrees/slack-dev-server/.lock`.** Picked for durability under heavy usage and to leave the door open for multiple junior instances or long-lived background processes coordinating on the same host. In-process primitives (`async-mutex`, `p-queue`) were considered and rejected because they don't survive a junior restart mid-validation.
 
 What this means concretely:
 
-- Each repo's dev-server worktree has its own `.lock` file. `proper-lockfile.lock(<repo>/.claude/dev-server, { stale: <slotTimeoutMs>, retries: { forever: true, minTimeout: 1000, maxTimeout: 5000 } })` is the acquire call.
+- Each repo's dev-server worktree has its own `.lock` file. `proper-lockfile.lock(<repo>.junior-worktrees/slack-dev-server, { stale: <slotTimeoutMs>, retries: { forever: true, minTimeout: 1000, maxTimeout: 5000 } })` is the acquire call.
 - Acquire returns a `release` function. Reproducer phase-2 wraps the entire validation walk in `try { await acquire(); ... } finally { await release(); }`.
 - `stale` config doubles as the slot timeout — if a holder crashes or hangs past the threshold, `proper-lockfile` lets the next acquirer steal the lock. We choose `stale = 10 min` (top of the 5–10 min slot-timeout range).
 - The lock file co-locates with metadata: alongside `.lock` we write `.lock.meta.json` with `{ holderThreadId, holderPid, branch, acquiredAt }`. Future acquirers / `!devserver status` read it for human-friendly waiter context.
@@ -108,7 +110,7 @@ Trap to watch:
 **Lead initiates, junior executes.** Concretely: junior's slack-bot MCP server exposes a new tool `register_worktree(repo, branch?)`. Lead calls it on intake, after writing `state.json`, once per routed repo. The tool:
 
 1. Resolves the repo's `RepoConfig`. Errors if unknown.
-2. If `repo.worktreeSetupCommand` is configured (e.g. `"bin/setup-worktree.sh"`), runs `<repo.path>/<command> <worktreePath> <branch>`. Otherwise runs `git fetch origin && git worktree add <worktreePath> -b <branch> <baseRef>` directly.
+2. If `repo.worktreeSetupCommand` is configured, runs the target-repo command as `<repo.path>/<command> <branch> --path <worktreePath> --base <baseRef>`. Otherwise runs `git fetch origin --prune` and `git worktree add <worktreePath> -b <branch> <baseRef>` directly.
 3. Sets `worktreePath = <repo.path>.junior-worktrees/slack-<threadId>` and `branch = slack/<threadId>` (unless caller overrides).
 4. Persists `session.worktreePaths[repo] = worktreePath` via `SessionManager.updateSession`.
 5. Returns `{ path, branch }` to the caller.
@@ -160,7 +162,7 @@ interface RepoConfig {
   devCommand?: string;          // "pnpm dev" | "npm run dev" — junior runs this
   devPort?: number;             // 3000 | 3001 | 8000 — readiness probe target
   readyUrl?: string;            // "http://localhost:3000" — what junior curls
-  worktreeSetupCommand?: string; // optional; e.g. "bin/setup-worktree.sh"
+  worktreeSetupCommand?: string; // optional target-repo setup command; receives branch, --path, and --base
 }
 ```
 
@@ -186,10 +188,10 @@ Humans posting `!devserver fix/foo app-frontend` from a thread (or even outside 
 
 ### Lockfile bootstrap
 
-The lockfile path is `<repo>/.claude/dev-server/.lock`. The dev-server worktree must exist before the lock can be acquired. Junior on boot:
+The lockfile path is `<repo>.junior-worktrees/slack-dev-server/.lock`. The dev-server worktree must exist before the lock can be acquired. Junior on boot:
 
-1. For each `RepoConfig` with a `devCommand`, ensure `<repo>/.claude/dev-server/` exists as a worktree on `defaultBase`. Create it if missing using the same logic as `register_worktree` (with branch `dev-server-slot/<repo>` to avoid clashing with thread worktrees).
-2. Scan `<repo>/.claude/dev-server/.lock.meta.json`. If it claims a holder PID that doesn't exist anymore, treat as orphan — clear the lock and the queue file.
+1. For each `RepoConfig` with a `devCommand`, ensure `<repo>.junior-worktrees/slack-dev-server/` exists as a worktree on `defaultBase`. Create it if missing using the same logic as `register_worktree` (with branch `dev-server-slot/<repo>` to avoid clashing with thread worktrees).
+2. Scan `<repo>.junior-worktrees/slack-dev-server/.lock.meta.json`. If it claims a holder PID that doesn't exist anymore, treat as orphan — clear the lock and the queue file.
 3. Scan the configured `devPort`. If a listener exists and isn't us (PID mismatch with `.lock.meta.json`), refuse to spawn until the human frees it. Log it loudly.
 
 This is the entirety of `lifecycle/dev-server.ts`'s startup path; the rest is event-driven from `!devserver` directives.
@@ -199,7 +201,7 @@ This is the entirety of `lifecycle/dev-server.ts`'s startup path; the rest is ev
 Extend `lifecycle/cleanup.ts`:
 
 - For each stale session, walk `session.worktreePaths` (in addition to the old single `worktreePath`). For each `(repo, path)`, run `worktreeManager.isWorktreeDirty(path)` — if clean, `removeWorktree(repo, threadId)`; if dirty, log a warning and skip.
-- The dev-server worktree (`<repo>/.claude/dev-server/`) is NEVER cleaned up by stale-session sweeps. It's a permanent fixture, owned by junior, lifecycled by `lifecycle/dev-server.ts`.
+- The dev-server worktree (`<repo>.junior-worktrees/slack-dev-server/`) is NEVER cleaned up by stale-session sweeps. It's a permanent fixture, owned by junior, lifecycled by `lifecycle/dev-server.ts`.
 
 ### Test plan
 
@@ -237,11 +239,11 @@ Each step lands as one commit (or one PR) with prompt updates and code changes c
 2. **Scope-2a — dev-server lifecycle (one commit).**
    - `RepoConfig`: add `devCommand`, `devPort`, `readyUrl`.
    - New module `src/lifecycle/dev-server.ts` — tracks PID + branch per repo, spawn/kill/ready-probe, idle TTL, shutdown teardown.
-   - Bootstrap on junior boot: ensure `<repo>/.claude/dev-server/` exists; orphan-PID check; external-listener check.
+   - Bootstrap on junior boot: ensure `<repo>.junior-worktrees/slack-dev-server/` exists; orphan-PID check; external-listener check.
    - Tests: unit with mocked `Bun.spawn` for spawn/kill/probe paths.
 3. **Scope-2b — `!devserver` directive + lockfile queue (one commit).**
    - Add `proper-lockfile` dep.
-   - Lockfile + `.lock.meta.json` + `.queue` files at `<repo>/.claude/dev-server/`.
+   - Lockfile + `.lock.meta.json` + `.queue` files at `<repo>.junior-worktrees/slack-dev-server/`.
    - `!devserver <branch> [repo]`, `!devserver status`, `!devserver kill <repo>` directives in `src/support/router.ts`.
    - Reproducer + lead prompt updates: reproducer waits for `!devserver` ready; lead orchestrates the dispatch sequence.
    - Tests: directive parser unit; lockfile integration with a stubbed dev command.

--- a/docs/features/codex-provider-plan.md
+++ b/docs/features/codex-provider-plan.md
@@ -1,5 +1,7 @@
 # Codex Provider Plan
 
+> **Historical implementation plan.** Codex app-server is implemented under `src/codex-app-server` and selected with `RUNNER_PROVIDER=codex-app-server`. This document preserves the earlier decision record; current behavior is indexed in [`../code_index/codex-app-server.md`](../code_index/codex-app-server.md).
+
 Date: 2026-05-25
 
 This document plans a Codex runner provider for Junior after the stacked PRs
@@ -14,7 +16,7 @@ It supersedes the older Codex-only runner notes as an implementation plan, but
 keeps their verified CLI findings where they still match the installed Codex
 CLI.
 
-## Recommendation
+## Historical recommendation
 
 Build a **Codex app-server provider first if and only if Phase 0 proves config,
 hook, and MCP isolation**. Keep a **Codex CLI provider as the fallback path** if

--- a/docs/features/codex-runner-codex.md
+++ b/docs/features/codex-runner-codex.md
@@ -1,5 +1,7 @@
 # Codex Runner — Codex Scope
 
+> **Historical implementation plan.** The provider boundary and Codex app-server path described here have since landed under `src/runners` and `src/codex-app-server`. See [`runner-providers.md`](runner-providers.md) and [`../code_index/codex-app-server.md`](../code_index/codex-app-server.md) for current behavior.
+
 Date: 2026-05-15
 
 This is an independent implementation scope for replacing Junior's hard-coded
@@ -24,7 +26,7 @@ The immediate goal is not to delete Claude support. The clean replacement path i
 to introduce a runner boundary, make Claude one adapter, make Codex another
 adapter, then switch the default provider once Codex has parity.
 
-## Current Reality
+## Historical snapshot (superseded)
 
 The app is still Claude-shaped at the execution boundary:
 
@@ -39,7 +41,7 @@ The app is still Claude-shaped at the execution boundary:
 - `src/slack/home.ts` emits `claude --resume <sessionId>` hints.
 - `src/config.ts` only exposes `config.claude`.
 
-There is no `src/runners/` abstraction today.
+At the time of this plan there was no `src/runners/` abstraction; the current implementation has that boundary.
 
 Important current behavior to preserve:
 

--- a/docs/features/codex-runner.md
+++ b/docs/features/codex-runner.md
@@ -1,6 +1,8 @@
 # Codex Runner
 
-> Last audited 2026-05-15 against `src/` at `4aa25ab` (main) and `codex-cli 0.130.0`. Original draft 2026-04-28 against `codex-cli 0.125.0`.
+> **Historical design record.** Codex app-server is now implemented under `src/codex-app-server` and selected with `RUNNER_PROVIDER=codex-app-server`. Use [`runner-providers.md`](runner-providers.md) and [`../code_index/codex-app-server.md`](../code_index/codex-app-server.md) for the current contract. The implementation-plan language below is retained for context.
+
+> Original audit: 2026-05-15 against `src/` at `4aa25ab` (main) and `codex-cli 0.130.0`; initial draft 2026-04-28 against `codex-cli 0.125.0`.
 
 ## Problem
 

--- a/docs/features/dynamic-workflows.md
+++ b/docs/features/dynamic-workflows.md
@@ -1,11 +1,13 @@
 # Dynamic Workflows
 
+> **Current status (2026-07-21):** Shipped. The registry, SQLite state/run store, hot reload, scheduler, Slack commands, and localhost dashboard endpoint are live. Current definitions include `worklog`, `release-notes`, `memory-consolidation`, and `worktree-prune`; private overlays may add or override definitions.
+
 ## Problem
 
 Junior needs recurring and on-demand workflows that can be added without restarting the bot. The first workflow is a daily worklog: collect my PRs and commits, turn them into grouped "things I did", store a markdown artifact, and post a Slack summary.
 
 **Who has this problem:** Junior operators who need repeatable automation.
-**What happens today:** Work has to be prompted manually or hard-coded into the bot.
+**What happens today:** Workflow definitions are discovered from `workflows/` and `agents-org/workflows/`, reloaded on file changes, persisted in SQLite, and controllable through `!workflow` / `!workflows`. The dashboard exposes the same state at `GET /api/workflows`.
 **Painful part:** Every new cron-like behavior currently risks becoming a code deploy.
 **"Finally" moment:** Add or edit `workflows/worklog.workflow.md`; Junior reloads it, schedules it, and owners can `!workflow run worklog` or `!workflow stop worklog` from Slack.
 
@@ -226,7 +228,7 @@ The CLI uses `MEMORY_DB_PATH` when set, otherwise `data/memory.db`. Because work
 
 Workflow runner configs can set `idleTimeoutMs` to recover from a silent CLI run before the hard `timeoutMs` expires. The executor starts an idle timer for each CLI attempt and resets it on every normalized runner event. When the timer fires, Junior sends `SIGINT` to the provider process, waits up to 10 seconds for it to exit, then sends `SIGKILL` as a cleanup fallback. If the run has already emitted a provider session id, Junior immediately spawns a new `opencode run --session <id>` / `claude --resume <id>` attempt with a compact "continue from the last completed step" prompt. `maxIdleInterrupts` bounds the number of resume attempts; after that, the run fails normally.
 
-This is a CLI fallback, not OpenCode's native TUI interrupt. OpenCode's TUI uses the server `session.abort` API after repeated Escape presses; a future SDK/server provider should use that API directly instead of process signals.
+This is a CLI fallback, not OpenCode's native server interrupt. The implemented OpenCode SDK/server provider uses provider-native abort semantics; the fallback applies to silent CLI workflow attempts.
 
 ## Dependencies
 
@@ -245,3 +247,7 @@ This is a CLI fallback, not OpenCode's native TUI interrupt. OpenCode's TUI uses
 - Per-output templates.
 - Workflow-specific secrets.
 - A UI for workflow states and history.
+
+The localhost dashboard already exposes workflow definitions, state, recent runs,
+and registry errors through `GET /api/workflows`; a richer interactive UI remains
+out of scope.

--- a/docs/features/interactive-driver.md
+++ b/docs/features/interactive-driver.md
@@ -1,5 +1,7 @@
 # Interactive Claude Driver
 
+> **Current status (2026-07-21):** Implemented and opt-in. `src/claude/driver.ts`, `HeadlessDriver`, and `TmuxDriver` are live behind `DEFAULT_CLAUDE_DRIVER`; the default remains `headless` while tmux continues its production soak. The historical iterations below document how the feature evolved.
+
 > Drive Claude Code as a persistent TTY session (tmux) instead of one short-lived `claude -p` per turn. Forced by Anthropic's pricing change: `claude -p` (headless) is moving off Max subscription onto separate API credits, while interactive TUI usage stays under the subscription. Coexist with the current headless driver behind a flag; flip the default per-thread once the new path is proven.
 
 ## Problem
@@ -9,9 +11,9 @@ Today every Slack message spawns a new `claude -p <prompt> --resume <id> --outpu
 Anthropic is changing the terms: the headless `-p` flag will be billed against API credits, not the Max subscription. Only the interactive TUI session counts as subscription usage. That removes the substrate the project was built on — every Slack turn currently costs API credits we don't want to spend.
 
 **Who has this problem:** The whole bot. Every Slack message turn runs through `spawnClaude`. Bug-pipeline persistent agents (lead, reproducer, thinker, review) are particularly exposed — they fan out and would burn through credits fastest.
-**What happens today:** `src/claude/spawner.ts` calls `Bun.spawn(["claude", "-p", ...])` and pipes stream-json out of stdout. There is no driver abstraction — the spawner *is* the driver, baked into the session manager.
+**What happens today:** `src/claude/driver.ts` selects a headless or tmux driver. The headless driver wraps `claude -p` stream-json, while the tmux driver owns the persistent TTY, transcript tail, turn boundary, reconciliation, eviction, and interrupt behavior.
 **Painful part:** Interactive Claude does not emit `--output-format stream-json`. It paints a TUI: ANSI escapes, cursor positioning, redraws. The whole event pipeline (init→tool_use→text→result) we depend on for live Slack status pills, session-id extraction, and turn completion has no obvious equivalent. We need a different signal channel — and process lifecycle is no longer "exit = done."
-**"Finally" moment:** A Slack message arrives, `driver.send(session, prompt)` pastes it into the thread's already-running `claude` TUI inside a detached tmux session, hooks fire as Claude works, the bot streams `tool_use` pills exactly like today, and a `Stop` hook fires the "turn done" signal. The Claude process never exits between turns. Bot restart re-attaches to the surviving tmux sessions. `CLAUDE_DRIVER=tmux` per thread (or globally) chooses this path; `CLAUDE_DRIVER=headless` is the fallback that still works for any code path that can tolerate API billing (utility commands, throwaway one-shots).
+**"Finally" moment:** A Slack message arrives, `driver.send(session, prompt)` uses the selected provider. In tmux mode the prompt is pasted into the thread's persistent Claude TUI, transcript events stream into Slack, and bot restart can re-attach. `DEFAULT_CLAUDE_DRIVER` selects the default; `!driver tmux` / `!driver headless` overrides a thread.
 
 ## Full Vision
 
@@ -24,7 +26,7 @@ Anthropic is changing the terms: the headless `-p` flag will be billed against A
 - **Bot-boot reconciliation.** On startup, the bot reads every session row with `driverMode = "tmux"` from sqlite. For each, runs `tmux has-session -t <name>`. If present: re-attach the transcript tail and Stop-signal watch — no state lost. If absent: mark `sessionId` stale and downgrade `status` to `idle` so the next turn cold-starts a fresh tmux session via `--resume <sessionId>` against the still-on-disk transcript.
 - **Eviction.** A background sweep kills tmux sessions whose `lastActivity` is older than `TMUX_IDLE_TTL_MS` (default 4h). Eviction = `tmux kill-session -t <name>`. The next Slack message spins it back up via `--resume`. RAM cost is bounded by active threads, not lifetime threads.
 - **Interrupts.** `driver.interrupt(session)` sends `Escape` keys (`tmux send-keys -t <name> Escape Escape`) to halt mid-turn. New in v2 — today's buffer-and-drain has no equivalent. Used by `!stop` thread command.
-- **Coexistence flag.** `ThreadSession.driverMode: "headless" | "tmux"`. Default selected by env `DEFAULT_CLAUDE_DRIVER=headless`. Per-thread override via `!driver tmux` / `!driver headless` for testing. The session manager picks `HeadlessDriver` or `TmuxDriver` from the session row — no other call site changes.
+- **Coexistence flag.** `ThreadSession.driverMode: "headless" | "tmux"`. Default selected by env `DEFAULT_CLAUDE_DRIVER=headless`. Per-thread override via `!driver tmux` / `!driver headless`. The session manager picks `HeadlessDriver` or `TmuxDriver` from the session row.
 
 ## Invariants (architectural commitments)
 
@@ -138,7 +140,7 @@ One thread, one agent, happy path only.
   - Session-id discovery: on first turn (no `--resume`), watch the project dir for the newest `*.jsonl` created after tmux start. Persist the discovered id.
 - `~/.claude/settings.json` template/check that ensures a `Stop` hook writes the sentinel. Document the install in `docs/features/project-setup.md`.
 
-**Test:** Set `CLAUDE_DRIVER=tmux` for one Slack thread. Send a message. See the Claude TUI run (attach with `tmux attach -t junior-<threadId>-junior` for debugging). See events stream into Slack via the same status pill code. Second message in the same thread reuses the tmux session — no `claude` re-launch.
+**Test:** Set `DEFAULT_CLAUDE_DRIVER=tmux` or use `!driver tmux` for one Slack thread. Send a message. See the Claude TUI run (attach with `tmux attach -t junior-<threadId>-junior` for debugging). See events stream into Slack via the same status pill code. Second message in the same thread reuses the tmux session — no `claude` re-launch.
 **Defers:** Reconciliation on restart, eviction, interrupts, multi-agent, error handling, `!driver` command.
 
 ### Iteration 3: Reconciliation on bot restart (~1h)
@@ -194,7 +196,7 @@ Persistent agents on tmux.
 - Eviction policy applied per-agent-session, not per-thread (a thread's reproducer can be evicted while lead stays warm).
 - Integration test: full bug-pipeline run in tmux mode, parallel agents, status pills correct, all four tmux sessions reconciled after a forced bot restart mid-flight.
 
-**Test:** Trigger a bug thread with `DEFAULT_CLAUDE_DRIVER=tmux`. Watch lead → reproducer → thinker → review fan out across four tmux sessions. Restart bot mid-pipeline. Pipeline resumes.
+**Historical test scenario:** Trigger a bug thread with `DEFAULT_CLAUDE_DRIVER=tmux`. Older pipeline iterations described lead → reproducer → thinker → review fan-out; current support routing uses the merged orchestrator plus `reproducer`/`review`, with `thinker` only as a legacy session alias.
 **Defers:** Default flip.
 
 ### Iteration 7: Default flip (~30min + soak)

--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -1,17 +1,19 @@
 # Bot Slack MCP Server
 
+> **Current status (2026-07-21):** Shipped. This server is the shared loopback MCP surface for Claude, OpenCode, and Codex runs. The code-index page is the compact current inventory; this feature page retains the design history and security rationale.
+
 ## Problem
 
 Spawned Claude Code processes need Slack access — to send messages, read channels, search conversations, and upload files. The official Slack plugin (`slack@claude-plugins-official`) provides this, but it sends messages as the user's personal OAuth identity (no `bot_id`). Junior's event handler filters by `bot_id` to prevent loops, so plugin messages bypass the filter and trigger an infinite loop: Claude posts via plugin → Junior picks it up as a new user message → spawns Claude again → repeat.
 
 **Who has this problem:** Any spawned Claude instance that needs to interact with Slack.
-**What happens today:** Slack plugin enabled → messages come from Pranav's account → Junior sees them as new events → infinite loop.
+**What happens today:** The bot-owned MCP path posts with Junior's bot identity, while ordinary self-authored bot events are filtered. Explicit persistent-agent directives and configured auto-trigger exceptions still pass through the event router by design.
 **Painful part:** The identity model. The plugin authenticates as the user, not the bot. There's no way to configure it to use the bot token.
 **"Finally" moment:** Claude sends messages that appear as Junior (the bot), event handler skips them, no loop.
 
 ## Solution
 
-A shared HTTP MCP server running inside Junior's main process. It uses the bot token (`SLACK_BOT_TOKEN`) so all messages carry Junior's `bot_id`. The event handler at `src/slack/events.ts:31` already filters by `selfBotId` — messages from the bot MCP server are automatically ignored.
+A shared HTTP MCP server running inside Junior's main process. It uses the bot token (`SLACK_BOT_TOKEN`) so messages carry Junior's `bot_id`. The event handler filters ordinary self-authored bot traffic; explicit directives and configured auto-trigger channels are handled as intentional exceptions.
 
 ### Why shared, not per-instance
 
@@ -74,7 +76,7 @@ Status pill updates that agents post mid-run go through `slack_send_message` wit
 
 ## Configuration
 
-- `.mcp.json` defines the server as `{ "type": "http", "url": "http://localhost:3456/mcp" }`
+- `.mcp.json` defines the local `slack-bot` server as `{ "type": "http", "url": "http://localhost:3456/mcp" }` and also carries the optional hosted Figma and Notion MCP entries.
 - `.claude/settings.json` grants `mcp__slack-bot__*` permissions
 - Port configurable via `MCP_PORT` env var (default 3456)
 - `--mcp-config` flag injected by `spawner.ts` when cwd differs from project root (worktree scenarios)
@@ -131,10 +133,9 @@ open-admin fallback never unlocks the archive). Unknown sessions deny. All
 message-bearing responses (including group subjects) are wrapped in an
 UNTRUSTED-content boundary before entering a tool-capable agent's context.
 
-Known residual: the `thread` query param is unsigned, so a caller that learns
-a real admin-DM thread id could still impersonate that session; signing the
-run context (a per-spawn credential) is the follow-up that would harden every
-slack-bot tool. Note the honest ceiling: agents with unrestricted Bash on this
+The run context is HMAC-signed per spawn, so callers cannot substitute a
+different channel or thread in the MCP query context. Note the honest ceiling:
+agents with unrestricted Bash on this
 machine can read `data/whatsapp.db` directly, so the MCP gate can never exceed
 filesystem-level protection — restricting which agents get Bash (or moving the
 archive off-box) is the stronger lever.

--- a/docs/features/persistent-agents.md
+++ b/docs/features/persistent-agents.md
@@ -2,6 +2,8 @@
 
 > **Status (2026-07 — 3-way agent merge):** `lead` and `thinker` retired as standalone agent definitions. There is now one orchestrator (`default.md`); support-channel sessions keep the `lead` session marker, which the router aliases to `default.md` and layers `common/bug-pipeline.md` on top of. The orchestrator runs the old thinker methodology **itself** in its own turn(s) — Phase 1 (3-5 hypotheses, cheap-evidence verification, mock-run protocol, anti-anchoring, Message 1 + human gate) and Phase 2 (scoping.md, then dispatch the implementation to `build`/`frontend` via the Task tool; the orchestrator never edits product code). The two-turn human gate survives. `reproducer` and `review` stay as persistent workers; `!thinker` no longer exists as a directive. Read the sections below with those substitutions: "thinker" → "the orchestrator's Phase 1/2", "!thinker proceed" → "the orchestrator posting Message 1 and stopping for the gate", "fix scoped by thinker" → "fix scoped by the orchestrator and dispatched to build/frontend via Task".
 
+> **Current runtime note:** Core Slack identities are `default`, `lead`, `reproducer`, `review`, and `echo`; private agents are loaded from `agents-org`. The long iteration and example sections below are retained as a migration/design record. Current dispatch and safety behavior is indexed in [`../code_index/persistent-agents.md`](../code_index/persistent-agents.md) and [`../code_index/agent-catalog.md`](../code_index/agent-catalog.md).
+
 > Same backbone as the wiped `support-lead-persistent-agents.md` (persistent Claude Code session per agent role, one thread holds many agent sessions, each agent posts to Slack with its own identity). Refined design after a session of pruning: lead-only dispatch (workers can't tag each other), `NO_SLACK_MESSAGE` for silence, observability-before-UI as a hard invariant, no internal-dispatch-plus-audit-log split. First product use is the bug pipeline; substrate is reusable.
 
 ## Problem
@@ -13,7 +15,7 @@ When a bug is reported in `#bugs-backlog`, Junior needs to triage it: pull obser
 3. **Opacity.** Humans only saw Junior's summaries. They couldn't see what research actually found, where the thinker pushed back, or what reasoning produced the chosen fix. The full picture was buried in workspace.md files on disk.
 
 **Who has this problem:** Pranav (operator), and any human watching `#bugs-backlog` for what Junior is doing on a bug.
-**What happens today:** Nothing — the previous pipeline is wiped. Bug threads in `#bugs-backlog` get auto-triggered via `events.ts` but currently have no agent to handle them.
+**What happens today:** Support-channel sessions route to the merged `default` orchestrator (with the `lead` marker where configured); `reproducer` and `review` remain addressable persistent workers, while private overlay workers are registered at boot. Typed product/bug pipeline persistence is available behind `PIPELINE_RUNTIME_MODE` and is off by default.
 **Painful part:** A bug pipeline is fundamentally a **multi-actor parallel system** dressed up to look sequential. Observability fetchers (NR, Sentry, Vercel) are independent and can race. The reproducer needs their output as context. Re-queries between thinker and research happen multiple times. Forcing this into a single Claude session loses parallelism and observability.
 **"Finally" moment:** A bug arrives in `#bugs-backlog`. The thread shows distinct messages from Lead, Research, Sentry, Vercel, Reproducer — each with their own identity, posting as they finish work, in parallel where it makes sense. Humans can `!research <follow-up>` directly. The full investigation reads top-to-bottom in the thread:
 
@@ -252,14 +254,18 @@ Already wired in `src/slack/responder.ts:54` (`updateStatus`) — posts a transi
 
 Two changes needed for the new architecture:
 
-1. **Per-agent keying.** `SlackResponder.statusMessages` is currently `Map<threadTs, StatusEntry>`. Re-key to `Map<${threadTs}:${agentName}, StatusEntry>` so concurrent persistent agents in the same thread don't clobber each other's pill. `updateStatus` and `deleteStatus` take an `agentName` argument; existing non-bug-pipeline callers pass `"lead"` (preserves current behavior).
+1. **Per-agent keying — shipped.** `SlackResponder.statusMessages` is keyed by
+   `${threadTs}:${agentName}`, so concurrent persistent agents in one thread do
+   not clobber each other's status pill.
 2. **Task-tool formatter.** Add a `"Task"` case to `formatToolBlock` (`src/slack/formatting.ts:31`) that pulls `subagent_type` from the input and renders `Calling <subagent_type>`. For parallel Task calls in one assistant event, `formatToolStatuses` should roll up: `"Calling nr-research, sentry-fetch, vercel-status (3 in progress)"` instead of returning N strings (which the current debounce eats anyway).
 
 `tool_result` events stay filtered out — content stays internal to the calling persistent agent's session.
 
 ### Lead prompt
 
-The lead's `.claude/agents/lead.md` (replaces the old `support-lead.md`) teaches:
+The support orchestrator uses `.claude/agents/default.md` with the `lead` marker
+and the appended `common/bug-pipeline.md`; there is no public `.claude/agents/lead.md`.
+The merged orchestrator prompt teaches:
 
 - The dispatch syntax: write `!<agent> <prompt>` on its own line to dispatch.
 - State-checking: read `agentSessions[name].status` before emitting. Don't dispatch a `busy` agent (will buffer); don't dispatch a `done` one without good reason.
@@ -270,7 +276,7 @@ The lead's `.claude/agents/lead.md` (replaces the old `support-lead.md`) teaches
 
 ## Iterations
 
-### Iteration 0: Substrate (~4h)
+### Iteration 0: Substrate (~4h) — shipped
 
 Multi-session thread model + router + agent identities. No real agents yet — test with a fake `!echo` agent.
 
@@ -294,7 +300,7 @@ Multi-session thread model + router + agent identities. No real agents yet — t
 
 **Defers:** Real agents, lead orchestration prompt, parallel observability.
 
-### Iteration 1: First sub-agent — `nr-research` (~3h)
+### Iteration 1: First sub-agent — `nr-research` (~3h) — shipped in overlays
 
 Validates the sub-agent (Task tool) tier end-to-end. nr-research is invoked from within a Claude session (initially the operator's, later the lead's), runs an NRQL query, writes findings to `$BUG_DIR/research.md`, returns a one-line summary, and exits. No Slack identity, no AgentSession entry.
 
@@ -309,7 +315,7 @@ Validates the sub-agent (Task tool) tier end-to-end. nr-research is invoked from
 
 **Defers:** Sentry, Vercel, parallel fan-out, lead orchestration.
 
-### Iteration 2: Parallel sub-agents — `sentry-fetch` + `vercel-status` (~3h)
+### Iteration 2: Parallel sub-agents — `sentry-fetch` + `vercel-status` (~3h) — shipped in overlays
 
 Prove parallel Task-tool fan-out.
 
@@ -323,7 +329,7 @@ Prove parallel Task-tool fan-out.
 
 **Defers:** Reproducer, lead orchestration.
 
-### Iteration 3: First persistent agent — `reproducer` (~4h)
+### Iteration 3: First persistent agent — `reproducer` (~4h) — shipped
 
 The first real persistent agent on top of the substrate. Single-concern UI walker. Runs after observability completes.
 
@@ -342,13 +348,13 @@ The first real persistent agent on top of the substrate. Single-concern UI walke
 
 **Defers:** Lead-driven orchestration (still manual), thinker/review/email-drafter, reproducer phase=validation.
 
-### Iteration 4: Lead orchestration prompt (~3h)
+### Iteration 4: Lead orchestration prompt (~3h) — superseded by the merged orchestrator
 
 Lead actually orchestrates the pipeline instead of being manually invoked.
 
 **What it adds:**
 
-- `.claude/agents/lead.md` (the lead's persistent-agent definition)
+- `default.md` plus the support-only `common/bug-pipeline.md` (there is no `lead.md`)
 - Auto-assign `#bugs-backlog` threads to `lead` agent type (already wired via `channelDefaults`)
 - Lead's prompt teaches:
   - Bug folder lifecycle: create `support/bugs/<product>/<bug-id>/` on intake (template restored)

--- a/docs/features/process-lifecycle.md
+++ b/docs/features/process-lifecycle.md
@@ -11,7 +11,10 @@
 Claude Code CLI processes can hang, crash, or produce errors. The bot needs to handle every failure mode gracefully — timeouts, spawn failures, non-zero exits, malformed output — without crashing itself or leaving sessions in a broken state. A zombie Claude process that never exits blocks the thread forever.
 
 **Who has this problem:** The bot server — one bad process shouldn't take down the whole system.
-**What happens today:** Nothing — no error handling.
+**What happens today:** Hard timeouts, process-tree cleanup, orphan detection,
+and provider-specific idle recovery are implemented. This document keeps the
+failure model and runtime invariants in one place; the iteration history below
+is historical.
 **Painful part:** The failure modes are many and subtle. Process hangs (no output, no exit). Process exits with non-zero but no stderr. Process produces partial JSON (stdout cut mid-line). Process exits mid-stream (session state may be corrupt). Max subscription rate limit hit (unclear error). The bot must handle all of these without human intervention.
 **"Finally" moment:** Claude hangs → user sees "Timed out after 5 minutes. Try a more specific prompt." Claude crashes → user sees "Something went wrong. Try again." No zombie processes. No stuck sessions.
 
@@ -22,7 +25,10 @@ Claude Code CLI processes can hang, crash, or produce errors. The bot needs to h
 - Process-tree cleanup: spawned CLIs run in their own process group, and cleanup signals the group so wrapper commands cannot leave grandchildren behind
 - Error categorization: timeout, crash, rate limit, auth failure, unknown
 - User-facing error messages in Slack (not raw stderr)
-- Session state recovery: if process dies mid-turn, session stays resumable
+- Session state recovery: if a provider emitted a native session id, headless
+  CLI providers may be interrupted and resumed within the configured retry
+  limit; server-attached providers own their interrupt path. Durable pipeline
+  state and artifacts remain authoritative.
 - Stale cleanup must not delete an idle parent thread while any persistent agent session is still busy.
 - Health check: periodic scan for orphaned processes
 - Metrics: track success/failure/timeout rates per agent type
@@ -114,7 +120,7 @@ When the bot itself shuts down (SIGINT, SIGTERM, restart), handle running proces
 | Console.log for errors | Iteration 1 (user-facing messages) |
 | No graceful shutdown | Iteration 3 |
 | No orphan detection | Iteration 4 |
-| No retry on failure | By design — user re-sends |
+| No automatic retry after a hard failure | By design — idle recovery is bounded and provider-specific |
 
 ## Cut List (true v2)
 

--- a/docs/features/project-setup.md
+++ b/docs/features/project-setup.md
@@ -1,11 +1,13 @@
 # Project Setup & Configuration
 
+> **Current status (2026-07-21):** The foundation described here is shipped. This page is also a historical record of the original bootstrap plan; for exact current symbols, see [`docs/code_index/project-setup.md`](../code_index/project-setup.md) and [`docs/README.md`](../README.md).
+
 ## Problem
 
 The bot needs environment configuration (Slack tokens, repo paths, timeouts) and project scaffolding (package.json, TypeScript config, directory structure) before any feature can be built. This doc covers the foundational setup.
 
 **Who has this problem:** The first developer (Claude or human) who starts building.
-**What happens today:** Empty repo with CLAUDE.md and feature docs.
+**What happens today:** A Bun/TypeScript Slack service with SQLite-backed sessions, normalized runner providers, dynamic workflows, pipeline stores, MCP tools, optional GitHub reconciliation, and an optional localhost dashboard.
 **Painful part:** Getting the right TypeScript config, ESM vs CJS, which Slack SDK version, how to structure a CLI-spawning server. Wrong choices here cascade into every feature.
 **"Finally" moment:** `bun run dev` starts the bot server. Hot reload works. TypeScript compiles cleanly. Slack connects. Ready to build features.
 
@@ -66,7 +68,7 @@ interface Config {
     tmuxIdleTtlMs: number;    // TMUX_IDLE_TTL_MS (default: 14400000 — 4h)
     tmuxSweepIntervalMs: number; // TMUX_SWEEP_INTERVAL_MS (default: 900000 — 15min)
   };
-  runner: { provider: "claude" | "opencode" };
+  runner: { provider: "claude" | "opencode" | "opencode-sdk" | "codex-app-server" };
   opencode: {
     model: string | null;
     timeoutMs: number;
@@ -75,6 +77,24 @@ interface Config {
     mcpEnabled: boolean;
     slackMcpEnabled: boolean;
     playwrightMcpEnabled: boolean;
+    mixpanelMcpEnabled: boolean;
+    mongodbMcpEnabled: boolean;
+  };
+  codex: {
+    mode: "app-server" | "cli";
+    model: string | null;
+    timeoutMs: number;
+    sandbox: "read-only" | "workspace-write" | "danger-full-access";
+    askForApproval: "untrusted" | "on-request" | "never";
+    searchEnabled: boolean;
+    appServerContinuityEnabled: boolean;
+    mcpEnabled: boolean;
+    slackMcpEnabled: boolean;
+    playwrightMcpEnabled: boolean;
+    mixpanelMcpEnabled: boolean;
+    mongodbMcpEnabled: boolean;
+    memoryMcpEnabled: boolean;
+    isolatedHomePath: string | null;
   };
   repos: RepoConfig[];                  // JSON in REPOS env var
   session: {
@@ -82,6 +102,21 @@ interface Config {
     store: "memory" | "sqlite";
     sqlitePath; homeWindowMs;
     defaultVerbosity: "quiet" | "normal" | "verbose";
+    idleTimeoutMs; maxIdleInterrupts;
+  };
+  memory: {
+    sqlitePath; embedProvider;
+    preRecall?: { enabled; runner; model?; timeoutMs };
+  };
+  threadArchives: { dir };
+  pipeline?: {
+    runtimeMode: "off" | "shadow" | "active";
+    legacyDirectivesEnabled; bugPipelineEnabled;
+    productPipelineEnabled; retentionDays;
+  };
+  github?: {
+    reconcileEnabled; eventWakeEnabled; reconcileToken;
+    reconcileUseCli; reconcileIntervalMs;
   };
   channelDefaults: Record<string, { agentType: string }>; // JSON
   adminSlackUserId: string | null;       // bootstrap admin; rest live in admins table
@@ -98,7 +133,7 @@ interface Config {
 | `SLACK_BOT_TOKEN` | yes | — | |
 | `SLACK_APP_TOKEN` | yes | — | Socket Mode `xapp-...` |
 | `SLACK_SIGNING_SECRET` | no | `""` | only needed if you ever switch to Events API |
-| `RUNNER_PROVIDER` | no | `opencode` | `opencode` \| `opencode-sdk` \| `codex-app-server` \| `claude`; `codex` is reserved for the future CLI fallback |
+| `RUNNER_PROVIDER` | no | `opencode` | `opencode` \| `opencode-sdk` \| `codex-app-server` \| `claude` |
 | `CLAUDE_MAX_TURNS` | no | `25` | |
 | `CLAUDE_TIMEOUT_MS` | no | `300000` | |
 | `CLAUDE_MODEL` | no | unset | passed through to `claude -p --model` |
@@ -110,6 +145,22 @@ interface Config {
 | `OPENCODE_MCP_ENABLED` | no | `true` | enables generated OpenCode MCP config for normal non-utility runs |
 | `OPENCODE_SLACK_MCP_ENABLED` | no | `true` | includes the local Slack MCP entry when MCP is enabled |
 | `OPENCODE_PLAYWRIGHT_MCP_ENABLED` | no | `true` | includes Playwright MCP in generated OpenCode config; set `false` to disable |
+| `OPENCODE_MIXPANEL_MCP_ENABLED` | no | `true` | includes the optional Mixpanel MCP entry |
+| `OPENCODE_MONGODB_MCP_ENABLED` | no | `true` | includes the optional MongoDB MCP entry |
+| `CODEX_MODE` | no | `app-server` | `app-server` or `cli`; app-server is the implemented Codex provider path |
+| `CODEX_MODEL` | no | unset | Codex model override |
+| `CODEX_TIMEOUT_MS` | no | `300000` | Codex turn timeout |
+| `CODEX_SANDBOX` | no | `workspace-write` | Codex sandbox policy |
+| `CODEX_ASK_FOR_APPROVAL` | no | `never` | Codex approval policy |
+| `CODEX_SEARCH_ENABLED` | no | `false` | Codex web search capability |
+| `CODEX_APP_SERVER_CONTINUITY_ENABLED` | no | `false` | Reuse Codex app-server sessions when supported |
+| `CODEX_MCP_ENABLED` | no | `true` | Enable generated Codex MCP config |
+| `CODEX_SLACK_MCP_ENABLED` | no | `true` | Include Slack MCP for Codex |
+| `CODEX_PLAYWRIGHT_MCP_ENABLED` | no | `true` | Include Playwright MCP for Codex |
+| `CODEX_MIXPANEL_MCP_ENABLED` | no | `true` | Include Mixpanel MCP for Codex |
+| `CODEX_MONGODB_MCP_ENABLED` | no | `true` | Include MongoDB MCP for Codex |
+| `CODEX_MEMORY_MCP_ENABLED` | no | `true` | Include memory MCP for Codex |
+| `CODEX_ISOLATED_HOME_PATH` | no | `data/codex-home` | Isolated Codex home directory |
 | `REPOS` | no | `[]` | JSON array of `RepoConfig` |
 | `CHANNEL_DEFAULTS` | no | `{"C05557KKV37":{"agentType":"lead"}}` | JSON, validated |
 | `SESSION_STORE` | no | `sqlite` | `sqlite` \| `memory` |
@@ -122,9 +173,17 @@ interface Config {
 | `ADMIN_SLACK_USER_ID` | no | unset | bootstrap admin; further admins live in the `admins` SQLite table |
 | `HTTP_DASHBOARD_PORT` | no | unset | localhost dashboard; must be a positive integer 1–65535 or unset |
 | `MCP_PORT` | no | `3456` | internal Slack-bot MCP server |
+| `MEMORY_EMBED_PROVIDER` | no | `local` | `local` or deterministic `hashing` test provider |
+| `PRE_RECALL_ENABLED` | no | `false` | optional pre-recall query extraction before runner turns |
+| `WHATSAPP_ENABLED` | no | `false` | enable read-only WhatsApp archive ingestion/tools |
+| `PIPELINE_RUNTIME_MODE` | no | `off` | `off`, `shadow`, or `active` |
+| `PRODUCT_PIPELINE_ENABLED` | no | `false` | typed product pipeline starts; requires active mode |
+| `BUG_PIPELINE_ENABLED` | no | `false` | typed bug pipeline starts; requires active mode |
+| `PIPELINE_RETENTION_DAYS` | no | `90` | terminal pipeline outbox retention |
+| `GITHUB_RECONCILE_ENABLED` | no | `false` | outbound read-only PR reconciliation |
 
 Validation rules (each throws on bad input):
-- `parseRunnerProvider` — must be `claude` or `opencode`; `codex` is a planned provider and currently rejected with a not-implemented error.
+- `parseRunnerProvider` — accepts only the four implemented providers: `claude`, `opencode`, `opencode-sdk`, and `codex-app-server`.
 - `parseStoreKind` — must be `memory` or `sqlite`.
 - `parseVerbosity` — must be `quiet`/`normal`/`verbose`.
 - `parseChannelDefaults` — must be a JSON object of `{channelId: {agentType: string}}`.
@@ -157,11 +216,17 @@ junior/
         factory.ts        -- createSessionStore(config)
         memory.ts         -- InMemorySessionStore
         sqlite.ts         -- SqliteSessionStore (bun:sqlite)
+    runners/
+      index.ts            -- normalized provider factory and dispatch
+      types.ts            -- provider-neutral SpawnResult/SpawnHandle contract
     claude/
-      spawner.ts          -- spawn claude -p, manage child process
-      args.ts             -- build CLI args from session state
-      parser.ts           -- stream-json line parser
-      types.ts            -- stream-json event types
+      spawner.ts          -- Claude headless/tmux provider
+      driver.ts           -- Claude driver selection and lifecycle
+    opencode/
+      spawner.ts          -- OpenCode CLI provider
+      sdk-provider.ts     -- OpenCode SDK provider
+    codex-app-server/
+      provider.ts         -- Codex app-server provider
     agents/
       router.ts           -- agent definition routing
       loader.ts           -- read .md files, parse frontmatter (incl. identity)
@@ -170,6 +235,11 @@ junior/
     support/
       router.ts           -- AgentDispatcher: per-agent persistent sessions
       agents.ts           -- overlay identity loading + per-agent context profile
+    memory/               -- claim store, embeddings, recall, consolidation
+    pipelines/            -- typed product/bug control plane and outbox
+    workflows/            -- dynamic workflow registry, store, runner
+    github/               -- optional PR reconciliation
+    whatsapp/             -- optional read-only archive ingestion
     mcp/
       slack-server.ts     -- internal MCP server exposed to spawned sessions
     http/
@@ -191,7 +261,7 @@ junior/
   docs/
     features/             -- feature docs
     code_index/           -- code indexes per module
-    workflows/            -- ideation and building workflows
+  workflows/              -- release notes, worklog, memory consolidation, worktree prune
   .env.example
   package.json
   tsconfig.json

--- a/docs/features/runner-providers.md
+++ b/docs/features/runner-providers.md
@@ -1,6 +1,6 @@
 # Runner Providers
 
-Date: 2026-05-15
+Date: 2026-07-21
 
 This supersedes a Codex-only replacement plan. The right architecture is a
 provider boundary: Junior owns Slack/session/worktree behavior, and provider
@@ -9,7 +9,17 @@ and resume semantics.
 
 ## Status
 
-The provider abstraction and OpenCode/Claude adapters are implemented. OpenCode is the default provider (`RUNNER_PROVIDER=opencode`); Claude remains the fallback provider.
+The provider abstraction and all four configured providers are implemented: OpenCode CLI, OpenCode SDK, Claude headless/tmux, and Codex app-server. OpenCode is the default provider (`RUNNER_PROVIDER=opencode`). The provider boundary is also used by workflow and memory-consolidation runs.
+
+| Provider value | Runtime | Continuity / interrupt behavior |
+|---|---|---|
+| `opencode` | `opencode run --format json` | Optional `--session`; CLI idle recovery requires `OPENCODE_CONTINUITY_ENABLED` |
+| `opencode-sdk` | OpenCode server/SDK session | Native session attach/abort; server-owned process |
+| `claude` | `claude -p` or opt-in tmux driver | `--resume`; tmux keeps an interactive process alive |
+| `codex-app-server` | Codex app-server protocol | `thread/resume`; optional idle interrupt/continue |
+
+The older Codex planning documents are design history; use this document and
+the code index for the current provider contract.
 
 OpenCode is currently a better replacement candidate than Codex for Junior's
 specific needs because it has:
@@ -23,7 +33,7 @@ specific needs because it has:
 - native MCP config in `opencode.json`
 - `OPENCODE_CONFIG_CONTENT` / `OPENCODE_CONFIG` for deterministic generated
   runtime config
-- `opencode serve` + `opencode run --attach` as a future optimization for MCP
+- `opencode serve` + `opencode run --attach` as an optional optimization for MCP
   cold-start cost
 
 OpenCode's server/SDK surface exposes a session abort API, and the OpenCode TUI
@@ -38,7 +48,7 @@ agent prompts.
 
 System prompts are the load-bearing surface for Junior. Junior's value is not
 just "run a coding CLI from Slack"; it is dynamic personas and workflows: build,
-frontend, review, architect, lead, reproducer, thinker, support fetchers, and
+frontend, review, architect, lead, reproducer, support fetchers, and
 repo-local overlays. Claude handles that with `--append-system-prompt`.
 
 OpenCode has a credible provider-native replacement:
@@ -47,12 +57,11 @@ OpenCode has a credible provider-native replacement:
 - override the built-in `build` primary agent with `agent.build.prompt`
 - run `opencode run --agent build`
 
-Codex does not currently expose an equivalent system-prompt flag. Its realistic
-v1 option is to prepend Junior's agent prompt to the first user prompt, which is
-weaker: it pollutes the user turn, has lower salience than a provider/system
-prompt, and forces Junior to reason carefully about resumed turns. The other
-Codex fallback, generating `AGENTS.md` in worktrees, writes prompt artifacts into
-target workspaces and creates cleanup/ownership questions.
+Codex CLI does not expose the same flag, but the implemented app-server adapter
+uses its developer-instructions field for the composed prompt. The isolated CLI
+fallback can prepend the prompt to its first user turn when app-server mode is
+not selected; that path remains weaker and must not be confused with the
+app-server contract.
 
 Configuration ergonomics also favor OpenCode:
 
@@ -79,7 +88,11 @@ App code should consume normalized runner events, never Claude/OpenCode/Codex
 native event shapes.
 
 ```ts
-export type RunnerProvider = "claude" | "opencode" | "codex";
+export type RunnerProvider =
+  | "claude"
+  | "opencode"
+  | "opencode-sdk"
+  | "codex-app-server";
 
 export type RunnerEvent =
   | { type: "init"; provider: RunnerProvider; sessionId: string }
@@ -205,7 +218,7 @@ back to the configured default or are omitted so OpenCode uses its own default.
 
 Do not guess the tool event schema from docs.
 
-## OpenCode SDK/Server Provider
+## OpenCode SDK/Server Provider — implemented
 
 OpenCode's TUI interrupt path does not send Escape bytes to a headless process.
 It calls the server/SDK `session.abort` API. Junior should use that API for the
@@ -409,9 +422,10 @@ Mitigations in code today:
   "subagent"` entries so Task fan-out works when the child cwd is a target repo
   or Junior's root. These subagents use a constrained permission surface:
   read/search tools and MCP tools only. Utility `session.cwd` runs do not receive
-  these support subagents. Persistent workers (`reproducer`, `thinker`,
-  `review`) are intentionally not exposed as OpenCode Task subagents; they must
-  remain Slack-dispatched persistent sessions with their own audit trail.
+  these support subagents. Persistent workers (`reproducer`, `review`, and
+  legacy `thinker` sessions) are intentionally not exposed as OpenCode Task
+  subagents; they must remain Slack-dispatched persistent sessions with their
+  own audit trail.
 
 If full isolation is required for a deployment (production, shared service
 accounts), run Junior with `HOME` / `XDG_CONFIG_HOME` pointed at an empty
@@ -439,7 +453,7 @@ inspectable, testable, and per-agent.
 Persist provider beside the native id.
 
 ```ts
-provider: "claude" | "opencode" | "codex";
+provider: "claude" | "opencode" | "opencode-sdk" | "codex-app-server";
 sessionId: string | null;
 ```
 
@@ -463,7 +477,7 @@ Rules:
 Start with global config:
 
 ```env
-RUNNER_PROVIDER=opencode|claude
+RUNNER_PROVIDER=opencode|opencode-sdk|codex-app-server|claude
 ```
 
 Default when unset: `opencode`.
@@ -473,11 +487,12 @@ Then add a thread command:
 ```text
 !provider claude
 !provider opencode
+!provider opencode-sdk
+!provider codex-app-server
 ```
 
-`codex` stays in the internal `RunnerProvider` union as a planned provider, but
-is rejected at config load and at `!provider codex` until the Codex adapter
-lands.
+`codex-app-server` is implemented. `CODEX_MODE=app-server` is the current
+transport; `CODEX_MODE=cli` is an isolated fallback for supported runs.
 
 Home/status output should show:
 
@@ -493,14 +508,18 @@ opencode --session <id>
 codex exec resume <id>
 ```
 
-## Implementation Plan
+## Historical implementation plan
+
+The steps below describe the migration that produced the provider boundary.
+They are retained for decision history; all four provider paths listed at the
+top are implemented.
 
 ### 1. Extract Runner Types
 
 - Add `src/runners/types.ts`.
 - Move `SpawnHandle` and `SpawnResult` out of `src/claude/types.ts`.
 - Update `lifecycle/timeout.ts`, `SessionManager`, and tests.
-- Keep runtime Claude-only.
+- Historical baseline: keep runtime Claude-only until the boundary is extracted.
 
 Exit criteria:
 

--- a/docs/features/session-management.md
+++ b/docs/features/session-management.md
@@ -1,8 +1,10 @@
 # Session Management
 
+> **Current status (2026-07-21):** Shipped. Production uses the SQLite-backed session store and normalized runner provider boundary; the in-memory store is retained for tests/dev. Current persistent Slack workers are `reproducer` and `review`, with `thinker` only as a legacy session alias.
+
 ## Problem
 
-Each Slack thread is one `ThreadSession`, but a single thread can run several persistent agents concurrently (lead, reproducer, thinker, build, reviewer, …). The manager owns:
+Each Slack thread is one `ThreadSession`, but a single thread can run several persistent agents concurrently (lead, reproducer, review, private overlay workers, …). The manager owns:
 
 - Per-thread lookup and creation
 - Per-agent run state, sessionId, pending buffer, pid

--- a/docs/features/session-persistence.md
+++ b/docs/features/session-persistence.md
@@ -1,11 +1,16 @@
 # Session Persistence
 
+> **Current status (2026-07-21):** SQLite is the production default and the current contract. The opening problem statement is historical context; use the “What happens today” and schema sections for live behavior.
+
 ## Problem
 
 Junior's session state lives in an in-memory `Map`. On restart — whether a crash, a deploy, or a manual stop — every thread's session ID, agent type, worktree path, and error history evaporates. Users hit their threads again and Junior has no idea who they are. Worktrees stay on disk but lose their binding to a thread.
 
 **Who has this problem:** Operators running Junior in production.
-**What happens today:** All sessions reset on restart. Users have to re-run `!build` / `!frontend` to re-bind agent type. `--resume` chains are broken.
+**What happens today:** Production sessions persist in SQLite and retain their
+provider/session metadata across restarts. The in-memory store still resets by
+design for tests and development. Pending messages are persisted as stale on
+restart because the process they were queued behind is gone.
 **Painful part:** A deploy silently throws away context that only existed in RAM. The home tab was the only place history showed up, and it was wiped too.
 **"Finally" moment:** Restart the bot, open the home tab, see every recent thread exactly as it was.
 
@@ -54,7 +59,7 @@ CREATE INDEX idx_sessions_last_activity ON sessions(last_activity);
 CREATE INDEX idx_sessions_status ON sessions(status);
 
 -- Per-agent rows for the persistent-agent substrate. One row per
--- (thread_id, agent_name) — e.g. lead, reproducer, thinker on a bug
+-- (thread_id, agent_name) — e.g. lead, reproducer, review on a bug
 -- pipeline thread. The parent ThreadSession's `agentSessions` map is
 -- rebuilt from these rows on load.
 CREATE TABLE agent_sessions (
@@ -78,7 +83,7 @@ CREATE TABLE admins (
 - `sessions.json` holds the full `ThreadSession` — including `muted`, `worktreePaths` (per-repo worktrees keyed by repo name), `defaultAgent` (the `!agent` override), and ephemeral `pendingMessages` (accepted as stale on restart per rule 11).
 - `last_activity` and `status` on `sessions` are denormalized for cheap queries (home window, orphan scan).
 - `agent_sessions` is the source of truth for each agent's `sessionId`, `status`, and `lastActivity`. `set()` resyncs the rows in a transaction; `get()`/`getAll()`/`getRecent()` reload them and overlay the JSON blob's `agentSessions` map (preserving in-memory-only fields `pendingMessages` and `pid`).
-- Migration story: schema is additive. `CREATE TABLE IF NOT EXISTS` brings up new tables on existing DBs. Field-level additions to `ThreadSession` are backfilled on read by `normalizeSession` (currently `leadSessionId`, `agentSessions`, `worktreePaths`, `muted`). Breaking changes nuke the db.
+- Migration story: schema is additive. `CREATE TABLE IF NOT EXISTS` brings up new tables on existing DBs. Field-level additions to `ThreadSession` are backfilled on read by `normalizeSession` (including `leadSessionId`, `agentSessions`, `worktreePaths`, and `muted`). Breaking changes require an explicit operator migration or a fresh local DB.
 
 PRAGMAs: `journal_mode=WAL`, `synchronous=NORMAL`. Standard for a single-writer SQLite embedded in a Bun server.
 

--- a/docs/features/slack-event-handler.md
+++ b/docs/features/slack-event-handler.md
@@ -16,7 +16,10 @@ The bot needs to receive Slack messages and route them to the right session. A m
 - Receive the bot's own posts (`ignoreSelf=false`) so orchestrator agents can dispatch workers via `!<persistent-agent>`. Drop incidental self-bot chatter to avoid loops.
 - Drop sibling-bot streaming updates (lines that start with `✽`).
 - Strip the bot's own `<@U…>` mentions from anywhere in the text before parsing.
-- Parse `!<command>` from the start of the message; pass `{ threadId, channel, user, text, ts, command, files }` to the session manager.
+- Parse leading `KNOWN_COMMANDS` from the start of the message; leave
+  persistent-agent directives such as `!review` and `!reproducer` intact for
+  `AgentDispatcher`; pass `{ threadId, channel, user, text, ts, command, files }`
+  to the session manager.
 - Acknowledge events quickly (Slack expects <3s response).
 - Publish a compact home tab summary of recent sessions, with permalinks and session metadata. Detailed per-session data opens in Slack modals from Home tab buttons.
 
@@ -33,7 +36,7 @@ The bot needs to receive Slack messages and route them to the right session. A m
 
 - `src/slack/app.ts` — `createSlackApp(config)` builds the Bolt `App` with Socket Mode and `ignoreSelf: false`.
 - `src/slack/events.ts` — `registerEventHandlers(app, onMessage, store?, selfBotId?, selfUserId?, autoTriggerChannels?)`. Registers `message` and `app_mention` listeners.
-- `src/slack/commands.ts` — `parseCommand(text)` extracts a leading `!<word>` from `KNOWN_COMMANDS`. `!<persistent-agent>` directives (e.g. `!lead`, `!reproducer`, `!thinker`, `!review`) are **not** in this set — they pass through with the prefix intact for the agent dispatcher.
+- `src/slack/commands.ts` — `parseCommand(text)` extracts a leading `!<word>` from `KNOWN_COMMANDS`. `!<persistent-agent>` directives (e.g. `!lead`, `!reproducer`, `!review`) are **not** in this set — they pass through with the prefix intact for the agent dispatcher. `!thinker` is legacy-only and is not a current directive.
 - `src/slack/responder.ts` — `SlackResponder` wraps `chat.postMessage`, `chat.update`, `chat.delete`, and `reactions.add`. Handles response splitting (via `formatting.ts`), agent identity (`username` + `icon_emoji` on posts), and per-agent status pills keyed by `${threadTs}:${agentName}` with a 1s debounce.
 - `src/slack/home.ts` — `registerHomeTab` listens for `app_home_opened` and `home_session_details` button actions. `publishHomeTab` calls `store.getRecent(windowMs)`, resolves Slack permalinks, and renders blocks: stats summary (active/idle/draining/errors/muted/total), Active Sessions, Recent Sessions (last 10 idle), Recent Errors (last 5). Each session block stays compact (status, lead agent, provider, repo, last activity, mute flag, pending count, agent count) and includes a `View details` button. Detail modals show worktree path, resume command, per-agent resume/status rows, and last error, split into Slack-safe section blocks. Last-error text is passed through the same prompt-leak sanitizer used for runner error replies before it appears in Home or modals.
 - `src/slack/files.ts` — `downloadSlackFiles(files, threadId, botToken)` fetches Slack attachments to `/tmp/junior-files/<threadId>/` so the runner can read them from disk.
@@ -91,11 +94,13 @@ Drop rules, `threadId` extraction, structured event passed to session manager. N
 
 `parseCommand` strips `!<word>` from message start when the word is in `KNOWN_COMMANDS`. See [thread-commands.md](thread-commands.md) for the command set and admin gating (`!reset`, `!mute`, `!unmute`, `!agent`).
 
-### Iteration 3: DM, edits, files (partly shipped)
+### Iteration 3: DM, edits, files, and action surfaces (shipped)
 
 - DMs (`channel_type === "im"`) bypass the mention requirement.
 - Message edits/deletes have no `text` and fall through `no-text`.
 - File uploads: attachments are downloaded by `files.ts` and the local paths are passed to the runner as context.
+- Home-tab detail modals and agent action/approval buttons are wired through
+  `src/slack/home.ts`, `src/slack/action-buttons.ts`, and `src/slack/action-store.ts`.
 - No outgoing rate-limit beyond the 1s status-pill debounce.
 
 ## Shortcuts
@@ -107,7 +112,8 @@ Drop rules, `threadId` extraction, structured event passed to session manager. N
 
 ## Cut List (true v2)
 
-- Slack interactive components (buttons, modals, dropdowns).
+- More interactive components (dropdowns and complex command forms); home
+  detail modals and action/approval buttons are already shipped.
 - Emoji reactions as commands (`:rocket:` → deploy).
 - Multi-workspace support (multiple Slack workspaces).
 - Message scheduling / delayed responses.

--- a/docs/features/thread-clear-command.md
+++ b/docs/features/thread-clear-command.md
@@ -1,8 +1,10 @@
 # Thread Clear Command (`!clear`)
 
+> **Current status (2026-07-21):** Shipped. The implementation lives in `src/slack/thread-archive.ts` and the command is handled by the thread-command path. The sections below preserve the original behavior specification and test plan.
+
 Date: 2026-05-28
 
-Proposal for a new thread command that archives a Slack thread to markdown on disk, then deletes every message posted by Junior (including agent personas) from that thread.
+The `!clear` command archives a Slack thread to markdown on disk, then deletes every message posted by Junior (including agent personas) from that thread.
 
 ## Problem
 
@@ -10,7 +12,7 @@ Long Junior threads accumulate dozens of status pills, multi-chunk responses, an
 
 **Who has this problem:** Anyone running multi-turn bug-pipeline or build threads where Junior, Lead, Reproducer, Thinker, and Reviewer have posted many messages.
 
-**What happens today:** No way to bulk-remove bot messages. Users scroll past stale status updates or manually delete messages one at a time (Slack UI only; Junior has no command).
+**What happens today:** Admins can use `!clear` to preserve a local archive, delete Junior-authored messages, and leave session/provider state untouched.
 
 **Painful part:** Deletion without backup is irreversible. Slack's own message retention policies vary by workspace; Junior should not assume Slack search or exports will preserve the thread.
 
@@ -321,4 +323,4 @@ User: !clear
 | New Slack scopes | None |
 | Primary new code | `src/slack/thread-archive.ts` + `handleCommand` case |
 
-Estimated effort: **~2–3 hours** (implementation + tests + docs index updates).
+Original estimate: **~2–3 hours** (implementation + tests + docs index updates).

--- a/docs/features/thread-commands.md
+++ b/docs/features/thread-commands.md
@@ -5,7 +5,9 @@
 Users need to control thread behavior beyond just sending messages. Reset a broken session, check what's running, switch agent types, change the target repo or branch. These are control-plane operations that don't need Claude — the bot handles them directly.
 
 **Who has this problem:** Users managing active Slack threads.
-**What happens today:** Nothing — no way to control sessions.
+**What happens today:** Junior handles thread controls directly in
+`SessionManager`; persistent-agent directives are routed separately by
+`AgentDispatcher` and are not part of `KNOWN_COMMANDS`.
 **Painful part:** Namespace collision. `!build fix auth` is a command + prompt. `!reset` is a pure command. `!status` might be a Slack-native command. Need clean parsing that doesn't conflict with Slack's built-in slash commands.
 **"Finally" moment:** `!status` → "Session active. Agent: build. Worktree: slack/1234. Last activity: 2 min ago." `!reset` → "Session cleared." Everything feels controllable.
 
@@ -16,7 +18,8 @@ Users need to control thread behavior beyond just sending messages. Reset a brok
 - `!status` — Show session state (agent type, worktree, busy/idle, last activity, pending messages count)
 - `!build [prompt]` — Set agent to build, create worktree if needed, run prompt
 - `!frontend [prompt]` — Set agent to frontend, create worktree, run prompt
-- `!review [prompt]` — Set agent to review (no worktree needed), run prompt
+- `!review` — Dispatch to the persistent review agent. It is not a normal
+  `KNOWN_COMMANDS` command; the support router handles the directive.
 - `!architect [prompt]` — Set agent to architect, run prompt
 - `!repo <name>` — Switch target repo for this thread
 - `!branch <ref>` — Set worktree base ref (next worktree creation uses this)
@@ -26,6 +29,11 @@ Users need to control thread behavior beyond just sending messages. Reset a brok
 - `!aside [text]` — Drop just this message; everything else in the thread continues as normal. For human-to-human sidebar without leaving the thread.
 - `!listen` — Wake Junior back up from auto-dormant mode. Anyone in the thread can use it.
 - `!help` — List available commands
+- `!provider <name>` — Switch the thread's runner provider (`claude`,
+  `opencode`, `opencode-sdk`, or `codex-app-server`)
+- `!stop` — Stop the active runner/driver
+- `!driver <headless|tmux>` — Select Claude's driver mode for the thread
+- `!workflow ...` / `!workflows` — Inspect and control dynamic workflows
 
 ## Admin-only commands
 

--- a/docs/features/whatsapp-tools.md
+++ b/docs/features/whatsapp-tools.md
@@ -89,7 +89,6 @@ prints the visible groups, and exits. Auth state persists in
 
 The Hermes buildathon tracker this replaced (LLM task extraction, task tables,
 custom Notion database sync, mentor-links script) shipped in PR #121/#122 and
-was removed after the event; see git history of
-`docs/features/whatsapp-hermes-tracker.md` for its design. A possible future
-direction from that era — reply-in-group as Pranav — remains unbuilt and gated
-on his explicit approval.
+was removed after the event. Its design is historical and is not part of the
+current documentation tree. A possible future direction from that era —
+reply-in-group as Pranav — remains unbuilt and gated on his explicit approval.

--- a/docs/features/worktree-manager.md
+++ b/docs/features/worktree-manager.md
@@ -1,5 +1,7 @@
 # Worktree Manager
 
+> **Current status (2026-07-21):** Shipped. Worktrees are sibling directories under `<repo>.junior-worktrees/`; delegated setup commands receive `branch --path <abs> --base <ref>`.
+
 > **Two flows live here.** The single-target-repo flow (driven by `!repo <name>`) creates one worktree per thread at `session.worktreePath`. The bug-pipeline flow (lead-driven) creates one worktree per routed repo per thread at `session.worktreePaths[repo]`, plus a dedicated dev-server worktree per repo at a fixed path. See [bug-pipeline-worktrees.md](bug-pipeline-worktrees.md) for the full bug-pipeline design and [process-lifecycle.md](process-lifecycle.md) for the dev-server lifecycle that owns the dev-server worktree.
 
 ## Problem
@@ -7,7 +9,7 @@
 When a Slack thread needs to edit code in a target repo (example-backend, example-frontend), it needs its own git worktree so concurrent threads don't collide on file state. The worktree manager creates, tracks, and cleans up worktrees in target repos — not in junior's own workspace.
 
 **Who has this problem:** Any thread that does code work on a shared repo.
-**What happens today:** Nothing — no code isolation.
+**What happens today:** Threads with a target repo receive sibling worktrees; bug-pipeline intake can register one per routed repo, and the dev-server manager owns a dedicated sibling slot. Dirty worktrees are preserved during cleanup.
 **Painful part:** Worktree lifecycle. Creating is easy. Knowing when to create (not every thread needs one), cleaning up safely (check for uncommitted changes), and handling edge cases (stale branches, dangling worktrees from crashed processes) is hard.
 **"Finally" moment:** Two Slack threads edit example-backend simultaneously. Neither sees the other's changes. Both can commit and push independently.
 
@@ -36,7 +38,7 @@ interface RepoConfig {
   path: string;                       // "/Users/.../projects/app-backend"
   defaultBase: string;                // "origin/main"
   // Optional — bug-pipeline / dev-server fields:
-  worktreeSetupCommand?: string;      // e.g. "bin/setup-worktree.sh" — resolved relative to `path`
+  worktreeSetupCommand?: string;      // target-repo command, resolved relative to `path`, receiving branch/--path/--base
   devCommand?: string;                // e.g. "pnpm dev", "npm run dev" — split on whitespace, no shell
   devPort?: number;                   // e.g. 3000, 8000 — readiness probe target
   readyUrl?: string;                  // e.g. "http://localhost:3000" — defaults to localhost:<devPort>

--- a/docs/security.md
+++ b/docs/security.md
@@ -21,7 +21,11 @@ Junior uses the native permission models of its runners:
 - **Claude Code**: Uses `--permission-mode bypassPermissions` for trusted developer use, or can be configured for restricted modes.
 
 ## 4. MCP Server Security
-The in-process Slack MCP server is intended for locally spawned runner processes and requires a shared `MCP_PORT`. It does not currently bind explicitly to loopback, so treat it as local-network exposed unless the host firewall or deployment environment restricts the port.
+The in-process MCP server is intended for locally spawned runner processes and
+requires a shared `MCP_PORT`. It binds to both IPv4 loopback (`127.0.0.1`) and,
+when available, IPv6 loopback (`::1`). It has no application-layer auth, so do
+not change those bindings or expose the port through a proxy without a security
+review.
 
 ## 5. Environment Variables
 Sensitive tokens (`SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`) should be stored in a `.env` file that is never committed (included in `.gitignore`).


### PR DESCRIPTION
## Summary
- audit README, CLAUDE.md, .env.example, architecture/security docs, feature docs, and code indexes
- document the four runner providers, SQLite persistence, MCP/HTTP routes, workflows, pipelines, GitHub reconciliation, WhatsApp archive, and current agent catalog
- add a canonical docs map and historical-status guidance

## Verification
- bun test: 1277 passed, 2 skipped, 0 failed
- internal Markdown link check: 111 tracked/current files, no broken local links
- git diff --check: passed
- bun run typecheck: existing MCP/Zod schema typing errors remain in src/mcp/slack-server.ts, src/mcp/mongodb-proxy.ts, and src/mcp/whatsapp-tools.ts; no source files in those modules changed here

Three read-only audit agents were run in parallel. Existing unrelated worktree changes were preserved and excluded from this PR.