### PR TITLE
feat(runbooks): add constrained authoring and dry-run PR creation

### DIFF
--- a/src/mcp/slack-server.ts
+++ b/src/mcp/slack-server.ts
@@ -79,7 +79,18 @@ import {
   recordSuccessfulExecution as promotionRecordExecution,
   checkPromotionThreshold as promotionCheckThreshold,
   listCandidates as promotionListCandidates,
+  getCandidate as promotionGetCandidate,
 } from "../runbooks/promotion.ts";
+import {
+  renderRunbookTemplate,
+  generateProposalReport,
+  type AuthoringContext as AuthoringContextType,
+} from "../runbooks/authoring.ts";
+import { classifyReusablePattern } from "../runbooks/classifier.ts";
+import {
+  createRunbookPr,
+  type PrCreationResult as PrCreationResultType,
+} from "../runbooks/github.ts";
 
 const MCP_PORT = Number(process.env.MCP_PORT ?? "3456");
 const FALLBACK_AGENTS_DIR = ".claude/agents";
@@ -1098,6 +1109,65 @@ function registerTools(server: McpServer, runContext: SlackMcpRunContext | null 
             }, null, 2),
           },
         ],
+      };
+    },
+  );
+
+  registerTool(
+    server,
+    "runbook_propose",
+    {
+      description:
+        "Generate a runbook proposal from a promotion candidate. Returns rendered .runbook.md content, a structured proposal report, and a dry-run PR result.",
+      inputSchema: {
+        fingerprint: z.string().describe("Intent fingerprint from a promotion candidate"),
+        dry_run: z.boolean().optional().describe("Whether to skip actual PR creation (default true)"),
+        inferred_inputs: z.array(z.object({
+          name: z.string(),
+          type: z.string(),
+          required: z.boolean(),
+          description: z.string().optional(),
+        })).optional().describe("Inferred typed inputs for the runbook"),
+        inferred_capabilities: z.array(z.string()).optional().describe("Inferred capability bundles"),
+        inferred_assertions: z.array(z.string()).optional().describe("Inferred verification assertions"),
+      },
+    },
+    async ({ fingerprint, dry_run, inferred_inputs, inferred_capabilities, inferred_assertions }) => {
+      const candidate = promotionGetCandidate(fingerprint);
+      if (!candidate) {
+        return {
+          content: [{ type: "text" as const, text: JSON.stringify({ error: `no candidate found for fingerprint "${fingerprint}"` }) }],
+        };
+      }
+
+      const context: AuthoringContextType = {
+        candidate,
+        executionEvidence: [],
+        inferredInputs: inferred_inputs,
+        inferredCapabilities: inferred_capabilities,
+        inferredVerificationAssertions: inferred_assertions,
+      };
+
+      const rendered = renderRunbookTemplate(context);
+      const classification = classifyReusablePattern(
+        candidate.normalizedIntent,
+        candidate.ownerAgent,
+        candidate.risk,
+        candidate.capabilities,
+        candidate.occurrenceCount,
+      );
+      const report = generateProposalReport(context, rendered, classification);
+
+      let pr: PrCreationResultType | undefined;
+      if (rendered.ok) {
+        pr = await createRunbookPr(rendered, report, { dryRun: dry_run ?? true });
+      }
+
+      return {
+        content: [{
+          type: "text" as const,
+          text: JSON.stringify({ rendered, report, pr }, null, 2),
+        }],
       };
     },
   );

