### PR TITLE
feat(runbooks): add schema, loader, validator, registry, and MCP tools

### DIFF
--- a/src/mcp/slack-server.ts
+++ b/src/mcp/slack-server.ts
@@ -68,6 +68,10 @@ import {
   postGitHubReview,
   readGitHubReviewState,
 } from "../github/review-comments.ts";
+import {
+  getRunbook,
+  searchRunbooks,
+} from "../runbooks/registry.ts";
 
 const MCP_PORT = Number(process.env.MCP_PORT ?? "3456");
 const FALLBACK_AGENTS_DIR = ".claude/agents";
@@ -920,6 +924,72 @@ function registerTools(server: McpServer, runContext: SlackMcpRunContext | null 
               null,
               2,
             ),
+          },
+        ],
+      };
+    },
+  );
+
+  registerTool(
+    server,
+    "runbook_search",
+    {
+      description:
+        "Search Junior runbook definitions by query, tags, owner agent, or risk level.",
+      inputSchema: {
+        query: z.string().optional().describe("Case-insensitive text to match against runbook name, description, or tags"),
+        tags: z.array(z.string()).optional().describe("Filter by tag (OR match)"),
+        owner_agent: z.string().optional().describe("Filter by owning agent name"),
+        risk: z.string().optional().describe("Filter by risk level"),
+        limit: z.number().optional().describe("Maximum results to return (default 25, max 100)"),
+      },
+    },
+    async ({ query, tags, owner_agent, risk, limit }) => {
+      const results = searchRunbooks({
+        query,
+        tags,
+        ownerAgent: owner_agent,
+        risk,
+        limit: Math.min(limit ?? 25, 100),
+      });
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify({ runbooks: results }, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  registerTool(
+    server,
+    "runbook_get",
+    {
+      description:
+        "Get a runbook definition by name, including its full prompt, inputs, verification, and provenance.",
+      inputSchema: {
+        name: z.string().describe("Runbook name (kebab-case)"),
+      },
+    },
+    async ({ name }) => {
+      const def = getRunbook(name);
+      if (!def) {
+        return {
+          content: [
+            {
+              type: "text" as const,
+              text: JSON.stringify({ error: `runbook "${name}" not found` }),
+            },
+          ],
+        };
+      }
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(def, null, 2),
           },
         ],
       };

--- a/src/runbooks/__fixtures__/transfer-ai-roadmaps.runbook.md
+++ b/src/runbooks/__fixtures__/transfer-ai-roadmaps.runbook.md
@@ -1,0 +1,46 @@
+---
+schemaVersion: 1
+name: transfer-ai-roadmaps
+description: Transfer every AI roadmap owned by one user to another user.
+ownerAgent: db-executioner
+intent:
+  examples:
+    - move all AI roadmaps from one account to another
+    - transfer AI roadmaps from user A to user B
+  excludes:
+    - transfer arbitrary user-owned data
+    - move one Notion roadmap
+inputs:
+  - name: sourceEmail
+    type: email
+    required: true
+    description: Email of the current roadmap owner
+  - name: targetEmail
+    type: email
+    required: true
+    description: Email of the new roadmap owner
+risk: production-write
+approval:
+  required: true
+  afterSteps:
+    - resolve-users
+    - count-roadmaps
+capabilities:
+  - mongo.read
+  - migration.execute
+verification:
+  required: true
+  assertions:
+    - source roadmap count is zero
+    - target roadmap count increased by the matched count
+tags:
+  - database
+  - ai-roadmaps
+---
+
+Resolve the source and target users by exact normalized email. Require exactly
+one user for each input. Count the matching `airoadmaps` documents, then present
+the exact source ID, target ID, filter, matched count, mutation path, and
+rollback story for approval. Execute only after approval and verify both source
+and target counts. S3 object keys are not rewritten because access is by key,
+not by roadmap owner linkage.

--- a/src/runbooks/capabilities.test.ts
+++ b/src/runbooks/capabilities.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+  CAPABILITY_BUNDLES,
+  isCapabilitySubset,
+  isValidCapabilityBundle,
+  listCapabilityBundles,
+} from "./capabilities.ts";
+import {
+  AGENT_IDENTITIES,
+  registerAgentIdentity,
+} from "../support/agents.ts";
+
+describe("capability bundles", () => {
+  describe("isValidCapabilityBundle", () => {
+    it("all defined bundles are valid", () => {
+      for (const name of Object.keys(CAPABILITY_BUNDLES)) {
+        expect(isValidCapabilityBundle(name)).toBe(true);
+      }
+    });
+
+    it("unknown bundle is invalid", () => {
+      expect(isValidCapabilityBundle("nonexistent.bundle")).toBe(false);
+      expect(isValidCapabilityBundle("")).toBe(false);
+      expect(isValidCapabilityBundle("mongo")).toBe(false);
+    });
+  });
+
+  describe("listCapabilityBundles", () => {
+    it("returns all bundle names", () => {
+      const bundles = listCapabilityBundles();
+      expect(bundles).toContain("mongo.read");
+      expect(bundles).toContain("migration.execute");
+      expect(bundles).toContain("slack.read");
+      expect(bundles).toContain("github.read");
+      expect(bundles.length).toBe(Object.keys(CAPABILITY_BUNDLES).length);
+    });
+  });
+
+  describe("isCapabilitySubset", () => {
+    describe("build agent (has repo-read + repo-write)", () => {
+      it("mongo.read OK (requires repo-read)", () => {
+        const result = isCapabilitySubset(["mongo.read"], "build");
+        expect(result.ok).toBe(true);
+        expect(result.violations).toEqual([]);
+      });
+
+      it("migration.execute OK (requires repo-read + repo-write)", () => {
+        const result = isCapabilitySubset(["migration.execute"], "build");
+        expect(result.ok).toBe(true);
+        expect(result.violations).toEqual([]);
+      });
+
+      it("multiple valid bundles OK", () => {
+        const result = isCapabilitySubset(
+          ["mongo.read", "migration.execute", "migration.inspect"],
+          "build",
+        );
+        expect(result.ok).toBe(true);
+        expect(result.violations).toEqual([]);
+      });
+    });
+
+    describe("review agent (has repo-read but NOT repo-write)", () => {
+      it("mongo.read OK (requires only repo-read)", () => {
+        const result = isCapabilitySubset(["mongo.read"], "review");
+        expect(result.ok).toBe(true);
+        expect(result.violations).toEqual([]);
+      });
+
+      it("migration.execute FAILS (requires repo-write which review lacks)", () => {
+        const result = isCapabilitySubset(["migration.execute"], "review");
+        expect(result.ok).toBe(false);
+        expect(result.violations.length).toBeGreaterThan(0);
+        expect(result.violations[0]).toContain("repo-write");
+        expect(result.violations[0]).toContain("review");
+      });
+
+      it("github.read OK (requires repo-read + github-review-read)", () => {
+        const result = isCapabilitySubset(["github.read"], "review");
+        expect(result.ok).toBe(true);
+        expect(result.violations).toEqual([]);
+      });
+    });
+
+    describe("overlay-only agent (no catalog entry)", () => {
+      beforeEach(() => {
+        registerAgentIdentity("overlay-only-test", {
+          username: "Overlay Test",
+          iconEmoji: ":test_tube:",
+        });
+      });
+
+      afterEach(() => {
+        delete AGENT_IDENTITIES["overlay-only-test"];
+      });
+
+      it("validates bundle names only, no capability check", () => {
+        const result = isCapabilitySubset(
+          ["mongo.read", "migration.execute"],
+          "overlay-only-test",
+        );
+        expect(result.ok).toBe(true);
+        expect(result.violations).toEqual([]);
+      });
+
+      it("unknown bundle still reported for overlay-only agent", () => {
+        const result = isCapabilitySubset(
+          ["mongo.read", "bogus.cap"],
+          "overlay-only-test",
+        );
+        expect(result.ok).toBe(false);
+        expect(result.violations.length).toBe(1);
+        expect(result.violations[0]).toContain('unknown capability bundle "bogus.cap"');
+      });
+    });
+
+    describe("unknown bundle", () => {
+      it("reports a violation for an unknown bundle", () => {
+        const result = isCapabilitySubset(
+          ["mongo.read", "nonexistent.bundle"],
+          "build",
+        );
+        expect(result.ok).toBe(false);
+        expect(
+          result.violations.some((v) =>
+            v.includes('unknown capability bundle "nonexistent.bundle"'),
+          ),
+        ).toBe(true);
+      });
+    });
+  });
+});

--- a/src/runbooks/capabilities.ts
+++ b/src/runbooks/capabilities.ts
@@ -1,0 +1,88 @@
+import type { AgentCapability } from "../agents/manifest.ts";
+import { resolveAgentManifest } from "../agents/registry.ts";
+
+export interface CapabilityBundle {
+  description: string;
+  requiredAgentCapabilities: readonly AgentCapability[];
+}
+
+export const CAPABILITY_BUNDLES: Record<string, CapabilityBundle> = {
+  "mongo.read": {
+    description: "Schema, find, count, and aggregate without mutation",
+    requiredAgentCapabilities: ["repo-read"],
+  },
+  "migration.inspect": {
+    description: "Read models and migration scripts",
+    requiredAgentCapabilities: ["repo-read"],
+  },
+  "migration.execute": {
+    description: "Execute an approved repository migration path",
+    requiredAgentCapabilities: ["repo-read", "repo-write"],
+  },
+  "slack.read": {
+    description: "Read the scoped channel or thread",
+    requiredAgentCapabilities: ["repo-read"],
+  },
+  "slack.post": {
+    description: "Post non-secret results in the scoped thread",
+    requiredAgentCapabilities: ["repo-read"],
+  },
+  "credential.deliver": {
+    description: "Deliver a credential through the approved private channel",
+    requiredAgentCapabilities: ["repo-read"],
+  },
+  "github.read": {
+    description: "Read repository and pull-request state",
+    requiredAgentCapabilities: ["repo-read", "github-review-read"],
+  },
+  "github.propose": {
+    description: "Create a branch and pull request through the approved identity",
+    requiredAgentCapabilities: ["repo-read", "repo-write"],
+  },
+};
+
+export function isValidCapabilityBundle(name: string): boolean {
+  return name in CAPABILITY_BUNDLES;
+}
+
+export function listCapabilityBundles(): string[] {
+  return Object.keys(CAPABILITY_BUNDLES);
+}
+
+export function isCapabilitySubset(
+  requested: string[],
+  ownerAgent: string,
+): { ok: boolean; violations: string[] } {
+  const manifest = resolveAgentManifest(ownerAgent);
+  if (!manifest) {
+    // Overlay-only agents lack a catalog entry. Validate bundle names only;
+    // capability enforcement defers to runtime dispatch policy.
+    const violations: string[] = [];
+    for (const name of requested) {
+      if (!CAPABILITY_BUNDLES[name]) {
+        violations.push(`unknown capability bundle "${name}"`);
+      }
+    }
+    return { ok: violations.length === 0, violations };
+  }
+
+  const agentCaps = new Set<string>(manifest.capabilities);
+  const violations: string[] = [];
+
+  for (const bundleName of requested) {
+    const bundle = CAPABILITY_BUNDLES[bundleName];
+    if (!bundle) {
+      violations.push(`unknown capability bundle "${bundleName}"`);
+      continue;
+    }
+    for (const required of bundle.requiredAgentCapabilities) {
+      if (!agentCaps.has(required)) {
+        violations.push(
+          `capability "${bundleName}" requires agent capability "${required}" not held by "${ownerAgent}"`,
+        );
+      }
+    }
+  }
+
+  return { ok: violations.length === 0, violations };
+}

--- a/src/runbooks/loader.test.ts
+++ b/src/runbooks/loader.test.ts
@@ -1,0 +1,289 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import path from "node:path";
+import fs from "node:fs/promises";
+import { loadRunbookDefinition } from "./loader.ts";
+import {
+  AGENT_IDENTITIES,
+  registerAgentIdentity,
+} from "../support/agents.ts";
+
+const fixtureDir = path.join(import.meta.dir, "__fixtures__");
+const fixturePath = path.join(fixtureDir, "transfer-ai-roadmaps.runbook.md");
+const tmpDir = path.join(import.meta.dir, "__loader_test");
+
+describe("loadRunbookDefinition", () => {
+  beforeEach(() => {
+    registerAgentIdentity("db-executioner", {
+      username: "DB Executioner",
+      iconEmoji: ":database:",
+    });
+  });
+
+  afterEach(async () => {
+    delete AGENT_IDENTITIES["db-executioner"];
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("loads a valid runbook from the fixture with correct types", async () => {
+    const result = await loadRunbookDefinition(fixturePath);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const def = result.definition;
+    expect(def.schemaVersion).toBe(1);
+    expect(def.name).toBe("transfer-ai-roadmaps");
+    expect(def.description).toBe(
+      "Transfer every AI roadmap owned by one user to another user.",
+    );
+    expect(def.ownerAgent).toBe("db-executioner");
+    expect(def.risk).toBe("production-write");
+    expect(def.approval.required).toBe(true);
+    expect(def.verification.required).toBe(true);
+    expect(def.origin).toBe("private");
+    expect(def.filePath).toBe(fixturePath);
+    expect(def.prompt).toBeTruthy();
+    expect(def.tags).toEqual(["database", "ai-roadmaps"]);
+  });
+
+  it("returns ok: false for a missing file", async () => {
+    const result = await loadRunbookDefinition("/nonexistent/path.runbook.md");
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors[0].field).toBe("file");
+    expect(result.errors[0].message).toContain("file not found");
+  });
+
+  it("returns error for missing frontmatter", async () => {
+    await fs.mkdir(tmpDir, { recursive: true });
+    const noFmPath = path.join(tmpDir, "no-fm.runbook.md");
+    await Bun.write(noFmPath, "Just some content without frontmatter.");
+
+    const result = await loadRunbookDefinition(noFmPath);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.errors.some((e) => e.field === "frontmatter")).toBe(true);
+  });
+
+  it("produces a stable content digest for the same file", async () => {
+    const r1 = await loadRunbookDefinition(fixturePath);
+    const r2 = await loadRunbookDefinition(fixturePath);
+    expect(r1.ok).toBe(true);
+    expect(r2.ok).toBe(true);
+    if (!r1.ok || !r2.ok) return;
+    expect(r1.definition.contentDigest).toBe(r2.definition.contentDigest);
+    // Must be a hex string
+    expect(r1.definition.contentDigest).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("digest changes when content changes", async () => {
+    await fs.mkdir(tmpDir, { recursive: true });
+
+    const content1 = `---
+schemaVersion: 1
+name: digest-test
+description: Digest test version 1
+ownerAgent: build
+intent:
+  examples:
+    - do thing one
+risk: workspace-write
+approval:
+  required: false
+capabilities:
+  - mongo.read
+verification:
+  required: true
+  assertions:
+    - thing was done
+tags:
+  - test
+---
+
+Do version one.`;
+
+    const content2 = `---
+schemaVersion: 1
+name: digest-test
+description: Digest test version 2
+ownerAgent: build
+intent:
+  examples:
+    - do thing one
+risk: workspace-write
+approval:
+  required: false
+capabilities:
+  - mongo.read
+verification:
+  required: true
+  assertions:
+    - thing was done
+tags:
+  - test
+---
+
+Do version two.`;
+
+    const p1 = path.join(tmpDir, "digest-test.runbook.md");
+    await Bun.write(p1, content1);
+    const r1 = await loadRunbookDefinition(p1);
+
+    await Bun.write(p1, content2);
+    const r2 = await loadRunbookDefinition(p1);
+
+    expect(r1.ok).toBe(true);
+    expect(r2.ok).toBe(true);
+    if (!r1.ok || !r2.ok) return;
+    expect(r1.definition.contentDigest).not.toBe(
+      r2.definition.contentDigest,
+    );
+  });
+
+  it("parses all YAML structures from the fixture correctly", async () => {
+    const result = await loadRunbookDefinition(fixturePath);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+
+    const def = result.definition;
+
+    // Scalar values
+    expect(typeof def.schemaVersion).toBe("number");
+    expect(typeof def.name).toBe("string");
+    expect(typeof def.description).toBe("string");
+
+    // Arrays of scalars
+    expect(def.intent.examples).toBeArray();
+    expect(def.intent.examples.length).toBeGreaterThanOrEqual(2);
+    expect(def.intent.excludes).toBeArray();
+    expect(def.intent.excludes.length).toBeGreaterThanOrEqual(1);
+    expect(def.tags).toBeArray();
+    expect(def.capabilities).toBeArray();
+
+    // Nested objects
+    expect(typeof def.approval.required).toBe("boolean");
+    expect(def.approval.afterSteps).toBeArray();
+
+    // Arrays of objects (inputs)
+    expect(def.inputs).toBeArray();
+    expect(def.inputs.length).toBe(2);
+    expect(def.inputs[0].name).toBe("sourceEmail");
+    expect(def.inputs[0].type).toBe("email");
+    expect(def.inputs[0].required).toBe(true);
+    expect(def.inputs[0].description).toBe(
+      "Email of the current roadmap owner",
+    );
+    expect(def.inputs[1].name).toBe("targetEmail");
+    expect(def.inputs[1].type).toBe("email");
+  });
+
+  it("unquotes quoted string values in frontmatter", async () => {
+    await fs.mkdir(tmpDir, { recursive: true });
+    const quotedPath = path.join(tmpDir, "quoted-test.runbook.md");
+    await Bun.write(
+      quotedPath,
+      `---
+schemaVersion: 1
+name: "quoted-test"
+description: 'A quoted description'
+ownerAgent: build
+intent:
+  examples:
+    - "do a quoted thing"
+risk: workspace-write
+approval:
+  required: false
+capabilities:
+  - mongo.read
+verification:
+  required: true
+  assertions:
+    - thing was done
+tags:
+  - test
+---
+
+Do the test thing.`,
+    );
+
+    const result = await loadRunbookDefinition(quotedPath);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.definition.name).toBe("quoted-test");
+    expect(result.definition.description).toBe("A quoted description");
+  });
+
+  it("parses boolean values correctly", async () => {
+    await fs.mkdir(tmpDir, { recursive: true });
+    const boolPath = path.join(tmpDir, "bool-test.runbook.md");
+    await Bun.write(
+      boolPath,
+      `---
+schemaVersion: 1
+name: bool-test
+description: Boolean test
+ownerAgent: build
+intent:
+  examples:
+    - do a bool thing
+risk: production-write
+approval:
+  required: true
+capabilities:
+  - mongo.read
+verification:
+  required: true
+  assertions:
+    - thing was done
+tags:
+  - test
+---
+
+Do the test.`,
+    );
+
+    const result = await loadRunbookDefinition(boolPath);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.definition.approval.required).toBe(true);
+    expect(result.definition.verification.required).toBe(true);
+  });
+
+  it("parses number values correctly", async () => {
+    const result = await loadRunbookDefinition(fixturePath);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.definition.schemaVersion).toBe(1);
+    expect(typeof result.definition.schemaVersion).toBe("number");
+  });
+
+  it("respects the origin option", async () => {
+    const result = await loadRunbookDefinition(fixturePath, {
+      origin: "public",
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.definition.origin).toBe("public");
+  });
+
+  it("respects filenameForValidation option", async () => {
+    // The fixture name is "transfer-ai-roadmaps" which matches its file.
+    // Giving a mismatched filenameForValidation should cause a validation error.
+    const result = await loadRunbookDefinition(fixturePath, {
+      filenameForValidation: "wrong-name",
+    });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(
+      result.errors.some((e) => e.field === "name" && e.message.includes("does not match")),
+    ).toBe(true);
+  });
+
+  it("extracts prompt body as trimmed content after frontmatter", async () => {
+    const result = await loadRunbookDefinition(fixturePath);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.definition.prompt).toContain("Resolve the source");
+    expect(result.definition.prompt).not.toContain("---");
+    expect(result.definition.prompt).not.toContain("schemaVersion");
+  });
+});

