### PR TITLE
Isolate pipeline agents in managed worktrees

### DIFF
--- a/.claude/agents/common/bug-pipeline.md
+++ b/.claude/agents/common/bug-pipeline.md
@@ -12,7 +12,7 @@ Every bug follows explicit states; your action at each is fixed by this table. *
 
 | Current state | Trigger | Next action |
 |---|---|---|
-| NEW BUG | Report received | Intake: read images, write report.md + state.json, register worktrees |
+| NEW BUG | Report received | Intake: read images, write report.md + state.json, verify routed workspaces |
 | INTAKE DONE | report.md written | Fan-out observability (parallel Task: nr-research, sentry-fetch, vercel-status) |
 | OBSERVABILITY DONE | All 3 files written + read | Classify read-only vs write-path |
 | READ-ONLY | Classification done | `!reproducer` with observability context |
@@ -47,7 +47,7 @@ STOP if you catch yourself about to: open Playwright/a browser to verify (→ `!
 1. **Triage every attached image** (runtime preamble has the read rule). Extract verbatim into `report.md`: URL from the address bar (routes via `support/repo-routing.yaml`), page title, visible errors/toasts, devtools console/network, browser tabs. Pull all the signal so the reproducer doesn't re-extract.
 2. Recall memory for the affected repos and reporter.
 3. Create the bug folder, write `report.md` + `state.json` (you are the ONLY writer of `state.json`).
-4. **Register a worktree per routed repo** before any dispatch — for each repo the bug touches (per `support/repo-routing.yaml`), `mcp__slack-bot__register_worktree({ thread_id: "<thread ts>", repo: "<repo>" })`. This persists paths so every later agent and your own Phase-1 reads see them in `<workspace>`; skip it and agents touch the bare repo. Capture the returned paths for dispatch prompts.
+4. **Verify one managed workspace per routed repo** before any dispatch. Durable pipeline `repoRefs` are the source of truth and Junior provisions their thread worktrees automatically. Confirm every repo the bug touches (per `support/repo-routing.yaml`) appears in `<workspace>`; if one is absent, escalate the control-plane mismatch instead of calling git or falling back to a bare checkout. Capture the provided paths for dispatch prompts.
 5. **Fan out observability first** — parallel Task in one message: `nr-research` → `$BUG_DIR/research.md`, `sentry-fetch` → `$BUG_DIR/sentry.md`, `vercel-status` → `$BUG_DIR/vercel.md`. (`email-drafter` → `$BUG_DIR/email.md` later, if email-worthy.)
 6. Read the three files. Synthesize the load-bearing facts into ONE Slack message referencing each path — failing endpoint, blast radius (quantified, not "looks like N users"), deploy correlation, exception class. No raw NRQL/Sentry dumps; never end on a raw `DONE:` Task result.
 7. **Classify the failure path**, then take the chained action. Read-only: a tight target prompt in `!reproducer` prevents cold exploration; if access-gated, name the admin-creds path for the impersonation fallback. Write-path: note in-thread "Skipping reproducer — write-path bug; both reproduction and validation would fire real prod writes."

--- a/.claude/agents/common/runtime-environment.md
+++ b/.claude/agents/common/runtime-environment.md
@@ -19,7 +19,7 @@ For browser screenshots specifically, extract:
 
 **Repo paths for this thread are dynamic — read the `<workspace>` block at the top of your prompt.** When present, it lists each routed repo's per-thread worktree path, branch, and base. Use those paths for ALL reads, edits, and git commands.
 
-Never touch repos outside the `<workspace>` block. If you need to touch a repo and there's no entry for it, STOP and post a Slack note instead of improvising. The lead is responsible for registering the worktrees you need; if one is missing, that's a state error to flag, not a reason to fall back to anything else.
+Never touch repos outside the `<workspace>` block. If you need to touch a repo and there's no entry for it, STOP and post a Slack note instead of improvising. Durable pipeline dispatch provisions every configured run repo before your assignment starts; a missing entry is a control-plane state error to flag, not a reason to fall back to anything else. Outside a pipeline, the orchestrator may explicitly register a worktree.
 
 **Always read each repo's `CLAUDE.md` before working in it.** Each product repo has its own conventions (naming, patterns, deprecated paths, test/build commands, gotchas). Read it from the worktree path in the workspace block. The repo's `CLAUDE.md` overrides anything generic — if it says "use X pattern," use X even if your default would have been Y.
 

--- a/.claude/agents/review.md
+++ b/.claude/agents/review.md
@@ -63,7 +63,7 @@ Run six passes on the code. Do not blend them -- each pass has a different lens.
 
 Use the `<workspace>` block as the source of truth for repo paths. Review inside the routed per-thread worktree for the target repo, not the bare repo.
 
-If the needed target repo is missing from `<workspace>`, call `mcp__slack-bot__register_worktree({ thread_id: "<thread ts>", repo: "<repo name>" })` before reading code or running git commands in that repo. Do not create ad hoc worktrees with shell commands; Junior's MCP tool owns worktree creation and persistence.
+If a durable pipeline assignment is missing its target repo from `<workspace>`, report a control-plane blocker — pipeline dispatch should already have provisioned every run repo. For a non-pipeline/manual review, call `mcp__slack-bot__register_worktree({ thread_id: "<thread ts>", repo: "<repo name>" })` before reading code or running git commands in that repo. Do not create ad hoc worktrees with shell commands; Junior's MCP tool owns worktree creation and persistence.
 
 Use the worktree to:
 - read the full diff and surrounding code

--- a/docs/code_index/pipeline-routing.md
+++ b/docs/code_index/pipeline-routing.md
@@ -1,0 +1,40 @@
+# Code Index: Pipeline Worktree Routing
+
+Resolves durable pipeline repository references and chooses the Junior-managed worktree used as an assignment's process cwd. The session manager provisions every resolved repo before spawning a pipeline worker; this module contains the deterministic, side-effect-free routing rules.
+
+## Code Index
+
+### src/worktree
+
+| Symbol | File | Purpose |
+|---|---|---|
+| `resolvePipelineRepos(repos, repoRefs)` | `pipeline-routing.ts` | Resolves configured repositories in durable run order, dedupes resolved and unresolved refs, and returns unknown or ambiguous refs explicitly so dispatch can fail closed. |
+| `inferPipelinePrimaryRepo(input)` | `pipeline-routing.ts` | Chooses the initial cwd from review PR affinity, durable assignment workstream/agent affinity, then durable repo order. Emits diagnostics before any ambiguous fallback. |
+| `repoMatchesRef(repoName, ref)` | `review-routing.ts` | Matches configured names against short and owner-qualified repository refs. Shared by review and pipeline routing. |
+
+### src/session
+
+| Symbol | File | Purpose |
+|---|---|---|
+| `SessionManager.runRunnerWithAgent(...)` | `manager.ts` | Reads the active assignment/run, resolves every durable repo ref, provisions all per-thread worktrees, persists `worktreePaths`, clears stale utility cwd, and spawns from the selected managed path. |
+| `SessionManager.ensurePipelineWorktree(...)` | `manager.ts` | Reuses an existing deterministic worktree or single-flights concurrent creation for the same repo/thread. Rejects a setup result whose path differs from the manager-owned path. |
+
+## Routing Order
+
+1. Resolve every durable `repoRef`. Any unknown or ambiguous ref fails the assignment with an actionable setup error; Junior never falls back to a developer checkout.
+2. For `review`, an explicit PR URL may select one of the already-resolved repos.
+3. For other agents, a single `workstream:` assignment context ref wins; otherwise `frontend` and `build` use their catalog affinity.
+4. If affinity is absent or ambiguous, emit a diagnostic and use durable repo order.
+
+Repo-less trusted planner and orchestrator roles may operate in Junior's shared workspace because they have no target repository. Builder, reviewer, reproducer, and unknown roles require a configured repo and managed worktree; the decision comes from the trusted agent catalog rather than a role-name allowlist. A failed assignment can move the run to `needs-human`, but plain human/orchestrator turns do not inherit that assignment's setup gate, so the thread remains usable for diagnosis and `!reset`.
+
+## Failure and Recovery
+
+- Worktree setup failures are converted into the active assignment's durable pipeline settlement before the runner starts.
+- If settlement itself fails, the session still leaves `busy`, records the combined setup/settlement error, and invokes the normal error callback.
+- Provider cold starts and bounded pipeline continuations reuse the persisted managed cwd and injected multi-repo path map.
+
+## Dependencies
+
+- **Uses:** `config.RepoConfig`, `worktree/review-routing`, `WorktreeManager`, pipeline run/assignment state.
+- **Used by:** `SessionManager` pipeline dispatch and recovery.

--- a/docs/code_index/session-management.md
+++ b/docs/code_index/session-management.md
@@ -96,7 +96,7 @@ Handled in `handleCommand`: `build`, `frontend`, `architect` (set `agentType`, c
 
 ## Prompt Composition (in `runRunnerWithAgent`)
 
-1. Resolve target repo + (always) create worktree if `targetRepo` set
+1. For an active pipeline assignment, resolve every durable repo ref, provision all managed worktrees, and select the primary cwd from review/workstream affinity. Otherwise resolve `targetRepo` and create its worktree when set.
 2. Resolve agent definition + context profile (defaults to all-true)
 3. First turn: `buildPromptPreamble(...)` injects enabled blocks
 4. Resumed turn: just `buildWorkspaceBlock` (cheap safety insurance) if workspace flag is on
@@ -110,6 +110,8 @@ Handled in `handleCommand`: `build`, `frontend`, `architect` (set `agentType`, c
 
 - **Refetch-then-mutate in `onRunComplete`**: long-running agents may be minutes stale; refetch the row to avoid clobbering writes from other agents on the same thread.
 - **Handle ownership check**: if `this.handles.get(handleKey) !== ownHandle`, the run was replaced by `!reset` or a newer spawn — bail without writing or posting.
+- **Pipeline workspace gate**: only the active assignment inherits fail-closed repo/worktree setup. The trusted agent catalog allows planner/orchestrator roles to run repo-less; builder/reviewer/reproducer and unknown roles require a managed target repo. Later human turns remain usable if the assignment escalates to `needs-human`.
+- **Setup settlement containment**: pre-spawn failures attempt durable pipeline settlement, but a store failure during settlement is caught and folded into the normal setup-error path so the session cannot remain stuck `busy`.
 - **Idle interrupt/resume**: for headless CLI providers Junior owns, silent runs are SIGINT'd after `session.idleTimeoutMs`; if a native session id was captured, the retry uses `buildRunSession(...)` so provider-native continuity receives the latest `sessionId`. OpenCode idle recovery is gated by `OPENCODE_CONTINUITY_ENABLED`.
 - **Slack tool duplicate suppression**: if a runner used `slack_send_message` and its final response is the exact same text, skip `onResponse` to avoid double-posting the same Slack reply.
 - **`seenMessages` dedupe**: bounded set (cap 1000, drops oldest 500) keyed on `dedupeKey ?? ts`. Slack fires both `message` and `app_mention` for @mentions.

--- a/docs/code_index/worktree-manager.md
+++ b/docs/code_index/worktree-manager.md
@@ -48,6 +48,8 @@ Setup scripts that `cp -R .claude/.` would otherwise pull every sibling thread's
 
 `SessionManager` creates a worktree whenever `session.targetRepo` is set — not gated on agent type. Previously gated on `build`/`frontend`, which let other agents `cwd` into the shared origin repo and modify it.
 
+Durable pipeline assignments use a stricter path: `pipeline-routing.ts` resolves every run `repoRef`, and `SessionManager` provisions every resolved repo before spawning the worker. Concurrent fan-out creation for the same repo/thread is single-flighted. Repo-less orchestration may remain in Junior's workspace, but repo-bound pipeline agents never fall back to the target repo's developer checkout.
+
 ### Dirty-check before remove
 
 Callers should `isWorktreeDirty(path)` before `removeWorktree` so uncommitted work isn't silently destroyed. The cleanup pass in `lifecycle/cleanup.ts` skips busy/draining and deletes only stale idle sessions; worktree removal itself is not currently automatic on cleanup (worktrees outlive the session row).
@@ -55,4 +57,4 @@ Callers should `isWorktreeDirty(path)` before `removeWorktree` so uncommitted wo
 ## Dependencies
 
 - **Uses**: `config.RepoConfig`, `Bun.spawn` (git, optional setup script), `node:fs/promises` (stat)
-- **Used by**: `SessionManager.runClaudeWithAgent` (per-thread create), `DevServerManager.bootstrap` (shared dev-server worktree), MCP `register_worktree` tool (bug-pipeline intake)
+- **Used by**: `SessionManager.runRunnerWithAgent` (per-thread and durable pipeline provisioning), `DevServerManager.bootstrap` (shared dev-server worktree), MCP `register_worktree` tool (explicit/manual routing)

--- a/docs/features/bug-pipeline-worktrees.md
+++ b/docs/features/bug-pipeline-worktrees.md
@@ -2,12 +2,13 @@
 
 Status: **landed (Scopes 1, 2a, 2b)**. Step 4 (this doc sync) shipped 2026-04-30.
 
-> **Current implementation note (2026-07-21):** The implementation is live, but several sections below retain the original design discussion. The dev-server slot is a sibling worktree at `<repo>.junior-worktrees/slack-dev-server`; it is not under `<repo>/.claude/dev-server`. Current source: [`src/lifecycle/dev-server.ts`](../../src/lifecycle/dev-server.ts), [`src/lifecycle/dev-server-queue.ts`](../../src/lifecycle/dev-server-queue.ts), and [`docs/code_index/worktree-manager.md`](../code_index/worktree-manager.md).
+> **Current implementation note (2026-07-21):** Durable product and bug pipeline dispatch now owns worktree provisioning. Before an assignment starts, `SessionManager` resolves every durable `repoRef`, provisions one thread-scoped worktree per repo, persists the full path map, and chooses the process cwd from review/workstream affinity. Agents no longer depend on lead calling `register_worktree`. The trusted catalog permits repo-less planner/orchestrator work; repo-bound assignments fail closed until the run names a configured repo. The dev-server slot remains a sibling worktree at `<repo>.junior-worktrees/slack-dev-server`. Current source: [`src/worktree/pipeline-routing.ts`](../../src/worktree/pipeline-routing.ts), [`src/session/manager.ts`](../../src/session/manager.ts), [`src/lifecycle/dev-server.ts`](../../src/lifecycle/dev-server.ts), [`src/lifecycle/dev-server-queue.ts`](../../src/lifecycle/dev-server-queue.ts), and [`docs/code_index/pipeline-routing.md`](../code_index/pipeline-routing.md).
 
 Implementation history:
 - Scope-1 (PR #3, merged 2026-04-29): per-thread worktrees + `register_worktree` MCP tool. Code: `WorktreeManager.createWorktree(repo, threadId, baseRef?, branchOverride?)`, `ThreadSession.worktreePaths`, multi-repo `<workspace>` block in `buildWorkspaceBlock`.
 - Scope-2a (PR #4, merged 2026-04-30): `DevServerManager` (`src/lifecycle/dev-server.ts`) — owns dev-server PID/branch tracking, idle TTL sweeper, shutdown teardown, startup orphan check. Independently fixed the leaked-`pnpm dev` bug.
 - Scope-2b (PR #5, merged 2026-04-30): `DevServerQueue` (`src/lifecycle/dev-server-queue.ts`) — `proper-lockfile` per repo, `.lock.meta.json` (atomic write-tmp + rename) and append-only NDJSON `.queue` for waiter introspection, `onCompromised` handler wired to `stealStale` so stale-lock takeovers recover instead of crashing the bot. New `!devserver <branch> [repo]` / `!devserver status` / `!devserver kill <repo>` directives in `src/support/router.ts`.
+- Pipeline-owned provisioning (PR #133, 2026-07-21): durable pipeline `repoRefs` are resolved and provisioned before assignment spawn. Multi-repo setup is coalesced per repo/thread; recovery continuations reuse the managed cwd; unknown refs and missing worktrees escalate durably instead of falling back to a developer checkout.
 
 Captures the discussion in a Slack thread on 2026-04-29.
 
@@ -107,7 +108,7 @@ Trap to watch:
 
 ### Who creates worktrees, and how
 
-**Lead initiates, junior executes.** Concretely: junior's slack-bot MCP server exposes a new tool `register_worktree(repo, branch?)`. Lead calls it on intake, after writing `state.json`, once per routed repo. The tool:
+**Historical Scope-1 design:** lead initiated worktree setup by calling the slack-bot MCP tool `register_worktree(repo, branch?)` after writing `state.json`. The tool:
 
 1. Resolves the repo's `RepoConfig`. Errors if unknown.
 2. If `repo.worktreeSetupCommand` is configured, runs the target-repo command as `<repo.path>/<command> <branch> --path <worktreePath> --base <baseRef>`. Otherwise runs `git fetch origin --prune` and `git worktree add <worktreePath> -b <branch> <baseRef>` directly.
@@ -115,7 +116,7 @@ Trap to watch:
 4. Persists `session.worktreePaths[repo] = worktreePath` via `SessionManager.updateSession`.
 5. Returns `{ path, branch }` to the caller.
 
-Lead's prompt grows by ~3 lines: "after `state.json`, call `register_worktree` for each routed repo." Lead is the only persistent agent that calls this — workers see the paths via the workspace block, never call the tool themselves.
+**Current behavior:** pipeline dispatch does not rely on that prompt convention. `SessionManager` resolves the run's durable `repoRefs`, provisions every configured repo before spawn, and injects the resulting path map. `register_worktree` remains available for explicit/manual non-pipeline routing, but pipeline correctness no longer depends on an agent remembering to call it.
 
 ### Multi-repo workspace block format
 
@@ -144,10 +145,10 @@ For non-bug threads (single `worktreePath`), keep the existing single-workspace 
 
 ### Agent prompt rewrite plan (lands WITH Scope-1, not after)
 
-These edits ship in the same commit as the `register_worktree` tool — otherwise agents still cd into `~/projects/` and the worktree creation does nothing.
+These prompt edits shipped with the original `register_worktree` tool. They remain useful workspace guidance, while pipeline-owned provisioning is now the enforcement boundary.
 
 - **`runtime-environment.md`**: replace the "Repo locations" section. New text says: "Repo paths for THIS thread are listed in the `<workspace>` block at the top of your prompt. Use those — never `~/projects/<repo>/` directly. The bare repos are the human developer's working trees; touching them corrupts active branches." Also: "Don't run `pnpm dev` / `npm run dev` / any dev server yourself. Post `!devserver <branch> [repo]` in the thread; junior owns the dev-server slot. Wait for junior's ready message before walking."
-- **`lead.md`**: add an intake step after `state.json`: "For each routed repo in `repo-routing.yaml`, call the `register_worktree` MCP tool. Capture the returned paths and reference them in the dispatch prompt to reproducer/thinker so they know which workspace to use."
+- **`lead.md`** (historical): originally called `register_worktree` during intake. Current pipeline dispatch provisions from durable `repoRefs`; lead only needs to ensure those refs are correct.
 - **`reproducer.md`**: replace "check out the fix branch in `~/projects/<repo>/`" with "post `!devserver <branch> <repo>` and wait for junior's `ready` reply. Walk against `localhost:<port>` as before."
 - **`thinker.md`**: no path edits needed — it already follows whatever cwd it's spawned in (which will be the worktree once Scope-1 lands). Add one sentence: "the workspace block at the top of your prompt has the repo paths. Use them; don't cd elsewhere."
 

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -120,6 +120,18 @@ function createTestManager(
   );
 }
 
+function attachExistingPipelineWorktree(
+  manager: InstanceType<typeof SessionManager>,
+): void {
+  const worktreePath = "/tmp/junior.junior-worktrees/slack-thread-1";
+  manager.worktreeManager = {
+    getWorktreePath: () => worktreePath,
+    worktreeExists: mock(async () => true),
+    createWorktree: mock(async () => worktreePath),
+    getBranchName: () => "slack/thread-1",
+  } as unknown as WorktreeManager;
+}
+
 /**
  * Minimal fake driver map for tmux teardown tests — records close() calls so
  * the test can assert on (threadId, agentName) without booting a real tmux.
@@ -482,6 +494,216 @@ describe("SessionManager", () => {
     expect(mockSpawnFn.mock.calls[0][0].sessionId).toBe("review-in-worktree");
     expect(mockSpawnFn.mock.calls[0][0].sessionCwd).toBe(reviewWorktree);
     rmSync(reviewWorktree, { recursive: true, force: true });
+  });
+
+  it("provisions every pipeline repo and starts the worker in its workstream worktree", async () => {
+    const pipelineStore = new InMemoryPipelineStore();
+    await pipelineStore.createRun(
+      makeProductRun({
+        id: "run-worktrees",
+        threadId: "thread-1",
+        repoRefs: ["GrowthX-Club/junior", "GrowthX-Club/frontend"],
+      }),
+    );
+    await pipelineStore.createAssignment(
+      makeAssignmentCreate({
+        id: "assignment-frontend",
+        runId: "run-worktrees",
+        targetAgent: "frontend",
+        contextRefs: ["workstream:frontend"],
+      }),
+    );
+    manager.pipelineStore = pipelineStore;
+
+    const paths: Record<string, string> = {
+      junior: "/tmp/junior.junior-worktrees/slack-thread-1",
+      frontend: "/tmp/frontend.junior-worktrees/slack-thread-1",
+    };
+    const createWorktree = mock(async (repoName: string) => paths[repoName]!);
+    manager.worktreeManager = {
+      createWorktree,
+      getWorktreePath: (repoName: string) => paths[repoName]!,
+      worktreeExists: mock(async () => false),
+      getBranchName: () => "slack/thread-1",
+    } as unknown as WorktreeManager;
+
+    const existing = createSession("thread-1", "C123");
+    existing.activePipelineRunId = "run-worktrees";
+    existing.activePipelineKind = "product";
+    // Simulate legacy state pointing at the developer's checkout. Pipeline
+    // routing must overwrite both cwd sources before the provider starts.
+    existing.targetRepo = "junior";
+    existing.worktreePath = "/tmp/junior";
+    existing.cwd = "/tmp/junior";
+    await store.set(existing.threadId, existing);
+
+    await manager.handleAgentMessage(
+      makeEvent({
+        text: "implement the frontend workstream",
+        pipelineInvocation: {
+          runId: "run-worktrees",
+          assignmentId: "assignment-frontend",
+          dispatchKey: "dispatch-frontend",
+          outcomeCountAtDispatch: 0,
+          retryCount: 0,
+        },
+      }),
+      "frontend",
+    );
+    await waitFor(() => mockSpawnFn.mock.calls.length === 1);
+
+    expect(createWorktree).toHaveBeenCalledTimes(2);
+    expect(createWorktree).toHaveBeenCalledWith(
+      "junior",
+      "thread-1",
+      undefined,
+    );
+    expect(createWorktree).toHaveBeenCalledWith(
+      "frontend",
+      "thread-1",
+      undefined,
+    );
+    const runSession = mockSpawnFn.mock.calls[0]![0];
+    expect(runSession.cwd).toBeNull();
+    expect(runSession.targetRepo).toBe("frontend");
+    expect(runSession.worktreePath).toBe(paths.frontend);
+    expect(runSession.worktreePaths).toEqual(paths);
+  });
+
+  it("coalesces concurrent fan-out setup for the same pipeline worktree", async () => {
+    const pipelineStore = new InMemoryPipelineStore();
+    await pipelineStore.createRun(
+      makeProductRun({
+        id: "run-concurrent-worktree",
+        threadId: "thread-1",
+        repoRefs: ["GrowthX-Club/junior"],
+      }),
+    );
+    for (const [id, targetAgent] of [
+      ["assignment-build", "build"],
+      ["assignment-frontend-concurrent", "frontend"],
+    ] as const) {
+      await pipelineStore.createAssignment(
+        makeAssignmentCreate({
+          id,
+          runId: "run-concurrent-worktree",
+          targetAgent,
+        }),
+      );
+    }
+    manager.pipelineStore = pipelineStore;
+
+    const worktreePath = "/tmp/junior.junior-worktrees/slack-thread-1";
+    let releaseSetup!: () => void;
+    const setupGate = new Promise<void>((resolve) => {
+      releaseSetup = resolve;
+    });
+    const createWorktree = mock(async () => {
+      await setupGate;
+      return worktreePath;
+    });
+    manager.worktreeManager = {
+      createWorktree,
+      getWorktreePath: () => worktreePath,
+      worktreeExists: mock(async () => false),
+      getBranchName: () => "slack/thread-1",
+    } as unknown as WorktreeManager;
+
+    const existing = createSession("thread-1", "C123");
+    existing.activePipelineRunId = "run-concurrent-worktree";
+    existing.activePipelineKind = "product";
+    await store.set(existing.threadId, existing);
+
+    await Promise.all([
+      manager.handleAgentMessage(
+        makeEvent({
+          text: "build stream",
+          dedupeKey: "concurrent-build",
+          pipelineInvocation: {
+            runId: "run-concurrent-worktree",
+            assignmentId: "assignment-build",
+            dispatchKey: "dispatch-build",
+            outcomeCountAtDispatch: 0,
+            retryCount: 0,
+          },
+        }),
+        "build",
+      ),
+      manager.handleAgentMessage(
+        makeEvent({
+          text: "frontend stream",
+          dedupeKey: "concurrent-frontend",
+          pipelineInvocation: {
+            runId: "run-concurrent-worktree",
+            assignmentId: "assignment-frontend-concurrent",
+            dispatchKey: "dispatch-frontend-concurrent",
+            outcomeCountAtDispatch: 0,
+            retryCount: 0,
+          },
+        }),
+        "frontend",
+      ),
+    ]);
+    await waitFor(() => createWorktree.mock.calls.length === 1);
+    releaseSetup();
+    await waitFor(() => mockSpawnFn.mock.calls.length === 2);
+
+    expect(createWorktree).toHaveBeenCalledTimes(1);
+    expect(
+      mockSpawnFn.mock.calls.map((call) => call[0].worktreePath),
+    ).toEqual([worktreePath, worktreePath]);
+  });
+
+  it("fails closed when a pipeline cannot provision managed worktrees", async () => {
+    const pipelineStore = new InMemoryPipelineStore();
+    await pipelineStore.createRun(
+      makeProductRun({
+        id: "run-no-worktree-manager",
+        threadId: "thread-1",
+        repoRefs: ["GrowthX-Club/junior"],
+      }),
+    );
+    await pipelineStore.createAssignment(
+      makeAssignmentCreate({
+        id: "assignment-no-worktree-manager",
+        runId: "run-no-worktree-manager",
+        targetAgent: "build",
+      }),
+    );
+    manager.pipelineStore = pipelineStore;
+    const existing = createSession("thread-1", "C123");
+    existing.activePipelineRunId = "run-no-worktree-manager";
+    existing.activePipelineKind = "product";
+    existing.targetRepo = "junior";
+    existing.worktreePath = "/tmp/junior";
+    await store.set(existing.threadId, existing);
+    const errors = mock((_session: ThreadSession, _error: string | null) => {});
+    manager.onError = errors;
+
+    await manager.handleAgentMessage(
+      makeEvent({
+        text: "implement safely",
+        pipelineInvocation: {
+          runId: "run-no-worktree-manager",
+          assignmentId: "assignment-no-worktree-manager",
+          dispatchKey: "dispatch-no-worktree-manager",
+          outcomeCountAtDispatch: 0,
+          retryCount: 0,
+        },
+      }),
+      "build",
+    );
+    await waitFor(() => errors.mock.calls.length === 1);
+
+    expect(mockSpawnFn).not.toHaveBeenCalled();
+    expect(errors.mock.calls[0]![1]).toContain(
+      "worktree manager is unavailable",
+    );
+    expect((await store.get("thread-1"))?.agentSessions.build.status).toBe(
+      "failed",
+    );
+    expect((await pipelineStore.getRun("run-no-worktree-manager"))?.status)
+      .toBe("needs-human");
   });
 
   it("retries an unavailable Claude conversation once as a fresh session", async () => {
@@ -2775,7 +2997,10 @@ describe("typed pipeline settlement", () => {
   it("repairs an unavailable Claude session without consuming pipeline retries", async () => {
     const sessionStore = new InMemorySessionStore();
     const pipelineStore = new InMemoryPipelineStore(fakeClock(1_000));
-    await pipelineStore.createRun(makeProductRun({ phase: "building" }));
+    await pipelineStore.createRun(makeProductRun({
+      phase: "building",
+      repoRefs: ["junior"],
+    }));
     await pipelineStore.createAssignment(makeAssignmentCreate({
       id: "asg-invalid-session",
       targetAgent: "build",
@@ -2786,7 +3011,7 @@ describe("typed pipeline settlement", () => {
       agentName: "build",
       provider: "claude",
       sessionId: "missing-build-session",
-      sessionCwd: process.cwd(),
+      sessionCwd: "/tmp/junior.junior-worktrees/slack-thread-1",
       status: "idle",
       pendingMessages: [],
       lastActivity: Date.now(),
@@ -2802,6 +3027,7 @@ describe("typed pipeline settlement", () => {
       return handle;
     });
     manager.pipelineStore = pipelineStore;
+    attachExistingPipelineWorktree(manager);
     const errors = mock((_session, _error) => undefined);
     manager.onError = errors;
 
@@ -2859,7 +3085,10 @@ describe("typed pipeline settlement", () => {
   it("rebuilds exact assignment context when a settlement resume is unavailable", async () => {
     const sessionStore = new InMemorySessionStore();
     const pipelineStore = new InMemoryPipelineStore(fakeClock(1_000));
-    await pipelineStore.createRun(makeProductRun({ phase: "building" }));
+    await pipelineStore.createRun(makeProductRun({
+      phase: "building",
+      repoRefs: ["junior"],
+    }));
     await pipelineStore.createAssignment(makeAssignmentCreate({
       id: "asg-resume-context",
       targetAgent: "build",
@@ -2876,6 +3105,7 @@ describe("typed pipeline settlement", () => {
       return handle;
     });
     manager.pipelineStore = pipelineStore;
+    attachExistingPipelineWorktree(manager);
 
     await manager.handleAgentMessage(makeEvent({
       text: "initial assignment dispatch",
@@ -2939,7 +3169,10 @@ describe("typed pipeline settlement", () => {
   it("escalates a non-retryable provider failure without wasting continuations", async () => {
     const sessionStore = new InMemorySessionStore();
     const pipelineStore = new InMemoryPipelineStore(fakeClock(1_000));
-    await pipelineStore.createRun(makeProductRun({ phase: "building" }));
+    await pipelineStore.createRun(makeProductRun({
+      phase: "building",
+      repoRefs: ["junior"],
+    }));
     await pipelineStore.createAssignment(makeAssignmentCreate({
       id: "asg-provider-failure",
       targetAgent: "build",
@@ -2988,6 +3221,7 @@ describe("typed pipeline settlement", () => {
       return handle;
     });
     manager.pipelineStore = pipelineStore;
+    attachExistingPipelineWorktree(manager);
     const errors = mock((_session, _error) => undefined);
     manager.onError = errors;
 
@@ -3022,7 +3256,10 @@ describe("typed pipeline settlement", () => {
   it("does not resurrect a worker reset during continuation setup", async () => {
     const sessionStore = new InMemorySessionStore();
     const pipelineStore = new InMemoryPipelineStore(fakeClock(1_000));
-    await pipelineStore.createRun(makeProductRun({ phase: "building" }));
+    await pipelineStore.createRun(makeProductRun({
+      phase: "building",
+      repoRefs: ["junior"],
+    }));
     await pipelineStore.createAssignment(makeAssignmentCreate({
       id: "asg-reset-worker",
       targetAgent: "build",
@@ -3035,6 +3272,7 @@ describe("typed pipeline settlement", () => {
       return handle;
     });
     manager.pipelineStore = pipelineStore;
+    attachExistingPipelineWorktree(manager);
     let releaseRecall!: () => void;
     const recallGate = new Promise<void>((resolve) => { releaseRecall = resolve; });
     let recallCalls = 0;
@@ -3075,7 +3313,10 @@ describe("typed pipeline settlement", () => {
   it("does not resurrect a thread reset during continuation setup", async () => {
     const sessionStore = new InMemorySessionStore();
     const pipelineStore = new InMemoryPipelineStore(fakeClock(1_000));
-    await pipelineStore.createRun(makeProductRun({ phase: "building" }));
+    await pipelineStore.createRun(makeProductRun({
+      phase: "building",
+      repoRefs: ["junior"],
+    }));
     await pipelineStore.createAssignment(makeAssignmentCreate({
       id: "asg-reset-lead",
       targetAgent: "lead",
@@ -3088,6 +3329,7 @@ describe("typed pipeline settlement", () => {
       return handle;
     });
     manager.pipelineStore = pipelineStore;
+    attachExistingPipelineWorktree(manager);
     let releaseRecall!: () => void;
     const recallGate = new Promise<void>((resolve) => { releaseRecall = resolve; });
     let recallCalls = 0;
@@ -3128,7 +3370,10 @@ describe("typed pipeline settlement", () => {
   it("quietly resumes a max-turn Claude session and trusts its later durable outcome", async () => {
     const sessionStore = new InMemorySessionStore();
     const pipelineStore = new InMemoryPipelineStore(fakeClock(1_000));
-    await pipelineStore.createRun(makeProductRun({ phase: "building" }));
+    await pipelineStore.createRun(makeProductRun({
+      phase: "building",
+      repoRefs: ["junior"],
+    }));
     await pipelineStore.createAssignment(makeAssignmentCreate({
       id: "asg-settlement",
       targetAgent: "build",
@@ -3144,6 +3389,7 @@ describe("typed pipeline settlement", () => {
     };
     const manager = new SessionManager(sessionStore, testConfig, localSpawn);
     manager.pipelineStore = pipelineStore;
+    attachExistingPipelineWorktree(manager);
     const errors = mock((_session, _error) => undefined);
     manager.onError = errors;
 
@@ -3218,7 +3464,10 @@ describe("typed pipeline settlement", () => {
   it("posts one failure only after the bounded recovery budget is exhausted", async () => {
     const sessionStore = new InMemorySessionStore();
     const pipelineStore = new InMemoryPipelineStore(fakeClock(1_000));
-    await pipelineStore.createRun(makeProductRun({ phase: "building" }));
+    await pipelineStore.createRun(makeProductRun({
+      phase: "building",
+      repoRefs: ["junior"],
+    }));
     await pipelineStore.createAssignment(makeAssignmentCreate({
       id: "asg-exhausted",
       targetAgent: "build",
@@ -3231,6 +3480,7 @@ describe("typed pipeline settlement", () => {
       return handle;
     });
     manager.pipelineStore = pipelineStore;
+    attachExistingPipelineWorktree(manager);
     const errors = mock((_session, _error) => undefined);
     manager.onError = errors;
 
@@ -3267,7 +3517,10 @@ describe("typed pipeline settlement", () => {
   it("reports zero recovery continuations when no provider session can resume", async () => {
     const sessionStore = new InMemorySessionStore();
     const pipelineStore = new InMemoryPipelineStore(fakeClock(1_000));
-    await pipelineStore.createRun(makeProductRun({ phase: "building" }));
+    await pipelineStore.createRun(makeProductRun({
+      phase: "building",
+      repoRefs: ["junior"],
+    }));
     await pipelineStore.createAssignment(makeAssignmentCreate({
       id: "asg-no-session",
       targetAgent: "build",
@@ -3276,6 +3529,7 @@ describe("typed pipeline settlement", () => {
     const handle = createMockHandle();
     const manager = new SessionManager(sessionStore, testConfig, () => handle);
     manager.pipelineStore = pipelineStore;
+    attachExistingPipelineWorktree(manager);
     const errors = mock((_session, _error) => undefined);
     const responses = mock((_session, _response) => undefined);
     manager.onError = errors;

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -706,6 +706,200 @@ describe("SessionManager", () => {
       .toBe("needs-human");
   });
 
+  it("allows repo-less orchestration assignments without a target worktree", async () => {
+    const pipelineStore = new InMemoryPipelineStore();
+    await pipelineStore.createRun(
+      makeProductRun({
+        id: "run-repo-less-pm",
+        threadId: "thread-1",
+        repoRefs: [],
+      }),
+    );
+    await pipelineStore.createAssignment(
+      makeAssignmentCreate({
+        id: "assignment-repo-less-pm",
+        runId: "run-repo-less-pm",
+        targetAgent: "pm",
+      }),
+    );
+    manager.pipelineStore = pipelineStore;
+    const existing = createSession("thread-1", "C123");
+    existing.activePipelineRunId = "run-repo-less-pm";
+    existing.activePipelineKind = "product";
+    await store.set(existing.threadId, existing);
+
+    await manager.handleAgentMessage(
+      makeEvent({
+        text: "discover and write the product brief",
+        pipelineInvocation: {
+          runId: "run-repo-less-pm",
+          assignmentId: "assignment-repo-less-pm",
+          dispatchKey: "dispatch-repo-less-pm",
+          outcomeCountAtDispatch: 0,
+          retryCount: 0,
+        },
+      }),
+      "pm",
+    );
+    await waitFor(() => mockSpawnFn.mock.calls.length === 1);
+
+    const runSession = mockSpawnFn.mock.calls[0]![0];
+    expect(runSession.targetRepo).toBeNull();
+    expect(runSession.worktreePath).toBeNull();
+    expect(runSession.cwd).toBeNull();
+  });
+
+  it("keeps human turns usable after a repo-less build assignment escalates", async () => {
+    const pipelineStore = new InMemoryPipelineStore();
+    await pipelineStore.createRun(
+      makeProductRun({
+        id: "run-repo-less-build",
+        threadId: "thread-1",
+        repoRefs: [],
+      }),
+    );
+    await pipelineStore.createAssignment(
+      makeAssignmentCreate({
+        id: "assignment-repo-less-build",
+        runId: "run-repo-less-build",
+        targetAgent: "build",
+      }),
+    );
+    manager.pipelineStore = pipelineStore;
+    const existing = createSession("thread-1", "C123");
+    existing.activePipelineRunId = "run-repo-less-build";
+    existing.activePipelineKind = "product";
+    await store.set(existing.threadId, existing);
+    const errors = mock((_session: ThreadSession, _error: string | null) => {});
+    manager.onError = errors;
+
+    await manager.handleAgentMessage(
+      makeEvent({
+        text: "implement without a repo",
+        pipelineInvocation: {
+          runId: "run-repo-less-build",
+          assignmentId: "assignment-repo-less-build",
+          dispatchKey: "dispatch-repo-less-build",
+          outcomeCountAtDispatch: 0,
+          retryCount: 0,
+        },
+      }),
+      "build",
+    );
+    await waitFor(() => errors.mock.calls.length === 1);
+    expect(errors.mock.calls[0]![1]).toContain("Add a repository to the run");
+    expect((await pipelineStore.getRun("run-repo-less-build"))?.status)
+      .toBe("needs-human");
+
+    await manager.handleMessage(
+      makeEvent({
+        text: "explain how I can recover this run",
+        ts: "human-recovery-turn",
+      }),
+    );
+    await waitFor(() => mockSpawnFn.mock.calls.length === 1);
+    expect(mockSpawnFn.mock.calls[0]![0].activePipelineInvocation).toBeNull();
+  });
+
+  it("fails unknown repo refs with an actionable error without wedging human turns", async () => {
+    const pipelineStore = new InMemoryPipelineStore();
+    await pipelineStore.createRun(
+      makeProductRun({
+        id: "run-unknown-repo",
+        threadId: "thread-1",
+        repoRefs: ["GrowthX-Club/not-configured"],
+      }),
+    );
+    await pipelineStore.createAssignment(
+      makeAssignmentCreate({
+        id: "assignment-unknown-repo",
+        runId: "run-unknown-repo",
+        targetAgent: "build",
+      }),
+    );
+    manager.pipelineStore = pipelineStore;
+    const existing = createSession("thread-1", "C123");
+    existing.activePipelineRunId = "run-unknown-repo";
+    existing.activePipelineKind = "product";
+    await store.set(existing.threadId, existing);
+    const errors = mock((_session: ThreadSession, _error: string | null) => {});
+    manager.onError = errors;
+
+    await manager.handleAgentMessage(
+      makeEvent({
+        text: "implement in the unknown repo",
+        pipelineInvocation: {
+          runId: "run-unknown-repo",
+          assignmentId: "assignment-unknown-repo",
+          dispatchKey: "dispatch-unknown-repo",
+          outcomeCountAtDispatch: 0,
+          retryCount: 0,
+        },
+      }),
+      "build",
+    );
+    await waitFor(() => errors.mock.calls.length === 1);
+    expect(errors.mock.calls[0]![1]).toContain(
+      "Update the run repository refs/configuration",
+    );
+
+    await manager.handleMessage(
+      makeEvent({ text: "what repo is missing?", ts: "unknown-repo-recovery" }),
+    );
+    await waitFor(() => mockSpawnFn.mock.calls.length === 1);
+  });
+
+  it("marks setup failed when durable pipeline settlement also throws", async () => {
+    const pipelineStore = new InMemoryPipelineStore();
+    await pipelineStore.createRun(
+      makeProductRun({
+        id: "run-settlement-failure",
+        threadId: "thread-1",
+        repoRefs: ["GrowthX-Club/junior"],
+      }),
+    );
+    await pipelineStore.createAssignment(
+      makeAssignmentCreate({
+        id: "assignment-settlement-failure",
+        runId: "run-settlement-failure",
+        targetAgent: "build",
+      }),
+    );
+    pipelineStore.recordOutcomeTransaction = mock(async () => {
+      throw new Error("pipeline store unavailable");
+    });
+    manager.pipelineStore = pipelineStore;
+    const existing = createSession("thread-1", "C123");
+    existing.activePipelineRunId = "run-settlement-failure";
+    existing.activePipelineKind = "product";
+    await store.set(existing.threadId, existing);
+    const errors = mock((_session: ThreadSession, _error: string | null) => {});
+    manager.onError = errors;
+
+    await manager.handleAgentMessage(
+      makeEvent({
+        text: "implement safely",
+        pipelineInvocation: {
+          runId: "run-settlement-failure",
+          assignmentId: "assignment-settlement-failure",
+          dispatchKey: "dispatch-settlement-failure",
+          outcomeCountAtDispatch: 0,
+          retryCount: 0,
+        },
+      }),
+      "build",
+    );
+    await waitFor(() => errors.mock.calls.length === 1);
+
+    expect(errors.mock.calls[0]![1]).toContain("worktree manager is unavailable");
+    expect(errors.mock.calls[0]![1]).toContain(
+      "Pipeline settlement also failed: pipeline store unavailable",
+    );
+    expect((await store.get("thread-1"))?.agentSessions.build.status).toBe(
+      "failed",
+    );
+  });
+
   it("retries an unavailable Claude conversation once as a fresh session", async () => {
     const localStore = new InMemorySessionStore();
     const handles: MockHandle[] = [];

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -726,6 +726,7 @@ describe("SessionManager", () => {
     const existing = createSession("thread-1", "C123");
     existing.activePipelineRunId = "run-repo-less-pm";
     existing.activePipelineKind = "product";
+    existing.cwd = "/tmp/stale-utility-cwd";
     await store.set(existing.threadId, existing);
 
     await manager.handleAgentMessage(
@@ -747,6 +748,7 @@ describe("SessionManager", () => {
     expect(runSession.targetRepo).toBeNull();
     expect(runSession.worktreePath).toBeNull();
     expect(runSession.cwd).toBeNull();
+    expect((await store.get("thread-1"))?.cwd).toBeNull();
   });
 
   it("keeps human turns usable after a repo-less build assignment escalates", async () => {

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -1,5 +1,5 @@
 import type { App } from "@slack/bolt";
-import type { Config } from "../config.ts";
+import type { Config, RepoConfig } from "../config.ts";
 import type { RunnerEvent, RunnerProvider, SpawnHandle, SpawnResult, SpawnRunnerFn } from "../runners/types.ts";
 import type {
   SlackMessageEvent,
@@ -14,6 +14,7 @@ import type {
   ThreadSession,
 } from "./types.ts";
 import type { AgentRouter } from "../agents/router.ts";
+import { resolveAgentManifest } from "../agents/registry.ts";
 import type { WorktreeManager } from "../worktree/manager.ts";
 import type { PipelineStore } from "../pipelines/store/interface.ts";
 import {
@@ -1339,28 +1340,24 @@ export class SessionManager {
           )
         : undefined;
 
-      if (activePipelineRun) {
+      if (activePipelineRun && pipelineInvocation) {
         // Durable repo refs, not a developer checkout or stale session cwd,
         // define the pipeline workspace. Provision every referenced repo so
-        // fan-out agents can collaborate through the injected path map.
-        if (!this.worktreeManager) {
-          throw new Error(
-            `Pipeline ${activePipelineRun.id.slice(0, 8)} cannot run: worktree manager is unavailable.`,
-          );
-        }
-
+        // fan-out agents can collaborate through the injected path map. Plain
+        // human turns on a needs-human run do not own an assignment, so they
+        // must remain usable to diagnose or reset an unrecoverable run.
         const resolution = resolvePipelineRepos(
           this.config.repos,
           activePipelineRun.repoRefs,
         );
         if (resolution.unresolvedRefs.length > 0) {
           throw new Error(
-            `Pipeline ${activePipelineRun.id.slice(0, 8)} cannot run: repository refs are not uniquely configured: ${resolution.unresolvedRefs.join(", ")}.`,
+            `Pipeline ${activePipelineRun.id.slice(0, 8)} cannot run assignment ${pipelineInvocation.assignmentId.slice(0, 8)}: repository refs are not uniquely configured: ${resolution.unresolvedRefs.join(", ")}. Update the run repository refs/configuration or use !reset after preserving any work.`,
           );
         }
 
         const pipelineRepos = [...resolution.repos];
-        const addRepo = (repo: Config["repos"][number] | undefined) => {
+        const addRepo = (repo: RepoConfig | undefined) => {
           if (repo && !pipelineRepos.some((item) => item.name === repo.name)) {
             pipelineRepos.push(repo);
           }
@@ -1379,50 +1376,68 @@ export class SessionManager {
           );
         }
         if (pipelineRepos.length === 0) {
-          throw new Error(
-            `Pipeline ${activePipelineRun.id.slice(0, 8)} cannot run without a configured repository and isolated worktree.`,
+          if (pipelineAgentRequiresWorktree(agentName)) {
+            throw new Error(
+              `Pipeline ${activePipelineRun.id.slice(0, 8)} cannot run ${agentName} assignment ${pipelineInvocation.assignmentId.slice(0, 8)} without a configured repository and isolated worktree. Add a repository to the run or use !reset after preserving any work.`,
+            );
+          }
+          _log.info(
+            "manager",
+            `pipeline.workspace.skip thread=${session.threadId} run=${activePipelineRun.id} assignment=${pipelineInvocation.assignmentId} agent=${agentName} reason=repo-less-orchestration`,
           );
-        }
+        } else {
+          if (!this.worktreeManager) {
+            throw new Error(
+              `Pipeline ${activePipelineRun.id.slice(0, 8)} cannot run assignment ${pipelineInvocation.assignmentId.slice(0, 8)}: worktree manager is unavailable. Use !reset after preserving any work.`,
+            );
+          }
 
-        const primaryRepo = inferPipelinePrimaryRepo({
-          configuredRepos: this.config.repos,
-          pipelineRepos,
-          prompt,
-          targetAgent: agentName,
-          assignmentContextRefs: activePipelineAssignment?.contextRefs,
-        });
-        if (!primaryRepo) {
-          throw new Error(
-            `Pipeline ${activePipelineRun.id.slice(0, 8)} cannot choose an isolated worktree.`,
-          );
-        }
+          const primaryRepo = inferPipelinePrimaryRepo({
+            configuredRepos: this.config.repos,
+            pipelineRepos,
+            prompt,
+            targetAgent: agentName,
+            assignmentContextRefs: activePipelineAssignment?.contextRefs,
+            onDiagnostic: (message) => {
+              _log.warn(
+                "manager",
+                `pipeline.workspace.affinity thread=${session.threadId} run=${activePipelineRun.id} assignment=${pipelineInvocation.assignmentId} agent=${agentName} detail=${message}`,
+              );
+            },
+          });
+          if (!primaryRepo) {
+            throw new Error(
+              `Pipeline ${activePipelineRun.id.slice(0, 8)} cannot choose an isolated worktree. Use !reset after preserving any work.`,
+            );
+          }
 
-        const provisioned = await Promise.all(
-          pipelineRepos.map(async (repo) => [
-            repo.name,
-            await this.ensurePipelineWorktree(
+          const provisioned = await Promise.all(
+            pipelineRepos.map(async (repo) => [
               repo.name,
-              session.threadId,
-              session.baseRef ?? undefined,
-            ),
-          ] as const),
-        );
-        assertRunOwnership();
-        const provisionedPaths = Object.fromEntries(provisioned);
-        session = await this.mutateSession(session.threadId, (fresh) => {
+              await this.ensurePipelineWorktree(
+                repo.name,
+                session.threadId,
+                session.baseRef ?? undefined,
+              ),
+            ] as const),
+          );
           assertRunOwnership();
-          fresh.worktreePaths = {
-            ...fresh.worktreePaths,
-            ...provisionedPaths,
-          };
-          fresh.targetRepo = primaryRepo.name;
-          fresh.worktreePath = provisionedPaths[primaryRepo.name] ?? null;
-          // Utility commands can leave an explicit cwd on the thread. Once a
-          // durable pipeline owns the turn, persistently clear that override
-          // so provider cold starts and recovery continuations also stay in
-          // the managed worktree.
-          fresh.cwd = null;
-        });
+          const provisionedPaths = Object.fromEntries(provisioned);
+          session = await this.mutateSession(session.threadId, (fresh) => {
+            assertRunOwnership();
+            fresh.worktreePaths = {
+              ...fresh.worktreePaths,
+              ...provisionedPaths,
+            };
+            fresh.targetRepo = primaryRepo.name;
+            fresh.worktreePath = provisionedPaths[primaryRepo.name] ?? null;
+            // Utility commands can leave an explicit cwd on the thread. Once a
+            // durable pipeline owns the turn, persistently clear that override
+            // so provider cold starts and recovery continuations also stay in
+            // the managed worktree.
+            fresh.cwd = null;
+          });
+        }
       } else if (inferredReviewRepo && this.worktreeManager) {
         if (session.targetRepo !== inferredReviewRepo.name) {
           session = await this.mutateSession(session.threadId, (fresh) => {
@@ -2086,34 +2101,45 @@ export class SessionManager {
       }
       let fatalMessage = err instanceof Error ? err.message : String(err);
       if (!runnerStarted && expectedHandle && this.pipelineStore) {
-        const setupResult = await this.resolvePipelineInvocation(
-          session,
-          agentName,
-          {
-            provider: sessionProvider(
-              this.buildRunSession(
-                session,
-                agentName,
-                identityForAgent(agentName),
+        try {
+          const setupResult = await this.resolvePipelineInvocation(
+            session,
+            agentName,
+            {
+              provider: sessionProvider(
+                this.buildRunSession(
+                  session,
+                  agentName,
+                  identityForAgent(agentName),
+                ),
+                this.config,
               ),
-              this.config,
-            ),
-            sessionId: null,
-            response: "",
-            events: [],
-            exitCode: null,
-            error: fatalMessage,
-            completion: {
-              status: "failure",
-              reason: "provider_error",
-              retryable: false,
+              sessionId: null,
+              response: "",
+              events: [],
+              exitCode: null,
+              error: fatalMessage,
+              completion: {
+                status: "failure",
+                reason: "provider_error",
+                retryable: false,
+              },
             },
-          },
-          expectedHandle,
-          session.worktreePath ?? process.cwd(),
-        );
-        if (!setupResult) return;
-        fatalMessage = setupResult.error ?? fatalMessage;
+            expectedHandle,
+            session.worktreePath ?? process.cwd(),
+          );
+          if (!setupResult) return;
+          fatalMessage = setupResult.error ?? fatalMessage;
+        } catch (settlementErr) {
+          const settlementMessage = settlementErr instanceof Error
+            ? settlementErr.message
+            : String(settlementErr);
+          _log.error(
+            "pipeline",
+            `setup.settlement.fail thread=${session.threadId} agent=${agentName} err=${settlementMessage}`,
+          );
+          fatalMessage = `${fatalMessage} Pipeline settlement also failed: ${settlementMessage}`;
+        }
       }
       if (expectedHandle) this.handles.delete(reservationKey);
       // Agent prompt composition or worktree creation failed fatally
@@ -3232,6 +3258,14 @@ export class SessionManager {
   private handleKey(threadId: string, agentName: string): string {
     return `${threadId}:${agentName}`;
   }
+}
+
+function pipelineAgentRequiresWorktree(agentName: string): boolean {
+  const role = resolveAgentManifest(agentName)?.role;
+  // Unknown roles fail closed. Trusted orchestrators and planners can perform
+  // repo-less discovery/control-plane work; every execution/review role needs
+  // a target repository and a Junior-managed worktree.
+  return role !== "orchestrator" && role !== "planner";
 }
 
 const defaultSpawnRunnerForRuntime: SpawnRunnerFn =

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -61,6 +61,10 @@ import { DEFAULT_CONTEXT_PROFILE, type AgentContextProfile } from "../agents/loa
 import { downloadSlackFiles, sanitizeFileName } from "../slack/files.ts";
 import { log as _log } from "../logger.ts";
 import { inferReviewRepo } from "../worktree/review-routing.ts";
+import {
+  inferPipelinePrimaryRepo,
+  resolvePipelineRepos,
+} from "../worktree/pipeline-routing.ts";
 import { detectJavaScriptPackageManager } from "../worktree/package-manager.ts";
 import type { MemoryIngestor } from "../memory/ingestion.ts";
 import { createPreRecall, type PreRecallFn } from "../memory/pre-recall.ts";
@@ -80,6 +84,7 @@ export class SessionManager {
   private config: Config;
   private handles = new Map<string, SpawnHandle>();
   private seenMessages = new Set<string>();
+  private worktreeSetups = new Map<string, Promise<string>>();
   private spawnRunner: SpawnRunnerFn;
   private drivers: DriverMap;
   private memoryIngestor?: MemoryIngestor;
@@ -1295,6 +1300,7 @@ export class SessionManager {
         throw new RunOwnershipChangedError();
       }
     };
+    let runnerStarted = false;
     try {
       assertRunOwnership();
       let agentSession = isTopLevel
@@ -1303,37 +1309,127 @@ export class SessionManager {
       const agentIdentity = identityForAgent(agentName);
       const rawMessage = prompt;
 
-      // Reviewers run checks only in Junior-managed worktrees. Route each PR
-      // URL to its repo-specific worktree, and fall back to a pipeline repo ref
-      // only when the run names exactly one configured repo. This also lets one
-      // Slack session review PRs across different repositories without reusing
-      // the wrong checkout.
-      if (agentName === "review" && this.worktreeManager) {
-        let pipelineRepoRefs: string[] = [];
-        if (session.activePipelineRunId && this.pipelineStore) {
-          try {
-            const activeRun = await this.pipelineStore.getRun(
-              session.activePipelineRunId,
-            );
-            pipelineRepoRefs = activeRun?.repoRefs ?? [];
-          } catch (err) {
-            _log.warn(
-              "manager",
-              `review repo inference failed for pipeline ${session.activePipelineRunId}: ${err instanceof Error ? err.message : String(err)}`,
-            );
-          }
+      const pipelineInvocation = isTopLevel
+        ? session.activePipelineInvocation
+        : agentSession?.activePipelineInvocation;
+      const pipelineRunId =
+        pipelineInvocation?.runId ?? session.activePipelineRunId;
+      let activePipelineRun = pipelineRunId && this.pipelineStore
+        ? await this.pipelineStore.getRun(pipelineRunId)
+        : undefined;
+      if (activePipelineRun?.status === "terminal") {
+        activePipelineRun = undefined;
+      }
+      const activePipelineAssignment =
+        pipelineInvocation && this.pipelineStore
+          ? await this.pipelineStore.getAssignment(
+              pipelineInvocation.assignmentId,
+            )
+          : undefined;
+      assertRunOwnership();
+
+      // An explicit PR URL is the strongest repo-affinity signal for review.
+      // Outside a pipeline this preserves the existing review routing; inside
+      // one it also selects which of the provisioned repo worktrees is primary.
+      const inferredReviewRepo = agentName === "review"
+        ? inferReviewRepo(
+            this.config.repos,
+            prompt,
+            activePipelineRun?.repoRefs ?? [],
+          )
+        : undefined;
+
+      if (activePipelineRun) {
+        // Durable repo refs, not a developer checkout or stale session cwd,
+        // define the pipeline workspace. Provision every referenced repo so
+        // fan-out agents can collaborate through the injected path map.
+        if (!this.worktreeManager) {
+          throw new Error(
+            `Pipeline ${activePipelineRun.id.slice(0, 8)} cannot run: worktree manager is unavailable.`,
+          );
         }
-        assertRunOwnership();
-        const inferredRepo = inferReviewRepo(
+
+        const resolution = resolvePipelineRepos(
           this.config.repos,
-          prompt,
-          pipelineRepoRefs,
+          activePipelineRun.repoRefs,
         );
-        if (inferredRepo && session.targetRepo !== inferredRepo.name) {
+        if (resolution.unresolvedRefs.length > 0) {
+          throw new Error(
+            `Pipeline ${activePipelineRun.id.slice(0, 8)} cannot run: repository refs are not uniquely configured: ${resolution.unresolvedRefs.join(", ")}.`,
+          );
+        }
+
+        const pipelineRepos = [...resolution.repos];
+        const addRepo = (repo: Config["repos"][number] | undefined) => {
+          if (repo && !pipelineRepos.some((item) => item.name === repo.name)) {
+            pipelineRepos.push(repo);
+          }
+        };
+        addRepo(inferredReviewRepo);
+        if (
+          activePipelineRun.repoRefs.length === 0 &&
+          pipelineRepos.length === 0
+        ) {
+          addRepo(
+            session.targetRepo
+              ? this.config.repos.find(
+                  (repo) => repo.name === session.targetRepo,
+                )
+              : undefined,
+          );
+        }
+        if (pipelineRepos.length === 0) {
+          throw new Error(
+            `Pipeline ${activePipelineRun.id.slice(0, 8)} cannot run without a configured repository and isolated worktree.`,
+          );
+        }
+
+        const primaryRepo = inferPipelinePrimaryRepo({
+          configuredRepos: this.config.repos,
+          pipelineRepos,
+          prompt,
+          targetAgent: agentName,
+          assignmentContextRefs: activePipelineAssignment?.contextRefs,
+        });
+        if (!primaryRepo) {
+          throw new Error(
+            `Pipeline ${activePipelineRun.id.slice(0, 8)} cannot choose an isolated worktree.`,
+          );
+        }
+
+        const provisioned = await Promise.all(
+          pipelineRepos.map(async (repo) => [
+            repo.name,
+            await this.ensurePipelineWorktree(
+              repo.name,
+              session.threadId,
+              session.baseRef ?? undefined,
+            ),
+          ] as const),
+        );
+        assertRunOwnership();
+        const provisionedPaths = Object.fromEntries(provisioned);
+        session = await this.mutateSession(session.threadId, (fresh) => {
+          assertRunOwnership();
+          fresh.worktreePaths = {
+            ...fresh.worktreePaths,
+            ...provisionedPaths,
+          };
+          fresh.targetRepo = primaryRepo.name;
+          fresh.worktreePath = provisionedPaths[primaryRepo.name] ?? null;
+          // Utility commands can leave an explicit cwd on the thread. Once a
+          // durable pipeline owns the turn, persistently clear that override
+          // so provider cold starts and recovery continuations also stay in
+          // the managed worktree.
+          fresh.cwd = null;
+        });
+      } else if (inferredReviewRepo && this.worktreeManager) {
+        if (session.targetRepo !== inferredReviewRepo.name) {
           session = await this.mutateSession(session.threadId, (fresh) => {
             assertRunOwnership();
-            fresh.targetRepo = inferredRepo.name;
-            fresh.worktreePath = fresh.worktreePaths[inferredRepo.name] ?? null;
+            fresh.targetRepo = inferredReviewRepo.name;
+            fresh.worktreePath =
+              fresh.worktreePaths[inferredReviewRepo.name] ?? null;
           });
         }
       }
@@ -1689,6 +1785,7 @@ export class SessionManager {
           imagePaths,
         );
       }
+      runnerStarted = true;
       let attemptedResumeId = runSession.sessionId;
       const handle = withTimeout(
         rawHandle,
@@ -1987,6 +2084,37 @@ export class SessionManager {
       if (expectedHandle && this.handles.get(reservationKey) !== expectedHandle) {
         return;
       }
+      let fatalMessage = err instanceof Error ? err.message : String(err);
+      if (!runnerStarted && expectedHandle && this.pipelineStore) {
+        const setupResult = await this.resolvePipelineInvocation(
+          session,
+          agentName,
+          {
+            provider: sessionProvider(
+              this.buildRunSession(
+                session,
+                agentName,
+                identityForAgent(agentName),
+              ),
+              this.config,
+            ),
+            sessionId: null,
+            response: "",
+            events: [],
+            exitCode: null,
+            error: fatalMessage,
+            completion: {
+              status: "failure",
+              reason: "provider_error",
+              retryable: false,
+            },
+          },
+          expectedHandle,
+          session.worktreePath ?? process.cwd(),
+        );
+        if (!setupResult) return;
+        fatalMessage = setupResult.error ?? fatalMessage;
+      }
       if (expectedHandle) this.handles.delete(reservationKey);
       // Agent prompt composition or worktree creation failed fatally
       try {
@@ -2000,7 +2128,7 @@ export class SessionManager {
           }
           fresh.lastError = {
             type: "setup",
-            message: err instanceof Error ? err.message : String(err),
+            message: fatalMessage,
             timestamp: Date.now(),
           };
         });
@@ -2950,6 +3078,49 @@ export class SessionManager {
         "manager",
         `review verification disabled: package manager is absent or ambiguous in ${runSession.worktreePath}`,
       );
+    }
+  }
+
+  /**
+   * Return the deterministic Junior-managed worktree for a pipeline repo.
+   * Concurrent fan-out can dispatch multiple agents before the first setup
+   * finishes, so coalesce creation per repo/thread instead of racing two
+   * `git worktree add` processes against the same path and branch.
+   */
+  private async ensurePipelineWorktree(
+    repoName: string,
+    threadId: string,
+    baseRef?: string,
+  ): Promise<string> {
+    const manager = this.worktreeManager;
+    if (!manager) throw new Error("worktree manager is unavailable");
+
+    const expectedPath = manager.getWorktreePath(repoName, threadId);
+    if (await manager.worktreeExists(repoName, threadId)) {
+      return expectedPath;
+    }
+
+    const key = `${repoName}:${threadId}`;
+    const existing = this.worktreeSetups.get(key);
+    if (existing) return existing;
+
+    const setup = manager.createWorktree(repoName, threadId, baseRef).then(
+      (createdPath) => {
+        if (createdPath !== expectedPath) {
+          throw new Error(
+            `worktree setup returned ${createdPath}; expected managed path ${expectedPath}`,
+          );
+        }
+        return createdPath;
+      },
+    );
+    this.worktreeSetups.set(key, setup);
+    try {
+      return await setup;
+    } finally {
+      if (this.worktreeSetups.get(key) === setup) {
+        this.worktreeSetups.delete(key);
+      }
     }
   }
 

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -1385,6 +1385,13 @@ export class SessionManager {
             "manager",
             `pipeline.workspace.skip thread=${session.threadId} run=${activePipelineRun.id} assignment=${pipelineInvocation.assignmentId} agent=${agentName} reason=repo-less-orchestration`,
           );
+          session = await this.mutateSession(session.threadId, (fresh) => {
+            assertRunOwnership();
+            // A prior utility command may have pinned the thread to an
+            // arbitrary cwd. Repo-less pipeline work belongs in Junior's
+            // workspace, not that stale override.
+            fresh.cwd = null;
+          });
         } else {
           if (!this.worktreeManager) {
             throw new Error(

--- a/src/worktree/pipeline-routing.test.ts
+++ b/src/worktree/pipeline-routing.test.ts
@@ -25,6 +25,7 @@ describe("pipeline worktree routing", () => {
         "GrowthX-Club/gx-admin-client",
         "gx-backend",
         "GrowthX-Club/not-configured",
+        "GrowthX-Club/not-configured",
         "gx-admin-client",
       ]),
     ).toEqual({
@@ -53,6 +54,54 @@ describe("pipeline worktree routing", () => {
         assignmentContextRefs: ["workstream:backend"],
       })?.name,
     ).toBe("gx-backend");
+  });
+
+  it("does not let an incidental PR URL override a build workstream", () => {
+    expect(
+      inferPipelinePrimaryRepo({
+        configuredRepos: repos,
+        pipelineRepos: repos,
+        prompt:
+          "fix the backend while preserving context from https://github.com/GrowthX-Club/gx-admin-client/pull/42",
+        targetAgent: "build",
+        assignmentContextRefs: ["workstream:backend"],
+      })?.name,
+    ).toBe("gx-backend");
+  });
+
+  it("reports ambiguous affinities before falling back to durable repo order", () => {
+    const diagnostics: string[] = [];
+    const selected = inferPipelinePrimaryRepo({
+      configuredRepos: repos,
+      pipelineRepos: [repos[1]!, repos[0]!],
+      prompt: "coordinate both streams",
+      targetAgent: "build",
+      assignmentContextRefs: ["workstream:frontend", "workstream:backend"],
+      onDiagnostic: (message) => diagnostics.push(message),
+    });
+
+    expect(selected?.name).toBe("gx-admin-client");
+    expect(diagnostics).toEqual([
+      "multiple assignment workstreams (frontend, backend); falling back to durable repo order",
+      "no unique repo affinity for a multi-repo pipeline; falling back to durable repo order",
+    ]);
+  });
+
+  it("reports a missing workstream match before falling back", () => {
+    const diagnostics: string[] = [];
+    const selected = inferPipelinePrimaryRepo({
+      configuredRepos: repos,
+      pipelineRepos: repos,
+      prompt: "implement the mobile stream",
+      targetAgent: "build",
+      assignmentContextRefs: ["workstream:mobile"],
+      onDiagnostic: (message) => diagnostics.push(message),
+    });
+
+    expect(selected?.name).toBe("gx-backend");
+    expect(diagnostics).toEqual([
+      "no pipeline repo matches mobile affinity; falling back to durable repo order",
+    ]);
   });
 
   it("lets an explicit PR URL choose the initial worktree", () => {

--- a/src/worktree/pipeline-routing.test.ts
+++ b/src/worktree/pipeline-routing.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "bun:test";
+import type { RepoConfig } from "../config.ts";
+import {
+  inferPipelinePrimaryRepo,
+  resolvePipelineRepos,
+} from "./pipeline-routing.ts";
+
+const repos: RepoConfig[] = [
+  {
+    name: "gx-backend",
+    path: "/repos/gx-backend",
+    defaultBase: "origin/main",
+  },
+  {
+    name: "gx-admin-client",
+    path: "/repos/gx-admin-client",
+    defaultBase: "origin/main",
+  },
+];
+
+describe("pipeline worktree routing", () => {
+  it("resolves repo refs in durable run order and reports unknown refs", () => {
+    expect(
+      resolvePipelineRepos(repos, [
+        "GrowthX-Club/gx-admin-client",
+        "gx-backend",
+        "GrowthX-Club/not-configured",
+        "gx-admin-client",
+      ]),
+    ).toEqual({
+      repos: [repos[1], repos[0]],
+      unresolvedRefs: ["GrowthX-Club/not-configured"],
+    });
+  });
+
+  it("routes frontend and backend workstreams to their own repo", () => {
+    expect(
+      inferPipelinePrimaryRepo({
+        configuredRepos: repos,
+        pipelineRepos: repos,
+        prompt: "implement the assigned stream",
+        targetAgent: "build",
+        assignmentContextRefs: ["workstream:frontend"],
+      })?.name,
+    ).toBe("gx-admin-client");
+
+    expect(
+      inferPipelinePrimaryRepo({
+        configuredRepos: repos,
+        pipelineRepos: repos,
+        prompt: "implement the assigned stream",
+        targetAgent: "build",
+        assignmentContextRefs: ["workstream:backend"],
+      })?.name,
+    ).toBe("gx-backend");
+  });
+
+  it("lets an explicit PR URL choose the initial worktree", () => {
+    expect(
+      inferPipelinePrimaryRepo({
+        configuredRepos: repos,
+        pipelineRepos: repos,
+        prompt:
+          "review https://github.com/GrowthX-Club/gx-admin-client/pull/42",
+        targetAgent: "review",
+      })?.name,
+    ).toBe("gx-admin-client");
+  });
+});

--- a/src/worktree/pipeline-routing.ts
+++ b/src/worktree/pipeline-routing.ts
@@ -18,11 +18,15 @@ export function resolvePipelineRepos(
   const resolved: RepoConfig[] = [];
   const unresolvedRefs: string[] = [];
   const seen = new Set<string>();
+  const seenUnresolved = new Set<string>();
 
   for (const ref of repoRefs) {
     const matches = repos.filter((repo) => repoMatchesRef(repo.name, ref));
     if (matches.length !== 1) {
-      unresolvedRefs.push(ref);
+      if (!seenUnresolved.has(ref)) {
+        seenUnresolved.add(ref);
+        unresolvedRefs.push(ref);
+      }
       continue;
     }
     const repo = matches[0]!;
@@ -37,8 +41,9 @@ export function resolvePipelineRepos(
 
 /**
  * Pick the pipeline worktree used as the process cwd. Every resolved repo gets
- * its own worktree; this only chooses the initial checkout. Explicit PR URLs
- * win, then assignment workstream/agent affinity, then durable repo order.
+ * its own worktree; this only chooses the initial checkout. Review assignments
+ * prefer an explicit PR URL. Other agents prefer durable assignment
+ * workstream/agent affinity so incidental URLs in context cannot reroute them.
  */
 export function inferPipelinePrimaryRepo(input: {
   configuredRepos: RepoConfig[];
@@ -46,26 +51,49 @@ export function inferPipelinePrimaryRepo(input: {
   prompt: string;
   targetAgent: string;
   assignmentContextRefs?: string[];
+  onDiagnostic?: (message: string) => void;
 }): RepoConfig | undefined {
-  const explicit = inferReviewRepo(input.configuredRepos, input.prompt);
-  if (
-    explicit &&
-    input.pipelineRepos.some((repo) => repo.name === explicit.name)
-  ) {
-    return explicit;
+  if (input.targetAgent === "review") {
+    const explicit = inferReviewRepo(input.configuredRepos, input.prompt);
+    if (
+      explicit &&
+      input.pipelineRepos.some((repo) => repo.name === explicit.name)
+    ) {
+      return explicit;
+    }
   }
 
-  const workstream = input.assignmentContextRefs
-    ?.find((ref) => ref.startsWith("workstream:"))
-    ?.slice("workstream:".length)
-    .trim()
-    .toLowerCase();
-  const affinity = workstream || agentWorkstream(input.targetAgent);
+  const workstreams = [
+    ...new Set(
+      (input.assignmentContextRefs ?? [])
+        .filter((ref) => ref.startsWith("workstream:"))
+        .map((ref) => ref.slice("workstream:".length).trim().toLowerCase())
+        .filter(Boolean),
+    ),
+  ];
+  if (workstreams.length > 1) {
+    input.onDiagnostic?.(
+      `multiple assignment workstreams (${workstreams.join(", ")}); falling back to durable repo order`,
+    );
+  }
+  const workstream = workstreams.length === 1 ? workstreams[0] : undefined;
+  const affinity = workstreams.length > 1
+    ? undefined
+    : workstream || agentWorkstream(input.targetAgent);
   if (affinity) {
     const matches = input.pipelineRepos.filter((repo) =>
       repoMatchesWorkstream(repo.name, affinity)
     );
     if (matches.length === 1) return matches[0];
+    input.onDiagnostic?.(
+      matches.length === 0
+        ? `no pipeline repo matches ${affinity} affinity; falling back to durable repo order`
+        : `${matches.length} pipeline repos match ${affinity} affinity; falling back to durable repo order`,
+    );
+  } else if (input.pipelineRepos.length > 1) {
+    input.onDiagnostic?.(
+      "no unique repo affinity for a multi-repo pipeline; falling back to durable repo order",
+    );
   }
 
   return input.pipelineRepos[0];

--- a/src/worktree/pipeline-routing.ts
+++ b/src/worktree/pipeline-routing.ts
@@ -1,0 +1,93 @@
+import type { RepoConfig } from "../config.ts";
+import { inferReviewRepo, repoMatchesRef } from "./review-routing.ts";
+
+export type PipelineRepoResolution = {
+  repos: RepoConfig[];
+  unresolvedRefs: string[];
+};
+
+/**
+ * Resolve durable pipeline repo refs to configured repositories while
+ * preserving the run's order. Unknown refs are returned explicitly so callers
+ * can fail closed instead of falling back to a developer checkout.
+ */
+export function resolvePipelineRepos(
+  repos: RepoConfig[],
+  repoRefs: string[],
+): PipelineRepoResolution {
+  const resolved: RepoConfig[] = [];
+  const unresolvedRefs: string[] = [];
+  const seen = new Set<string>();
+
+  for (const ref of repoRefs) {
+    const matches = repos.filter((repo) => repoMatchesRef(repo.name, ref));
+    if (matches.length !== 1) {
+      unresolvedRefs.push(ref);
+      continue;
+    }
+    const repo = matches[0]!;
+    if (!seen.has(repo.name)) {
+      seen.add(repo.name);
+      resolved.push(repo);
+    }
+  }
+
+  return { repos: resolved, unresolvedRefs };
+}
+
+/**
+ * Pick the pipeline worktree used as the process cwd. Every resolved repo gets
+ * its own worktree; this only chooses the initial checkout. Explicit PR URLs
+ * win, then assignment workstream/agent affinity, then durable repo order.
+ */
+export function inferPipelinePrimaryRepo(input: {
+  configuredRepos: RepoConfig[];
+  pipelineRepos: RepoConfig[];
+  prompt: string;
+  targetAgent: string;
+  assignmentContextRefs?: string[];
+}): RepoConfig | undefined {
+  const explicit = inferReviewRepo(input.configuredRepos, input.prompt);
+  if (
+    explicit &&
+    input.pipelineRepos.some((repo) => repo.name === explicit.name)
+  ) {
+    return explicit;
+  }
+
+  const workstream = input.assignmentContextRefs
+    ?.find((ref) => ref.startsWith("workstream:"))
+    ?.slice("workstream:".length)
+    .trim()
+    .toLowerCase();
+  const affinity = workstream || agentWorkstream(input.targetAgent);
+  if (affinity) {
+    const matches = input.pipelineRepos.filter((repo) =>
+      repoMatchesWorkstream(repo.name, affinity)
+    );
+    if (matches.length === 1) return matches[0];
+  }
+
+  return input.pipelineRepos[0];
+}
+
+function agentWorkstream(agent: string): "backend" | "frontend" | null {
+  if (agent === "frontend") return "frontend";
+  if (agent === "build") return "backend";
+  return null;
+}
+
+function repoMatchesWorkstream(repoName: string, workstream: string): boolean {
+  const normalized = repoName.toLowerCase();
+  if (workstream === "frontend") {
+    return /(?:^|[-_/])(client|frontend|web|admin|expo|next)(?:$|[-_/])/.test(
+      normalized,
+    );
+  }
+  if (workstream === "backend") {
+    return /(?:^|[-_/])(backend|api|service|server)(?:$|[-_/])/.test(
+      normalized,
+    );
+  }
+  return false;
+}

--- a/src/worktree/review-routing.ts
+++ b/src/worktree/review-routing.ts
@@ -25,7 +25,7 @@ export function inferReviewRepo(
   return refMatches.length === 1 ? refMatches[0] : undefined;
 }
 
-function repoMatchesRef(repoName: string, ref: string): boolean {
+export function repoMatchesRef(repoName: string, ref: string): boolean {
   const normalized = ref.trim().replace(/\.git$/i, "").replace(/\/+$/, "");
   return (
     normalized.toLowerCase() === repoName.toLowerCase() ||
@@ -36,4 +36,3 @@ function repoMatchesRef(repoName: string, ref: string): boolean {
 function escapeRegExp(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }
-


### PR DESCRIPTION
## Summary
- resolve every durable pipeline repo ref before dispatch
- provision and persist one Junior-managed worktree per repo/thread
- select the invocation cwd by review and durable workstream affinity
- coalesce concurrent setup and fail closed with a durable, recoverable escalation
- keep recovery continuations in the same managed worktree
- allow repo-less planner/orchestrator assignments while keeping human recovery turns usable
- synchronize public agent prompts and worktree documentation

## Why
Pipeline agents must not run in the developer main checkout or inherit a stale utility cwd. Multi-repo runs also need every referenced repo provisioned before fan-out.

## Review fixes
- prevent repo-less and unknown-repo failures from wedging the thread
- contain pipeline-store errors during pre-spawn settlement
- keep incidental PR URLs from rerouting non-review agents
- diagnose ambiguous workstream affinity and dedupe unresolved refs
- clear stale utility cwd for repo-less orchestration

## Validation
Two consecutive clean passes on the final head:
- `git diff --check`
- `bun run typecheck`
- `bun test` — 1,290 passed, 2 expected embedding skips, 0 failed, 3,938 assertions

## Runtime note
The currently running Junior process was not restarted.