--- a/src/runbooks/authoring.test.ts
+++ b/src/runbooks/authoring.test.ts
@@ -1,0 +1,533 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+  renderRunbookTemplate,
+  renderAgentExtensionProposal,
+  generateProposalReport,
+  type AuthoringContext,
+} from "./authoring.ts";
+import { classifyReusablePattern } from "./classifier.ts";
+import type { PromotionCandidate } from "./types.ts";
+import type { RunbookRunEvidence } from "./evidence.ts";
+import {
+  AGENT_IDENTITIES,
+  registerAgentIdentity,
+} from "../support/agents.ts";
+
+function makeCandidate(
+  overrides?: Partial<PromotionCandidate>,
+): PromotionCandidate {
+  return {
+    fingerprint: "fp-test",
+    proposedKind: "runbook",
+    normalizedIntent: "transfer data from one account to another",
+    ownerAgent: "build",
+    occurrenceCount: 3,
+    successfulCount: 3,
+    firstSeenAt: Date.now(),
+    lastSeenAt: Date.now(),
+    evidenceRefs: ["run-1", "run-2", "run-3"],
+    procedureMemoryIds: [],
+    status: "tracking",
+    risk: "production-write",
+    capabilities: ["mongo.read"],
+    ...overrides,
+  };
+}
+
+function makeEvidence(
+  overrides?: Partial<RunbookRunEvidence>,
+): RunbookRunEvidence {
+  return {
+    runId: "run-1",
+    runbookName: "test",
+    contentDigest: "abc",
+    ownerAgent: "build",
+    risk: "production-write",
+    boundInputs: {},
+    status: "completed",
+    startedAt: Date.now(),
+    intentFingerprint: "fp-test",
+    ...overrides,
+  };
+}
+
+function makeContext(
+  overrides?: Partial<AuthoringContext>,
+): AuthoringContext {
+  return {
+    candidate: makeCandidate(),
+    executionEvidence: [makeEvidence()],
+    ...overrides,
+  };
+}
+
+describe("runbook authoring", () => {
+  beforeEach(() => {
+    registerAgentIdentity("db-executioner", {
+      username: "DB",
+      iconEmoji: ":db:",
+    });
+  });
+
+  afterEach(() => {
+    delete AGENT_IDENTITIES["db-executioner"];
+  });
+
+  describe("renderRunbookTemplate", () => {
+    it("valid candidate renders ok: true with content string", () => {
+      const result = renderRunbookTemplate(makeContext());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(typeof result.content).toBe("string");
+      expect(result.content.length).toBeGreaterThan(0);
+    });
+
+    it("rendered content starts with frontmatter delimiter", () => {
+      const result = renderRunbookTemplate(makeContext());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.content.startsWith("---")).toBe(true);
+    });
+
+    it("rendered content contains schemaVersion: 1", () => {
+      const result = renderRunbookTemplate(makeContext());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.content).toContain("schemaVersion: 1");
+    });
+
+    it("rendered filename is kebab-case ending in .runbook.md", () => {
+      const result = renderRunbookTemplate(makeContext());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.filename).toMatch(/^[a-z0-9]+(-[a-z0-9]+)*\.runbook\.md$/);
+    });
+
+    it("name is max 50 chars with a very long normalizedIntent", () => {
+      const longIntent =
+        "transfer all data from one very long account name to another extremely long account name with extra details";
+      const ctx = makeContext({
+        candidate: makeCandidate({ normalizedIntent: longIntent }),
+      });
+      const result = renderRunbookTemplate(ctx);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // filename = name + ".runbook.md", so name = filename minus suffix
+      const name = result.filename.replace(/\.runbook\.md$/, "");
+      expect(name.length).toBeLessThanOrEqual(50);
+    });
+
+    it("high-risk candidate content contains approval required: true", () => {
+      const ctx = makeContext({
+        candidate: makeCandidate({ risk: "production-write" }),
+      });
+      const result = renderRunbookTemplate(ctx);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.content).toContain("approval:");
+      expect(result.content).toContain("required: true");
+    });
+
+    it("read-only risk sets verification required to false", () => {
+      const ctx = makeContext({
+        candidate: makeCandidate({ risk: "read-only" }),
+      });
+      const result = renderRunbookTemplate(ctx);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      // verification section should say required: false
+      const verificationMatch = result.content.match(
+        /verification:\n\s+required:\s+(true|false)/,
+      );
+      expect(verificationMatch).not.toBeNull();
+      expect(verificationMatch![1]).toBe("false");
+    });
+
+    it("production-write risk sets verification required to true", () => {
+      const ctx = makeContext({
+        candidate: makeCandidate({ risk: "production-write" }),
+      });
+      const result = renderRunbookTemplate(ctx);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      const verificationMatch = result.content.match(
+        /verification:\n\s+required:\s+(true|false)/,
+      );
+      expect(verificationMatch).not.toBeNull();
+      expect(verificationMatch![1]).toBe("true");
+    });
+
+    it("empty normalizedIntent returns ok: false with reason", () => {
+      const ctx = makeContext({
+        candidate: makeCandidate({ normalizedIntent: "" }),
+      });
+      const result = renderRunbookTemplate(ctx);
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(typeof result.reason).toBe("string");
+      expect(result.reason.length).toBeGreaterThan(0);
+    });
+
+    it("validationErrors is an array for valid output", () => {
+      const result = renderRunbookTemplate(makeContext());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(Array.isArray(result.validationErrors)).toBe(true);
+    });
+
+    it("zero validation errors when ownerAgent is catalog agent 'build'", () => {
+      const ctx = makeContext({
+        candidate: makeCandidate({ ownerAgent: "build" }),
+      });
+      const result = renderRunbookTemplate(ctx);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.validationErrors).toHaveLength(0);
+    });
+
+    it("content does not contain secret patterns", () => {
+      const ctx = makeContext();
+      const result = renderRunbookTemplate(ctx);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+
+      const secretPatterns = [
+        /mongodb\+srv:\/\//i,
+        /Bearer\s+[A-Za-z0-9\-._~+/]+=*/,
+        /\bsk-[A-Za-z0-9]{20,}/,
+        /\bghp_[A-Za-z0-9]{36,}/,
+        /\bgho_[A-Za-z0-9]{36,}/,
+        /password\s*[:=]\s*\S+/i,
+        /\bAKIA[0-9A-Z]{16}\b/,
+      ];
+
+      for (const pattern of secretPatterns) {
+        expect(pattern.test(result.content)).toBe(false);
+      }
+    });
+
+    it("with inferredInputs, inputs section appears in rendered content", () => {
+      const ctx = makeContext({
+        inferredInputs: [
+          {
+            name: "userId",
+            type: "objectId",
+            required: true,
+            description: "the target user",
+          },
+          {
+            name: "dryRun",
+            type: "boolean",
+            required: false,
+          },
+        ],
+      });
+      const result = renderRunbookTemplate(ctx);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.content).toContain("inputs:");
+      expect(result.content).toContain("name: userId");
+      expect(result.content).toContain("type: objectId");
+      expect(result.content).toContain("required: true");
+      expect(result.content).toContain("description: the target user");
+      expect(result.content).toContain("name: dryRun");
+      expect(result.content).toContain("type: boolean");
+    });
+
+    it("with inferredCapabilities, capabilities appear in content", () => {
+      const ctx = makeContext({
+        inferredCapabilities: ["mongo.read", "slack.post"],
+      });
+      const result = renderRunbookTemplate(ctx);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.content).toContain("capabilities:");
+      expect(result.content).toContain("- mongo.read");
+      expect(result.content).toContain("- slack.post");
+    });
+
+    it("with inferredVerificationAssertions, assertions appear in content", () => {
+      const ctx = makeContext({
+        inferredVerificationAssertions: [
+          "data was transferred",
+          "old account has zero items",
+        ],
+      });
+      const result = renderRunbookTemplate(ctx);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.content).toContain("assertions:");
+      expect(result.content).toContain("- data was transferred");
+      expect(result.content).toContain("- old account has zero items");
+    });
+
+    it("with procedureMemory, prompt body references them", () => {
+      const ctx = makeContext({
+        procedureMemory: [
+          "always verify the account exists first",
+          "use bulk operations for large transfers",
+        ],
+      });
+      const result = renderRunbookTemplate(ctx);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.content).toContain(
+        "always verify the account exists first",
+      );
+      expect(result.content).toContain(
+        "use bulk operations for large transfers",
+      );
+      expect(result.content).toContain("Reference procedure notes:");
+    });
+
+    it("metadata contains templateVersion, generatedAt, and sourceFingerprint", () => {
+      const result = renderRunbookTemplate(makeContext());
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.metadata.templateVersion).toBe("1.0");
+      expect(typeof result.metadata.generatedAt).toBe("number");
+      expect(result.metadata.sourceFingerprint).toBe("fp-test");
+    });
+
+    it("renders with db-executioner ownerAgent after registration", () => {
+      const ctx = makeContext({
+        candidate: makeCandidate({ ownerAgent: "db-executioner" }),
+      });
+      const result = renderRunbookTemplate(ctx);
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.content).toContain("ownerAgent: db-executioner");
+      // db-executioner is registered as persistent agent via registerAgentIdentity,
+      // so the validator should not flag ownerAgent as unknown
+      const ownerErrors = result.validationErrors.filter(
+        (e) => e.field === "ownerAgent",
+      );
+      expect(ownerErrors).toHaveLength(0);
+    });
+  });
+
+  describe("renderAgentExtensionProposal", () => {
+    it("returns targetAgent matching candidate.ownerAgent", () => {
+      const ctx = makeContext();
+      const proposal = renderAgentExtensionProposal(ctx);
+      expect(proposal.targetAgent).toBe(ctx.candidate.ownerAgent);
+    });
+
+    it("returns non-empty description and reason", () => {
+      const proposal = renderAgentExtensionProposal(makeContext());
+      expect(proposal.description.length).toBeGreaterThan(0);
+      expect(proposal.reason.length).toBeGreaterThan(0);
+    });
+
+    it("suggestedRouting contains normalizedIntent", () => {
+      const intent = "transfer data from one account to another";
+      const ctx = makeContext({
+        candidate: makeCandidate({ normalizedIntent: intent }),
+      });
+      const proposal = renderAgentExtensionProposal(ctx);
+      expect(proposal.suggestedRouting).toContain(intent);
+    });
+
+    it("suggestedCapabilities uses inferredCapabilities when provided", () => {
+      const ctx = makeContext({
+        inferredCapabilities: ["mongo.read", "github.read"],
+      });
+      const proposal = renderAgentExtensionProposal(ctx);
+      expect(proposal.suggestedCapabilities).toEqual([
+        "mongo.read",
+        "github.read",
+      ]);
+    });
+
+    it("suggestedCapabilities falls back to candidate.capabilities", () => {
+      const ctx = makeContext({
+        candidate: makeCandidate({ capabilities: ["slack.read"] }),
+      });
+      // no inferredCapabilities set
+      const proposal = renderAgentExtensionProposal(ctx);
+      expect(proposal.suggestedCapabilities).toEqual(["slack.read"]);
+    });
+
+    it("description mentions the ownerAgent name", () => {
+      const ctx = makeContext({
+        candidate: makeCandidate({ ownerAgent: "build" }),
+      });
+      const proposal = renderAgentExtensionProposal(ctx);
+      expect(proposal.description).toContain("build");
+    });
+
+    it("reason includes successfulCount", () => {
+      const ctx = makeContext({
+        candidate: makeCandidate({ successfulCount: 5 }),
+      });
+      const proposal = renderAgentExtensionProposal(ctx);
+      expect(proposal.reason).toContain("5");
+    });
+  });
+
+  describe("generateProposalReport", () => {
+    function makeReport(
+      contextOverrides?: Partial<AuthoringContext>,
+      classificationOverrides?: Partial<
+        ReturnType<typeof classifyReusablePattern>
+      >,
+    ) {
+      const ctx = makeContext(contextOverrides);
+      const rendered = renderRunbookTemplate(ctx);
+      const classification = {
+        classification: "runbook" as const,
+        confidence: 0.75,
+        reason: "repeated ordered procedure within existing owner capability boundary",
+        ...classificationOverrides,
+      };
+      return generateProposalReport(ctx, rendered, classification);
+    }
+
+    it("report has all required fields", () => {
+      const report = makeReport();
+      expect(typeof report.artifactClass).toBe("string");
+      expect(typeof report.reason).toBe("string");
+      expect(typeof report.riskClassification).toBe("string");
+      expect(Array.isArray(report.existingConsidered)).toBe(true);
+      expect(Array.isArray(report.executionEvidence)).toBe(true);
+      expect(Array.isArray(report.linkedProcedureMemory)).toBe(true);
+      expect(Array.isArray(report.positiveExamples)).toBe(true);
+      expect(Array.isArray(report.negativeExamples)).toBe(true);
+      expect(Array.isArray(report.requestedCapabilities)).toBe(true);
+      expect(Array.isArray(report.humanGates)).toBe(true);
+      expect(Array.isArray(report.validationOutput)).toBe(true);
+      expect(typeof report.verificationBehavior).toBe("string");
+      expect(typeof report.rollbackBehavior).toBe("string");
+    });
+
+    it("high-risk candidate has non-empty humanGates", () => {
+      const report = makeReport({
+        candidate: makeCandidate({ risk: "production-write" }),
+      });
+      expect(report.humanGates.length).toBeGreaterThan(0);
+      expect(report.humanGates[0]).toContain("production-write");
+    });
+
+    it("read-only risk has empty humanGates", () => {
+      const report = makeReport({
+        candidate: makeCandidate({ risk: "read-only" }),
+      });
+      expect(report.humanGates).toHaveLength(0);
+    });
+
+    it("report includes execution evidence entries", () => {
+      const evidence = [
+        makeEvidence({ runId: "run-a", status: "completed" }),
+        makeEvidence({ runId: "run-b", status: "failed" }),
+      ];
+      const report = makeReport({ executionEvidence: evidence });
+      expect(report.executionEvidence).toHaveLength(2);
+      expect(report.executionEvidence[0].runId).toBe("run-a");
+      expect(report.executionEvidence[0].status).toBe("completed");
+      expect(report.executionEvidence[1].runId).toBe("run-b");
+      expect(report.executionEvidence[1].status).toBe("failed");
+    });
+
+    it("report includes linked procedure memory", () => {
+      const report = makeReport({
+        procedureMemory: ["always backup first", "verify after transfer"],
+      });
+      expect(report.linkedProcedureMemory).toEqual([
+        "always backup first",
+        "verify after transfer",
+      ]);
+    });
+
+    it("positiveExamples and negativeExamples are non-empty", () => {
+      const report = makeReport();
+      expect(report.positiveExamples.length).toBeGreaterThan(0);
+      expect(report.negativeExamples.length).toBeGreaterThan(0);
+    });
+
+    it("validationOutput comes from the rendered result", () => {
+      // Valid candidate with build ownerAgent should have zero validation errors
+      const report = makeReport({
+        candidate: makeCandidate({ ownerAgent: "build" }),
+      });
+      expect(report.validationOutput).toHaveLength(0);
+    });
+
+    it("validationOutput is empty array when rendered fails", () => {
+      const ctx = makeContext({
+        candidate: makeCandidate({ normalizedIntent: "" }),
+      });
+      const rendered = renderRunbookTemplate(ctx);
+      // rendered is ok: false
+      expect(rendered.ok).toBe(false);
+      const classification = {
+        classification: "runbook" as const,
+        confidence: 0.75,
+        reason: "test",
+      };
+      const report = generateProposalReport(ctx, rendered, classification);
+      expect(report.validationOutput).toHaveLength(0);
+    });
+
+    it("destructive risk produces humanGates and rollback plan required", () => {
+      const report = makeReport({
+        candidate: makeCandidate({ risk: "destructive" }),
+      });
+      expect(report.humanGates.length).toBeGreaterThan(0);
+      expect(report.rollbackBehavior).toContain("rollback plan required");
+    });
+
+    it("riskClassification matches candidate risk", () => {
+      const report = makeReport({
+        candidate: makeCandidate({ risk: "credential" }),
+      });
+      expect(report.riskClassification).toBe("credential");
+    });
+
+    it("artifactClass and reason come from classification", () => {
+      const report = makeReport(undefined, {
+        classification: "agent-extension",
+        reason: "owner lacks capability X",
+      });
+      expect(report.artifactClass).toBe("agent-extension");
+      expect(report.reason).toBe("owner lacks capability X");
+    });
+
+    it("existingConsidered populated when classification has existingMatch", () => {
+      const report = makeReport(undefined, {
+        existingMatch: { name: "old-runbook", kind: "runbook" },
+      });
+      expect(report.existingConsidered).toHaveLength(1);
+      expect(report.existingConsidered[0].name).toBe("old-runbook");
+      expect(report.existingConsidered[0].kind).toBe("runbook");
+      expect(report.existingConsidered[0].whyNotSufficient.length).toBeGreaterThan(0);
+    });
+
+    it("existingConsidered empty when classification has no existingMatch", () => {
+      const report = makeReport(undefined, {
+        existingMatch: undefined,
+      });
+      expect(report.existingConsidered).toHaveLength(0);
+    });
+
+    it("requestedCapabilities uses inferredCapabilities when available", () => {
+      const report = makeReport({
+        inferredCapabilities: ["mongo.read", "slack.post"],
+      });
+      expect(report.requestedCapabilities).toEqual(["mongo.read", "slack.post"]);
+    });
+
+    it("read-only verification behavior says no verification required", () => {
+      const report = makeReport({
+        candidate: makeCandidate({ risk: "read-only" }),
+      });
+      expect(report.verificationBehavior).toContain("no verification required");
+    });
+
+    it("non-read-only verification behavior says verification required", () => {
+      const report = makeReport({
+        candidate: makeCandidate({ risk: "workspace-write" }),
+      });
+      expect(report.verificationBehavior).toContain("verification required");
+    });
+  });
+});