--- a/src/runbooks/loader.test.ts
+++ b/src/runbooks/loader.test.ts
@@ -286,4 +286,48 @@ Do the test.`,
     expect(result.definition.prompt).not.toContain("---");
     expect(result.definition.prompt).not.toContain("schemaVersion");
   });
+
+  it("parses array items containing colons as plain strings, not objects", async () => {
+    await fs.mkdir(tmpDir, { recursive: true });
+    const colonPath = path.join(tmpDir, "colon-test.runbook.md");
+    await Bun.write(
+      colonPath,
+      `---
+schemaVersion: 1
+name: colon-test
+description: Test colon handling in arrays
+ownerAgent: build
+intent:
+  examples:
+    - connect via http://example.com
+    - step: run the migration
+risk: workspace-write
+approval:
+  required: false
+capabilities:
+  - mongo.read
+verification:
+  required: true
+  assertions:
+    - source count: 0
+    - target count increased by: matched count
+tags:
+  - test
+---
+
+Do the test.`,
+    );
+
+    const result = await loadRunbookDefinition(colonPath);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.definition.intent.examples).toEqual([
+      "connect via http://example.com",
+      "step: run the migration",
+    ]);
+    expect(result.definition.verification.assertions).toEqual([
+      "source count: 0",
+      "target count increased by: matched count",
+    ]);
+  });
 });

--- a/src/runbooks/loader.ts
+++ b/src/runbooks/loader.ts
@@ -1,0 +1,310 @@
+import type { RunbookDefinition, RunbookLoadResult } from "./types.ts";
+import { validateRunbook } from "./validator.ts";
+
+export async function loadRunbookDefinition(
+  filePath: string,
+  options?: { origin?: "private" | "public"; filenameForValidation?: string },
+): Promise<RunbookLoadResult> {
+  const file = Bun.file(filePath);
+  if (!(await file.exists())) {
+    return {
+      ok: false,
+      errors: [{ field: "file", message: `file not found: ${filePath}` }],
+      filePath,
+    };
+  }
+
+  const raw = await file.text();
+  const contentDigest = computeDigest(raw);
+  const { frontmatter, body } = extractFrontmatter(raw);
+
+  if (!frontmatter) {
+    return {
+      ok: false,
+      errors: [{ field: "frontmatter", message: "missing YAML frontmatter" }],
+      filePath,
+    };
+  }
+
+  const parsed = parseYamlFrontmatter(frontmatter);
+  const origin = options?.origin ?? "private";
+
+  const definition: RunbookDefinition = {
+    schemaVersion: toNumber(parsed.schemaVersion) ?? 0,
+    name: toString(parsed.name) ?? "",
+    description: toString(parsed.description) ?? "",
+    ownerAgent: toString(parsed.ownerAgent) ?? "",
+    intent: {
+      examples: toStringArray(parsed.intent?.examples) ?? [],
+      excludes: toStringArray(parsed.intent?.excludes) ?? [],
+    },
+    inputs: toInputArray(parsed.inputs),
+    risk: toString(parsed.risk) as RunbookDefinition["risk"],
+    approval: {
+      required: toBool(parsed.approval?.required) ?? false,
+      afterSteps: toStringArray(parsed.approval?.afterSteps),
+    },
+    capabilities: toStringArray(parsed.capabilities) ?? [],
+    verification: {
+      required: toBool(parsed.verification?.required) ?? false,
+      assertions: toStringArray(parsed.verification?.assertions) ?? [],
+    },
+    tags: toStringArray(parsed.tags) ?? [],
+    prompt: body.trim(),
+    filePath,
+    origin,
+    contentDigest,
+  };
+
+  const filename = options?.filenameForValidation ?? filenameStem(filePath);
+  const errors = validateRunbook(definition, filename);
+
+  if (errors.length > 0) {
+    return { ok: false, errors, filePath };
+  }
+
+  return { ok: true, definition };
+}
+
+function computeDigest(content: string): string {
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(content);
+  return hasher.digest("hex");
+}
+
+function filenameStem(filePath: string): string {
+  const base = filePath.split("/").pop() ?? "";
+  return base.replace(/\.runbook\.md$/, "");
+}
+
+function extractFrontmatter(raw: string): {
+  frontmatter: string | null;
+  body: string;
+} {
+  if (!raw.startsWith("---")) {
+    return { frontmatter: null, body: raw };
+  }
+  const end = raw.indexOf("\n---", 3);
+  if (end === -1) {
+    return { frontmatter: null, body: raw };
+  }
+  const fm = raw.slice(4, end);
+  const body = raw.slice(end + 4);
+  return { frontmatter: fm, body };
+}
+
+// ─── minimal nested YAML parser ─────────────────────────────────────────────
+//
+// Handles the subset of YAML used by runbook frontmatter:
+// - scalar key: value
+// - nested objects (indented keys)
+// - arrays of scalars (- item)
+// - arrays of objects (- name: foo\n  type: bar)
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type YamlNode = Record<string, any>;
+
+function parseYamlFrontmatter(text: string): YamlNode {
+  const lines = text.split("\n");
+  return parseBlock(lines, 0, 0).node;
+}
+
+function parseBlock(
+  lines: string[],
+  start: number,
+  baseIndent: number,
+): { node: YamlNode; nextLine: number } {
+  const node: YamlNode = {};
+  let i = start;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    if (line.trim() === "" || line.trim().startsWith("#")) {
+      i++;
+      continue;
+    }
+
+    const indent = countIndent(line);
+    if (indent < baseIndent) break;
+
+    const trimmed = line.trim();
+
+    if (trimmed.startsWith("- ")) {
+      break;
+    }
+
+    const colonIdx = trimmed.indexOf(":");
+    if (colonIdx === -1) {
+      i++;
+      continue;
+    }
+
+    const key = trimmed.slice(0, colonIdx).trim();
+    const valueStr = trimmed.slice(colonIdx + 1).trim();
+
+    if (valueStr === "") {
+      const nextIndent = peekIndent(lines, i + 1);
+      if (nextIndent > indent) {
+        const nextTrimmed = lines[i + 1]?.trim() ?? "";
+        if (nextTrimmed.startsWith("- ")) {
+          const arr = parseArray(lines, i + 1, nextIndent);
+          node[key] = arr.items;
+          i = arr.nextLine;
+        } else {
+          const sub = parseBlock(lines, i + 1, nextIndent);
+          node[key] = sub.node;
+          i = sub.nextLine;
+        }
+      } else {
+        node[key] = "";
+        i++;
+      }
+    } else {
+      node[key] = parseScalar(valueStr);
+      i++;
+    }
+  }
+
+  return { node, nextLine: i };
+}
+
+function parseArray(
+  lines: string[],
+  start: number,
+  baseIndent: number,
+): { items: (string | YamlNode)[]; nextLine: number } {
+  const items: (string | YamlNode)[] = [];
+  let i = start;
+
+  while (i < lines.length) {
+    const line = lines[i];
+    if (line.trim() === "" || line.trim().startsWith("#")) {
+      i++;
+      continue;
+    }
+
+    const indent = countIndent(line);
+    if (indent < baseIndent) break;
+
+    const trimmed = line.trim();
+    if (!trimmed.startsWith("- ")) break;
+
+    const value = trimmed.slice(2).trim();
+    const colonIdx = value.indexOf(":");
+    if (colonIdx !== -1 && value.slice(colonIdx + 1).trim() !== "") {
+      // Array of objects: - key: value
+      const obj: YamlNode = {};
+      const objKey = value.slice(0, colonIdx).trim();
+      const objVal = value.slice(colonIdx + 1).trim();
+      obj[objKey] = parseScalar(objVal);
+
+      // Check for continuation keys at deeper indent
+      const contIndent = indent + 2;
+      i++;
+      while (i < lines.length) {
+        const contLine = lines[i];
+        if (contLine.trim() === "") {
+          i++;
+          continue;
+        }
+        const ci = countIndent(contLine);
+        if (ci < contIndent) break;
+        const ct = contLine.trim();
+        const cc = ct.indexOf(":");
+        if (cc === -1 || ct.startsWith("- ")) break;
+        obj[ct.slice(0, cc).trim()] = parseScalar(ct.slice(cc + 1).trim());
+        i++;
+      }
+      items.push(obj);
+    } else if (colonIdx !== -1 && value.slice(colonIdx + 1).trim() === "") {
+      // Array item with nested object: - key:\n    subkey: val
+      const obj: YamlNode = {};
+      const objKey = value.slice(0, colonIdx).trim();
+      i++;
+      const nestedIndent = peekIndent(lines, i);
+      if (nestedIndent > indent) {
+        const sub = parseBlock(lines, i, nestedIndent);
+        obj[objKey] = sub.node;
+        i = sub.nextLine;
+      } else {
+        obj[objKey] = "";
+      }
+      items.push(obj);
+    } else {
+      items.push(parseScalar(value) as string);
+      i++;
+    }
+  }
+
+  return { items, nextLine: i };
+}
+
+function parseScalar(s: string): string | number | boolean {
+  if (s === "true") return true;
+  if (s === "false") return false;
+  // Strip surrounding quotes
+  if ((s.startsWith('"') && s.endsWith('"')) || (s.startsWith("'") && s.endsWith("'"))) {
+    return s.slice(1, -1);
+  }
+  const n = Number(s);
+  if (!Number.isNaN(n) && s !== "") return n;
+  return s;
+}
+
+function countIndent(line: string): number {
+  let n = 0;
+  for (const ch of line) {
+    if (ch === " ") n++;
+    else break;
+  }
+  return n;
+}
+
+function peekIndent(lines: string[], start: number): number {
+  for (let i = start; i < lines.length; i++) {
+    const t = lines[i].trim();
+    if (t !== "" && !t.startsWith("#")) return countIndent(lines[i]);
+  }
+  return 0;
+}
+
+// ─── type coercions ─────────────────────────────────────────────────────────
+
+function toString(v: unknown): string | undefined {
+  if (v === undefined || v === null) return undefined;
+  return String(v);
+}
+
+function toNumber(v: unknown): number | undefined {
+  if (v === undefined || v === null) return undefined;
+  const n = Number(v);
+  return Number.isNaN(n) ? undefined : n;
+}
+
+function toBool(v: unknown): boolean | undefined {
+  if (v === undefined || v === null) return undefined;
+  if (typeof v === "boolean") return v;
+  if (v === "true") return true;
+  if (v === "false") return false;
+  return undefined;
+}
+
+function toStringArray(v: unknown): string[] | undefined {
+  if (!Array.isArray(v)) return undefined;
+  return v.map((item) => (typeof item === "string" ? item : String(item)));
+}
+
+function toInputArray(v: unknown): RunbookDefinition["inputs"] {
+  if (!Array.isArray(v)) return [];
+  return v
+    .filter((item): item is YamlNode => typeof item === "object" && item !== null)
+    .map((item) => ({
+      name: toString(item.name) ?? "",
+      type: (toString(item.type) ?? "string") as RunbookDefinition["inputs"][number]["type"],
+      required: toBool(item.required) ?? false,
+      ...(item.enumValues
+        ? { enumValues: toStringArray(item.enumValues) }
+        : {}),
+      ...(item.description ? { description: toString(item.description) } : {}),
+    }));
+}

--- a/src/runbooks/loader.ts
+++ b/src/runbooks/loader.ts
@@ -192,30 +192,40 @@ function parseArray(
     const value = trimmed.slice(2).trim();
     const colonIdx = value.indexOf(":");
     if (colonIdx !== -1 && value.slice(colonIdx + 1).trim() !== "") {
-      // Array of objects: - key: value
-      const obj: YamlNode = {};
-      const objKey = value.slice(0, colonIdx).trim();
-      const objVal = value.slice(colonIdx + 1).trim();
-      obj[objKey] = parseScalar(objVal);
-
-      // Check for continuation keys at deeper indent
+      // Only treat as object if continuation keys follow at indent+2
       const contIndent = indent + 2;
-      i++;
-      while (i < lines.length) {
-        const contLine = lines[i];
-        if (contLine.trim() === "") {
+      const nextContentIdx = nextNonBlankLine(lines, i + 1);
+      const hasCont =
+        nextContentIdx !== -1 &&
+        countIndent(lines[nextContentIdx]) >= contIndent &&
+        !lines[nextContentIdx].trim().startsWith("- ");
+
+      if (hasCont) {
+        const obj: YamlNode = {};
+        const objKey = value.slice(0, colonIdx).trim();
+        const objVal = value.slice(colonIdx + 1).trim();
+        obj[objKey] = parseScalar(objVal);
+
+        i++;
+        while (i < lines.length) {
+          const contLine = lines[i];
+          if (contLine.trim() === "") {
+            i++;
+            continue;
+          }
+          const ci = countIndent(contLine);
+          if (ci < contIndent) break;
+          const ct = contLine.trim();
+          const cc = ct.indexOf(":");
+          if (cc === -1 || ct.startsWith("- ")) break;
+          obj[ct.slice(0, cc).trim()] = parseScalar(ct.slice(cc + 1).trim());
           i++;
-          continue;
         }
-        const ci = countIndent(contLine);
-        if (ci < contIndent) break;
-        const ct = contLine.trim();
-        const cc = ct.indexOf(":");
-        if (cc === -1 || ct.startsWith("- ")) break;
-        obj[ct.slice(0, cc).trim()] = parseScalar(ct.slice(cc + 1).trim());
+        items.push(obj);
+      } else {
+        items.push(value);
         i++;
       }
-      items.push(obj);
     } else if (colonIdx !== -1 && value.slice(colonIdx + 1).trim() === "") {
       // Array item with nested object: - key:\n    subkey: val
       const obj: YamlNode = {};
@@ -258,6 +268,14 @@ function countIndent(line: string): number {
     else break;
   }
   return n;
+}
+
+function nextNonBlankLine(lines: string[], start: number): number {
+  for (let i = start; i < lines.length; i++) {
+    const t = lines[i].trim();
+    if (t !== "" && !t.startsWith("#")) return i;
+  }
+  return -1;
 }
 
 function peekIndent(lines: string[], start: number): number {

--- a/src/runbooks/registry.test.ts
+++ b/src/runbooks/registry.test.ts
@@ -1,0 +1,258 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import path from "node:path";
+import fs from "node:fs/promises";
+import {
+  clearRegistryForTests,
+  getContentDigest,
+  getRunbook,
+  listRunbooks,
+  loadRunbookRegistryFromDir,
+  searchRunbooks,
+} from "./registry.ts";
+import {
+  AGENT_IDENTITIES,
+  registerAgentIdentity,
+} from "../support/agents.ts";
+
+const fixtureDir = path.join(import.meta.dir, "__fixtures__");
+const tmpDir = path.join(import.meta.dir, "__registry_test");
+
+const VALID_RUNBOOK = `---
+schemaVersion: 1
+name: test-runbook
+description: A test runbook for registry tests
+ownerAgent: build
+intent:
+  examples:
+    - do a test thing
+  excludes:
+    - do something else
+inputs:
+  - name: target
+    type: string
+    required: true
+risk: workspace-write
+approval:
+  required: false
+capabilities:
+  - mongo.read
+verification:
+  required: true
+  assertions:
+    - thing was done
+tags:
+  - test
+  - registry
+---
+
+Do the test thing.`;
+
+const SECOND_RUNBOOK = `---
+schemaVersion: 1
+name: second-runbook
+description: A second test runbook for search testing
+ownerAgent: review
+intent:
+  examples:
+    - do a second thing
+  excludes:
+    - not this
+risk: read-only
+approval:
+  required: false
+capabilities:
+  - mongo.read
+verification:
+  required: false
+  assertions: []
+tags:
+  - search-test
+  - readonly
+---
+
+Do the second thing.`;
+
+describe("runbook registry", () => {
+  beforeEach(async () => {
+    registerAgentIdentity("db-executioner", {
+      username: "DB Executioner",
+      iconEmoji: ":database:",
+    });
+    await fs.mkdir(tmpDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    delete AGENT_IDENTITIES["db-executioner"];
+    clearRegistryForTests();
+    await fs.rm(tmpDir, { recursive: true, force: true });
+  });
+
+  describe("load from directory", () => {
+    it("loads the fixture file from a directory", async () => {
+      const result = await loadRunbookRegistryFromDir(fixtureDir, "private");
+      expect(result.loaded).toBeGreaterThanOrEqual(1);
+      expect(result.errors).toBe(0);
+    });
+
+    it("loads runbooks from a temp directory", async () => {
+      await Bun.write(path.join(tmpDir, "test-runbook.runbook.md"), VALID_RUNBOOK);
+
+      const result = await loadRunbookRegistryFromDir(tmpDir, "private");
+      expect(result.loaded).toBe(1);
+      expect(result.errors).toBe(0);
+    });
+  });
+
+  describe("getRunbook", () => {
+    it("returns the loaded definition", async () => {
+      await loadRunbookRegistryFromDir(fixtureDir, "private");
+
+      const def = getRunbook("transfer-ai-roadmaps");
+      expect(def).toBeDefined();
+      expect(def!.name).toBe("transfer-ai-roadmaps");
+      expect(def!.description).toContain("AI roadmap");
+      expect(def!.ownerAgent).toBe("db-executioner");
+    });
+
+    it("returns undefined for unknown name", async () => {
+      await loadRunbookRegistryFromDir(fixtureDir, "private");
+
+      const def = getRunbook("nonexistent-runbook");
+      expect(def).toBeUndefined();
+    });
+  });
+
+  describe("getContentDigest", () => {
+    it("returns the hex digest for a loaded runbook", async () => {
+      await loadRunbookRegistryFromDir(fixtureDir, "private");
+
+      const digest = getContentDigest("transfer-ai-roadmaps");
+      expect(digest).toBeDefined();
+      expect(digest).toMatch(/^[0-9a-f]{64}$/);
+    });
+
+    it("returns undefined for unknown name", async () => {
+      const digest = getContentDigest("nonexistent");
+      expect(digest).toBeUndefined();
+    });
+  });
+
+  describe("searchRunbooks", () => {
+    beforeEach(async () => {
+      await Bun.write(path.join(tmpDir, "test-runbook.runbook.md"), VALID_RUNBOOK);
+      await Bun.write(path.join(tmpDir, "second-runbook.runbook.md"), SECOND_RUNBOOK);
+      await loadRunbookRegistryFromDir(tmpDir, "private");
+    });
+
+    it("matches by query in name/description", () => {
+      const results = searchRunbooks({ query: "test" });
+      expect(results.length).toBeGreaterThanOrEqual(1);
+      expect(results.some((r) => r.name === "test-runbook")).toBe(true);
+    });
+
+    it("matches by query in description", () => {
+      const results = searchRunbooks({ query: "second" });
+      expect(results.length).toBeGreaterThanOrEqual(1);
+      expect(results.some((r) => r.name === "second-runbook")).toBe(true);
+    });
+
+    it("filters by tags", () => {
+      const results = searchRunbooks({ tags: ["search-test"] });
+      expect(results.length).toBe(1);
+      expect(results[0].name).toBe("second-runbook");
+    });
+
+    it("filters by ownerAgent", () => {
+      const results = searchRunbooks({ ownerAgent: "review" });
+      expect(results.length).toBe(1);
+      expect(results[0].name).toBe("second-runbook");
+    });
+
+    it("filters by risk", () => {
+      const results = searchRunbooks({ risk: "read-only" });
+      expect(results.length).toBe(1);
+      expect(results[0].name).toBe("second-runbook");
+    });
+
+    it("respects limit", () => {
+      const results = searchRunbooks({ limit: 1 });
+      expect(results.length).toBe(1);
+    });
+
+    it("returns empty for non-matching query", () => {
+      const results = searchRunbooks({ query: "zzzzz-no-match-zzzzz" });
+      expect(results).toEqual([]);
+    });
+
+    it("search results have the expected shape", () => {
+      const results = searchRunbooks({ query: "test" });
+      expect(results.length).toBeGreaterThanOrEqual(1);
+      const r = results[0];
+      expect(r).toHaveProperty("name");
+      expect(r).toHaveProperty("description");
+      expect(r).toHaveProperty("ownerAgent");
+      expect(r).toHaveProperty("risk");
+      expect(r).toHaveProperty("tags");
+      expect(r).toHaveProperty("origin");
+      expect(r).toHaveProperty("contentDigest");
+    });
+  });
+
+  describe("listRunbooks", () => {
+    it("returns all loaded runbooks", async () => {
+      await Bun.write(path.join(tmpDir, "test-runbook.runbook.md"), VALID_RUNBOOK);
+      await Bun.write(path.join(tmpDir, "second-runbook.runbook.md"), SECOND_RUNBOOK);
+      await loadRunbookRegistryFromDir(tmpDir, "private");
+
+      const all = listRunbooks();
+      expect(all.length).toBe(2);
+      const names = all.map((d) => d.name).sort();
+      expect(names).toEqual(["second-runbook", "test-runbook"]);
+    });
+
+    it("returns empty when nothing is loaded", () => {
+      const all = listRunbooks();
+      expect(all).toEqual([]);
+    });
+  });
+
+  describe("last-known-good behavior", () => {
+    it("valid runbook survives overwrite with invalid content on reload", async () => {
+      // First load: valid content
+      await Bun.write(path.join(tmpDir, "test-runbook.runbook.md"), VALID_RUNBOOK);
+      const r1 = await loadRunbookRegistryFromDir(tmpDir, "private");
+      expect(r1.loaded).toBe(1);
+      expect(r1.errors).toBe(0);
+
+      const defBefore = getRunbook("test-runbook");
+      expect(defBefore).toBeDefined();
+      expect(defBefore!.description).toContain("test runbook");
+
+      // Overwrite with invalid content (missing frontmatter)
+      await Bun.write(
+        path.join(tmpDir, "test-runbook.runbook.md"),
+        "This has no frontmatter at all — totally invalid.",
+      );
+
+      // Reload — the invalid load should fail but the valid entry should survive
+      const r2 = await loadRunbookRegistryFromDir(tmpDir, "private");
+      expect(r2.errors).toBe(1);
+
+      // The previously valid entry should still be in the registry
+      const defAfter = getRunbook("test-runbook");
+      expect(defAfter).toBeDefined();
+      expect(defAfter!.description).toContain("test runbook");
+    });
+  });
+
+  describe("clearRegistryForTests", () => {
+    it("empties the registry", async () => {
+      await Bun.write(path.join(tmpDir, "test-runbook.runbook.md"), VALID_RUNBOOK);
+      await loadRunbookRegistryFromDir(tmpDir, "private");
+      expect(listRunbooks().length).toBe(1);
+
+      clearRegistryForTests();
+      expect(listRunbooks().length).toBe(0);
+    });
+  });
+});

--- a/src/runbooks/registry.ts
+++ b/src/runbooks/registry.ts
@@ -32,7 +32,8 @@ export async function reloadRunbookRegistry(): Promise<{
         loaded++;
       } else {
         // Last-known-good: don't replace a valid entry with a broken reload
-        if (!registry.has(result.filePath)) {
+        const expectedName = file.replace(/\.runbook\.md$/, "");
+        if (!registry.has(expectedName)) {
           log.warn(
             "runbooks",
             `failed to load ${filePath}: ${result.errors.map((e) => e.message).join("; ")}`,
@@ -136,7 +137,8 @@ export async function loadRunbookRegistryFromDir(
       registry.set(result.definition.name, result.definition);
       loaded++;
     } else {
-      if (!registry.has(result.filePath)) {
+      const expectedName = file.replace(/\.runbook\.md$/, "");
+      if (!registry.has(expectedName)) {
         log.warn(
           "runbooks",
           `failed to load ${filePath}: ${result.errors.map((e) => e.message).join("; ")}`,

--- a/src/runbooks/registry.ts
+++ b/src/runbooks/registry.ts
@@ -1,0 +1,162 @@
+import { readdir } from "fs/promises";
+import { log } from "../logger.ts";
+import { loadRunbookDefinition } from "./loader.ts";
+import type { RunbookDefinition } from "./types.ts";
+
+const PRIVATE_RUNBOOKS_DIR = "agents-org/runbooks";
+const PUBLIC_RUNBOOKS_DIR = "runbooks";
+
+const registry = new Map<string, RunbookDefinition>();
+
+export async function reloadRunbookRegistry(): Promise<{
+  loaded: number;
+  errors: number;
+}> {
+  let loaded = 0;
+  let errors = 0;
+
+  for (const dir of [
+    { path: PRIVATE_RUNBOOKS_DIR, origin: "private" as const },
+    { path: PUBLIC_RUNBOOKS_DIR, origin: "public" as const },
+  ]) {
+    const files = await runbookFiles(dir.path);
+    for (const file of files) {
+      const filePath = `${dir.path}/${file}`;
+      const result = await loadRunbookDefinition(filePath, {
+        origin: dir.origin,
+        filenameForValidation: file.replace(/\.runbook\.md$/, ""),
+      });
+
+      if (result.ok) {
+        registry.set(result.definition.name, result.definition);
+        loaded++;
+      } else {
+        // Last-known-good: don't replace a valid entry with a broken reload
+        if (!registry.has(result.filePath)) {
+          log.warn(
+            "runbooks",
+            `failed to load ${filePath}: ${result.errors.map((e) => e.message).join("; ")}`,
+          );
+        }
+        errors++;
+      }
+    }
+  }
+
+  log.info("runbooks", `registry reload: ${loaded} loaded, ${errors} errors`);
+  return { loaded, errors };
+}
+
+export function getRunbook(name: string): RunbookDefinition | undefined {
+  return registry.get(name);
+}
+
+export function getContentDigest(name: string): string | undefined {
+  return registry.get(name)?.contentDigest;
+}
+
+export function listRunbooks(): RunbookDefinition[] {
+  return [...registry.values()];
+}
+
+export interface RunbookSearchOptions {
+  query?: string;
+  tags?: string[];
+  ownerAgent?: string;
+  risk?: string;
+  limit?: number;
+}
+
+export interface RunbookSearchResult {
+  name: string;
+  description: string;
+  ownerAgent: string;
+  risk: string;
+  tags: string[];
+  origin: "private" | "public";
+  contentDigest: string;
+}
+
+export function searchRunbooks(
+  options: RunbookSearchOptions,
+): RunbookSearchResult[] {
+  const query = options.query?.trim().toLowerCase();
+  const limit = Math.min(options.limit ?? 25, 100);
+  const results: RunbookSearchResult[] = [];
+
+  for (const def of registry.values()) {
+    if (query) {
+      const haystack =
+        `${def.name} ${def.description} ${def.tags.join(" ")}`.toLowerCase();
+      if (!haystack.includes(query)) continue;
+    }
+    if (options.tags && options.tags.length > 0) {
+      const defTags = new Set(def.tags);
+      if (!options.tags.some((t) => defTags.has(t))) continue;
+    }
+    if (options.ownerAgent && def.ownerAgent !== options.ownerAgent) continue;
+    if (options.risk && def.risk !== options.risk) continue;
+
+    results.push({
+      name: def.name,
+      description: def.description,
+      ownerAgent: def.ownerAgent,
+      risk: def.risk,
+      tags: def.tags,
+      origin: def.origin,
+      contentDigest: def.contentDigest,
+    });
+
+    if (results.length >= limit) break;
+  }
+
+  return results;
+}
+
+export function clearRegistryForTests(): void {
+  registry.clear();
+}
+
+export async function loadRunbookRegistryFromDir(
+  dirPath: string,
+  origin: "private" | "public",
+): Promise<{ loaded: number; errors: number }> {
+  let loaded = 0;
+  let errors = 0;
+  const files = await runbookFiles(dirPath);
+
+  for (const file of files) {
+    const filePath = `${dirPath}/${file}`;
+    const result = await loadRunbookDefinition(filePath, {
+      origin,
+      filenameForValidation: file.replace(/\.runbook\.md$/, ""),
+    });
+
+    if (result.ok) {
+      registry.set(result.definition.name, result.definition);
+      loaded++;
+    } else {
+      if (!registry.has(result.filePath)) {
+        log.warn(
+          "runbooks",
+          `failed to load ${filePath}: ${result.errors.map((e) => e.message).join("; ")}`,
+        );
+      }
+      errors++;
+    }
+  }
+
+  return { loaded, errors };
+}
+
+async function runbookFiles(dirPath: string): Promise<string[]> {
+  try {
+    const entries = await readdir(dirPath, { withFileTypes: true });
+    return entries
+      .filter((e) => e.isFile() && e.name.endsWith(".runbook.md"))
+      .map((e) => e.name)
+      .sort();
+  } catch {
+    return [];
+  }
+}

--- a/src/runbooks/types.ts
+++ b/src/runbooks/types.ts
@@ -1,0 +1,94 @@
+export interface RunbookInput {
+  name: string;
+  type: RunbookInputType;
+  required: boolean;
+  enumValues?: string[];
+  description?: string;
+}
+
+export type RunbookInputType =
+  | "string"
+  | "email"
+  | "objectId"
+  | "number"
+  | "boolean"
+  | "enum";
+
+export const RUNBOOK_INPUT_TYPES: readonly RunbookInputType[] = [
+  "string",
+  "email",
+  "objectId",
+  "number",
+  "boolean",
+  "enum",
+];
+
+export type RunbookRisk =
+  | "read-only"
+  | "workspace-write"
+  | "production-write"
+  | "destructive"
+  | "credential"
+  | "privacy-sensitive"
+  | "payment"
+  | "access-control";
+
+export const RUNBOOK_RISKS: readonly RunbookRisk[] = [
+  "read-only",
+  "workspace-write",
+  "production-write",
+  "destructive",
+  "credential",
+  "privacy-sensitive",
+  "payment",
+  "access-control",
+];
+
+export const HIGH_RISK_KINDS: readonly RunbookRisk[] = [
+  "production-write",
+  "destructive",
+  "credential",
+  "privacy-sensitive",
+  "payment",
+  "access-control",
+];
+
+export interface RunbookApproval {
+  required: boolean;
+  afterSteps?: string[];
+}
+
+export interface RunbookVerification {
+  required: boolean;
+  assertions: string[];
+}
+
+export interface RunbookDefinition {
+  schemaVersion: number;
+  name: string;
+  description: string;
+  ownerAgent: string;
+  intent: {
+    examples: string[];
+    excludes: string[];
+  };
+  inputs: RunbookInput[];
+  risk: RunbookRisk;
+  approval: RunbookApproval;
+  capabilities: string[];
+  verification: RunbookVerification;
+  tags: string[];
+  prompt: string;
+  filePath: string;
+  origin: "private" | "public";
+  contentDigest: string;
+}
+
+export interface RunbookValidationError {
+  field: string;
+  message: string;
+}
+
+export type RunbookLoadResult =
+  | { ok: true; definition: RunbookDefinition }
+  | { ok: false; errors: RunbookValidationError[]; filePath: string };

--- a/src/runbooks/validator.test.ts
+++ b/src/runbooks/validator.test.ts
@@ -1,0 +1,467 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import path from "node:path";
+import fs from "node:fs/promises";
+import { validateRunbook } from "./validator.ts";
+import { loadRunbookDefinition } from "./loader.ts";
+import type { RunbookDefinition } from "./types.ts";
+import {
+  AGENT_IDENTITIES,
+  registerAgentIdentity,
+} from "../support/agents.ts";
+
+const fixtureDir = path.join(import.meta.dir, "__fixtures__");
+const fixturePath = path.join(fixtureDir, "transfer-ai-roadmaps.runbook.md");
+
+/** Build a minimal valid RunbookDefinition for inline tests. */
+function makeValidDef(overrides?: Partial<RunbookDefinition>): RunbookDefinition {
+  return {
+    schemaVersion: 1,
+    name: "test-runbook",
+    description: "A test runbook",
+    ownerAgent: "build",
+    intent: {
+      examples: ["do a test thing"],
+      excludes: ["do something else"],
+    },
+    inputs: [
+      { name: "target", type: "string", required: true },
+    ],
+    risk: "workspace-write",
+    approval: { required: false },
+    capabilities: ["mongo.read"],
+    verification: { required: true, assertions: ["thing was done"] },
+    tags: ["test"],
+    prompt: "Do the test thing.",
+    filePath: "/tmp/test-runbook.runbook.md",
+    origin: "private",
+    contentDigest: "abc123",
+    ...overrides,
+  };
+}
+
+describe("validateRunbook", () => {
+  beforeEach(() => {
+    registerAgentIdentity("db-executioner", {
+      username: "DB Executioner",
+      iconEmoji: ":database:",
+    });
+  });
+
+  afterEach(() => {
+    delete AGENT_IDENTITIES["db-executioner"];
+  });
+
+  it("valid definition produces zero errors", () => {
+    const def = makeValidDef();
+    const errors = validateRunbook(def, "test-runbook");
+    expect(errors).toEqual([]);
+  });
+
+  it("valid fixture produces zero errors", async () => {
+    const result = await loadRunbookDefinition(fixturePath);
+    expect(result.ok).toBe(true);
+  });
+
+  describe("name validation", () => {
+    it("accepts kebab-case name", () => {
+      const def = makeValidDef({ name: "foo-bar" });
+      const errors = validateRunbook(def, "foo-bar");
+      const nameErrors = errors.filter((e) => e.field === "name");
+      expect(nameErrors).toEqual([]);
+    });
+
+    it("rejects non-kebab-case name", () => {
+      const def = makeValidDef({ name: "Foo_Bar" });
+      const errors = validateRunbook(def, "Foo_Bar");
+      expect(errors.some((e) => e.field === "name" && e.message.includes("kebab-case"))).toBe(
+        true,
+      );
+    });
+
+    it("rejects name that does not match filename", () => {
+      const def = makeValidDef({ name: "foo" });
+      const errors = validateRunbook(def, "bar");
+      expect(
+        errors.some((e) => e.field === "name" && e.message.includes("does not match")),
+      ).toBe(true);
+    });
+
+    it("rejects empty name", () => {
+      const def = makeValidDef({ name: "" });
+      const errors = validateRunbook(def, "");
+      expect(errors.some((e) => e.field === "name" && e.message.includes("required"))).toBe(
+        true,
+      );
+    });
+  });
+
+  describe("schemaVersion", () => {
+    it("accepts schemaVersion 1", () => {
+      const def = makeValidDef({ schemaVersion: 1 });
+      const errors = validateRunbook(def, "test-runbook");
+      expect(errors.filter((e) => e.field === "schemaVersion")).toEqual([]);
+    });
+
+    it("rejects schemaVersion other than 1", () => {
+      const def = makeValidDef({ schemaVersion: 2 });
+      const errors = validateRunbook(def, "test-runbook");
+      expect(
+        errors.some(
+          (e) => e.field === "schemaVersion" && e.message.includes("expected 1"),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("description", () => {
+    it("rejects empty description", () => {
+      const def = makeValidDef({ description: "" });
+      const errors = validateRunbook(def, "test-runbook");
+      expect(
+        errors.some((e) => e.field === "description" && e.message.includes("required")),
+      ).toBe(true);
+    });
+  });
+
+  describe("ownerAgent", () => {
+    it("accepts a catalog agent as ownerAgent", () => {
+      const def = makeValidDef({ ownerAgent: "build" });
+      const errors = validateRunbook(def, "test-runbook");
+      expect(errors.filter((e) => e.field === "ownerAgent")).toEqual([]);
+    });
+
+    it("accepts a persistent (overlay) agent as ownerAgent", () => {
+      const def = makeValidDef({ ownerAgent: "db-executioner" });
+      const errors = validateRunbook(def, "test-runbook");
+      expect(errors.filter((e) => e.field === "ownerAgent")).toEqual([]);
+    });
+
+    it("rejects unknown ownerAgent", () => {
+      const def = makeValidDef({ ownerAgent: "nonexistent-agent" });
+      const errors = validateRunbook(def, "test-runbook");
+      expect(
+        errors.some(
+          (e) => e.field === "ownerAgent" && e.message.includes("not found"),
+        ),
+      ).toBe(true);
+    });
+
+    it("rejects empty ownerAgent", () => {
+      const def = makeValidDef({ ownerAgent: "" });
+      const errors = validateRunbook(def, "test-runbook");
+      expect(
+        errors.some((e) => e.field === "ownerAgent" && e.message.includes("required")),
+      ).toBe(true);
+    });
+  });
+
+  describe("intent", () => {
+    it("requires at least one intent example", () => {
+      const def = makeValidDef({
+        intent: { examples: [], excludes: [] },
+      });
+      const errors = validateRunbook(def, "test-runbook");
+      expect(
+        errors.some(
+          (e) =>
+            e.field === "intent.examples" &&
+            e.message.includes("at least one"),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("inputs", () => {
+    it("rejects unknown input types", () => {
+      const def = makeValidDef({
+        inputs: [
+          { name: "when", type: "date" as never, required: true },
+        ],
+      });
+      const errors = validateRunbook(def, "test-runbook");
+      expect(
+        errors.some(
+          (e) => e.field === "inputs[0].type" && e.message.includes("unknown input type"),
+        ),
+      ).toBe(true);
+    });
+
+    it("rejects enum input without enumValues", () => {
+      const def = makeValidDef({
+        inputs: [
+          { name: "status", type: "enum", required: true },
+        ],
+      });
+      const errors = validateRunbook(def, "test-runbook");
+      expect(
+        errors.some(
+          (e) =>
+            e.field === "inputs[0].enumValues" &&
+            e.message.includes("enumValues"),
+        ),
+      ).toBe(true);
+    });
+
+    it("accepts enum input with enumValues", () => {
+      const def = makeValidDef({
+        inputs: [
+          {
+            name: "status",
+            type: "enum",
+            required: true,
+            enumValues: ["active", "inactive"],
+          },
+        ],
+      });
+      const errors = validateRunbook(def, "test-runbook");
+      expect(errors.filter((e) => e.field.startsWith("inputs"))).toEqual([]);
+    });
+  });
+
+  describe("risk", () => {
+    it("rejects unknown risk", () => {
+      const def = makeValidDef({ risk: "medium" as never });
+      const errors = validateRunbook(def, "test-runbook");
+      expect(
+        errors.some((e) => e.field === "risk" && e.message.includes("unknown risk")),
+      ).toBe(true);
+    });
+
+    it("accepts all valid risk levels", () => {
+      const validRisks = [
+        "read-only",
+        "workspace-write",
+        "production-write",
+        "destructive",
+        "credential",
+        "privacy-sensitive",
+        "payment",
+        "access-control",
+      ] as const;
+
+      for (const risk of validRisks) {
+        const def = makeValidDef({
+          risk,
+          // Satisfy the constraints for high-risk and mutation
+          approval: { required: true },
+          verification: { required: true, assertions: ["ok"] },
+        });
+        const errors = validateRunbook(def, "test-runbook");
+        expect(errors.filter((e) => e.field === "risk")).toEqual([]);
+      }
+    });
+  });
+
+  describe("high-risk approval requirement", () => {
+    const highRiskKinds = [
+      "production-write",
+      "destructive",
+      "credential",
+      "privacy-sensitive",
+      "payment",
+      "access-control",
+    ] as const;
+
+    for (const risk of highRiskKinds) {
+      it(`${risk} without approval.required = true is rejected`, () => {
+        const def = makeValidDef({
+          risk,
+          approval: { required: false },
+          verification: { required: true, assertions: ["ok"] },
+        });
+        const errors = validateRunbook(def, "test-runbook");
+        expect(
+          errors.some(
+            (e) =>
+              e.field === "approval.required" &&
+              e.message.includes("requires approval"),
+          ),
+        ).toBe(true);
+      });
+
+      it(`${risk} with approval.required = true passes`, () => {
+        const def = makeValidDef({
+          risk,
+          approval: { required: true },
+          verification: { required: true, assertions: ["ok"] },
+        });
+        const errors = validateRunbook(def, "test-runbook");
+        expect(errors.filter((e) => e.field === "approval.required")).toEqual(
+          [],
+        );
+      });
+    }
+  });
+
+  describe("mutation risk verification requirement", () => {
+    it("workspace-write without verification.required is rejected", () => {
+      const def = makeValidDef({
+        risk: "workspace-write",
+        verification: { required: false, assertions: [] },
+      });
+      const errors = validateRunbook(def, "test-runbook");
+      expect(
+        errors.some(
+          (e) =>
+            e.field === "verification.required" &&
+            e.message.includes("mutation risk"),
+        ),
+      ).toBe(true);
+    });
+
+    it("read-only risk does NOT require verification", () => {
+      const def = makeValidDef({
+        risk: "read-only",
+        verification: { required: false, assertions: [] },
+        capabilities: ["mongo.read"],
+      });
+      const errors = validateRunbook(def, "test-runbook");
+      expect(errors.filter((e) => e.field === "verification.required")).toEqual(
+        [],
+      );
+    });
+  });
+
+  describe("capabilities", () => {
+    it("rejects unknown capability bundle", () => {
+      const def = makeValidDef({
+        capabilities: ["mongo.read", "unknown.bundle"],
+      });
+      const errors = validateRunbook(def, "test-runbook");
+      expect(
+        errors.some(
+          (e) =>
+            e.field === "capabilities" &&
+            e.message.includes('unknown capability bundle "unknown.bundle"'),
+        ),
+      ).toBe(true);
+    });
+
+    it("rejects capability widening: review agent requesting migration.execute", () => {
+      const def = makeValidDef({
+        ownerAgent: "review",
+        capabilities: ["migration.execute"],
+      });
+      const errors = validateRunbook(def, "test-runbook");
+      expect(
+        errors.some(
+          (e) =>
+            e.field === "capabilities" &&
+            e.message.includes("repo-write") &&
+            e.message.includes("review"),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("secret detection", () => {
+    it("detects mongodb+srv:// in prompt", () => {
+      const def = makeValidDef({
+        prompt: "Connect to mongodb+srv://user:pass@host/db",
+      });
+      const errors = validateRunbook(def, "test-runbook");
+      expect(
+        errors.some(
+          (e) => e.field === "content" && e.message.includes("secret pattern"),
+        ),
+      ).toBe(true);
+    });
+
+    it("detects Bearer token in description", () => {
+      const def = makeValidDef({
+        description: "Use Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9 to auth",
+      });
+      const errors = validateRunbook(def, "test-runbook");
+      expect(
+        errors.some(
+          (e) => e.field === "content" && e.message.includes("secret pattern"),
+        ),
+      ).toBe(true);
+    });
+
+    it("detects sk- key pattern", () => {
+      const def = makeValidDef({
+        prompt: "Use sk-1234567890abcdefghijklmnop for API",
+      });
+      const errors = validateRunbook(def, "test-runbook");
+      expect(
+        errors.some(
+          (e) => e.field === "content" && e.message.includes("secret pattern"),
+        ),
+      ).toBe(true);
+    });
+
+    it("detects ghp_ token pattern", () => {
+      const def = makeValidDef({
+        prompt:
+          "Token: ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl",
+      });
+      const errors = validateRunbook(def, "test-runbook");
+      expect(
+        errors.some(
+          (e) => e.field === "content" && e.message.includes("secret pattern"),
+        ),
+      ).toBe(true);
+    });
+
+    it("detects gho_ token pattern", () => {
+      const def = makeValidDef({
+        prompt:
+          "Token: gho_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijkl",
+      });
+      const errors = validateRunbook(def, "test-runbook");
+      expect(
+        errors.some(
+          (e) => e.field === "content" && e.message.includes("secret pattern"),
+        ),
+      ).toBe(true);
+    });
+
+    it("detects password=xxx pattern", () => {
+      const def = makeValidDef({
+        prompt: "Set password=supersecret123 in config",
+      });
+      const errors = validateRunbook(def, "test-runbook");
+      expect(
+        errors.some(
+          (e) => e.field === "content" && e.message.includes("secret pattern"),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  describe("prompt", () => {
+    it("rejects empty prompt", () => {
+      const def = makeValidDef({ prompt: "" });
+      const errors = validateRunbook(def, "test-runbook");
+      expect(
+        errors.some(
+          (e) => e.field === "prompt" && e.message.includes("required"),
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it("accumulates multiple errors (not just the first)", () => {
+    const def = makeValidDef({
+      schemaVersion: 99,
+      name: "",
+      description: "",
+      ownerAgent: "",
+      intent: { examples: [], excludes: [] },
+      prompt: "",
+    });
+    const errors = validateRunbook(def, "");
+    // Should have errors for at least: schemaVersion, name, description,
+    // ownerAgent, intent.examples, prompt
+    expect(errors.length).toBeGreaterThanOrEqual(5);
+
+    const fields = errors.map((e) => e.field);
+    expect(fields).toContain("schemaVersion");
+    expect(fields).toContain("name");
+    expect(fields).toContain("description");
+    expect(fields).toContain("ownerAgent");
+    expect(fields).toContain("intent.examples");
+    expect(fields).toContain("prompt");
+  });
+});

--- a/src/runbooks/validator.ts
+++ b/src/runbooks/validator.ts
@@ -1,0 +1,152 @@
+import { resolveAgentManifest } from "../agents/registry.ts";
+import { isPersistentAgent } from "../support/agents.ts";
+import { isCapabilitySubset, isValidCapabilityBundle } from "./capabilities.ts";
+import {
+  HIGH_RISK_KINDS,
+  RUNBOOK_INPUT_TYPES,
+  RUNBOOK_RISKS,
+  type RunbookDefinition,
+  type RunbookRisk,
+  type RunbookValidationError,
+} from "./types.ts";
+
+const KEBAB_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
+
+const SECRET_PATTERNS = [
+  /mongodb\+srv:\/\//i,
+  /Bearer\s+[A-Za-z0-9\-._~+/]+=*/,
+  /\bsk-[A-Za-z0-9]{20,}/,
+  /\bghp_[A-Za-z0-9]{36,}/,
+  /\bgho_[A-Za-z0-9]{36,}/,
+  /password\s*[:=]\s*\S+/i,
+  /\bAKIA[0-9A-Z]{16}\b/,
+];
+
+export function validateRunbook(
+  def: RunbookDefinition,
+  expectedFilename: string,
+): RunbookValidationError[] {
+  const errors: RunbookValidationError[] = [];
+
+  if (def.schemaVersion !== 1) {
+    errors.push({
+      field: "schemaVersion",
+      message: `expected 1, got ${def.schemaVersion}`,
+    });
+  }
+
+  if (!def.name) {
+    errors.push({ field: "name", message: "name is required" });
+  } else if (!KEBAB_RE.test(def.name)) {
+    errors.push({
+      field: "name",
+      message: `name must be kebab-case, got "${def.name}"`,
+    });
+  } else if (def.name !== expectedFilename) {
+    errors.push({
+      field: "name",
+      message: `name "${def.name}" does not match filename "${expectedFilename}"`,
+    });
+  }
+
+  if (!def.description) {
+    errors.push({ field: "description", message: "description is required" });
+  }
+
+  if (!def.ownerAgent) {
+    errors.push({ field: "ownerAgent", message: "ownerAgent is required" });
+  } else if (!resolveAgentManifest(def.ownerAgent) && !isPersistentAgent(def.ownerAgent)) {
+    errors.push({
+      field: "ownerAgent",
+      message: `ownerAgent "${def.ownerAgent}" not found in trusted catalog or identity registry`,
+    });
+  }
+
+  if (!def.intent.examples || def.intent.examples.length === 0) {
+    errors.push({
+      field: "intent.examples",
+      message: "at least one intent example is required",
+    });
+  }
+
+  for (let i = 0; i < def.inputs.length; i++) {
+    const input = def.inputs[i];
+    if (!input.name) {
+      errors.push({
+        field: `inputs[${i}].name`,
+        message: "input name is required",
+      });
+    }
+    if (!RUNBOOK_INPUT_TYPES.includes(input.type)) {
+      errors.push({
+        field: `inputs[${i}].type`,
+        message: `unknown input type "${input.type}"; allowed: ${RUNBOOK_INPUT_TYPES.join(", ")}`,
+      });
+    }
+    if (input.type === "enum" && (!input.enumValues || input.enumValues.length === 0)) {
+      errors.push({
+        field: `inputs[${i}].enumValues`,
+        message: `enum input "${input.name}" must declare enumValues`,
+      });
+    }
+  }
+
+  if (!RUNBOOK_RISKS.includes(def.risk)) {
+    errors.push({
+      field: "risk",
+      message: `unknown risk "${def.risk}"; allowed: ${RUNBOOK_RISKS.join(", ")}`,
+    });
+  }
+
+  if (
+    HIGH_RISK_KINDS.includes(def.risk as RunbookRisk) &&
+    !def.approval.required
+  ) {
+    errors.push({
+      field: "approval.required",
+      message: `risk "${def.risk}" requires approval.required = true`,
+    });
+  }
+
+  if (def.risk !== "read-only" && !def.verification.required) {
+    errors.push({
+      field: "verification.required",
+      message: `mutation risk "${def.risk}" requires verification.required = true`,
+    });
+  }
+
+  for (const cap of def.capabilities) {
+    if (!isValidCapabilityBundle(cap)) {
+      errors.push({
+        field: "capabilities",
+        message: `unknown capability bundle "${cap}"`,
+      });
+    }
+  }
+
+  const validCaps = def.capabilities.filter(isValidCapabilityBundle);
+  if (validCaps.length > 0 && def.ownerAgent) {
+    const subset = isCapabilitySubset(validCaps, def.ownerAgent);
+    if (!subset.ok) {
+      for (const v of subset.violations) {
+        errors.push({ field: "capabilities", message: v });
+      }
+    }
+  }
+
+  if (!def.prompt) {
+    errors.push({ field: "prompt", message: "prompt body is required" });
+  }
+
+  const fullText = `${def.description}\n${def.prompt}\n${JSON.stringify(def.inputs)}`;
+  for (const pattern of SECRET_PATTERNS) {
+    if (pattern.test(fullText)) {
+      errors.push({
+        field: "content",
+        message: `content matches secret pattern: ${pattern.source}`,
+      });
+    }
+  }
+
+  return errors;
+}


### PR DESCRIPTION
## Summary
Iteration 1 of the common-task-agent-authoring plan. Builds the foundational runbook infrastructure:

- **Types** (`src/runbooks/types.ts`) — `RunbookDefinition`, `RunbookInput`, `RunbookRisk`, validation error types
- **Capability bundles** (`src/runbooks/capabilities.ts`) — 8 provider-neutral bundles (mongo.read, migration.execute, slack.read/post, credential.deliver, github.read/propose, migration.inspect) with subset validation against owner agent catalog capabilities
- **Loader** (`src/runbooks/loader.ts`) — YAML frontmatter parser for `.runbook.md` files with SHA-256 content digest
- **Validator** (`src/runbooks/validator.ts`) — name/kebab-case, schema version, owner agent resolution, input type allowlist, risk-to-gate enforcement, capability subset check, secret scanning
- **Registry** (`src/runbooks/registry.ts`) — fixed-root discovery, last-known-good reload, search/get/list/digest
- **MCP tools** — `runbook_search` and `runbook_get` registered alongside existing agent tools
- **Fixture** — `transfer-ai-roadmaps.runbook.md` example from the plan doc

## Test plan
- [x] 85/85 runbook tests pass (loader, validator, registry, capabilities — 198 assertions)
- [x] 138/138 existing agent tests pass (no regressions)
- [x] Fixture loads, validates, is searchable, has stable content digest
- [x] Capability widening beyond owner agent fails closed
- [x] High-risk runbooks without approval gates rejected
- [x] Secret patterns in content detected and rejected
- [x] Last-known-good registry behavior on invalid reload

🤖 Generated with [Claude Code](https://claude.com/claude-code)