### PR TITLE
fix: suppress duplicate default escalation audits

### DIFF
--- a/.claude/agents/common/pipeline-outcome.md
+++ b/.claude/agents/common/pipeline-outcome.md
@@ -27,6 +27,11 @@ and GitHub comments do not settle an assignment.
   satisfied. For a default run it completes the task; typed controllers may
   advance or fan in according to their own policy.
 
+For ordinary `kind: default` runs, settlement is internal control-plane state:
+an `escalate` outcome does not publish a second Slack audit message. Put the
+human-facing question or blocker in the turn's one normal Slack response.
+Product and bug pipeline escalations remain visible human-gate audits.
+
 Use one transport per delegation. Do not call `agent_dispatch` and then also
 report a handoff. An accepted or duplicate dispatch receipt is already the
 durable outcome for this invocation.

--- a/src/pipelines/pump-wait.test.ts
+++ b/src/pipelines/pump-wait.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it, mock } from "bun:test";
 import { fakeClock } from "../time/clock.ts";
 import { pumpOutbox } from "./pump.ts";
 import { InMemoryPipelineStore } from "./store/memory.ts";
-import { makeAssignmentCreate, makeDefaultRun } from "./store/test-helpers.ts";
+import {
+  makeAssignmentCreate,
+  makeDefaultRun,
+  makeProductRun,
+} from "./store/test-helpers.ts";
 
 describe("pipeline wait deadline", () => {
   it("durably escalates and audits when a wait expires", async () => {
@@ -50,5 +54,95 @@ describe("pipeline wait deadline", () => {
       status: "needs-human",
     });
     expect(audit).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("pipeline escalation audit", () => {
+  it("keeps ordinary default-run settlement internal", async () => {
+    const clock = fakeClock(1_000);
+    const store = new InMemoryPipelineStore(clock);
+    await store.createRun(makeDefaultRun());
+    await store.createAssignment(makeAssignmentCreate({
+      id: "default-asg",
+      runId: "default-run-1",
+      targetAgent: "default",
+      idempotencyKey: "default-asg-key",
+    }));
+    const escalated = await store.recordOutcomeTransaction({
+      outcome: {
+        assignmentId: "default-asg",
+        expectedRunVersion: 0,
+        action: "escalate",
+        status: "blocked",
+        reason: "Need the user to choose a repository",
+        evidenceRefs: [],
+        artifactRefs: [],
+        blockers: [{
+          kind: "human_gate",
+          detail: "Choose a repository",
+        }],
+        checks: [],
+        progressFingerprint: "default-repo-choice",
+      },
+      actorType: "agent",
+      actorId: "default",
+      idempotencyKey: "default-repo-choice",
+    });
+    expect(escalated.status).toBe("escalated");
+
+    const audit = mock(async () => undefined);
+    const report = await pumpOutbox({
+      store,
+      clock,
+      dispatcher: { handleAgentMessage: async () => undefined },
+      audit,
+    });
+
+    expect(report.delivered).toBe(1);
+    expect(audit).not.toHaveBeenCalled();
+  });
+
+  it("still publishes typed-pipeline human-gate audits", async () => {
+    const clock = fakeClock(1_000);
+    const store = new InMemoryPipelineStore(clock);
+    await store.createRun(makeProductRun());
+    await store.createAssignment(makeAssignmentCreate());
+    const escalated = await store.recordOutcomeTransaction({
+      outcome: {
+        assignmentId: "asg-1",
+        expectedRunVersion: 0,
+        action: "escalate",
+        status: "blocked",
+        reason: "Need product approval",
+        evidenceRefs: [],
+        artifactRefs: [],
+        blockers: [{
+          kind: "human_gate",
+          detail: "Approve the product decision",
+        }],
+        checks: [],
+        progressFingerprint: "product-approval",
+      },
+      actorType: "agent",
+      actorId: "build",
+      idempotencyKey: "product-approval",
+    });
+    expect(escalated.status).toBe("escalated");
+
+    const audit = mock(async () => undefined);
+    const report = await pumpOutbox({
+      store,
+      clock,
+      dispatcher: { handleAgentMessage: async () => undefined },
+      audit,
+    });
+
+    expect(report.delivered).toBe(1);
+    expect(audit).toHaveBeenCalledTimes(1);
+    expect(audit).toHaveBeenCalledWith({
+      channelId: "C1",
+      threadId: "T1",
+      text: ":raising_hand: Need product approval",
+    });
   });
 });

--- a/src/pipelines/pump.ts
+++ b/src/pipelines/pump.ts
@@ -291,6 +291,12 @@ async function handleOutboxItem(
   if (item.eventType === "assignment.escalate") {
     const run = await store.getRun(item.runId);
     if (!run) return "skipped";
+    // A default run is the durable envelope around an ordinary Slack turn.
+    // Its agent already owns the user-facing reply, so publishing the
+    // settlement reason here creates a second, internal-sounding recap in the
+    // thread. Typed pipelines still need a visible human-gate audit because
+    // their worker turns commonly finish with NO_SLACK_MESSAGE.
+    if (run.kind === "default") return "delivered";
     const reason = typeof item.payload.reason === "string"
       ? item.payload.reason
       : "The assignment needs human attention";


### PR DESCRIPTION
## Summary
- Suppress public `assignment.escalate` audit messages for ordinary default runs so Slack threads receive only the agent's user-facing response.
- Preserve typed product/bug escalation audits and system-generated wait-timeout alerts, with regression coverage and updated agent guidance.

## Test plan
- [x] `bun run typecheck`
- [x] `bun test src/pipelines/pump-wait.test.ts`
- [x] `bun test`