--- a/src/runbooks/authoring.ts
+++ b/src/runbooks/authoring.ts
@@ -1,0 +1,270 @@
+import type { ClassificationResult } from "./classifier.ts";
+import type { RunbookRunEvidence } from "./evidence.ts";
+import { validateRunbook } from "./validator.ts";
+import { HIGH_RISK_KINDS, type PromotionCandidate, type RunbookDefinition, type RunbookRisk, type RunbookValidationError } from "./types.ts";
+
+export interface AuthoringContext {
+  candidate: PromotionCandidate;
+  executionEvidence: RunbookRunEvidence[];
+  procedureMemory?: string[];
+  inferredInputs?: Array<{
+    name: string;
+    type: string;
+    required: boolean;
+    description?: string;
+  }>;
+  inferredCapabilities?: string[];
+  inferredVerificationAssertions?: string[];
+}
+
+export type AuthoringResult =
+  | {
+      ok: true;
+      content: string;
+      filename: string;
+      validationErrors: RunbookValidationError[];
+      metadata: {
+        templateVersion: string;
+        generatedAt: number;
+        sourceFingerprint: string;
+      };
+    }
+  | { ok: false; reason: string };
+
+export function renderRunbookTemplate(
+  context: AuthoringContext,
+): AuthoringResult {
+  const { candidate } = context;
+
+  const name = deriveKebabName(candidate.normalizedIntent);
+  if (!name) {
+    return { ok: false, reason: "could not derive a valid kebab-case name from normalized intent" };
+  }
+
+  const risk: RunbookRisk = candidate.risk ?? "production-write";
+  const approvalRequired = HIGH_RISK_KINDS.includes(risk) || risk !== "read-only";
+  const verificationRequired = risk !== "read-only";
+
+  const capabilities = context.inferredCapabilities ?? candidate.capabilities;
+  const inputs = context.inferredInputs ?? [];
+  const assertions = context.inferredVerificationAssertions ?? (verificationRequired ? ["operation completed successfully"] : []);
+
+  const intentExamples = candidate.normalizedIntent
+    ? [candidate.normalizedIntent]
+    : ["perform the described task"];
+
+  const lines: string[] = ["---"];
+  lines.push(`schemaVersion: 1`);
+  lines.push(`name: ${name}`);
+  lines.push(`description: ${candidate.normalizedIntent || "Auto-generated runbook from promotion candidate"}`);
+  lines.push(`ownerAgent: ${candidate.ownerAgent}`);
+  lines.push(`intent:`);
+  lines.push(`  examples:`);
+  for (const ex of intentExamples) {
+    lines.push(`    - ${ex}`);
+  }
+  lines.push(`  excludes:`);
+  lines.push(`    - unrelated task`);
+
+  if (inputs.length > 0) {
+    lines.push(`inputs:`);
+    for (const input of inputs) {
+      lines.push(`  - name: ${input.name}`);
+      lines.push(`    type: ${input.type}`);
+      lines.push(`    required: ${input.required}`);
+      if (input.description) {
+        lines.push(`    description: ${input.description}`);
+      }
+    }
+  } else {
+    lines.push(`inputs: []`);
+  }
+
+  lines.push(`risk: ${risk}`);
+  lines.push(`approval:`);
+  lines.push(`  required: ${approvalRequired}`);
+  if (capabilities.length > 0) {
+    lines.push(`capabilities:`);
+    for (const cap of capabilities) {
+      lines.push(`  - ${cap}`);
+    }
+  } else {
+    lines.push(`capabilities: []`);
+  }
+  lines.push(`verification:`);
+  lines.push(`  required: ${verificationRequired}`);
+  if (assertions.length > 0) {
+    lines.push(`  assertions:`);
+    for (const a of assertions) {
+      lines.push(`    - ${a}`);
+    }
+  }
+  lines.push(`tags:`);
+  lines.push(`  - auto-generated`);
+  lines.push(`---`);
+  lines.push(``);
+  lines.push(buildPromptBody(context));
+  lines.push(``);
+
+  const content = lines.join("\n");
+  const filename = `${name}.runbook.md`;
+
+  const tempDef: RunbookDefinition = {
+    schemaVersion: 1,
+    name,
+    description: candidate.normalizedIntent || "Auto-generated runbook",
+    ownerAgent: candidate.ownerAgent,
+    intent: { examples: intentExamples, excludes: ["unrelated task"] },
+    inputs: inputs.map((i) => ({
+      name: i.name,
+      type: i.type as RunbookDefinition["inputs"][number]["type"],
+      required: i.required,
+      description: i.description,
+    })),
+    risk,
+    approval: { required: approvalRequired },
+    capabilities,
+    verification: { required: verificationRequired, assertions },
+    tags: ["auto-generated"],
+    prompt: buildPromptBody(context),
+    filePath: `runbooks/${filename}`,
+    origin: "private",
+    contentDigest: "",
+  };
+
+  const validationErrors = validateRunbook(tempDef, name);
+
+  return {
+    ok: true,
+    content,
+    filename,
+    validationErrors,
+    metadata: {
+      templateVersion: "1.0",
+      generatedAt: Date.now(),
+      sourceFingerprint: candidate.fingerprint,
+    },
+  };
+}
+
+export interface AgentExtensionProposal {
+  targetAgent: string;
+  description: string;
+  suggestedRouting: string[];
+  suggestedCapabilities: string[];
+  reason: string;
+}
+
+export function renderAgentExtensionProposal(
+  context: AuthoringContext,
+): AgentExtensionProposal {
+  const { candidate } = context;
+  return {
+    targetAgent: candidate.ownerAgent,
+    description: `Extend ${candidate.ownerAgent} to handle: ${candidate.normalizedIntent}`,
+    suggestedRouting: candidate.normalizedIntent
+      ? [candidate.normalizedIntent]
+      : [],
+    suggestedCapabilities: context.inferredCapabilities ?? candidate.capabilities,
+    reason: `${candidate.successfulCount} successful executions of this pattern were handled by ${candidate.ownerAgent}, but it lacks the declared capability boundary for this class of work.`,
+  };
+}
+
+export interface ProposalReport {
+  artifactClass: string;
+  reason: string;
+  existingConsidered: Array<{
+    name: string;
+    kind: string;
+    whyNotSufficient: string;
+  }>;
+  executionEvidence: Array<{
+    runId: string;
+    status: string;
+    date: number;
+  }>;
+  linkedProcedureMemory: string[];
+  positiveExamples: string[];
+  negativeExamples: string[];
+  requestedCapabilities: string[];
+  riskClassification: string;
+  humanGates: string[];
+  verificationBehavior: string;
+  rollbackBehavior: string;
+  validationOutput: RunbookValidationError[];
+}
+
+export function generateProposalReport(
+  context: AuthoringContext,
+  rendered: AuthoringResult,
+  classification: ClassificationResult,
+): ProposalReport {
+  const { candidate, executionEvidence } = context;
+  const risk: RunbookRisk = candidate.risk ?? "production-write";
+  const isHighRisk = HIGH_RISK_KINDS.includes(risk);
+
+  return {
+    artifactClass: classification.classification,
+    reason: classification.reason,
+    existingConsidered: classification.existingMatch
+      ? [
+          {
+            name: classification.existingMatch.name,
+            kind: classification.existingMatch.kind,
+            whyNotSufficient: "existing definition does not cover this specific intent pattern",
+          },
+        ]
+      : [],
+    executionEvidence: executionEvidence.map((e) => ({
+      runId: e.runId,
+      status: e.status,
+      date: e.startedAt,
+    })),
+    linkedProcedureMemory: context.procedureMemory ?? [],
+    positiveExamples: candidate.normalizedIntent
+      ? [candidate.normalizedIntent]
+      : [],
+    negativeExamples: ["unrelated task"],
+    requestedCapabilities: context.inferredCapabilities ?? candidate.capabilities,
+    riskClassification: risk,
+    humanGates: isHighRisk
+      ? [`human approval required before execution (risk: ${risk})`]
+      : [],
+    verificationBehavior: risk !== "read-only"
+      ? "post-execution verification required"
+      : "no verification required (read-only)",
+    rollbackBehavior: isHighRisk
+      ? "rollback plan required before execution"
+      : "standard rollback procedure",
+    validationOutput: rendered.ok ? rendered.validationErrors : [],
+  };
+}
+
+function deriveKebabName(intent: string): string | null {
+  if (!intent) return null;
+  const kebab = intent
+    .toLowerCase()
+    .replace(/<[^>]+>/g, "")
+    .replace(/[^\w\s]/g, "")
+    .replace(/\s+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-{2,}/g, "-");
+
+  if (!kebab) return null;
+  return kebab.slice(0, 50).replace(/-$/, "");
+}
+
+function buildPromptBody(context: AuthoringContext): string {
+  const parts: string[] = [];
+  parts.push("Execute the procedure as described.");
+
+  if (context.procedureMemory && context.procedureMemory.length > 0) {
+    parts.push("");
+    parts.push("Reference procedure notes:");
+    for (const mem of context.procedureMemory) {
+      parts.push(`- ${mem}`);
+    }
+  }
+
+  return parts.join("\n");
+}

