### PR TITLE
feat(runbooks): add intent matching, input binding, and execution evidence

### DIFF
--- a/src/mcp/slack-server.ts
+++ b/src/mcp/slack-server.ts
@@ -72,6 +72,8 @@ import {
   getRunbook,
   searchRunbooks,
 } from "../runbooks/registry.ts";
+import { selectRunbook } from "../runbooks/selector.ts";
+import type { RunbookRisk } from "../runbooks/types.ts";
 
 const MCP_PORT = Number(process.env.MCP_PORT ?? "3456");
 const FALLBACK_AGENTS_DIR = ".claude/agents";
@@ -990,6 +992,35 @@ function registerTools(server: McpServer, runContext: SlackMcpRunContext | null 
           {
             type: "text" as const,
             text: JSON.stringify(def, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  registerTool(
+    server,
+    "runbook_select",
+    {
+      description:
+        "Select the best matching runbook for a natural-language request, bind inputs from context, and return execution evidence. Falls back to procedure-memory guidance when no runbook matches.",
+      inputSchema: {
+        request: z.string().describe("Natural-language description of the task"),
+        context: z.record(z.string()).optional().describe("Key-value pairs from thread context for input binding"),
+        owner_agent: z.string().optional().describe("Filter to runbooks owned by this agent"),
+        risk_ceiling: z.string().optional().describe("Exclude runbooks above this risk level"),
+      },
+    },
+    async ({ request, context, owner_agent, risk_ceiling }) => {
+      const result = selectRunbook(request, context ?? {}, {
+        ownerAgent: owner_agent,
+        riskCeiling: risk_ceiling as RunbookRisk | undefined,
+      });
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: JSON.stringify(result, null, 2),
           },
         ],
       };

--- a/src/runbooks/binder.test.ts
+++ b/src/runbooks/binder.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it } from "bun:test";
+import { bindInputs, redactBoundInputs } from "./binder.ts";
+import type { RunbookDefinition, RunbookInput } from "./types.ts";
+
+function makeRunbook(inputs: RunbookInput[]): RunbookDefinition {
+  return {
+    schemaVersion: 1,
+    name: "test-binder-runbook",
+    description: "A minimal runbook for binder tests",
+    ownerAgent: "build",
+    intent: { examples: ["do a thing"], excludes: [] },
+    inputs,
+    risk: "read-only",
+    approval: { required: false },
+    capabilities: [],
+    verification: { required: false, assertions: [] },
+    tags: [],
+    prompt: "Do the thing.",
+    filePath: "test.runbook.md",
+    origin: "private",
+    contentDigest: "abc123",
+  };
+}
+
+describe("bindInputs", () => {
+  it("binds email inputs from context", () => {
+    const rb = makeRunbook([
+      { name: "sourceEmail", type: "email", required: true },
+    ]);
+    const result = bindInputs(rb, { sourceEmail: "alice@example.com" });
+    expect(result.bound.sourceEmail).toBe("alice@example.com");
+    expect(result.missing).toEqual([]);
+  });
+
+  it("validates email format (rejects invalid email)", () => {
+    const rb = makeRunbook([
+      { name: "sourceEmail", type: "email", required: true },
+    ]);
+    const result = bindInputs(rb, { sourceEmail: "not-an-email" });
+    expect(result.bound.sourceEmail).toBeUndefined();
+    expect(result.missing).toContain("sourceEmail");
+  });
+
+  it("binds objectId inputs (24-char hex string)", () => {
+    const rb = makeRunbook([
+      { name: "userId", type: "objectId", required: true },
+    ]);
+    const result = bindInputs(rb, { userId: "507f1f77bcf86cd799439011" });
+    expect(result.bound.userId).toBe("507f1f77bcf86cd799439011");
+    expect(result.missing).toEqual([]);
+  });
+
+  it("rejects invalid objectId (wrong length)", () => {
+    const rb = makeRunbook([
+      { name: "userId", type: "objectId", required: true },
+    ]);
+    const result = bindInputs(rb, { userId: "507f1f77" });
+    expect(result.bound.userId).toBeUndefined();
+    expect(result.missing).toContain("userId");
+  });
+
+  it("rejects invalid objectId (non-hex characters)", () => {
+    const rb = makeRunbook([
+      { name: "userId", type: "objectId", required: true },
+    ]);
+    const result = bindInputs(rb, { userId: "507f1f77bcf86cd79943ZZZZ" });
+    expect(result.bound.userId).toBeUndefined();
+    expect(result.missing).toContain("userId");
+  });
+
+  it("binds number inputs", () => {
+    const rb = makeRunbook([
+      { name: "count", type: "number", required: true },
+    ]);
+    const result = bindInputs(rb, { count: "42" });
+    expect(result.bound.count).toBe(42);
+    expect(result.missing).toEqual([]);
+  });
+
+  it("rejects non-numeric strings for number type", () => {
+    const rb = makeRunbook([
+      { name: "count", type: "number", required: true },
+    ]);
+    const result = bindInputs(rb, { count: "not-a-number" });
+    expect(result.bound.count).toBeUndefined();
+    expect(result.missing).toContain("count");
+  });
+
+  it("binds boolean inputs (true/false/yes/no/1/0)", () => {
+    const rb = makeRunbook([
+      { name: "dryRun", type: "boolean", required: true },
+    ]);
+
+    for (const [raw, expected] of [
+      ["true", true],
+      ["false", false],
+      ["yes", true],
+      ["no", false],
+      ["1", true],
+      ["0", false],
+    ] as Array<[string, boolean]>) {
+      const result = bindInputs(rb, { dryRun: raw });
+      expect(result.bound.dryRun).toBe(expected);
+      expect(result.missing).toEqual([]);
+    }
+  });
+
+  it("binds enum inputs when value is in enumValues", () => {
+    const rb = makeRunbook([
+      {
+        name: "env",
+        type: "enum",
+        required: true,
+        enumValues: ["staging", "production"],
+      },
+    ]);
+    const result = bindInputs(rb, { env: "staging" });
+    expect(result.bound.env).toBe("staging");
+    expect(result.missing).toEqual([]);
+  });
+
+  it("rejects enum values not in enumValues", () => {
+    const rb = makeRunbook([
+      {
+        name: "env",
+        type: "enum",
+        required: true,
+        enumValues: ["staging", "production"],
+      },
+    ]);
+    const result = bindInputs(rb, { env: "development" });
+    expect(result.bound.env).toBeUndefined();
+    expect(result.missing).toContain("env");
+  });
+
+  it("binds string inputs (any value)", () => {
+    const rb = makeRunbook([
+      { name: "note", type: "string", required: true },
+    ]);
+    const result = bindInputs(rb, { note: "anything at all" });
+    expect(result.bound.note).toBe("anything at all");
+    expect(result.missing).toEqual([]);
+  });
+
+  it("reports missing required inputs", () => {
+    const rb = makeRunbook([
+      { name: "sourceEmail", type: "email", required: true },
+      { name: "targetEmail", type: "email", required: true },
+    ]);
+    const result = bindInputs(rb, { sourceEmail: "a@b.com" });
+    expect(result.bound.sourceEmail).toBe("a@b.com");
+    expect(result.missing).toContain("targetEmail");
+  });
+
+  it("does not report missing optional inputs", () => {
+    const rb = makeRunbook([
+      { name: "note", type: "string", required: false },
+    ]);
+    const result = bindInputs(rb, {});
+    expect(result.missing).toEqual([]);
+    expect(result.bound.note).toBeUndefined();
+  });
+
+  it("context key matching is case-insensitive", () => {
+    const rb = makeRunbook([
+      { name: "sourceEmail", type: "email", required: true },
+    ]);
+    const result = bindInputs(rb, { sourceemail: "user@example.com" });
+    expect(result.bound.sourceEmail).toBe("user@example.com");
+    expect(result.missing).toEqual([]);
+  });
+});
+
+describe("redactBoundInputs", () => {
+  it("masks emails: 'user@example.com' -> 'u***@example.com'", () => {
+    const rb = makeRunbook([
+      { name: "sourceEmail", type: "email", required: true },
+    ]);
+    const redacted = redactBoundInputs(
+      { sourceEmail: "user@example.com" },
+      rb,
+    );
+    expect(redacted.sourceEmail).toBe("u***@example.com");
+  });
+
+  it("masks objectIds: keeps first 4 and last 4 chars", () => {
+    const rb = makeRunbook([
+      { name: "userId", type: "objectId", required: true },
+    ]);
+    const redacted = redactBoundInputs(
+      { userId: "507f1f77bcf86cd799439011" },
+      rb,
+    );
+    expect(redacted.userId).toBe("507f***9011");
+  });
+
+  it("passes through string/number/boolean values unchanged", () => {
+    const rb = makeRunbook([
+      { name: "note", type: "string", required: true },
+      { name: "count", type: "number", required: true },
+      { name: "dryRun", type: "boolean", required: true },
+    ]);
+    const redacted = redactBoundInputs(
+      { note: "hello world", count: 42, dryRun: true },
+      rb,
+    );
+    expect(redacted.note).toBe("hello world");
+    expect(redacted.count).toBe("42");
+    expect(redacted.dryRun).toBe("true");
+  });
+});

--- a/src/runbooks/binder.ts
+++ b/src/runbooks/binder.ts
@@ -1,0 +1,96 @@
+import type { RunbookDefinition } from "./types.ts";
+
+export interface BoundInputs {
+  bound: Record<string, string | number | boolean>;
+  missing: string[];
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const OBJECT_ID_RE = /^[a-f0-9]{24}$/;
+
+export function bindInputs(
+  runbook: RunbookDefinition,
+  context: Record<string, string>,
+): BoundInputs {
+  const bound: Record<string, string | number | boolean> = {};
+  const missing: string[] = [];
+
+  const contextLower = new Map<string, string>();
+  for (const [k, v] of Object.entries(context)) {
+    contextLower.set(k.toLowerCase(), v);
+  }
+
+  for (const input of runbook.inputs) {
+    const raw = contextLower.get(input.name.toLowerCase());
+
+    if (raw === undefined || raw === "") {
+      if (input.required) missing.push(input.name);
+      continue;
+    }
+
+    const validated = validateAndCoerce(raw, input.type, input.enumValues);
+    if (validated !== null) {
+      bound[input.name] = validated;
+    } else if (input.required) {
+      missing.push(input.name);
+    }
+  }
+
+  return { bound, missing };
+}
+
+function validateAndCoerce(
+  raw: string,
+  type: string,
+  enumValues?: string[],
+): string | number | boolean | null {
+  switch (type) {
+    case "string":
+      return raw;
+    case "email":
+      return EMAIL_RE.test(raw) ? raw : null;
+    case "objectId":
+      return OBJECT_ID_RE.test(raw.toLowerCase()) ? raw.toLowerCase() : null;
+    case "number": {
+      const n = Number(raw);
+      return Number.isNaN(n) ? null : n;
+    }
+    case "boolean":
+      if (raw === "true" || raw === "1" || raw === "yes") return true;
+      if (raw === "false" || raw === "0" || raw === "no") return false;
+      return null;
+    case "enum":
+      return enumValues?.includes(raw) ? raw : null;
+    default:
+      return null;
+  }
+}
+
+export function redactBoundInputs(
+  bound: Record<string, string | number | boolean>,
+  runbook: RunbookDefinition,
+): Record<string, string> {
+  const redacted: Record<string, string> = {};
+  const inputTypes = new Map(runbook.inputs.map((i) => [i.name, i.type]));
+
+  for (const [key, value] of Object.entries(bound)) {
+    const type = inputTypes.get(key);
+    redacted[key] = redactValue(String(value), type ?? "string");
+  }
+
+  return redacted;
+}
+
+function redactValue(value: string, type: string): string {
+  switch (type) {
+    case "email": {
+      const at = value.indexOf("@");
+      if (at <= 1) return "***@***";
+      return value[0] + "***@" + value.slice(at + 1);
+    }
+    case "objectId":
+      return value.slice(0, 4) + "***" + value.slice(-4);
+    default:
+      return value;
+  }
+}

--- a/src/runbooks/evidence.test.ts
+++ b/src/runbooks/evidence.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import path from "node:path";
+import {
+  AGENT_IDENTITIES,
+  registerAgentIdentity,
+} from "../support/agents.ts";
+import {
+  clearRegistryForTests,
+  getRunbook,
+  loadRunbookRegistryFromDir,
+} from "./registry.ts";
+import {
+  createRunEvidence,
+  createIntentFingerprint,
+  buildProcedureFallback,
+} from "./evidence.ts";
+import type { RunbookDefinition } from "./types.ts";
+
+const FIXTURE_DIR = path.join(import.meta.dir, "__fixtures__");
+
+describe("runbook evidence", () => {
+  let runbook: RunbookDefinition;
+
+  beforeEach(async () => {
+    registerAgentIdentity("db-executioner", {
+      username: "DB Executioner",
+      iconEmoji: ":database:",
+    });
+    clearRegistryForTests();
+    await loadRunbookRegistryFromDir(FIXTURE_DIR, "private");
+    runbook = getRunbook("transfer-ai-roadmaps")!;
+  });
+
+  afterEach(() => {
+    delete AGENT_IDENTITIES["db-executioner"];
+    clearRegistryForTests();
+  });
+
+  describe("createRunEvidence", () => {
+    it("returns evidence with correct fields", () => {
+      const evidence = createRunEvidence(
+        runbook,
+        { sourceEmail: "alice@example.com", targetEmail: "bob@example.com" },
+        "move all AI roadmaps from one account to another",
+        Date.now(),
+      );
+
+      expect(evidence.runbookName).toBe("transfer-ai-roadmaps");
+      expect(evidence.contentDigest).toBe(runbook.contentDigest);
+      expect(evidence.risk).toBe("production-write");
+      expect(evidence.status).toBe("selected");
+      expect(evidence.ownerAgent).toBe("db-executioner");
+    });
+
+    it("has redacted bound inputs (emails masked)", () => {
+      const evidence = createRunEvidence(
+        runbook,
+        { sourceEmail: "alice@example.com", targetEmail: "bob@example.com" },
+        "move all AI roadmaps",
+        Date.now(),
+      );
+
+      expect(evidence.boundInputs.sourceEmail).toBe("a***@example.com");
+      expect(evidence.boundInputs.targetEmail).toBe("b***@example.com");
+    });
+
+    it("has a non-empty runId", () => {
+      const evidence = createRunEvidence(
+        runbook,
+        { sourceEmail: "alice@example.com" },
+        "move all AI roadmaps",
+        Date.now(),
+      );
+
+      expect(evidence.runId).toBeTruthy();
+      expect(evidence.runId.length).toBeGreaterThan(0);
+    });
+
+    it("has a non-empty intentFingerprint", () => {
+      const evidence = createRunEvidence(
+        runbook,
+        { sourceEmail: "alice@example.com" },
+        "move all AI roadmaps",
+        Date.now(),
+      );
+
+      expect(evidence.intentFingerprint).toBeTruthy();
+      expect(evidence.intentFingerprint.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("createIntentFingerprint", () => {
+    it("is stable for the same request and runbook", () => {
+      const fp1 = createIntentFingerprint(
+        "move all AI roadmaps from one account to another",
+        runbook,
+      );
+      const fp2 = createIntentFingerprint(
+        "move all AI roadmaps from one account to another",
+        runbook,
+      );
+      expect(fp1).toBe(fp2);
+    });
+
+    it("differs for different requests", () => {
+      const fp1 = createIntentFingerprint(
+        "move all AI roadmaps from one account to another",
+        runbook,
+      );
+      const fp2 = createIntentFingerprint(
+        "transfer roadmaps from staging to production",
+        runbook,
+      );
+      expect(fp1).not.toBe(fp2);
+    });
+
+    it("does NOT contain raw emails in the hex output", () => {
+      const fp = createIntentFingerprint(
+        "move AI roadmaps from user@example.com to other@test.com",
+        runbook,
+      );
+      expect(fp).not.toContain("user@example.com");
+      expect(fp).not.toContain("other@test.com");
+      // Should be a hex string
+      expect(fp).toMatch(/^[0-9a-f]+$/);
+    });
+
+    it("does NOT contain raw objectIds in the hex output", () => {
+      const fp = createIntentFingerprint(
+        "move AI roadmaps for 507f1f77bcf86cd799439011",
+        runbook,
+      );
+      expect(fp).not.toContain("507f1f77bcf86cd799439011");
+      expect(fp).toMatch(/^[0-9a-f]+$/);
+    });
+  });
+
+  describe("buildProcedureFallback", () => {
+    it("returns a lowercase normalized query", () => {
+      const fallback = buildProcedureFallback("Move ALL Roadmaps NOW!");
+      expect(fallback.query).toBe("move all roadmaps now");
+    });
+
+    it("includes the warning about procedure memory", () => {
+      const fallback = buildProcedureFallback("anything");
+      expect(fallback.warning).toContain("procedure memory");
+      expect(fallback.warning.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/runbooks/evidence.ts
+++ b/src/runbooks/evidence.ts
@@ -60,15 +60,16 @@ export function createIntentFingerprint(
   return hasher.digest("hex");
 }
 
+const NAME_PATTERN = /\b[A-Z][a-z]+ [A-Z][a-z]+\b/g;
+
 const PII_PATTERNS = [
   /\b[^\s@]+@[^\s@]+\.[^\s@]+\b/g,
   /\b[a-f0-9]{24}\b/g,
   /\b\d{10,}\b/g,
-  /\b[A-Z][a-z]+ [A-Z][a-z]+\b/g,
 ];
 
 function normalizeForFingerprint(text: string): string {
-  let normalized = text.toLowerCase().trim();
+  let normalized = text.trim().replace(NAME_PATTERN, "<REDACTED>").toLowerCase();
   for (const pattern of PII_PATTERNS) {
     normalized = normalized.replace(pattern, "<REDACTED>");
   }

--- a/src/runbooks/evidence.ts
+++ b/src/runbooks/evidence.ts
@@ -1,0 +1,102 @@
+import type { RunbookDefinition, RunbookRisk } from "./types.ts";
+import { redactBoundInputs } from "./binder.ts";
+
+export interface RunbookRunEvidence {
+  runId: string;
+  runbookName: string;
+  contentDigest: string;
+  ownerAgent: string;
+  risk: RunbookRisk;
+  boundInputs: Record<string, string>;
+  approvalRef?: string;
+  status:
+    | "selected"
+    | "approved"
+    | "executing"
+    | "completed"
+    | "failed"
+    | "rejected";
+  verificationResults?: string[];
+  startedAt: number;
+  completedAt?: number;
+  intentFingerprint: string;
+}
+
+export function createRunEvidence(
+  runbook: RunbookDefinition,
+  boundInputs: Record<string, string | number | boolean>,
+  request: string,
+  startedAt: number,
+): RunbookRunEvidence {
+  return {
+    runId: generateRunId(),
+    runbookName: runbook.name,
+    contentDigest: runbook.contentDigest,
+    ownerAgent: runbook.ownerAgent,
+    risk: runbook.risk,
+    boundInputs: redactBoundInputs(boundInputs, runbook),
+    status: "selected",
+    startedAt,
+    intentFingerprint: createIntentFingerprint(request, runbook),
+  };
+}
+
+export function createIntentFingerprint(
+  request: string,
+  runbook: RunbookDefinition,
+): string {
+  const normalized = normalizeForFingerprint(request);
+  const components = [
+    normalized,
+    runbook.ownerAgent,
+    runbook.risk,
+    runbook.capabilities.sort().join(","),
+    `approval:${runbook.approval.required}:${runbook.approval.afterSteps?.length ?? 0}`,
+    `verification:${runbook.verification.required}:${runbook.verification.assertions.length}`,
+  ];
+
+  const hasher = new Bun.CryptoHasher("sha256");
+  hasher.update(components.join("|"));
+  return hasher.digest("hex");
+}
+
+const PII_PATTERNS = [
+  /\b[^\s@]+@[^\s@]+\.[^\s@]+\b/g,
+  /\b[a-f0-9]{24}\b/g,
+  /\b\d{10,}\b/g,
+  /\b[A-Z][a-z]+ [A-Z][a-z]+\b/g,
+];
+
+function normalizeForFingerprint(text: string): string {
+  let normalized = text.toLowerCase().trim();
+  for (const pattern of PII_PATTERNS) {
+    normalized = normalized.replace(pattern, "<REDACTED>");
+  }
+  return normalized
+    .replace(/[^\w\s<>]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function generateRunId(): string {
+  const bytes = new Uint8Array(12);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+export interface ProcedureFallback {
+  query: string;
+  warning: string;
+}
+
+export function buildProcedureFallback(request: string): ProcedureFallback {
+  return {
+    query: request
+      .toLowerCase()
+      .replace(/[^\w\s]/g, " ")
+      .replace(/\s+/g, " ")
+      .trim(),
+    warning:
+      "No reviewed runbook found. Recalling procedure memory — treat as hypothesis, not execution authority.",
+  };
+}

--- a/src/runbooks/matcher.test.ts
+++ b/src/runbooks/matcher.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import path from "node:path";
+import {
+  AGENT_IDENTITIES,
+  registerAgentIdentity,
+} from "../support/agents.ts";
+import {
+  clearRegistryForTests,
+  loadRunbookRegistryFromDir,
+} from "./registry.ts";
+import { matchRunbook, matchRunbookDetailed } from "./matcher.ts";
+
+const FIXTURE_DIR = path.join(import.meta.dir, "__fixtures__");
+
+describe("runbook matcher", () => {
+  beforeEach(async () => {
+    registerAgentIdentity("db-executioner", {
+      username: "DB Executioner",
+      iconEmoji: ":database:",
+    });
+    clearRegistryForTests();
+    await loadRunbookRegistryFromDir(FIXTURE_DIR, "private");
+  });
+
+  afterEach(() => {
+    delete AGENT_IDENTITIES["db-executioner"];
+    clearRegistryForTests();
+  });
+
+  describe("matchRunbook", () => {
+    it("selects transfer-ai-roadmaps for a close intent match", () => {
+      const result = matchRunbook(
+        "move all AI roadmaps from one account to another",
+      );
+      expect(result).not.toBeNull();
+      expect(result!.runbook.name).toBe("transfer-ai-roadmaps");
+      expect(result!.confidence).toBeGreaterThan(0.6);
+    });
+
+    it("selects transfer-ai-roadmaps for a variant phrasing", () => {
+      const result = matchRunbook(
+        "transfer AI roadmaps from user A to user B",
+      );
+      expect(result).not.toBeNull();
+      expect(result!.runbook.name).toBe("transfer-ai-roadmaps");
+      expect(result!.confidence).toBeGreaterThan(0.6);
+    });
+
+    it("selects for a rephrased request that shares enough tokens", () => {
+      const result = matchRunbook(
+        "move all AI roadmaps from account A to another account",
+      );
+      expect(result).not.toBeNull();
+      expect(result!.runbook.name).toBe("transfer-ai-roadmaps");
+    });
+
+    it("does NOT select for 'move one Notion roadmap' (excluded phrase)", () => {
+      const result = matchRunbook("move one Notion roadmap");
+      expect(result).toBeNull();
+    });
+
+    it("does NOT select for 'transfer every document owned by A'", () => {
+      const result = matchRunbook("transfer every document owned by A");
+      expect(result).toBeNull();
+    });
+
+    it("returns null for a completely unrelated request", () => {
+      const result = matchRunbook(
+        "unrelated task about cooking a nice meal for dinner",
+      );
+      expect(result).toBeNull();
+    });
+
+    it("filters by ownerAgent", () => {
+      const result = matchRunbook(
+        "move all AI roadmaps from one account to another",
+        { ownerAgent: "build" },
+      );
+      // db-executioner != build, so no match
+      expect(result).toBeNull();
+    });
+
+    it("filters by riskCeiling (excludes production-write runbooks)", () => {
+      const result = matchRunbook(
+        "move all AI roadmaps from one account to another",
+        { riskCeiling: "workspace-write" },
+      );
+      // transfer-ai-roadmaps is production-write, ceiling is workspace-write
+      expect(result).toBeNull();
+    });
+
+    it("respects minConfidence option", () => {
+      // "transfer AI roadmaps" shares partial tokens with the example
+      // "transfer AI roadmaps from user A to user B", giving a moderate
+      // Jaccard score (below default 0.6 but above 0.3).
+      const partialRequest = "transfer AI roadmaps";
+
+      // Default threshold (0.6) rejects the partial match
+      const defaultResult = matchRunbook(partialRequest);
+      expect(defaultResult).toBeNull();
+
+      // Lowering minConfidence to 0.3 accepts it
+      const lowResult = matchRunbook(partialRequest, { minConfidence: 0.3 });
+      expect(lowResult).not.toBeNull();
+      expect(lowResult!.runbook.name).toBe("transfer-ai-roadmaps");
+    });
+  });
+
+  describe("matchRunbookDetailed", () => {
+    it("returns 'excluded' reason when exclusion fires", () => {
+      // Use low minConfidence so we don't hit below-threshold first
+      const { result, reason, candidates } = matchRunbookDetailed(
+        "move one Notion roadmap",
+        { minConfidence: 0.1 },
+      );
+      expect(result).toBeNull();
+      expect(reason).toBe("excluded");
+      expect(candidates).toBeDefined();
+    });
+
+    it("returns 'below-threshold' reason for a weak match", () => {
+      const { result, reason, candidates } = matchRunbookDetailed(
+        "unrelated task about cooking a nice meal for dinner",
+      );
+      expect(result).toBeNull();
+      expect(reason).toBe("below-threshold");
+      expect(candidates).toBeDefined();
+    });
+
+    it("returns candidates list with names and confidences", () => {
+      const { candidates } = matchRunbookDetailed(
+        "move all AI roadmaps from one account to another",
+      );
+      // Even on a successful match, candidates may or may not be present.
+      // On a failed match, candidates should always be present.
+      const failed = matchRunbookDetailed(
+        "unrelated task about cooking a nice meal for dinner",
+      );
+      expect(failed.candidates).toBeDefined();
+      expect(failed.candidates!.length).toBeGreaterThanOrEqual(1);
+      expect(failed.candidates![0]).toHaveProperty("name");
+      expect(failed.candidates![0]).toHaveProperty("confidence");
+    });
+
+    it("returns a successful result for a strong match", () => {
+      const { result, reason } = matchRunbookDetailed(
+        "move all AI roadmaps from one account to another",
+      );
+      expect(result).not.toBeNull();
+      expect(result!.runbook.name).toBe("transfer-ai-roadmaps");
+      expect(result!.confidence).toBeGreaterThan(0.6);
+      expect(reason).toBeUndefined();
+    });
+
+    it("returns 'risk-ceiling' when all runbooks exceed the ceiling", () => {
+      const { result, reason } = matchRunbookDetailed(
+        "move all AI roadmaps from one account to another",
+        { riskCeiling: "read-only" },
+      );
+      expect(result).toBeNull();
+      expect(reason).toBe("risk-ceiling");
+    });
+  });
+});

--- a/src/runbooks/matcher.ts
+++ b/src/runbooks/matcher.ts
@@ -1,0 +1,217 @@
+import { listRunbooks } from "./registry.ts";
+import { RUNBOOK_RISKS, type RunbookDefinition, type RunbookRisk } from "./types.ts";
+
+export interface MatchResult {
+  runbook: RunbookDefinition;
+  confidence: number;
+  matchedExample: string;
+}
+
+export interface MatchOptions {
+  ownerAgent?: string;
+  riskCeiling?: RunbookRisk;
+  minConfidence?: number;
+}
+
+const DEFAULT_MIN_CONFIDENCE = 0.6;
+const AMBIGUITY_GAP = 0.15;
+
+export function matchRunbook(
+  request: string,
+  options?: MatchOptions,
+): MatchResult | null {
+  const minConfidence = options?.minConfidence ?? DEFAULT_MIN_CONFIDENCE;
+  const riskCeiling = options?.riskCeiling;
+  const riskCeilingIdx = riskCeiling ? RUNBOOK_RISKS.indexOf(riskCeiling) : -1;
+
+  const candidates = listRunbooks().filter((rb) => {
+    if (options?.ownerAgent && rb.ownerAgent !== options.ownerAgent) return false;
+    if (riskCeiling && riskCeilingIdx >= 0) {
+      const rbIdx = RUNBOOK_RISKS.indexOf(rb.risk);
+      if (rbIdx > riskCeilingIdx) return false;
+    }
+    return true;
+  });
+
+  if (candidates.length === 0) return null;
+
+  const reqTokens = tokenize(request);
+  const scored: Array<MatchResult & { excluded: boolean }> = [];
+
+  for (const rb of candidates) {
+    let bestScore = 0;
+    let bestExample = "";
+
+    for (const example of rb.intent.examples) {
+      const score = jaccardSimilarity(reqTokens, tokenize(example));
+      if (score > bestScore) {
+        bestScore = score;
+        bestExample = example;
+      }
+    }
+
+    let excluded = false;
+    for (const exclude of rb.intent.excludes) {
+      const excScore = jaccardSimilarity(reqTokens, tokenize(exclude));
+      if (excScore > bestScore) {
+        excluded = true;
+        break;
+      }
+    }
+
+    scored.push({
+      runbook: rb,
+      confidence: bestScore,
+      matchedExample: bestExample,
+      excluded,
+    });
+  }
+
+  scored.sort((a, b) => b.confidence - a.confidence);
+
+  const best = scored[0];
+  if (!best || best.confidence < minConfidence) return null;
+  if (best.excluded) return null;
+
+  if (scored.length > 1) {
+    const second = scored[1];
+    if (best.confidence - second.confidence < AMBIGUITY_GAP) return null;
+  }
+
+  return {
+    runbook: best.runbook,
+    confidence: best.confidence,
+    matchedExample: best.matchedExample,
+  };
+}
+
+export function matchRunbookDetailed(
+  request: string,
+  options?: MatchOptions,
+): {
+  result: MatchResult | null;
+  reason?: "no-match" | "ambiguous" | "excluded" | "below-threshold" | "risk-ceiling";
+  candidates?: Array<{ name: string; confidence: number }>;
+} {
+  const minConfidence = options?.minConfidence ?? DEFAULT_MIN_CONFIDENCE;
+  const riskCeiling = options?.riskCeiling;
+  const riskCeilingIdx = riskCeiling ? RUNBOOK_RISKS.indexOf(riskCeiling) : -1;
+
+  const allRunbooks = listRunbooks();
+  const candidates = allRunbooks.filter((rb) => {
+    if (options?.ownerAgent && rb.ownerAgent !== options.ownerAgent) return false;
+    if (riskCeiling && riskCeilingIdx >= 0) {
+      const rbIdx = RUNBOOK_RISKS.indexOf(rb.risk);
+      if (rbIdx > riskCeilingIdx) return false;
+    }
+    return true;
+  });
+
+  if (candidates.length === 0) {
+    if (allRunbooks.length > 0 && riskCeiling) {
+      return { result: null, reason: "risk-ceiling" };
+    }
+    return { result: null, reason: "no-match" };
+  }
+
+  const reqTokens = tokenize(request);
+  const scored: Array<{
+    name: string;
+    runbook: RunbookDefinition;
+    confidence: number;
+    matchedExample: string;
+    excluded: boolean;
+  }> = [];
+
+  for (const rb of candidates) {
+    let bestScore = 0;
+    let bestExample = "";
+
+    for (const example of rb.intent.examples) {
+      const score = jaccardSimilarity(reqTokens, tokenize(example));
+      if (score > bestScore) {
+        bestScore = score;
+        bestExample = example;
+      }
+    }
+
+    let excluded = false;
+    for (const exclude of rb.intent.excludes) {
+      const excScore = jaccardSimilarity(reqTokens, tokenize(exclude));
+      if (excScore > bestScore) {
+        excluded = true;
+        break;
+      }
+    }
+
+    scored.push({
+      name: rb.name,
+      runbook: rb,
+      confidence: bestScore,
+      matchedExample: bestExample,
+      excluded,
+    });
+  }
+
+  scored.sort((a, b) => b.confidence - a.confidence);
+  const candidateList = scored.map((s) => ({
+    name: s.name,
+    confidence: s.confidence,
+  }));
+
+  const best = scored[0];
+  if (!best || best.confidence < minConfidence) {
+    return {
+      result: null,
+      reason: "below-threshold",
+      candidates: candidateList,
+    };
+  }
+
+  if (best.excluded) {
+    return {
+      result: null,
+      reason: "excluded",
+      candidates: candidateList,
+    };
+  }
+
+  if (scored.length > 1) {
+    const second = scored[1];
+    if (best.confidence - second.confidence < AMBIGUITY_GAP) {
+      return {
+        result: null,
+        reason: "ambiguous",
+        candidates: candidateList,
+      };
+    }
+  }
+
+  return {
+    result: {
+      runbook: best.runbook,
+      confidence: best.confidence,
+      matchedExample: best.matchedExample,
+    },
+  };
+}
+
+function tokenize(text: string): Set<string> {
+  return new Set(
+    text
+      .toLowerCase()
+      .replace(/[^\w\s]/g, " ")
+      .split(/\s+/)
+      .filter((t) => t.length > 1),
+  );
+}
+
+function jaccardSimilarity(a: Set<string>, b: Set<string>): number {
+  if (a.size === 0 && b.size === 0) return 0;
+  let intersection = 0;
+  for (const token of a) {
+    if (b.has(token)) intersection++;
+  }
+  const union = a.size + b.size - intersection;
+  return union === 0 ? 0 : intersection / union;
+}

--- a/src/runbooks/selector.test.ts
+++ b/src/runbooks/selector.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import path from "node:path";
+import {
+  AGENT_IDENTITIES,
+  registerAgentIdentity,
+} from "../support/agents.ts";
+import {
+  clearRegistryForTests,
+  loadRunbookRegistryFromDir,
+} from "./registry.ts";
+import { selectRunbook } from "./selector.ts";
+
+const FIXTURE_DIR = path.join(import.meta.dir, "__fixtures__");
+
+describe("runbook selector", () => {
+  beforeEach(async () => {
+    registerAgentIdentity("db-executioner", {
+      username: "DB Executioner",
+      iconEmoji: ":database:",
+    });
+    clearRegistryForTests();
+    await loadRunbookRegistryFromDir(FIXTURE_DIR, "private");
+  });
+
+  afterEach(() => {
+    delete AGENT_IDENTITIES["db-executioner"];
+    clearRegistryForTests();
+  });
+
+  it("selects with bound inputs when email context is provided", () => {
+    const result = selectRunbook(
+      "move all AI roadmaps from one account to another",
+      {
+        sourceEmail: "alice@example.com",
+        targetEmail: "bob@example.com",
+      },
+    );
+    expect(result.selected).toBe(true);
+    if (!result.selected) return;
+    expect(result.runbook.name).toBe("transfer-ai-roadmaps");
+    expect(result.boundInputs.bound.sourceEmail).toBe("alice@example.com");
+    expect(result.boundInputs.bound.targetEmail).toBe("bob@example.com");
+    expect(result.boundInputs.missing).toEqual([]);
+  });
+
+  it("selects but reports missing targetEmail when not provided", () => {
+    const result = selectRunbook(
+      "move all AI roadmaps from one account to another",
+      { sourceEmail: "alice@example.com" },
+    );
+    expect(result.selected).toBe(true);
+    if (!result.selected) return;
+    expect(result.boundInputs.bound.sourceEmail).toBe("alice@example.com");
+    expect(result.boundInputs.missing).toContain("targetEmail");
+  });
+
+  it("does not select for 'move one Notion roadmap'", () => {
+    const result = selectRunbook("move one Notion roadmap", {});
+    expect(result.selected).toBe(false);
+    if (result.selected) return;
+    expect(["below-threshold", "excluded"]).toContain(result.reason);
+  });
+
+  it("does not select for 'transfer every document owned by A'", () => {
+    const result = selectRunbook("transfer every document owned by A", {});
+    expect(result.selected).toBe(false);
+  });
+
+  it("does not select for a completely unrelated request", () => {
+    const result = selectRunbook(
+      "completely unrelated request about weather patterns",
+      {},
+    );
+    expect(result.selected).toBe(false);
+    if (result.selected) return;
+    expect(["below-threshold", "no-match"]).toContain(result.reason);
+  });
+
+  it("non-match result includes procedureFallback with query and warning", () => {
+    const result = selectRunbook(
+      "completely unrelated request about weather patterns",
+      {},
+    );
+    expect(result.selected).toBe(false);
+    if (result.selected) return;
+    expect(result.procedureFallback).toBeDefined();
+    expect(result.procedureFallback.query).toBeTruthy();
+    expect(result.procedureFallback.query).toBe(
+      result.procedureFallback.query.toLowerCase(),
+    );
+    expect(result.procedureFallback.warning).toContain("procedure memory");
+  });
+
+  it("selected result includes evidence with correct digest, risk, and redacted inputs", () => {
+    const result = selectRunbook(
+      "move all AI roadmaps from one account to another",
+      {
+        sourceEmail: "alice@example.com",
+        targetEmail: "bob@example.com",
+      },
+    );
+    expect(result.selected).toBe(true);
+    if (!result.selected) return;
+
+    expect(result.evidence.runbookName).toBe("transfer-ai-roadmaps");
+    expect(result.evidence.contentDigest).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.evidence.risk).toBe("production-write");
+    expect(result.evidence.status).toBe("selected");
+    // Emails should be redacted in evidence
+    expect(result.evidence.boundInputs.sourceEmail).toBe("a***@example.com");
+    expect(result.evidence.boundInputs.targetEmail).toBe("b***@example.com");
+    expect(result.evidence.intentFingerprint).toBeTruthy();
+    expect(result.evidence.runId).toBeTruthy();
+  });
+
+  it("selected result confidence is > 0.6", () => {
+    const result = selectRunbook(
+      "move all AI roadmaps from one account to another",
+      {
+        sourceEmail: "alice@example.com",
+        targetEmail: "bob@example.com",
+      },
+    );
+    expect(result.selected).toBe(true);
+    if (!result.selected) return;
+    expect(result.confidence).toBeGreaterThan(0.6);
+  });
+});

--- a/src/runbooks/selector.ts
+++ b/src/runbooks/selector.ts
@@ -1,0 +1,62 @@
+import { bindInputs, type BoundInputs } from "./binder.ts";
+import { createRunEvidence, buildProcedureFallback, type RunbookRunEvidence, type ProcedureFallback } from "./evidence.ts";
+import { matchRunbookDetailed, type MatchOptions } from "./matcher.ts";
+import type { RunbookDefinition } from "./types.ts";
+
+export type SelectionResult =
+  | {
+      selected: true;
+      runbook: RunbookDefinition;
+      confidence: number;
+      matchedExample: string;
+      boundInputs: BoundInputs;
+      evidence: RunbookRunEvidence;
+    }
+  | {
+      selected: false;
+      reason:
+        | "no-match"
+        | "ambiguous"
+        | "excluded"
+        | "below-threshold"
+        | "risk-ceiling";
+      candidates?: Array<{ name: string; confidence: number }>;
+      procedureFallback: ProcedureFallback;
+    };
+
+export function selectRunbook(
+  request: string,
+  context: Record<string, string>,
+  options?: MatchOptions,
+): SelectionResult {
+  const { result, reason, candidates } = matchRunbookDetailed(
+    request,
+    options,
+  );
+
+  if (!result) {
+    return {
+      selected: false,
+      reason: reason ?? "no-match",
+      candidates,
+      procedureFallback: buildProcedureFallback(request),
+    };
+  }
+
+  const bound = bindInputs(result.runbook, context);
+  const evidence = createRunEvidence(
+    result.runbook,
+    bound.bound,
+    request,
+    Date.now(),
+  );
+
+  return {
+    selected: true,
+    runbook: result.runbook,
+    confidence: result.confidence,
+    matchedExample: result.matchedExample,
+    boundInputs: bound,
+    evidence,
+  };
+}


### PR DESCRIPTION
## Summary
Iteration 2 of the common-task-agent-authoring plan. Adds deterministic runbook selection:

- **Intent matcher** (`src/runbooks/matcher.ts`) — token-overlap scoring with exclusion checking, confidence threshold, ambiguity gap enforcement
- **Input binder** (`src/runbooks/binder.ts`) — typed input extraction with email/objectId/enum validation, PII redaction
- **Execution evidence** (`src/runbooks/evidence.ts`) — privacy-safe intent fingerprinting, run tracking with version digest and redacted inputs
- **Selection pipeline** (`src/runbooks/selector.ts`) — combines matching, binding, evidence; procedure-memory fallback signal when no runbook matches
- **MCP tool** — `runbook_select` registered alongside existing tools

## Test plan
- [x] 135/135 runbook tests pass (49 new for selection pipeline)
- [x] 138/138 existing agent tests pass (no regressions)
- [x] "move my AI roadmaps from A to B" consistently selects transfer-ai-roadmaps
- [x] "move one Notion roadmap" and "transfer every document" correctly excluded
- [x] Ambiguous matches return null with reason and candidates
- [x] Missing required inputs reported with names
- [x] Intent fingerprints are stable and contain no raw PII
- [x] Includes Iteration 1 review warning fixes (YAML colon parsing, LKG log key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)