### PR TITLE
Fix pipeline causal context across dispatch and resume

### DIFF
--- a/src/pipelines/dispatch.ts
+++ b/src/pipelines/dispatch.ts
@@ -39,6 +39,12 @@ export type DispatchAssignmentInput = {
   assignment: Assignment;
   /** Optional free-text prompt body (defaults to assignment.objective). */
   prompt?: string;
+  /**
+   * Slack message that caused this dispatch, when one exists. Thread-history
+   * injection excludes this exact message because the prompt already contains
+   * it; using the thread root here would instead hide the original request.
+   */
+  sourceMessageTs?: string;
   /** Synthetic user id recorded on the internal event. */
   userId?: string;
   /** Shared idempotency / dedupe key for the synthetic Slack event. */
@@ -143,13 +149,16 @@ export async function dispatchAssignment(
   const dedupeKey =
     input.dedupeKey ??
     `pipeline:${run.id}:${assignment.id}:${assignment.idempotencyKey}`;
+  const syntheticTs =
+    input.sourceMessageTs ??
+    `pipeline:${run.id}:${assignment.id}:${assignment.updatedAt}`;
 
   const event: SlackMessageEvent = {
     threadId: run.threadId,
     channel: run.channelId,
     user: input.userId ?? "pipeline-internal",
     text: prompt,
-    ts: run.threadId,
+    ts: syntheticTs,
     command: null,
     isSelfBot: true,
     botUsername: "pipeline",
@@ -183,14 +192,18 @@ export async function dispatchAssignment(
     };
   }
 
-  // Slack audit is best-effort — failure must not lose the handoff.
-  await safeAudit(deps.audit, {
-    channelId: run.channelId,
-    threadId: run.threadId,
-    text: busy
-      ? `:hourglass_flowing_sand: *Pipeline handoff buffered* \`${assignment.sourceAgent}\` → \`${targetAgent}\` (\`${assignment.id.slice(0, 8)}\`)`
-      : `:arrow_right: *Pipeline handoff* \`${assignment.sourceAgent}\` → \`${targetAgent}\` (\`${assignment.id.slice(0, 8)}\`)`,
-  });
+  // Default runs are the invisible durability layer for ordinary messages.
+  // Only explicit product/bug pipelines should add handoff chatter to Slack.
+  if (run.kind !== "default") {
+    // Slack audit is best-effort — failure must not lose the handoff.
+    await safeAudit(deps.audit, {
+      channelId: run.channelId,
+      threadId: run.threadId,
+      text: busy
+        ? `:hourglass_flowing_sand: *Pipeline handoff buffered* \`${assignment.sourceAgent}\` → \`${targetAgent}\` (\`${assignment.id.slice(0, 8)}\`)`
+        : `:arrow_right: *Pipeline handoff* \`${assignment.sourceAgent}\` → \`${targetAgent}\` (\`${assignment.id.slice(0, 8)}\`)`,
+    });
+  }
 
   return {
     status: busy ? "buffered" : "dispatched",

--- a/src/pipelines/outcomes-handoffs.test.ts
+++ b/src/pipelines/outcomes-handoffs.test.ts
@@ -7,7 +7,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fakeClock } from "../time/clock.ts";
 import { InMemoryPipelineStore } from "./store/memory.ts";
-import { makeAssignmentCreate, makeProductRun } from "./store/test-helpers.ts";
+import {
+  makeAssignmentCreate,
+  makeDefaultRun,
+  makeProductRun,
+} from "./store/test-helpers.ts";
 import {
   parseAgentOutcome,
   registerPr,
@@ -332,10 +336,10 @@ describe("dispatch + busy buffer", () => {
     );
     const run = (await store.getRun("run-1"))!;
 
-    const dispatches: Array<{ agent: string; text: string }> = [];
+    const dispatches: Array<{ agent: string; text: string; ts: string }> = [];
     const dispatcher = {
       handleAgentMessage: mock(async (event: SlackMessageEvent, agentName: string) => {
-        dispatches.push({ agent: agentName, text: event.text });
+        dispatches.push({ agent: agentName, text: event.text, ts: event.ts });
       }),
     };
 
@@ -359,13 +363,14 @@ describe("dispatch + busy buffer", () => {
           get: async () => busySession,
         },
       },
-      { run, assignment },
+      { run, assignment, sourceMessageTs: "1700000000.000123" },
     );
 
     expect(result.status).toBe("buffered");
     expect(dispatches).toHaveLength(1);
     expect(dispatches[0]!.agent).toBe("architect");
     expect(dispatches[0]!.text).toContain("<pipeline-assignment>");
+    expect(dispatches[0]!.ts).toBe("1700000000.000123");
   });
 
   it("reports dispatched when target is idle", async () => {
@@ -396,9 +401,67 @@ describe("dispatch + busy buffer", () => {
 
     expect(result.status).toBe("dispatched");
   });
+
+  it("keeps ordinary default-run dispatch audits out of Slack", async () => {
+    const store = new InMemoryPipelineStore(fakeClock(1000));
+    await store.createRun(makeDefaultRun());
+    const assignment = await store.createAssignment(
+      makeAssignmentCreate({
+        id: "default-asg",
+        runId: "default-run-1",
+        targetAgent: "default",
+        sourceAgent: "human",
+        objective: "answer the user",
+        idempotencyKey: "default-asg",
+      }),
+    );
+    const run = (await store.getRun("default-run-1"))!;
+    const audit = mock(async () => undefined);
+
+    await dispatchAssignment(
+      {
+        dispatcher: { handleAgentMessage: async () => undefined },
+        audit,
+      },
+      { run, assignment, sourceMessageTs: "1700000000.000789" },
+    );
+
+    expect(audit).not.toHaveBeenCalled();
+  });
 });
 
 describe("outbox pump replay", () => {
+  it("preserves the source Slack timestamp through the outbox dispatch", async () => {
+    const clock = fakeClock(1000);
+    const store = new InMemoryPipelineStore(clock);
+    await seedPmRun(store);
+    await store.enqueueOutbox({
+      id: "source-ts-outbox",
+      runId: "run-1",
+      assignmentId: "asg-pm",
+      eventType: "assignment.dispatch",
+      payload: {
+        assignmentId: "asg-pm",
+        sourceMessageTs: "1700000000.000456",
+      },
+      idempotencyKey: "source-ts-outbox",
+    });
+
+    const events: SlackMessageEvent[] = [];
+    await pumpOutbox({
+      store,
+      clock,
+      dispatcher: {
+        handleAgentMessage: async (event) => {
+          events.push(event);
+        },
+      },
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]!.ts).toBe("1700000000.000456");
+  });
+
   it("replays undelivered dispatch after simulated crash between commit and mark", async () => {
     const clock = fakeClock(1000);
     const store = new InMemoryPipelineStore(clock);
@@ -497,6 +560,80 @@ describe("outbox pump replay", () => {
     expect(report.reclaimed).toBe(1);
     expect(report.delivered).toBe(1);
     expect(wakes).toEqual(["architect"]);
+  });
+});
+
+describe("delegated parent resume", () => {
+  it("injects the completed child verdict so the parent does not wait again", async () => {
+    const clock = fakeClock(1000);
+    const store = new InMemoryPipelineStore(clock);
+    await seedPmRun(store);
+
+    const delegated = await requestHandoff(
+      { store },
+      {
+        assignmentId: "asg-pm",
+        expectedRunVersion: 0,
+        targetAgent: "architect",
+        objective: "review the plan",
+        reason: "need a delegated verdict",
+        progressFingerprint: "delegate-review",
+        idempotencyKey: "delegate-review",
+        nextIdempotencyKey: "delegate-review:child",
+        action: "delegate",
+        auth: auth("pm"),
+      },
+    );
+    expect(delegated.status).toBe("accepted");
+    const childAssignmentId = delegated.assignmentId;
+    if (!childAssignmentId) throw new Error("delegation did not create a child");
+
+    await pumpOutbox({
+      store,
+      clock,
+      dispatcher: { handleAgentMessage: async () => undefined },
+    });
+
+    const completed = await reportOutcome(
+      { store },
+      {
+        outcome: {
+          assignmentId: childAssignmentId,
+          expectedRunVersion: delegated.runVersion,
+          action: "complete",
+          status: "succeeded",
+          reason: "Architecture review approved with no blockers",
+          evidenceRefs: ["review:approved"],
+          artifactRefs: ["artifact:plan"],
+          blockers: [],
+          checks: [{ name: "review", status: "passed", evidenceRef: "review:approved" }],
+          progressFingerprint: "architect-approved",
+        },
+        idempotencyKey: "architect-approved",
+        auth: auth("architect"),
+      },
+    );
+    expect(completed.status).toBe("accepted");
+
+    const resumes: SlackMessageEvent[] = [];
+    await pumpOutbox({
+      store,
+      clock,
+      dispatcher: {
+        handleAgentMessage: async (event) => {
+          resumes.push(event);
+        },
+      },
+    });
+
+    expect(resumes).toHaveLength(1);
+    expect(resumes[0]!.text).toContain("<delegated-result>");
+    expect(resumes[0]!.text).toContain("Architecture review approved with no blockers");
+    expect(resumes[0]!.text).toContain("review:approved");
+    expect(resumes[0]!.text).toContain(
+      "do not wait for the same child again",
+    );
+    expect(resumes[0]!.ts).not.toBe("T1");
   });
 });
 

--- a/src/pipelines/pump.ts
+++ b/src/pipelines/pump.ts
@@ -8,7 +8,7 @@ import type { Clock } from "../time/clock.ts";
 import { systemClock } from "../time/clock.ts";
 import { log } from "../logger.ts";
 import type { PipelineStore } from "./store/interface.ts";
-import type { PipelineOutboxRecord } from "./types.ts";
+import type { Assignment, PipelineOutboxRecord } from "./types.ts";
 import {
   dispatchAssignment,
   type DispatchDeps,
@@ -193,6 +193,10 @@ async function handleOutboxItem(
       }
     }
 
+    const sourceMessageTs =
+      typeof item.payload.sourceMessageTs === "string"
+        ? item.payload.sourceMessageTs
+        : undefined;
     const result = await dispatchAssignment(
       { ...dispatchDeps, bugContext, productContext },
       {
@@ -201,12 +205,9 @@ async function handleOutboxItem(
         // Resume wakes can carry a human follow-up, a dev-server URL, or a
         // generic recovery instruction. All retain the exact assignment.
         prompt: item.eventType === "assignment.resume"
-          ? typeof item.payload.prompt === "string"
-            ? `${assignment.objective}\n\n[task-follow-up]\n${item.payload.prompt}`
-            : typeof item.payload.readyUrl === "string"
-              ? `${assignment.objective}\n\n[devserver.ready] ${item.payload.readyUrl}`
-              : `${assignment.objective}\n\n[pipeline.recovery] Resume from durable state without repeating completed mutations. Report a typed outcome before ending.`
+          ? await buildResumePrompt(store, assignment, item.payload)
           : undefined,
+        sourceMessageTs,
         dedupeKey: `pipeline-outbox:${item.idempotencyKey}`,
         pipelineInvocation: {
           runId: run.id,
@@ -287,6 +288,53 @@ async function handleOutboxItem(
     `skipping unknown outbox eventType=${item.eventType} id=${item.id}`,
   );
   return "skipped";
+}
+
+async function buildResumePrompt(
+  store: PipelineStore,
+  assignment: Assignment,
+  payload: Record<string, unknown>,
+): Promise<string> {
+  if (typeof payload.prompt === "string") {
+    return `${assignment.objective}\n\n[task-follow-up]\n${payload.prompt}`;
+  }
+  if (typeof payload.readyUrl === "string") {
+    return `${assignment.objective}\n\n[devserver.ready] ${payload.readyUrl}`;
+  }
+
+  const completedChildAssignmentId =
+    typeof payload.completedChildAssignmentId === "string"
+      ? payload.completedChildAssignmentId
+      : null;
+  if (completedChildAssignmentId) {
+    const child = await store.getAssignment(completedChildAssignmentId);
+    const outcomes = child
+      ? await store.listOutcomes(completedChildAssignmentId)
+      : [];
+    const latestOutcome = outcomes[outcomes.length - 1];
+    if (child && latestOutcome) {
+      return [
+        assignment.objective,
+        "",
+        "<delegated-result>",
+        `completed_child_assignment_id: ${child.id}`,
+        `target_agent: ${child.targetAgent}`,
+        `child_status: ${child.status}`,
+        `outcome_action: ${latestOutcome.action}`,
+        `outcome_status: ${latestOutcome.status}`,
+        `reason: ${latestOutcome.reason}`,
+        `evidence_refs: ${JSON.stringify(latestOutcome.evidenceRefs)}`,
+        `artifact_refs: ${JSON.stringify(latestOutcome.artifactRefs)}`,
+        `checks: ${JSON.stringify(latestOutcome.checks)}`,
+        "instruction: The delegated child has finished. Use this verdict to advance the parent; do not wait for the same child again.",
+        "</delegated-result>",
+        "",
+        "[pipeline.recovery] Resume from durable state without repeating completed mutations. Report a typed outcome before ending.",
+      ].join("\n");
+    }
+  }
+
+  return `${assignment.objective}\n\n[pipeline.recovery] Resume from durable state without repeating completed mutations. Report a typed outcome before ending.`;
 }
 
 async function auditOutbox(


### PR DESCRIPTION
## Summary
- preserve the triggering Slack message timestamp through durable outbox dispatch so thread context retains the root request
- resume delegated parents with the completed child typed verdict instead of a generic recovery prompt
- keep default-run durability audits invisible for ordinary Slack conversations

## Verification
- `bun test`: 1,323 passed, 2 skipped, 0 failed
- `bun run typecheck`
- `bun run build`
- two consecutive clean verification passes