--- a/src/runbooks/github.test.ts
+++ b/src/runbooks/github.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { createRunbookPr } from "./github.ts";
+import {
+  renderRunbookTemplate,
+  generateProposalReport,
+  type AuthoringContext,
+  type AuthoringResult,
+} from "./authoring.ts";
+import { classifyReusablePattern } from "./classifier.ts";
+import type { PromotionCandidate } from "./types.ts";
+import type { RunbookRunEvidence } from "./evidence.ts";
+import type { ProposalReport } from "./authoring.ts";
+import {
+  AGENT_IDENTITIES,
+  registerAgentIdentity,
+} from "../support/agents.ts";
+
+function makeCandidate(
+  overrides?: Partial<PromotionCandidate>,
+): PromotionCandidate {
+  return {
+    fingerprint: "fp-test",
+    proposedKind: "runbook",
+    normalizedIntent: "transfer data from one account to another",
+    ownerAgent: "build",
+    occurrenceCount: 3,
+    successfulCount: 3,
+    firstSeenAt: Date.now(),
+    lastSeenAt: Date.now(),
+    evidenceRefs: ["run-1", "run-2", "run-3"],
+    procedureMemoryIds: [],
+    status: "tracking",
+    risk: "production-write",
+    capabilities: ["mongo.read"],
+    ...overrides,
+  };
+}
+
+function makeEvidence(
+  overrides?: Partial<RunbookRunEvidence>,
+): RunbookRunEvidence {
+  return {
+    runId: "run-1",
+    runbookName: "test",
+    contentDigest: "abc",
+    ownerAgent: "build",
+    risk: "production-write",
+    boundInputs: {},
+    status: "completed",
+    startedAt: Date.now(),
+    intentFingerprint: "fp-test",
+    ...overrides,
+  };
+}
+
+function makeContext(
+  overrides?: Partial<AuthoringContext>,
+): AuthoringContext {
+  return {
+    candidate: makeCandidate(),
+    executionEvidence: [makeEvidence()],
+    ...overrides,
+  };
+}
+
+/** Build a valid rendered result and proposal report for PR tests. */
+function buildRenderedAndReport(
+  contextOverrides?: Partial<AuthoringContext>,
+): { rendered: AuthoringResult; report: ProposalReport } {
+  const ctx = makeContext(contextOverrides);
+  const rendered = renderRunbookTemplate(ctx);
+  const classification = classifyReusablePattern(
+    ctx.candidate.normalizedIntent,
+    ctx.candidate.ownerAgent,
+    ctx.candidate.risk,
+    ctx.candidate.capabilities,
+    ctx.candidate.occurrenceCount,
+  );
+  const report = generateProposalReport(ctx, rendered, classification);
+  return { rendered, report };
+}
+
+describe("runbook github PR creation", () => {
+  beforeEach(() => {
+    registerAgentIdentity("db-executioner", {
+      username: "DB",
+      iconEmoji: ":db:",
+    });
+  });
+
+  afterEach(() => {
+    delete AGENT_IDENTITIES["db-executioner"];
+  });
+
+  describe("createRunbookPr", () => {
+    it("dry-run returns ok: true with prUrl, branchName, filePath, prBody", async () => {
+      const { rendered, report } = buildRenderedAndReport();
+      const result = await createRunbookPr(rendered, report, { dryRun: true });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(typeof result.prUrl).toBe("string");
+      expect(typeof result.branchName).toBe("string");
+      expect(typeof result.filePath).toBe("string");
+      expect(typeof result.prBody).toBe("string");
+    });
+
+    it("branchName is runbook/<name>", async () => {
+      const { rendered, report } = buildRenderedAndReport();
+      const result = await createRunbookPr(rendered, report, { dryRun: true });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.branchName).toMatch(/^runbook\/[a-z0-9-]+$/);
+      // Verify it matches the name derived from the rendered filename
+      const expectedName = (rendered as Extract<AuthoringResult, { ok: true }>)
+        .filename.replace(/\.runbook\.md$/, "");
+      expect(result.branchName).toBe(`runbook/${expectedName}`);
+    });
+
+    it("filePath is runbooks/<name>.runbook.md", async () => {
+      const { rendered, report } = buildRenderedAndReport();
+      const result = await createRunbookPr(rendered, report, { dryRun: true });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.filePath).toMatch(/^runbooks\/[a-z0-9-]+\.runbook\.md$/);
+    });
+
+    it("prBody contains 'Runbook Proposal' heading", async () => {
+      const { rendered, report } = buildRenderedAndReport();
+      const result = await createRunbookPr(rendered, report, { dryRun: true });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.prBody).toContain("## Runbook Proposal");
+    });
+
+    it("prBody contains risk classification", async () => {
+      const { rendered, report } = buildRenderedAndReport({
+        candidate: makeCandidate({ risk: "destructive" }),
+      });
+      const result = await createRunbookPr(rendered, report, { dryRun: true });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.prBody).toContain("destructive");
+    });
+
+    it("prBody contains execution evidence section", async () => {
+      const evidence = [
+        makeEvidence({ runId: "run-ev-1", status: "completed" }),
+        makeEvidence({ runId: "run-ev-2", status: "completed" }),
+      ];
+      const { rendered, report } = buildRenderedAndReport({
+        executionEvidence: evidence,
+      });
+      const result = await createRunbookPr(rendered, report, { dryRun: true });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.prBody).toContain("### Execution evidence");
+      expect(result.prBody).toContain("run-ev-1");
+      expect(result.prBody).toContain("run-ev-2");
+    });
+
+    it("invalid rendered input (ok: false) returns ok: false", async () => {
+      const failedRendered: AuthoringResult = {
+        ok: false,
+        reason: "could not derive name",
+      };
+      const { report } = buildRenderedAndReport();
+      const result = await createRunbookPr(failedRendered, report, {
+        dryRun: true,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.reason).toContain("rendered content is invalid");
+    });
+
+    it("non-dry-run (dryRun: false) returns ok: false with 'not yet implemented'", async () => {
+      const { rendered, report } = buildRenderedAndReport();
+      const result = await createRunbookPr(rendered, report, {
+        dryRun: false,
+      });
+      expect(result.ok).toBe(false);
+      if (result.ok) return;
+      expect(result.reason).toContain("not yet implemented");
+    });
+
+    it("prBody contains verification and rollback sections", async () => {
+      const { rendered, report } = buildRenderedAndReport();
+      const result = await createRunbookPr(rendered, report, { dryRun: true });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.prBody).toContain("### Verification");
+      expect(result.prBody).toContain("### Rollback");
+    });
+
+    it("prBody contains human gates for high-risk candidates", async () => {
+      const { rendered, report } = buildRenderedAndReport({
+        candidate: makeCandidate({ risk: "payment" }),
+      });
+      const result = await createRunbookPr(rendered, report, { dryRun: true });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.prBody).toContain("### Human gates");
+    });
+
+    it("prBody contains capabilities section", async () => {
+      const { rendered, report } = buildRenderedAndReport({
+        candidate: makeCandidate({ capabilities: ["mongo.read"] }),
+      });
+      const result = await createRunbookPr(rendered, report, { dryRun: true });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.prBody).toContain("### Capabilities");
+      expect(result.prBody).toContain("`mongo.read`");
+    });
+
+    it("default dryRun is true when options omitted", async () => {
+      const { rendered, report } = buildRenderedAndReport();
+      const result = await createRunbookPr(rendered, report);
+      // No options = dryRun defaults to true
+      expect(result.ok).toBe(true);
+    });
+
+    it("prBody contains routing examples", async () => {
+      const { rendered, report } = buildRenderedAndReport();
+      const result = await createRunbookPr(rendered, report, { dryRun: true });
+      expect(result.ok).toBe(true);
+      if (!result.ok) return;
+      expect(result.prBody).toContain("### Routing examples (should match)");
+      expect(result.prBody).toContain(
+        "### Routing examples (should NOT match)",
+      );
+    });
+  });
+});

