### PR TITLE
fix: bind repositories during pipeline dispatch

### DIFF
--- a/.claude/agents/common/pipeline-outcome.md
+++ b/.claude/agents/common/pipeline-outcome.md
@@ -14,6 +14,10 @@ and GitHub comments do not settle an assignment.
   ownership to exactly one successor.
 - `agent_dispatch(mode="delegate")` creates a child assignment. Your assignment
   waits and is resumed automatically after the child reports `complete`.
+- A worktree-backed target requires durable repository binding. Pass
+  `repo_refs` to `agent_dispatch`; naming a repo only in the prompt or
+  `artifact_refs` does not bind it. A missing repo is rejected before a child
+  assignment is created.
 - `wait` is only for a runtime-supported external event with a real durable
   wake source and a Unix-epoch-millisecond deadline. Never wait for another
   agent; delegate or hand off instead.
@@ -47,6 +51,12 @@ still active, then retry once with the same semantic key. Never announce that
 work advanced before the control-plane receipt is accepted. If the tool is
 missing or disabled, report a control-plane failure instead of pretending that
 Slack prose advanced the run.
+
+After an infrastructure failure moves a run to `needs-human`, the next human
+message creates a recovery assignment. Retry `agent_dispatch` from that
+assignment with the corrected `repo_refs`; for typed product/bug runs also pass
+the legal active `to_phase`. The repository update, phase resume, and successor
+assignment commit atomically, so `!reset` is not required for this repair.
 
 Starting a product or bug pipeline remains a separate intelligent decision.
 Only an authorized orchestrator calls `pipeline_start_run`; it promotes the

--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -110,6 +110,14 @@ pulled onto disk but the running process has not registered its `username` /
 `iconEmoji` yet. Agent prompts themselves are read from disk on each resolve;
 the registry reload is for persistent-agent identity/dispatch metadata.
 
+`agent_dispatch` accepts `repo_refs` for worktree-backed successors. The refs
+are validated against configured repositories and bound to the run in the same
+transaction that creates the successor assignment. Dispatch fails before
+mutation when a worktree-backed target has no effective repository. A
+human-input recovery assignment can retry an escalated run with corrected
+`repo_refs`; default runs resume to `working`, while typed runs require an
+explicit legal `to_phase`.
+
 ### WhatsApp tools
 
 The `whatsapp_*` tools (`src/mcp/whatsapp-tools.ts`) are the only read surface
@@ -149,7 +157,8 @@ perform the requested operation, and close the store after each call. The local
 embedding model (harrier-270 ONNX) is lazy-loaded on the first recall/add, never at
 server startup.
 
-- `memory_recall` accepts `query`, `repo`, `kinds`, `entity_refs`, and `limit`. It
+- `memory_recall` accepts `query`, `repo`, `tags` (OR match), `kinds`,
+  `entity_refs`, and `limit`. It
   fetches the keyed entity profiles verbatim by `entity_ref` (no vector) and embeds
   `query` locally to cosine-rank the atomic claim store; returns the profiles plus
   the top-k claims. Recall is cosine-only — there is no FTS channel.

