### PR TITLE
Reopen product pipelines after dev regressions

### DIFF
--- a/.claude/agents/common/product-pipeline.md
+++ b/.claude/agents/common/product-pipeline.md
@@ -10,6 +10,8 @@ Generic rules already loaded are not restated: memory (core), Task-vs-directive 
 discovery → spec-drafting → awaiting-product-decision → ready-to-build
 → building → aggregate-verification → pr-open → reviewing ↔ fixing
 → approved → ready-for-human-merge → shipped | needs-human | abandoned
+
+approved | ready-for-human-merge → fixing (when dev/staging verification finds a regression)
 ```
 
 | Phase | Who acts | Exit |
@@ -24,7 +26,7 @@ discovery → spec-drafting → awaiting-product-decision → ready-to-build
 | reviewing | review (read-only) | typed verdict: approved \| changes_requested |
 | fixing | responsible builder | new revision digest; gates reopen |
 | approved | orchestrator | all required gates on same attempt/SHA |
-| ready-for-human-merge | human | protected-branch merges; then shipped |
+| ready-for-human-merge | human | verify the dev/staging merge; ship after the protected main merge, or reopen fixing on a regression |
 
 ## Ownership (non-negotiable)
 
@@ -50,6 +52,8 @@ Register every PR with exact owner/repo/number/role/workstreamKey/expectedHeadSh
 ## Review ↔ rework
 
 Changes requested → responsible builder. Unchanged findings without a new revision or evidence → escalate (no infinite loop). New revision → re-review on the new digest.
+
+Dev/staging verification is also a rework gate. If a regression is discovered after the secondary dev PR merges, hand off the responsible builder with `to_phase="fixing"` and an exact `dev-verification:<message-or-artifact-ref>` (or `staging-verification:`) evidence ref; untyped tool/agent failures must wait or escalate and cannot reopen an approved candidate. Reopen the same run rather than starting a disconnected pipeline. The controller atomically invalidates the approved revision gates and archives the old dev-PR association. Update the still-open primary main PR with the fix, register its new head SHA, run aggregate verification and review again, then open and merge a fresh secondary dev PR for the new revision. A merged dev PR is historical evidence and cannot represent later commits. Once the run is `shipped` or `abandoned`, create a separate follow-up instead of reopening it.
 
 ## Outcomes
 

--- a/src/mcp/slack-server.ts
+++ b/src/mcp/slack-server.ts
@@ -743,13 +743,16 @@ function registerTools(server: McpServer, runContext: SlackMcpRunContext | null 
         reason: z.string().optional().describe("Why this agent/ownership transition is needed"),
         idempotency_key: z.string().min(1).describe("Stable semantic key reused on retries"),
         to_phase: z.string().optional().describe("Optional legal controller phase for a handoff"),
+        evidence_refs: z.array(z.string()).optional().describe("Durable evidence references supporting the transition"),
+        artifact_refs: z.array(z.string()).optional().describe("Durable artifact references inherited by the child assignment"),
+        acceptance_criteria: z.array(z.string()).optional().describe("Acceptance criteria for the child assignment"),
         channel_id: z.string().optional().describe("Deprecated; authenticated channel is derived from signed context"),
         thread_ts: z.string().optional().describe("Deprecated; authenticated thread is derived from signed context"),
         user_id: z.string().optional().describe("User id to record on the synthetic internal event (default: mcp-internal)"),
         trigger_ts: z.string().optional().describe("Slack message timestamp that caused the dispatch. Defaults to thread_ts."),
       },
     },
-    async ({ agent_name, prompt, mode, reason, idempotency_key, to_phase, channel_id, thread_ts, user_id, trigger_ts }) => {
+    async ({ agent_name, prompt, mode, reason, idempotency_key, to_phase, evidence_refs, artifact_refs, acceptance_criteria, channel_id, thread_ts, user_id, trigger_ts }) => {
       if (!sessionManager) {
         return { content: [{ type: "text" as const, text: "Error: session manager not available" }] };
       }
@@ -782,6 +785,9 @@ function registerTools(server: McpServer, runContext: SlackMcpRunContext | null 
           reason: reason?.trim() || `${runContext.agent} dispatched ${targetAgent}`,
           idempotency_key: idempotency_key.trim(),
           to_phase,
+          evidence_refs,
+          artifact_refs,
+          acceptance_criteria,
         });
       }
       if (pipelineRuntime && session?.activeRunId) {

--- a/src/pipelines/product/controller.test.ts
+++ b/src/pipelines/product/controller.test.ts
@@ -10,6 +10,7 @@ import {
   ensureProductRevisionGates,
   fanOutBuilders,
   loadSkipReasons,
+  mergedDevPrCoverage,
   reduceProductOutcome,
   registerProductPr,
   shouldCreateProductRun,
@@ -515,6 +516,54 @@ describe("backend feature → ready-for-human-merge", () => {
     version = r.runVersion;
     expect((await store.getRun(run.id))?.phase).toBe("approved");
 
+    await store.commitPrRegistration({
+      registration: {
+        runId: run.id,
+        assignmentId: reviewer.id,
+        owner: "acme",
+        repo: "example-backend",
+        number: 43,
+        role: "dev-pr",
+        workstreamKey: "backend",
+        attemptId,
+        expectedHeadSha: "sha-be-1",
+      },
+      actorId: "default",
+      runPhase: "approved",
+      now: clock.now(),
+    });
+    expect(
+      (await store.listPipelineGitHubResources(run.id, true)).some(
+        (association) => association.role === "dev-pr",
+      ),
+    ).toBe(true);
+    const devAssociation = (
+      await store.listPipelineGitHubResources(run.id, true)
+    ).find((association) => association.role === "dev-pr")!;
+    const devResource = await store.getGitHubResource(
+      devAssociation.resourceId,
+    );
+    if (!devResource) throw new Error("missing dev PR resource");
+    await store.upsertGitHubResource({
+      ...devResource,
+      snapshot: {
+        state: "MERGED",
+        isDraft: false,
+        baseRefName: "dev",
+        headRefName: "feat/invites",
+        headRefOid: "sha-be-1",
+        reviewDecision: "APPROVED",
+        mergeable: "MERGEABLE",
+        mergedAt: "2026-07-21T00:00:00Z",
+        closedAt: null,
+        checkRollup: "SUCCESS",
+        checkRollupSha: "sha-be-1",
+        updatedAt: "2026-07-21T00:00:00Z",
+      },
+      terminalAt: clock.now(),
+      updatedAt: clock.now(),
+    });
+
     const mergeCoord = await store.createAssignment(
       makeAssignmentCreate({
         id: "asg-merge-gate",
@@ -541,6 +590,131 @@ describe("backend feature → ready-for-human-merge", () => {
     });
     expect(r.status).toBe("accepted");
     expect((await store.getRun(run.id))?.phase).toBe("ready-for-human-merge");
+
+    const qaReopen = await store.createAssignment(
+      makeAssignmentCreate({
+        id: "asg-dev-qa",
+        runId: run.id,
+        sourceAgent: "human",
+        targetAgent: "default",
+        objective: "investigate a regression discovered after the dev merge",
+        attemptId,
+        candidateRevisionDigest: "d1",
+        idempotencyKey: "dev-qa-1",
+        status: "leased",
+      }),
+    );
+
+    const devRegressionOutcome = (expectedRunVersion: number) =>
+      baseOutcome({
+        assignmentId: qaReopen.id,
+        expectedRunVersion,
+        action: "handoff",
+        status: "progress",
+        targetAgent: "build",
+        reason: "dev verification found a regression",
+        evidenceRefs: ["dev-verification:slack:dev-regression-1"],
+        progressFingerprint: "dev-regression-1",
+        checks: [
+          {
+            name: "dev-verification",
+            status: "failed",
+            evidenceRef: "slack:dev-regression-1",
+          },
+        ],
+        nextAssignment: {
+          parentAssignmentId: qaReopen.id,
+          targetAgent: "build",
+          objective: "fix the regression discovered in dev verification",
+          contextRefs: [],
+          artifactRefs: [],
+          acceptanceCriteria: ["dev regression no longer reproduces"],
+          mutationScope: ["worktree-code"],
+          dependsOn: [],
+          attempt: 1,
+          attemptId,
+          candidateRevisionDigest: "d1",
+          deadlineAt: null,
+          idempotencyKey: "dev-regression-1:next",
+        },
+      });
+
+    const untypedFailure = await reduceProductOutcome(cfg(store, clock), {
+      actorId: "default",
+      toPhase: "fixing",
+      outcome: baseOutcome({
+        assignmentId: qaReopen.id,
+        expectedRunVersion: r.runVersion,
+        action: "handoff",
+        status: "progress",
+        targetAgent: "build",
+        reason: "a tool failed",
+        progressFingerprint: "untyped-tool-failure",
+        nextAssignment: {
+          parentAssignmentId: qaReopen.id,
+          targetAgent: "build",
+          objective: "retry after tool failure",
+          contextRefs: [],
+          artifactRefs: [],
+          acceptanceCriteria: [],
+          mutationScope: ["worktree-code"],
+          dependsOn: [],
+          attempt: 1,
+          attemptId,
+          candidateRevisionDigest: "d1",
+          deadlineAt: null,
+          idempotencyKey: "untyped-tool-failure:next",
+        },
+      }),
+    });
+    expect(untypedFailure.status).toBe("rejected");
+    expect(untypedFailure.reason).toMatch(/dev-verification/i);
+    expect((await store.getRun(run.id))?.phase).toBe("ready-for-human-merge");
+
+    const stale = await reduceProductOutcome(cfg(store, clock), {
+      actorId: "default",
+      toPhase: "fixing",
+      outcome: devRegressionOutcome(r.runVersion - 1),
+    });
+    expect(stale.status).toBe("rejected");
+    expect(
+      (await store.listGates(attemptId)).every(
+        (gate) => gate.status === "passed",
+      ),
+    ).toBe(true);
+
+    r = await reduceProductOutcome(cfg(store, clock), {
+      actorId: "default",
+      toPhase: "fixing",
+      outcome: devRegressionOutcome(r.runVersion),
+    });
+
+    expect(r.status).toBe("accepted");
+    expect((await store.getRun(run.id))?.phase).toBe("fixing");
+    expect(
+      (await store.listAssignments(run.id)).some(
+        (candidate) =>
+          candidate.parentAssignmentId === qaReopen.id &&
+          candidate.targetAgent === "build" &&
+          candidate.status === "pending",
+      ),
+    ).toBe(true);
+    expect(
+      (await store.listGates(attemptId)).every(
+        (gate) => gate.status === "invalidated",
+      ),
+    ).toBe(true);
+    expect(
+      (await store.listPipelineGitHubResources(run.id, true)).some(
+        (association) => association.role === "dev-pr",
+      ),
+    ).toBe(false);
+    expect(
+      (await store.listPipelineGitHubResources(run.id)).some(
+        (association) =>
+          association.role === "dev-pr" && association.active === false,
+      ),
+    ).toBe(true);
   });
 });
 
@@ -756,22 +930,10 @@ describe("review → fix → new revision → re-review", () => {
     expect(rev2.digest).not.toBe(rev1.digest);
     expect(rev2.invalidatedGateCount).toBeGreaterThanOrEqual(0);
 
-    await ensureProductRevisionGates(store, {
-      runId: created.run.id,
-      attemptId,
-      subjectSha: "bbb222",
-    });
-    for (const g of await store.listGates(attemptId)) {
-      if (g.status !== "invalidated") {
-        await store.upsertGate({ ...g, status: "passed", subjectSha: "bbb222" });
-      }
-    }
-    // Fresh gates for re-review
     const freshGates = await ensureProductRevisionGates(store, {
       runId: created.run.id,
       attemptId,
       subjectSha: "bbb222",
-      memberKey: "rework",
     });
     for (const g of freshGates) {
       await store.upsertGate({ ...g, status: "passed" });
@@ -959,6 +1121,50 @@ describe("unchanged findings escalate", () => {
 });
 
 describe("multi-PR same repo tracked separately", () => {
+  it("does not let dev PR workstreams satisfy each other's revision SHA", () => {
+    const members = [
+      {
+        memberKey: "backend",
+        repoRef: "example-backend",
+        branch: "feat/x",
+        headSha: "sha-backend",
+      },
+      {
+        memberKey: "frontend",
+        repoRef: "example-frontend",
+        branch: "feat/x",
+        headSha: "sha-frontend",
+      },
+    ];
+    const swapped = mergedDevPrCoverage(members, [
+      {
+        workstreamKey: "backend",
+        expectedHeadSha: "sha-frontend",
+        mergedHeadSha: "sha-frontend",
+      },
+      {
+        workstreamKey: "frontend",
+        expectedHeadSha: "sha-backend",
+        mergedHeadSha: "sha-backend",
+      },
+    ]);
+    expect(swapped.size).toBe(0);
+
+    const exact = mergedDevPrCoverage(members, [
+      {
+        workstreamKey: "backend",
+        expectedHeadSha: "sha-backend",
+        mergedHeadSha: "sha-backend",
+      },
+      {
+        workstreamKey: "frontend",
+        expectedHeadSha: "sha-frontend",
+        mergedHeadSha: "sha-frontend",
+      },
+    ]);
+    expect([...exact].sort()).toEqual(["backend", "frontend"]);
+  });
+
   it("registers two PRs in one repo with distinct workstream keys", async () => {
     const clock = fakeClock(1000);
     const store = new InMemoryPipelineStore(clock);
@@ -1060,7 +1266,7 @@ describe("multi-PR same repo tracked separately", () => {
       createdAt: 1000,
       finishedAt: null,
     });
-    await updateProductRevision(cfg(store), {
+    const initialRevision = await updateProductRevision(cfg(store), {
       attemptId,
       members: [
         {
@@ -1082,12 +1288,25 @@ describe("multi-PR same repo tracked separately", () => {
       attemptId,
       subjectSha: "aaa",
     });
+    expect(revisionGatesConsistent([]).ok).toBe(false);
+    const currentMembers = await store.listRevisionMembers(attemptId);
+    expect(
+      revisionGatesConsistent(
+        gates,
+        currentMembers,
+        initialRevision.digest,
+      ).ok,
+    ).toBe(false);
     for (const g of gates) {
       await store.upsertGate({ ...g, status: "passed" });
     }
-    expect(revisionGatesConsistent(await store.listGates(attemptId)).ok).toBe(
-      true,
-    );
+    expect(
+      revisionGatesConsistent(
+        await store.listGates(attemptId),
+        currentMembers,
+        initialRevision.digest,
+      ).ok,
+    ).toBe(true);
 
     // Change one member in same repo
     const result = await updateProductRevision(cfg(store), {
@@ -1163,6 +1382,22 @@ describe("phase suggestions", () => {
         reviewVerdict: "changes_requested",
       }),
     ).toBe("fixing");
+  });
+
+  it("suggests fixing when dev verification fails after approval", () => {
+    expect(
+      suggestPhaseAfterOutcome({
+        currentPhase: "ready-for-human-merge",
+        outcomeStatus: "failed",
+        devVerificationFailed: true,
+      }),
+    ).toBe("fixing");
+    expect(
+      suggestPhaseAfterOutcome({
+        currentPhase: "ready-for-human-merge",
+        outcomeStatus: "failed",
+      }),
+    ).toBeNull();
   });
 
   it("stays building when fan-out incomplete", () => {

--- a/src/pipelines/product/controller.ts
+++ b/src/pipelines/product/controller.ts
@@ -671,7 +671,18 @@ export async function reduceProductOutcome(
   const completedBuilders = builders.filter((a) => a.status === "completed");
 
   const skipReasons = await loadSkipReasons(store, run.id);
-  const registeredPrKeys = await loadRegisteredPrKeys(store, run.id);
+  const revisionMembers = run.activeAttemptId
+    ? await store.listRevisionMembers(run.activeAttemptId)
+    : [];
+  const activeAttempt = run.activeAttemptId
+    ? await store.getAttempt(run.activeAttemptId)
+    : undefined;
+  const registeredPrKeys = await loadRegisteredPrKeys(
+    store,
+    run.id,
+    run.activeAttemptId,
+    revisionMembers.map((member) => member.headSha),
+  );
   const recentReviewFingerprints = await loadReviewFingerprints(store, run.id);
   const gates = run.activeAttemptId
     ? await store.listGates(run.activeAttemptId)
@@ -727,7 +738,11 @@ export async function reduceProductOutcome(
       run.phase === "approved" ||
       run.phase === "ready-for-human-merge")
   ) {
-    const consistency = revisionGatesConsistent(gates);
+    const consistency = revisionGatesConsistent(
+      gates,
+      revisionMembers,
+      activeAttempt?.revisionDigest ?? null,
+    );
     if (!consistency.ok) {
       return {
         status: "rejected",
@@ -761,20 +776,6 @@ export async function reduceProductOutcome(
         observedAt: clock.now(),
       });
     }
-  }
-
-  // Failed review → rework invalidates gates on active attempt.
-  if (
-    input.outcome.status === "failed" &&
-    (run.phase === "reviewing" || run.phase === "aggregate-verification") &&
-    run.activeAttemptId
-  ) {
-    await invalidateAttemptGates(
-      store,
-      run.activeAttemptId,
-      "review or verification failed; rework required",
-      clock.now(),
-    );
   }
 
   // Fan-out bookkeeping when a builder completes.
@@ -811,6 +812,7 @@ export async function reduceProductOutcome(
   const reviewVerdict =
     input.reviewVerdict ??
     inferReviewVerdict(input.outcome, run.phase);
+  const devVerificationFailed = isDevVerificationRegression(input.outcome);
 
   let suggested: ProductPhase | undefined =
     (input.toPhase as ProductPhase | undefined) ??
@@ -828,6 +830,7 @@ export async function reduceProductOutcome(
           registeredPrKeys.some((k) => k.includes(`:${w}`) || k.endsWith(w)),
         ),
       needsProductDecision: input.needsProductDecision === true,
+      devVerificationFailed,
     }) ??
     undefined;
 
@@ -847,12 +850,75 @@ export async function reduceProductOutcome(
     suggested = input.toPhase as ProductPhase;
   }
 
+  const reopensApprovedCandidate =
+    suggested === "fixing" &&
+    (run.phase === "approved" || run.phase === "ready-for-human-merge");
+  if (reopensApprovedCandidate && !devVerificationFailed) {
+    return {
+      status: "rejected",
+      runVersion: run.stateVersion,
+      assignmentId: assignment.id,
+      reason:
+        "approved candidate rework requires failed dev-verification or staging-verification evidence",
+    };
+  }
+  if (
+    reopensApprovedCandidate &&
+    (input.outcome.action !== "handoff" ||
+      !isProductBuilderAgent(input.outcome.targetAgent ?? ""))
+  ) {
+    return {
+      status: "rejected",
+      runVersion: run.stateVersion,
+      assignmentId: assignment.id,
+      reason:
+        "approved candidate rework must hand off to a builder so fixing has an active owner",
+    };
+  }
+  const reopensRevision =
+    suggested === "fixing" &&
+    (run.phase === "aggregate-verification" ||
+      run.phase === "reviewing" ||
+      reopensApprovedCandidate);
+  if (suggested === "ready-for-human-merge" && run.phase === "approved") {
+    const mergedDevWorkstreams = await loadMergedDevPrWorkstreams(
+      store,
+      run.id,
+      run.activeAttemptId,
+      revisionMembers,
+    );
+    const requiredDevWorkstreams = workstreams.length > 0
+      ? workstreams
+      : revisionMembers.map((member) => member.memberKey);
+    const devMergeComplete =
+      requiredDevWorkstreams.length > 0 &&
+      requiredDevWorkstreams.every((workstream) =>
+        mergedDevWorkstreams.has(workstream)
+      );
+    if (!devMergeComplete) {
+      return {
+        status: "rejected",
+        runVersion: run.stateVersion,
+        assignmentId: assignment.id,
+        reason:
+          "ready-for-human-merge requires a merged dev PR for every current workstream and revision SHA",
+      };
+    }
+  }
+
   const receipt = await store.recordOutcomeTransaction({
     outcome: input.outcome,
     toPhase: suggested,
     actorType: input.actorType ?? "agent",
     actorId: input.actorId,
     idempotencyKey: input.idempotencyKey,
+    invalidateAttemptGates:
+      reopensRevision && run.activeAttemptId
+        ? { attemptId: run.activeAttemptId }
+        : undefined,
+    deactivateGitHubResourceRoles: reopensApprovedCandidate
+      ? ["dev-pr"]
+      : undefined,
   });
 
   return {
@@ -1120,7 +1186,7 @@ export async function registerProductPr(
       expectedHeadSha: input.expectedHeadSha,
       registrationKey: key,
     },
-    idempotencyKey: `pr-reg:${run.id}:${key}`,
+    idempotencyKey: `pr-reg:${run.id}:${key}:${input.attemptId ?? run.activeAttemptId ?? "none"}:${input.expectedHeadSha}`,
     occurredAt: now,
     observedAt: now,
   });
@@ -1162,27 +1228,60 @@ export async function ensureProductRevisionGates(
   },
 ): Promise<PipelineGate[]> {
   const now = Date.now();
-  const kinds = ["review", "checks", "aggregate"] as const;
+  const revisionMembers = await store.listRevisionMembers(input.attemptId);
+  const attempt = await store.getAttempt(input.attemptId);
+  const selectedMembers = input.memberKey
+    ? revisionMembers.filter(
+        (member) => member.memberKey === input.memberKey,
+      )
+    : revisionMembers;
+  const targets = selectedMembers.length > 0
+    ? selectedMembers
+    : [
+        {
+          memberKey: input.memberKey ?? "candidate",
+          headSha: input.subjectSha,
+        },
+      ];
   const gates: PipelineGate[] = [];
-  for (const gateKind of kinds) {
-    const gate: PipelineGate = {
-      id: `${input.attemptId}:${gateKind}:${input.memberKey ?? "aggregate"}`,
-      runId: input.runId,
-      attemptId: input.attemptId,
-      memberKey: input.memberKey ?? null,
-      githubResourceId: null,
-      gateKind,
-      status: "pending",
-      subjectSha: input.subjectSha,
-      evidenceRef: null,
-      provider: null,
-      model: null,
-      agentName: input.agentName ?? null,
-      updatedAt: now,
-    };
-    await store.upsertGate(gate);
-    gates.push(gate);
+  for (const member of targets) {
+    for (const gateKind of ["review", "checks"] as const) {
+      const gate: PipelineGate = {
+        id: `${input.attemptId}:${gateKind}:${member.memberKey}`,
+        runId: input.runId,
+        attemptId: input.attemptId,
+        memberKey: member.memberKey,
+        githubResourceId: null,
+        gateKind,
+        status: "pending",
+        subjectSha: member.headSha,
+        evidenceRef: null,
+        provider: null,
+        model: null,
+        agentName: input.agentName ?? null,
+        updatedAt: now,
+      };
+      await store.upsertGate(gate);
+      gates.push(gate);
+    }
   }
+  const aggregate: PipelineGate = {
+    id: `${input.attemptId}:aggregate:vector`,
+    runId: input.runId,
+    attemptId: input.attemptId,
+    memberKey: null,
+    githubResourceId: null,
+    gateKind: "aggregate",
+    status: "pending",
+    subjectSha: attempt?.revisionDigest ?? input.subjectSha,
+    evidenceRef: null,
+    provider: null,
+    model: null,
+    agentName: input.agentName ?? null,
+    updatedAt: now,
+  };
+  await store.upsertGate(aggregate);
+  gates.push(aggregate);
   return gates;
 }
 
@@ -1225,11 +1324,25 @@ export async function loadSkipReasons(
 async function loadRegisteredPrKeys(
   store: PipelineStore,
   runId: string,
+  attemptId: string | null,
+  revisionShas: string[],
 ): Promise<string[]> {
+  if (!attemptId || revisionShas.length === 0) return [];
+  const acceptedRoles = new Set(["candidate", "main-pr", "review-target"]);
+  const acceptedShas = new Set(revisionShas);
   const events = await store.listEvents(runId);
   const keys = new Set<string>();
   for (const e of events) {
     if (e.eventType !== "github.pr.registered") continue;
+    if (
+      e.payload.attemptId !== attemptId ||
+      typeof e.payload.role !== "string" ||
+      !acceptedRoles.has(e.payload.role) ||
+      typeof e.payload.expectedHeadSha !== "string" ||
+      !acceptedShas.has(e.payload.expectedHeadSha)
+    ) {
+      continue;
+    }
     const key =
       typeof e.payload.registrationKey === "string"
         ? e.payload.registrationKey
@@ -1259,10 +1372,98 @@ async function loadRegisteredPrKeys(
   if (store.listPipelineGitHubResources) {
     const assocs = await store.listPipelineGitHubResources(runId, true);
     for (const a of assocs) {
+      if (
+        a.attemptId !== attemptId ||
+        !acceptedRoles.has(a.role) ||
+        !a.expectedHeadSha ||
+        !acceptedShas.has(a.expectedHeadSha)
+      ) {
+        continue;
+      }
       keys.add(`${a.role}:${a.workstreamKey}`);
     }
   }
   return [...keys];
+}
+
+function isDevVerificationRegression(outcome: AgentOutcome): boolean {
+  const failedCheck = outcome.checks.find(
+    (check) =>
+      (check.name === "dev-verification" ||
+        check.name === "staging-verification") &&
+      check.status === "failed",
+  );
+  if (failedCheck?.evidenceRef?.trim()) return true;
+  return outcome.evidenceRefs.some(
+    (ref) => {
+      const [prefix, suffix] = ref.split(":", 2);
+      return (
+        (prefix === "dev-verification" || prefix === "staging-verification") &&
+        Boolean(suffix?.trim())
+      );
+    },
+  );
+}
+
+async function loadMergedDevPrWorkstreams(
+  store: PipelineStore,
+  runId: string,
+  attemptId: string | null,
+  revisionMembers: AttemptRevisionMember[],
+): Promise<Set<string>> {
+  if (!attemptId || revisionMembers.length === 0) return new Set();
+  const candidates: Array<{
+    workstreamKey: string;
+    expectedHeadSha: string;
+    mergedHeadSha: string;
+  }> = [];
+  const associations = await store.listPipelineGitHubResources(runId, true);
+  for (const association of associations) {
+    if (
+      association.role !== "dev-pr" ||
+      association.attemptId !== attemptId ||
+      !association.expectedHeadSha
+    ) {
+      continue;
+    }
+    const resource = await store.getGitHubResource(association.resourceId);
+    if (
+      resource?.snapshot?.state === "MERGED" &&
+      resource.snapshot.headRefOid === association.expectedHeadSha
+    ) {
+      candidates.push({
+        workstreamKey: association.workstreamKey,
+        expectedHeadSha: association.expectedHeadSha,
+        mergedHeadSha: resource.snapshot.headRefOid,
+      });
+    }
+  }
+  return mergedDevPrCoverage(revisionMembers, candidates);
+}
+
+export function mergedDevPrCoverage(
+  revisionMembers: AttemptRevisionMember[],
+  candidates: Array<{
+    workstreamKey: string;
+    expectedHeadSha: string;
+    mergedHeadSha: string;
+  }>,
+): Set<string> {
+  const requiredShaByWorkstream = new Map(
+    revisionMembers.map((member) => [member.memberKey, member.headSha]),
+  );
+  const covered = new Set<string>();
+  for (const candidate of candidates) {
+    const requiredSha = requiredShaByWorkstream.get(candidate.workstreamKey);
+    if (
+      requiredSha &&
+      candidate.expectedHeadSha === requiredSha &&
+      candidate.mergedHeadSha === requiredSha
+    ) {
+      covered.add(candidate.workstreamKey);
+    }
+  }
+  return covered;
 }
 
 async function loadReviewFingerprints(
@@ -1311,24 +1512,6 @@ function inferReviewVerdict(
   return null;
 }
 
-async function invalidateAttemptGates(
-  store: PipelineStore,
-  attemptId: string,
-  reason: string,
-  now: number,
-): Promise<void> {
-  const gates = await store.listGates(attemptId);
-  for (const g of gates) {
-    if (g.status === "invalidated") continue;
-    await store.upsertGate({
-      ...g,
-      status: "invalidated",
-      evidenceRef: reason,
-      updatedAt: now,
-    });
-  }
-}
-
 /**
  * Build injection block for dispatch when assignment is under an active product run.
  */
@@ -1349,7 +1532,12 @@ export async function productContextForAssignment(
     gates = await config.store.listGates(attemptId);
   }
   const skipReasons = await loadSkipReasons(config.store, run.id);
-  const registeredPrKeys = await loadRegisteredPrKeys(config.store, run.id);
+  const registeredPrKeys = await loadRegisteredPrKeys(
+    config.store,
+    run.id,
+    attemptId,
+    revisionMembers.map((member) => member.headSha),
+  );
   const workstreams = await loadWorkstreams(config.store, run.id);
   return buildProductContext({
     run,

--- a/src/pipelines/product/definition.ts
+++ b/src/pipelines/product/definition.ts
@@ -282,6 +282,8 @@ export function suggestPhaseAfterOutcome(input: {
   allPrsRegistered?: boolean;
   /** True when a material product decision is still open. */
   needsProductDecision?: boolean;
+  /** Typed evidence that dev/staging verification found a regression. */
+  devVerificationFailed?: boolean;
 }): ProductPhase | null {
   const {
     currentPhase,
@@ -291,6 +293,7 @@ export function suggestPhaseAfterOutcome(input: {
     allBuildersDone = true,
     allPrsRegistered = true,
     needsProductDecision = false,
+    devVerificationFailed = false,
   } = input;
 
   if (outcomeStatus === "blocked" || outcomeAction === "escalate") {
@@ -300,8 +303,14 @@ export function suggestPhaseAfterOutcome(input: {
   if (outcomeStatus === "failed") {
     if (
       currentPhase === "reviewing" ||
-      currentPhase === "aggregate-verification" ||
-      currentPhase === "approved"
+      currentPhase === "aggregate-verification"
+    ) {
+      return "fixing";
+    }
+    if (
+      devVerificationFailed &&
+      (currentPhase === "approved" ||
+        currentPhase === "ready-for-human-merge")
     ) {
       return "fixing";
     }
@@ -346,7 +355,8 @@ export function suggestPhaseAfterOutcome(input: {
     case "approved":
       return "ready-for-human-merge";
     case "ready-for-human-merge":
-      // Human merge only — agents cannot auto-ship.
+      // Human merge only — agents cannot auto-ship. A failed dev/staging
+      // verification is handled above and reopens the run at fixing.
       return null;
     default:
       return null;

--- a/src/pipelines/product/policy.ts
+++ b/src/pipelines/product/policy.ts
@@ -6,6 +6,7 @@
 import type {
   AgentOutcome,
   Assignment,
+  AttemptRevisionMember,
   PipelineGate,
   ProductRun,
 } from "../types.ts";
@@ -179,7 +180,17 @@ export function reviewFindingFingerprint(outcome: AgentOutcome): string | null {
 export function revisionGatesConsistent(gates: PipelineGate[]): {
   ok: boolean;
   reason?: string;
-} {
+};
+export function revisionGatesConsistent(
+  gates: PipelineGate[],
+  revisionMembers: AttemptRevisionMember[],
+  revisionDigest: string | null,
+): { ok: boolean; reason?: string };
+export function revisionGatesConsistent(
+  gates: PipelineGate[],
+  revisionMembers: AttemptRevisionMember[] = [],
+  revisionDigest: string | null = null,
+): { ok: boolean; reason?: string } {
   const active = gates.filter(
     (g) =>
       g.status !== "invalidated" &&
@@ -188,15 +199,79 @@ export function revisionGatesConsistent(gates: PipelineGate[]): {
         g.gateKind === "aggregate" ||
         g.gateKind === "human-merge"),
   );
-  if (active.length === 0) return { ok: true };
-
-  const shas = new Set(
-    active.map((g) => g.subjectSha).filter((s): s is string => s != null),
-  );
-  if (shas.size > 1) {
+  if (revisionMembers.length === 0 || !revisionDigest) {
     return {
       ok: false,
-      reason: `product aggregate gates subject SHAs diverge: ${[...shas].join(", ")}`,
+      reason: "product aggregate gates require a current revision vector",
+    };
+  }
+
+  for (const member of revisionMembers) {
+    for (const kind of ["review", "checks"] as const) {
+      const gate = active.find(
+        (candidate) =>
+          candidate.gateKind === kind &&
+          candidate.memberKey === member.memberKey &&
+          candidate.subjectSha === member.headSha,
+      );
+      if (!gate) {
+        return {
+          ok: false,
+          reason: `product aggregate gates missing ${kind} for ${member.memberKey}@${member.headSha}`,
+        };
+      }
+      if (gate.status !== "passed") {
+        return {
+          ok: false,
+          reason: `product ${kind} gate for ${member.memberKey} is ${gate.status}, expected passed`,
+        };
+      }
+    }
+  }
+
+  const aggregate = active.find(
+    (gate) =>
+      gate.gateKind === "aggregate" &&
+      gate.memberKey === null &&
+      gate.subjectSha === revisionDigest,
+  );
+  if (!aggregate) {
+    return {
+      ok: false,
+      reason: `product aggregate gate missing for revision ${revisionDigest}`,
+    };
+  }
+  if (aggregate.status !== "passed") {
+    return {
+      ok: false,
+      reason: `product aggregate gate is ${aggregate.status}, expected passed`,
+    };
+  }
+
+  const stale = active.find((gate) => {
+    if (gate.gateKind === "human-merge") return false;
+    if (gate.gateKind === "aggregate") {
+      return gate.memberKey !== null || gate.subjectSha !== revisionDigest;
+    }
+    const member = revisionMembers.find(
+      (candidate) => candidate.memberKey === gate.memberKey,
+    );
+    return !member || gate.subjectSha !== member.headSha;
+  });
+  if (stale) {
+    return {
+      ok: false,
+      reason: `product ${stale.gateKind} gate is not bound to the current revision vector`,
+    };
+  }
+
+  const incompleteHumanGate = active.find(
+    (gate) => gate.gateKind === "human-merge" && gate.status !== "passed",
+  );
+  if (incompleteHumanGate) {
+    return {
+      ok: false,
+      reason: `product human-merge gate is ${incompleteHumanGate.status}, expected passed`,
     };
   }
 
@@ -205,6 +280,13 @@ export function revisionGatesConsistent(gates: PipelineGate[]): {
     return {
       ok: false,
       reason: "product aggregate gates span multiple attempts",
+    };
+  }
+
+  if (active.some((gate) => !gate.subjectSha)) {
+    return {
+      ok: false,
+      reason: "product aggregate gate is missing subject SHA",
     };
   }
 

--- a/src/pipelines/store/memory.test.ts
+++ b/src/pipelines/store/memory.test.ts
@@ -538,7 +538,11 @@ describe("InMemoryPipelineStore", () => {
     await store.createRun(makeProductRun({ id: "run-a", threadId: "T-a" }));
     await store.createRun(makeProductRun({ id: "run-b", threadId: "T-b" }));
 
-    const register = (runId: string, assignmentId: string) =>
+    const register = (
+      runId: string,
+      assignmentId: string,
+      expectedHeadSha = "a".repeat(40),
+    ) =>
       store.commitPrRegistration({
         registration: {
           runId,
@@ -549,7 +553,7 @@ describe("InMemoryPipelineStore", () => {
           role: "candidate",
           workstreamKey: "backend",
           attemptId: null,
-          expectedHeadSha: "a".repeat(40),
+          expectedHeadSha,
         },
         actorId: "default",
         runPhase: "pr-open",
@@ -558,14 +562,20 @@ describe("InMemoryPipelineStore", () => {
 
     const first = await register("run-a", "asg-a");
     const second = await register("run-b", "asg-b");
+    const revised = await register("run-a", "asg-a", "b".repeat(40));
 
     expect(second.eventId).not.toBe(first.eventId);
+    expect(revised.eventId).not.toBe(first.eventId);
     expect(await store.listPipelineGitHubResources("run-a", true)).toHaveLength(
       1,
     );
     expect(await store.listPipelineGitHubResources("run-b", true)).toHaveLength(
       1,
     );
+    expect(
+      (await store.listPipelineGitHubResources("run-a", true))[0]
+        ?.expectedHeadSha,
+    ).toBe("b".repeat(40));
   });
 
   it("creates next assignment + outbox on handoff", async () => {

--- a/src/pipelines/store/memory.ts
+++ b/src/pipelines/store/memory.ts
@@ -300,6 +300,17 @@ export class InMemoryPipelineStore implements PipelineStore {
         reason: "run not found",
       };
     }
+    if (input.invalidateAttemptGates) {
+      const attempt = this.attempts.get(input.invalidateAttemptGates.attemptId);
+      if (!attempt || attempt.runId !== run.id) {
+        return {
+          status: "rejected",
+          runVersion: run.stateVersion,
+          assignmentId: assignment.id,
+          reason: "gate invalidation attempt does not belong to run",
+        };
+      }
+    }
 
     // Event idempotency: return prior receipt as duplicate.
     if (input.idempotencyKey) {
@@ -393,6 +404,40 @@ export class InMemoryPipelineStore implements PipelineStore {
           decision.outbox.idempotencyKey,
           decision.outbox.id,
         );
+      }
+    }
+
+    if (input.invalidateAttemptGates) {
+      const attemptId = input.invalidateAttemptGates.attemptId;
+      const gates = this.gates.get(attemptId) ?? [];
+      this.gates.set(
+        attemptId,
+        gates.map((gate) =>
+          gate.status === "invalidated"
+            ? gate
+            : {
+                ...gate,
+                status: "invalidated" as const,
+                updatedAt: this.clock.now(),
+              }
+        ),
+      );
+    }
+
+    if (input.deactivateGitHubResourceRoles?.length) {
+      const roles = new Set(input.deactivateGitHubResourceRoles);
+      for (const [id, association] of this.pipelineGithub.entries()) {
+        if (
+          association.runId === run.id &&
+          association.active &&
+          roles.has(association.role)
+        ) {
+          this.pipelineGithub.set(id, {
+            ...association,
+            active: false,
+            updatedAt: this.clock.now(),
+          });
+        }
       }
     }
 
@@ -995,7 +1040,7 @@ export class InMemoryPipelineStore implements PipelineStore {
     now: number;
   }): Promise<{ eventId: string }> {
     const { registration, actorId, runPhase, now } = input;
-    const idempotencyKey = `pr-reg:${registration.runId}:${registration.owner}/${registration.repo}#${registration.number}:${registration.role}:${registration.workstreamKey}`;
+    const idempotencyKey = `pr-reg:${registration.runId}:${registration.owner}/${registration.repo}#${registration.number}:${registration.role}:${registration.workstreamKey}:${registration.attemptId ?? "none"}:${registration.expectedHeadSha}`;
     const priorId = this.eventByIdempotency.get(idempotencyKey);
     if (priorId) {
       return { eventId: priorId };
@@ -1056,7 +1101,13 @@ export class InMemoryPipelineStore implements PipelineStore {
       });
     }
 