--- a/src/runbooks/github.ts
+++ b/src/runbooks/github.ts
@@ -1,0 +1,128 @@
+import type { AuthoringResult, ProposalReport } from "./authoring.ts";
+
+export type PrCreationResult =
+  | {
+      ok: true;
+      prUrl: string;
+      branchName: string;
+      filePath: string;
+      prBody: string;
+    }
+  | { ok: false; reason: string };
+
+const PRIVATE_REPO = "GrowthX-Club/junior-private-agents";
+
+export async function createRunbookPr(
+  rendered: AuthoringResult,
+  report: ProposalReport,
+  options?: {
+    dryRun?: boolean;
+    ghAccount?: string;
+  },
+): Promise<PrCreationResult> {
+  if (!rendered.ok) {
+    return { ok: false, reason: `rendered content is invalid: ${rendered.reason}` };
+  }
+
+  const dryRun = options?.dryRun ?? true;
+  const name = rendered.filename.replace(/\.runbook\.md$/, "");
+  const branchName = `runbook/${name}`;
+  const filePath = `runbooks/${rendered.filename}`;
+  const prBody = formatPrBody(report);
+
+  if (dryRun) {
+    return {
+      ok: true,
+      prUrl: `https://github.com/${PRIVATE_REPO}/pull/dry-run`,
+      branchName,
+      filePath,
+      prBody,
+    };
+  }
+
+  return {
+    ok: false,
+    reason: "live PR creation not yet implemented — use dryRun: true",
+  };
+}
+
+function formatPrBody(report: ProposalReport): string {
+  const lines: string[] = [];
+
+  lines.push(`## Runbook Proposal`);
+  lines.push(``);
+  lines.push(`**Artifact class:** ${report.artifactClass}`);
+  lines.push(`**Reason:** ${report.reason}`);
+  lines.push(`**Risk:** ${report.riskClassification}`);
+  lines.push(``);
+
+  if (report.existingConsidered.length > 0) {
+    lines.push(`### Existing definitions considered`);
+    for (const e of report.existingConsidered) {
+      lines.push(`- **${e.name}** (${e.kind}): ${e.whyNotSufficient}`);
+    }
+    lines.push(``);
+  }
+
+  if (report.executionEvidence.length > 0) {
+    lines.push(`### Execution evidence`);
+    for (const e of report.executionEvidence) {
+      lines.push(`- \`${e.runId}\`: ${e.status} (${new Date(e.date).toISOString()})`);
+    }
+    lines.push(``);
+  }
+
+  if (report.linkedProcedureMemory.length > 0) {
+    lines.push(`### Linked procedure memory`);
+    for (const m of report.linkedProcedureMemory) {
+      lines.push(`- ${m}`);
+    }
+    lines.push(``);
+  }
+
+  if (report.positiveExamples.length > 0) {
+    lines.push(`### Routing examples (should match)`);
+    for (const ex of report.positiveExamples) {
+      lines.push(`- ${ex}`);
+    }
+    lines.push(``);
+  }
+
+  if (report.negativeExamples.length > 0) {
+    lines.push(`### Routing examples (should NOT match)`);
+    for (const ex of report.negativeExamples) {
+      lines.push(`- ${ex}`);
+    }
+    lines.push(``);
+  }
+
+  if (report.requestedCapabilities.length > 0) {
+    lines.push(`### Capabilities`);
+    lines.push(report.requestedCapabilities.map((c) => `\`${c}\``).join(", "));
+    lines.push(``);
+  }
+
+  if (report.humanGates.length > 0) {
+    lines.push(`### Human gates`);
+    for (const g of report.humanGates) {
+      lines.push(`- ${g}`);
+    }
+    lines.push(``);
+  }
+
+  lines.push(`### Verification`);
+  lines.push(report.verificationBehavior);
+  lines.push(``);
+  lines.push(`### Rollback`);
+  lines.push(report.rollbackBehavior);
+
+  if (report.validationOutput.length > 0) {
+    lines.push(``);
+    lines.push(`### Validation warnings`);
+    for (const v of report.validationOutput) {
+      lines.push(`- **${v.field}**: ${v.message}`);
+    }
+  }
+
+  return lines.join("\n");
+}


### PR DESCRIPTION
## Summary
Iteration 4 of the common-task-agent-authoring plan. Adds template-based runbook generation and PR creation:

- **Authoring** (`src/runbooks/authoring.ts`) — renders `.runbook.md` from promotion candidates with post-render validation, agent extension proposals, structured proposal reports
- **GitHub PR** (`src/runbooks/github.ts`) — dry-run PR creation for `junior-private-agents`
- **MCP tool** — `runbook_propose` registered (dry-run by default)
- Includes Iteration 3 review fix (pre-hash normalized text in promotion candidates)

## Test plan
- [x] 224/224 runbook tests, 138/138 agent tests pass
- [x] Rendered .runbook.md passes existing validation
- [x] High-risk always gets approval gates
- [x] Dry-run PR returns correct structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)