--- a/src/index.ts
+++ b/src/index.ts
@@ -91,6 +91,7 @@ const pipelineToolRuntime: PipelineToolRuntime = {
   productPipelineEnabled: config.pipeline?.productPipelineEnabled ?? false,
   bugPipelineEnabled: config.pipeline?.bugPipelineEnabled ?? false,
   workspaceRoot: process.cwd(),
+  repos: config.repos,
   onOutcomeCommitted: async () => {
     // Shadow/off never dispatch — only active mode pumps the outbox.
     if (pipelineRuntimeMode !== "active") return;

--- a/src/mcp/slack-server.test.ts
+++ b/src/mcp/slack-server.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -6,6 +9,7 @@ import {
   addMemory,
   dispatchAgentDirectivesFromSlackPost,
   recallMemory,
+  registerTools,
   searchAgentDefinitions,
   sendSlackDirectMessage,
   type MemoryToolDeps,
@@ -13,6 +17,37 @@ import {
 import { createMemoryStore } from "../memory/factory.ts";
 import { HashingEmbeddingProvider } from "../memory/embedding/hashing.ts";
 import { createProfileStore } from "../memory/profiles/index.ts";
+
+describe("MCP Slack tool catalogue", () => {
+  it("serializes every registered tool through tools/list", async () => {
+    const server = new McpServer({ name: "slack-bot-test", version: "0.1.0" });
+    registerTools(server);
+
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "slack-bot-test-client", version: "0.1.0" });
+
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      const { tools } = await client.listTools();
+      const names = tools.map((tool) => tool.name);
+
+      expect(names).toContain("pipeline_report_outcome");
+      expect(names).toContain("runbook_select");
+      expect(names).toContain("promotion_record");
+      const dispatch = tools.find((tool) => tool.name === "agent_dispatch");
+      expect(dispatch?.inputSchema).toMatchObject({
+        properties: {
+          repo_refs: { type: "array" },
+        },
+      });
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});
 
 /**
  * Build memory-tool deps backed by REAL infrastructure (in-memory SQLite store,
@@ -82,6 +117,40 @@ describe("MCP memory v3 tools", () => {
 
       expect(result.claims.some((c) => c.id === id)).toBe(true);
       expect(result.profiles).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("memory_recall preserves legacy OR tag filtering", async () => {
+    const { deps, cleanup } = makeMemoryDeps();
+    try {
+      const relevant = await addMemory(
+        {
+          text: "Reuse the event registration pricing helper for summary-card tooltips",
+          tags: ["gx-client-next", "event-registration"],
+        },
+        deps,
+      );
+      await addMemory(
+        {
+          text: "Event payout invoices join through payment identifiers",
+          tags: ["payouts", "mongodb"],
+        },
+        deps,
+      );
+
+      const result = await recallMemory(
+        {
+          query:
+            "price breakdown tooltip event registration summary card pricing helper",
+          tags: ["gx-client-next", "event-registration", "pricing"],
+          limit: 5,
+        },
+        deps,
+      );
+
+      expect(result.claims.map((claim) => claim.id)).toEqual([relevant.id]);
     } finally {
       cleanup();
     }

--- a/src/mcp/slack-server.ts
+++ b/src/mcp/slack-server.ts
@@ -147,7 +147,7 @@ export function setPipelineRuntime(runtime: PipelineToolRuntime | undefined): vo
   pipelineRuntime = runtime;
 }
 
-function registerTools(server: McpServer, runContext: SlackMcpRunContext | null = null) {
+export function registerTools(server: McpServer, runContext: SlackMcpRunContext | null = null) {
   registerWhatsAppTools(server, {
     runContext,
     // Deny-by-default until the SessionManager/SessionStore are wired in:
@@ -789,13 +789,14 @@ function registerTools(server: McpServer, runContext: SlackMcpRunContext | null 
         evidence_refs: z.array(z.string()).optional().describe("Durable evidence references supporting the transition"),
         artifact_refs: z.array(z.string()).optional().describe("Durable artifact references inherited by the child assignment"),
         acceptance_criteria: z.array(z.string()).optional().describe("Acceptance criteria for the child assignment"),
+        repo_refs: z.array(z.string().min(1).max(200)).max(20).optional().describe("Repositories to validate and atomically bind to the durable run before dispatch"),
         channel_id: z.string().optional().describe("Deprecated; authenticated channel is derived from signed context"),
         thread_ts: z.string().optional().describe("Deprecated; authenticated thread is derived from signed context"),
         user_id: z.string().optional().describe("User id to record on the synthetic internal event (default: mcp-internal)"),
         trigger_ts: z.string().optional().describe("Slack message timestamp that caused the dispatch. Defaults to thread_ts."),
       },
     },
-    async ({ agent_name, prompt, mode, reason, idempotency_key, to_phase, evidence_refs, artifact_refs, acceptance_criteria, channel_id, thread_ts, user_id, trigger_ts }) => {
+    async ({ agent_name, prompt, mode, reason, idempotency_key, to_phase, evidence_refs, artifact_refs, acceptance_criteria, repo_refs, channel_id, thread_ts, user_id, trigger_ts }) => {
       if (!sessionManager) {
         return { content: [{ type: "text" as const, text: "Error: session manager not available" }] };
       }
@@ -831,6 +832,7 @@ function registerTools(server: McpServer, runContext: SlackMcpRunContext | null 
           evidence_refs,
           artifact_refs,
           acceptance_criteria,
+          repo_refs,
         });
       }
       if (pipelineRuntime && session?.activeRunId) {
@@ -1248,11 +1250,15 @@ function registerTools(server: McpServer, runContext: SlackMcpRunContext | null 
         "'gx-backend:repo'), their markdown profiles are fetched VERBATIM by key — no embedding, " +
         "no ranking — and are Junior-internal context (never surface a profile verbatim in a thread). " +
         "(2) SEMANTIC claims: `query` is embedded locally and matched against the atomic " +
-        "lesson/fact/situation-claim store by cosine (filtered by `repo`/`kinds`). " +
+        "lesson/fact/situation-claim store by cosine (filtered by `repo`/`tags`/`kinds`). " +
         "Returns the keyed profiles plus the top-k claims (text, score, repo, tags).",
       inputSchema: {
         query: z.string().describe("Natural-language query, embedded for semantic claim retrieval"),
         repo: z.string().optional().describe("Scope claims to a repo (e.g. 'gx-backend')"),
+        tags: z
+          .array(z.string())
+          .optional()
+          .describe("Restrict claims to any matching tag (OR match)"),
         kinds: z
           .array(z.enum(["lesson", "fact", "situation-claim"]))
           .optional()
@@ -1266,10 +1272,10 @@ function registerTools(server: McpServer, runContext: SlackMcpRunContext | null 
         limit: z.number().optional().describe("Max semantic claims to return (default 5, max 50)"),
       },
     },
-    async ({ query, repo, kinds, entity_refs, limit }) => {
+    async ({ query, repo, tags, kinds, entity_refs, limit }) => {
       return withMemoryStore(async (memory) => {
         const result = await recallMemory(
-          { query, repo, kinds, entityRefs: entity_refs, limit },
+          { query, repo, tags, kinds, entityRefs: entity_refs, limit },
           { store: memory, provider: await getEmbeddingProvider(), profileStore: getProfileStore() },
         );
         return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };
@@ -1731,6 +1737,8 @@ export interface RecallMemoryArgs {
   repo?: string;
   /** With `repo`, also include repo-less (global) claims. See ClaimRecallFilters. */
   repoIncludeGlobal?: boolean;
+  /** Restrict claims to any matching tag (OR match). */
+  tags?: string[];
   kinds?: ClaimKind[];
   entityRefs?: string[];
   limit?: number;
@@ -1791,6 +1799,7 @@ export async function recallMemory(
       filters.repo = args.repo;
       if (args.repoIncludeGlobal) filters.repoIncludeGlobal = true;
     }
+    if (args.tags && args.tags.length > 0) filters.tags = args.tags;
     if (kind) filters.kind = kind;
     const results = await deps.store.recallClaims({
       queryVector,

--- a/src/pipelines/bug/controller.ts
+++ b/src/pipelines/bug/controller.ts
@@ -487,6 +487,8 @@ export async function reduceBugOutcome(
     actorType?: "agent" | "human" | "system";
     actorId: string;
     idempotencyKey?: string;
+    /** Repository refs atomically bound with an accepted transition. */
+    repoRefs?: string[];
     riskClass?: RiskClass;
   },
 ): Promise<TransitionReceipt & { mode?: BugMode; notes?: string[] }> {
@@ -626,6 +628,7 @@ export async function reduceBugOutcome(
   const receipt = await store.recordOutcomeTransaction({
     outcome: input.outcome,
     toPhase: suggested,
+    repoRefs: input.repoRefs,
     actorType: input.actorType ?? "agent",
     actorId: input.actorId,
     idempotencyKey: input.idempotencyKey,

--- a/src/pipelines/outcomes.ts
+++ b/src/pipelines/outcomes.ts
@@ -41,6 +41,8 @@ export type ReportOutcomeInput = {
   outcome: AgentOutcome;
   /** Proposed phase advance. Omitted means keep current phase. */
   toPhase?: string;
+  /** Repository refs atomically bound when the transition commits. */
+  repoRefs?: string[];
   /** Optional event idempotency key for duplicate detection. */
   idempotencyKey?: string;
   auth: OutcomeAuthContext;
@@ -296,6 +298,7 @@ export async function reportOutcome(
       return reportOutcome(deps, {
         outcome: escalated,
         toPhase: "needs-human",
+        repoRefs: input.repoRefs,
         idempotencyKey:
           input.idempotencyKey ??
           `loop-escalate:${loopKey}:${assignment.id}`,
@@ -344,6 +347,7 @@ export async function reportOutcome(
   const receipt = await deps.store.recordOutcomeTransaction({
     outcome,
     toPhase: input.toPhase,
+    repoRefs: input.repoRefs,
     actorType: "agent",
     actorId: auth.agent,
     idempotencyKey: input.idempotencyKey,
@@ -392,6 +396,7 @@ export async function requestHandoff(
     evidenceRefs?: string[];
     artifactRefs?: string[];
     acceptanceCriteria?: string[];
+    repoRefs?: string[];
     mutationScope?: string[];
     contextRefs?: string[];
     dependsOn?: string[];
@@ -439,6 +444,7 @@ export async function requestHandoff(
   return reportOutcome(deps, {
     outcome,
     toPhase: args.toPhase,
+    repoRefs: args.repoRefs,
     idempotencyKey: args.idempotencyKey,
     auth: args.auth,
   });

--- a/src/pipelines/product/controller.ts
+++ b/src/pipelines/product/controller.ts
@@ -612,6 +612,8 @@ export async function reduceProductOutcome(
     actorType?: "agent" | "human" | "system";
     actorId: string;
     idempotencyKey?: string;
+    /** Repository refs atomically bound with an accepted transition. */
+    repoRefs?: string[];
     /** Optional review verdict for reviewing phase. */
     reviewVerdict?: "approved" | "changes_requested" | "comment" | null;
     /** When true, treat product decision as still open. */
@@ -911,6 +913,7 @@ export async function reduceProductOutcome(
   const receipt = await store.recordOutcomeTransaction({
     outcome: input.outcome,
     toPhase: suggested,
+    repoRefs: input.repoRefs,
     actorType: input.actorType ?? "agent",
     actorId: input.actorId,
     idempotencyKey: input.idempotencyKey,

--- a/src/pipelines/store/outcome-tx.ts
+++ b/src/pipelines/store/outcome-tx.ts
@@ -44,6 +44,7 @@ export type OutcomeTxContext = {
   input: {
     outcome: AgentOutcome;
     toPhase?: string;
+    repoRefs?: string[];
     actorType: "agent" | "human" | "system";
     actorId: string;
     idempotencyKey?: string;
@@ -218,6 +219,10 @@ export function decideOutcomeTransaction(
     ...run,
     phase: resolvedToPhase as PipelinePhase,
     status: runStatus,
+    repoRefs: uniqueStrings([
+      ...run.repoRefs,
+      ...(input.repoRefs ?? []),
+    ]),
     stateVersion: newVersion,
     terminalOutcome:
       runStatus === "terminal" ? terminalOutcome : run.terminalOutcome,

--- a/src/pipelines/store/sqlite.test.ts
+++ b/src/pipelines/store/sqlite.test.ts
@@ -396,12 +396,17 @@ describe("SqlitePipelineStore", () => {
         },
       }),
       toPhase: "reviewing",
+      repoRefs: ["example-frontend"],
       actorType: "agent",
       actorId: "build",
       idempotencyKey: "tx-1",
     });
     expect(receipt.status).toBe("accepted");
     expect(receipt.runVersion).toBe(1);
+    expect((await store.getRun("run-1"))?.repoRefs).toEqual([
+      "example-backend",
+      "example-frontend",
+    ]);
 
     const outcomes = await store.listOutcomes("asg-1");
     expect(outcomes).toHaveLength(1);

--- a/src/pipelines/store/sqlite.ts
+++ b/src/pipelines/store/sqlite.ts
@@ -1200,6 +1200,7 @@ export class SqlitePipelineStore implements PipelineStore {
           `UPDATE pipeline_runs SET
             phase = ?,
             status = ?,
+            repo_refs_json = ?,
             state_version = ?,
             terminal_outcome = ?,
             terminal_reason = ?,
@@ -1212,6 +1213,7 @@ export class SqlitePipelineStore implements PipelineStore {
         .run(
           decision.updatedRun.phase,
           decision.updatedRun.status,
+          JSON.stringify(decision.updatedRun.repoRefs),
           decision.updatedRun.stateVersion,
           decision.updatedRun.terminalOutcome,
           decision.updatedRun.terminalReason,

--- a/src/pipelines/tools-dispatch.test.ts
+++ b/src/pipelines/tools-dispatch.test.ts
@@ -33,6 +33,7 @@ describe("durable agent_dispatch", () => {
         objective: "review the implementation and continue",
         messageTs: "1700000000.101",
         targetAgent: "default",
+        repoRefs: ["junior"],
       },
     );
     await sessions.mutateThread(THREAD, (current) => {
@@ -110,6 +111,162 @@ describe("durable agent_dispatch", () => {
       eventType: "assignment.resume",
       assignmentId: started.assignment.id,
     });
+  });
+
+  it("rejects worktree dispatch before committing when no repository is bound", async () => {
+    const store = new InMemoryPipelineStore();
+    const sessions = new InMemorySessionStore();
+    const started = await createDefaultRun(
+      { store },
+      {
+        channelId: CHANNEL,
+        threadId: THREAD,
+        objective: "scope then build",
+        messageTs: "1700000000.104",
+        targetAgent: "default",
+      },
+    );
+    const session = createSession(THREAD, CHANNEL);
+    session.activePipelineInvocation = {
+      runId: started.run.id,
+      assignmentId: started.assignment.id,
+      dispatchKey: "repo-less-dispatch",
+      outcomeCountAtDispatch: 0,
+      retryCount: 0,
+    };
+    await sessions.set(THREAD, session);
+
+    const result = body(await pipelineDispatchAgent({
+      store,
+      sessionStore: sessions,
+      runtimeMode: "active",
+      githubTrackingEnabled: false,
+    }, {
+      agent: "default",
+      channel: CHANNEL,
+      threadId: THREAD,
+      runId: started.run.id,
+      assignmentId: started.assignment.id,
+      dispatchKey: "repo-less-dispatch",
+      signed: true,
+    }, {
+      target_agent: "build",
+      objective: "Implement the scoped change",
+      mode: "delegate",
+      reason: "The plan is ready",
+      idempotency_key: "repo-less-build",
+    }));
+
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain("retry agent_dispatch with repo_refs");
+    expect(await store.getRun(started.run.id)).toMatchObject({
+      phase: "working",
+      status: "active",
+      repoRefs: [],
+      stateVersion: 0,
+    });
+    expect(await store.getAssignment(started.assignment.id)).toMatchObject({
+      status: "pending",
+    });
+    expect(await store.listAssignments(started.run.id)).toHaveLength(1);
+  });
+
+  it("binds a missing repository and resumes a needs-human run atomically", async () => {
+    const store = new InMemoryPipelineStore();
+    const sessions = new InMemorySessionStore();
+    const started = await createDefaultRun(
+      { store },
+      {
+        channelId: CHANNEL,
+        threadId: THREAD,
+        objective: "scope then build",
+        messageTs: "1700000000.105",
+        targetAgent: "default",
+      },
+    );
+    const escalated = await store.recordOutcomeTransaction({
+      outcome: {
+        assignmentId: started.assignment.id,
+        expectedRunVersion: started.run.stateVersion,
+        action: "escalate",
+        status: "blocked",
+        reason: "Repository was missing",
+        evidenceRefs: [],
+        artifactRefs: [],
+        blockers: [{ kind: "infra_failure", detail: "No repository bound" }],
+        checks: [],
+        progressFingerprint: "missing-repository",
+      },
+      toPhase: "needs-human",
+      actorType: "system",
+      actorId: "pipeline-settlement",
+      idempotencyKey: "missing-repository",
+    });
+    expect(escalated.status).toBe("escalated");
+
+    const recovery = await store.createAssignment(makeAssignmentCreate({
+      id: "human-recovery",
+      runId: started.run.id,
+      parentAssignmentId: started.assignment.id,
+      sourceAgent: "human",
+      targetAgent: "default",
+      objective: "Retry in gx-backend",
+      contextRefs: ["control-branch:human-input"],
+      idempotencyKey: "human-recovery",
+    }));
+    const session = createSession(THREAD, CHANNEL);
+    session.activePipelineInvocation = {
+      runId: started.run.id,
+      assignmentId: recovery.id,
+      dispatchKey: "human-recovery-dispatch",
+      outcomeCountAtDispatch: 0,
+      retryCount: 0,
+    };
+    await sessions.set(THREAD, session);
+
+    const result = body(await pipelineDispatchAgent({
+      store,
+      sessionStore: sessions,
+      runtimeMode: "active",
+      githubTrackingEnabled: false,
+      repos: [{
+        name: "gx-backend",
+        path: "/tmp/gx-backend",
+        defaultBase: "origin/main",
+      }],
+    }, {
+      agent: "default",
+      channel: CHANNEL,
+      threadId: THREAD,
+      runId: started.run.id,
+      assignmentId: recovery.id,
+      dispatchKey: "human-recovery-dispatch",
+      signed: true,
+    }, {
+      target_agent: "build",
+      objective: "Implement the scoped change in gx-backend",
+      mode: "handoff",
+      reason: "The user supplied the missing repository",
+      idempotency_key: "recover-with-repo",
+      repo_refs: ["GrowthX-Club/gx-backend"],
+    }));
+
+    expect(result.ok).toBe(true);
+    expect(result.recovered).toBe(true);
+    expect(await store.getRun(started.run.id)).toMatchObject({
+      phase: "working",
+      status: "active",
+      repoRefs: ["GrowthX-Club/gx-backend"],
+      stateVersion: 2,
+    });
+    expect(await store.getAssignment(recovery.id)).toMatchObject({
+      status: "completed",
+    });
+    expect(await store.getAssignment(result.targetAssignmentId as string))
+      .toMatchObject({
+        targetAgent: "build",
+        status: "pending",
+      });
   });
 
   it("rejects dispatch when the signed caller does not own the assignment", async () => {

--- a/src/pipelines/tools.ts
+++ b/src/pipelines/tools.ts
@@ -4,6 +4,7 @@
  */
 
 import type { PipelineRuntimeMode } from "../config.ts";
+import type { RepoConfig } from "../config.ts";
 import {
   canEditProductCode,
   canWritePipelineArtifacts,
@@ -12,6 +13,7 @@ import {
 } from "../agents/capabilities.ts";
 import {
   canonicalAgentName,
+  resolveAgentManifest,
 } from "../agents/registry.ts";
 import { canDispatch } from "../support/agents.ts";
 import {
@@ -42,6 +44,7 @@ import {
 } from "./product/controller.ts";
 import { createBugRun, reduceBugOutcome } from "./bug/controller.ts";
 import type { BugMode } from "./bug/definition.ts";
+import { resolvePipelineRepos } from "../worktree/pipeline-routing.ts";
 
 export type PipelineToolRuntime = {
   store: PipelineStore;
@@ -51,6 +54,8 @@ export type PipelineToolRuntime = {
   productPipelineEnabled?: boolean;
   bugPipelineEnabled?: boolean;
   workspaceRoot?: string;
+  /** Configured repositories used to validate durable repo refs before dispatch. */
+  repos?: RepoConfig[];
   /** Optional post-outcome hook (e.g. pump outbox). */
   onOutcomeCommitted?: (receipt: TransitionReceipt) => Promise<void>;
   /** Optional immediate wake after a new or recovered pipeline start. */
@@ -699,6 +704,7 @@ export async function pipelineDispatchAgent(
     evidence_refs?: string[];
     artifact_refs?: string[];
     acceptance_criteria?: string[];
+    repo_refs?: string[];
   },
 ): Promise<ToolTextResult> {
   const disabled = requireActive(runtime);
@@ -749,6 +755,58 @@ export async function pipelineDispatchAgent(
       true,
     );
   }
+  const requestedRepoRefs = (args.repo_refs ?? [])
+    .map((ref) => ref.trim())
+    .filter(Boolean);
+  const effectiveRepoRefs = [
+    ...new Set([...run.repoRefs, ...requestedRepoRefs]),
+  ];
+  if (runtime.repos) {
+    const resolution = resolvePipelineRepos(runtime.repos, effectiveRepoRefs);
+    if (resolution.unresolvedRefs.length > 0) {
+      return textResult(
+        {
+          ok: false,
+          reason:
+            `repository refs are not uniquely configured: ${resolution.unresolvedRefs.join(", ")}`,
+          runId: run.id,
+          repoRefs: run.repoRefs,
+        },
+        true,
+      );
+    }
+  }
+  const targetRole = resolveAgentManifest(target)?.role;
+  const targetRequiresWorktree =
+    targetRole !== "orchestrator" && targetRole !== "planner";
+  if (targetRequiresWorktree && effectiveRepoRefs.length === 0) {
+    return textResult(
+      {
+        ok: false,
+        reason:
+          `agent "${target}" requires a configured repository and isolated worktree; retry agent_dispatch with repo_refs`,
+        runId: run.id,
+        repoRefs: run.repoRefs,
+      },
+      true,
+    );
+  }
+  if (
+    run.status === "needs-human" &&
+    run.kind !== "default" &&
+    !args.to_phase
+  ) {
+    return textResult(
+      {
+        ok: false,
+        reason:
+          `recovering a ${run.kind} run from needs-human requires to_phase plus any missing repo_refs`,
+        runId: run.id,
+        repoRefs: run.repoRefs,
+      },
+      true,
+    );
+  }
   const mutationScope = canEditProductCode(target)
     ? ["worktree-code"]
     : canWritePipelineArtifacts(target)
@@ -779,6 +837,9 @@ export async function pipelineDispatchAgent(
   }
   const inheritedBranch = source.contextRefs.find((ref) =>
     ref.startsWith("delegated-branch:")
+  );
+  const isHumanRecoveryBranch = source.contextRefs.includes(
+    "control-branch:human-input",
   );
   const delegatedBranch = inheritedBranch ??
     (args.mode === "delegate" ? `delegated-branch:${source.id}` : undefined);
@@ -817,7 +878,14 @@ export async function pipelineDispatchAgent(
     },
   };
   const genericDispatch =
-    run.kind === "default" || args.mode === "delegate" || Boolean(inheritedBranch);
+    run.kind === "default" ||
+    args.mode === "delegate" ||
+    Boolean(inheritedBranch) ||
+    isHumanRecoveryBranch;
+  const effectiveToPhase =
+    run.kind === "default" && run.status === "needs-human"
+      ? "working"
+      : args.to_phase;
   const receipt = genericDispatch
     ? await requestHandoff(
         {
@@ -834,6 +902,7 @@ export async function pipelineDispatchAgent(
           evidenceRefs: dispatchOutcome.evidenceRefs,
           artifactRefs: dispatchOutcome.artifactRefs,
           acceptanceCriteria: args.acceptance_criteria ?? run.acceptanceCriteria,
+          repoRefs: effectiveRepoRefs,
           mutationScope,
           contextRefs,
           attempt: source.attempt,
@@ -843,7 +912,7 @@ export async function pipelineDispatchAgent(
           idempotencyKey: stableKey,
           nextIdempotencyKey,
           action: args.mode,
-          toPhase: args.to_phase,
+          toPhase: effectiveToPhase,
           auth: authFromContext(runContext),
         },
       )
@@ -855,6 +924,7 @@ export async function pipelineDispatchAgent(
             toPhase: args.to_phase,
             actorId: caller,
             idempotencyKey: stableKey,
+            repoRefs: effectiveRepoRefs,
           },
         )
       : await reduceBugOutcome(
@@ -868,6 +938,7 @@ export async function pipelineDispatchAgent(
             toPhase: args.to_phase,
             actorId: caller,
             idempotencyKey: stableKey,
+            repoRefs: effectiveRepoRefs,
           },
         );
   if (receipt.status === "accepted" || receipt.status === "duplicate") {
@@ -880,6 +951,8 @@ export async function pipelineDispatchAgent(
       runId: run.id,
       sourceAssignmentId: source.id,
       targetAssignmentId: receipt.assignmentId,
+      repoRefs: effectiveRepoRefs,
+      recovered: run.status === "needs-human" && receipt.status === "accepted",
       receipt,
     },
     receipt.status === "rejected",

--- a/src/pipelines/types.ts
+++ b/src/pipelines/types.ts
@@ -470,6 +470,11 @@ export type RecordOutcomeInput = {
   outcome: AgentOutcome;
   /** Proposed phase advance. Omitted means keep current phase. */
   toPhase?: PipelinePhase | string;
+  /**
+   * Effective repository refs to bind to the run in the same transaction as
+   * the accepted outcome/next assignment.
+   */
+  repoRefs?: string[];
   actorType: "agent" | "human" | "system";
   actorId: string;
   /** Optional event idempotency key for duplicate detection. */


### PR DESCRIPTION
## Summary
- validate and atomically bind repository refs before dispatching worktree-backed agents
- allow human recovery assignments to resume escalated runs with corrected repository context
- expose the binding through MCP, preserve legacy memory tag filtering, and document the recovery contract

## Test plan
- [x] `bun run typecheck`
- [x] `bun test src/pipelines/tools-dispatch.test.ts src/pipelines/store/sqlite.test.ts src/mcp/slack-server.test.ts`
- [x] `bun test`