-    const assocId = crypto.randomUUID();
+    const existingAssociation = [...this.pipelineGithub.values()].find(
+      (association) =>
+        association.runId === registration.runId &&
+        association.resourceId === resourceId &&
+        association.role === registration.role,
+    );
+    const assocId = existingAssociation?.id ?? crypto.randomUUID();
     this.pipelineGithub.set(assocId, {
       id: assocId,
       runId: registration.runId,
@@ -1067,7 +1118,7 @@ export class InMemoryPipelineStore implements PipelineStore {
       registeredByAssignmentId: registration.assignmentId,
       expectedHeadSha: registration.expectedHeadSha,
       active: true,
-      createdAt: now,
+      createdAt: existingAssociation?.createdAt ?? now,
       updatedAt: now,
     });
 

--- a/src/pipelines/store/sqlite.test.ts
+++ b/src/pipelines/store/sqlite.test.ts
@@ -149,6 +149,91 @@ describe("SqlitePipelineStore", () => {
     expect(stale.reason).toMatch(/state version conflict/i);
   });
 
+  it("atomically invalidates gates with an accepted rework transition", async () => {
+    await store.createRun(
+      makeProductRun({ phase: "reviewing", activeAttemptId: "att-rework" }),
+    );
+    await store.createAssignment(makeAssignmentCreate());
+    await store.createAttempt({
+      id: "att-rework",
+      runId: "run-1",
+      ordinal: 1,
+      revisionDigest: "digest-1",
+      status: "open",
+      invalidatedAt: null,
+      invalidationReason: null,
+      createdAt: clock.now(),
+      finishedAt: null,
+    });
+    await store.upsertGate({
+      id: "gate-review",
+      runId: "run-1",
+      attemptId: "att-rework",
+      memberKey: null,
+      githubResourceId: null,
+      gateKind: "review",
+      status: "passed",
+      subjectSha: "sha-1",
+      evidenceRef: "review:approved",
+      provider: null,
+      model: null,
+      agentName: "review",
+      updatedAt: clock.now(),
+    });
+    await store.commitPrRegistration({
+      registration: {
+        runId: "run-1",
+        assignmentId: "asg-1",
+        owner: "acme",
+        repo: "backend",
+        number: 17,
+        role: "dev-pr",
+        workstreamKey: "backend",
+        attemptId: "att-rework",
+        expectedHeadSha: "sha-1",
+      },
+      actorId: "default",
+      runPhase: "reviewing",
+      now: clock.now(),
+    });
+
+    const stale = await store.recordOutcomeTransaction({
+      outcome: baseOutcome({ expectedRunVersion: 1 }),
+      toPhase: "fixing",
+      actorType: "agent",
+      actorId: "review",
+      invalidateAttemptGates: { attemptId: "att-rework" },
+      deactivateGitHubResourceRoles: ["dev-pr"],
+    });
+    expect(stale.status).toBe("rejected");
+    expect((await store.listGates("att-rework"))[0]?.status).toBe("passed");
+    expect(await store.listPipelineGitHubResources("run-1", true)).toHaveLength(
+      1,
+    );
+
+    const accepted = await store.recordOutcomeTransaction({
+      outcome: baseOutcome({
+        action: "complete",
+        status: "failed",
+        reason: "changes requested",
+      }),
+      toPhase: "fixing",
+      actorType: "agent",
+      actorId: "review",
+      invalidateAttemptGates: { attemptId: "att-rework" },
+      deactivateGitHubResourceRoles: ["dev-pr"],
+    });
+    expect(accepted.status).toBe("accepted");
+    expect((await store.getRun("run-1"))?.phase).toBe("fixing");
+    expect((await store.listGates("att-rework"))[0]).toMatchObject({
+      status: "invalidated",
+      evidenceRef: "review:approved",
+    });
+    expect(await store.listPipelineGitHubResources("run-1", true)).toHaveLength(
+      0,
+    );
+  });
+
   it("rejects mutation on terminal runs (immutability)", async () => {
     await store.createRun(
       makeProductRun({ phase: "ready-for-human-merge" }),
@@ -334,7 +419,11 @@ describe("SqlitePipelineStore", () => {
     await store.createRun(makeProductRun({ id: "run-a", threadId: "T-a" }));
     await store.createRun(makeProductRun({ id: "run-b", threadId: "T-b" }));
 
-    const register = (runId: string, assignmentId: string) =>
+    const register = (
+      runId: string,
+      assignmentId: string,
+      expectedHeadSha = "a".repeat(40),
+    ) =>
       store.commitPrRegistration({
         registration: {
           runId,
@@ -345,7 +434,7 @@ describe("SqlitePipelineStore", () => {
           role: "candidate",
           workstreamKey: "backend",
           attemptId: null,
-          expectedHeadSha: "a".repeat(40),
+          expectedHeadSha,
         },
         actorId: "default",
         runPhase: "pr-open",
@@ -354,14 +443,20 @@ describe("SqlitePipelineStore", () => {
 
     const first = await register("run-a", "asg-a");
     const second = await register("run-b", "asg-b");
+    const revised = await register("run-a", "asg-a", "b".repeat(40));
 
     expect(second.eventId).not.toBe(first.eventId);
+    expect(revised.eventId).not.toBe(first.eventId);
     expect(await store.listPipelineGitHubResources("run-a", true)).toHaveLength(
       1,
     );
     expect(await store.listPipelineGitHubResources("run-b", true)).toHaveLength(
       1,
     );
+    expect(
+      (await store.listPipelineGitHubResources("run-a", true))[0]
+        ?.expectedHeadSha,
+    ).toBe("b".repeat(40));
   });
 
   it("claims and reclaims outbox with fake clock", async () => {

--- a/src/pipelines/store/sqlite.ts
+++ b/src/pipelines/store/sqlite.ts
@@ -1123,6 +1123,17 @@ export class SqlitePipelineStore implements PipelineStore {
         reason: "run not found",
       };
     }
+    if (input.invalidateAttemptGates) {
+      const attempt = await this.getAttempt(input.invalidateAttemptGates.attemptId);
+      if (!attempt || attempt.runId !== run.id) {
+        return {
+          status: "rejected",
+          runVersion: run.stateVersion,
+          assignmentId: assignment.id,
+          reason: "gate invalidation attempt does not belong to run",
+        };
+      }
+    }
 
     if (input.idempotencyKey) {
       const prior = this.db
@@ -1273,6 +1284,36 @@ export class SqlitePipelineStore implements PipelineStore {
 
       if (decision.outbox && !input.suppressDispatch) {
         this.insertOutbox(decision.outbox);
+      }
+
+      if (input.invalidateAttemptGates) {
+        this.db
+          .query(
+            `UPDATE pipeline_gates SET status = 'invalidated', updated_at = ?
+             WHERE run_id = ? AND attempt_id = ? AND status != 'invalidated'`,
+          )
+          .run(
+            this.clock.now(),
+            run.id,
+            input.invalidateAttemptGates.attemptId,
+          );
+      }
+
+      if (input.deactivateGitHubResourceRoles?.length) {
+        const placeholders = input.deactivateGitHubResourceRoles
+          .map(() => "?")
+          .join(", ");
+        this.db
+          .query(
+            `UPDATE pipeline_github_resources
+             SET active = 0, updated_at = ?
+             WHERE run_id = ? AND active = 1 AND role IN (${placeholders})`,
+          )
+          .run(
+            this.clock.now(),
+            run.id,
+            ...input.deactivateGitHubResourceRoles,
+          );
       }
     });
 
@@ -2164,7 +2205,7 @@ export class SqlitePipelineStore implements PipelineStore {
     now: number;
   }): Promise<{ eventId: string }> {
     const { registration, actorId, runPhase, now } = input;
-    const idempotencyKey = `pr-reg:${registration.runId}:${registration.owner}/${registration.repo}#${registration.number}:${registration.role}:${registration.workstreamKey}`;
+    const idempotencyKey = `pr-reg:${registration.runId}:${registration.owner}/${registration.repo}#${registration.number}:${registration.role}:${registration.workstreamKey}:${registration.attemptId ?? "none"}:${registration.expectedHeadSha}`;
 
     const prior = this.db
       .query<{ id: string }, [string]>(

--- a/src/pipelines/transitions.test.ts
+++ b/src/pipelines/transitions.test.ts
@@ -47,6 +47,14 @@ describe("product transitions", () => {
     expect(isTerminalPhase("product", "needs-human")).toBe(false);
   });
 
+  it("reopens an approved candidate when dev verification finds a bug", () => {
+    expect(canTransition("product", "approved", "fixing")).toBe(true);
+    expect(
+      canTransition("product", "ready-for-human-merge", "fixing"),
+    ).toBe(true);
+    expect(canTransition("product", "shipped", "fixing")).toBe(false);
+  });
+
   it("assertTransition throws on illegal edges", () => {
     expect(() => assertTransition("product", "shipped", "building")).toThrow(
       /Illegal product phase transition/,

--- a/src/pipelines/transitions.ts
+++ b/src/pipelines/transitions.ts
@@ -60,8 +60,13 @@ const PRODUCT_TRANSITIONS: Record<ProductPhase, readonly ProductPhase[]> = {
     "needs-human",
     "abandoned",
   ],
-  approved: ["ready-for-human-merge", "needs-human", "abandoned"],
-  "ready-for-human-merge": ["shipped", "needs-human", "abandoned"],
+  approved: ["fixing", "ready-for-human-merge", "needs-human", "abandoned"],
+  "ready-for-human-merge": [
+    "fixing",
+    "shipped",
+    "needs-human",
+    "abandoned",
+  ],
   shipped: [],
   abandoned: [],
   "needs-human": [

--- a/src/pipelines/types.ts
+++ b/src/pipelines/types.ts
@@ -473,6 +473,12 @@ export type RecordOutcomeInput = {
   actorId: string;
   /** Optional event idempotency key for duplicate detection. */
   idempotencyKey?: string;
+  /** Gate invalidation committed atomically with the accepted phase change. */
+  invalidateAttemptGates?: {
+    attemptId: string;
+  };
+  /** GitHub associations made historical by the accepted transition. */
+  deactivateGitHubResourceRoles?: GitHubResourceRegistration["role"][];
   /**
    * When true (shadow mode), still persist outcome/event/assignment state but
    * do not enqueue dispatch/continue/resume outbox items. Shadow records


### PR DESCRIPTION
## Summary

- allow approved product runs to return to `fixing` when dev or staging verification finds a regression
- require the reopen to carry typed evidence and hand ownership to a builder
- atomically invalidate prior gates and archive the merged dev-PR association
- bind review/check gates to every current workstream SHA and the aggregate gate to the current revision digest
- require a merged dev PR for every exact workstream/SHA before returning to `ready-for-human-merge`
- update agent guidance for fix → verify → review → fresh dev PR → re-merge loops

## Safety

- stale CAS outcomes cannot invalidate valid gates or archive associations
- unrelated tool/agent failures cannot reopen an approved candidate
- old PR registrations and cross-workstream SHAs cannot satisfy current gates
- merged dev PRs remain historical; a later candidate must register a fresh current dev PR

## Review

Independent review completed clean after three correction passes covering transaction atomicity, gate completeness, registration freshness, typed evidence, active builder ownership, and exact workstream/SHA matching.

## Verification

Two consecutive clean passes:

- `bun run typecheck`
- `bun test` — 1,313 passed, 2 model-download tests skipped, 0 failed
- `git diff --check`

## Operational note

Junior was not restarted.