### PR TITLE
feat(dashboard): 3D memory galaxy with tag and semantic querying

### DIFF
--- a/docs/code_index/http-dashboard.md
+++ b/docs/code_index/http-dashboard.md
@@ -19,7 +19,8 @@ Localhost-only HTTP server for operator inspection (sessions, dev-servers, workf
 | `handleMemoryList()` | `routes/memory.ts` | `GET /api/memory` — list files under `docs/` |
 | `handleMemoryRead(filePath)` | `routes/memory.ts` | `GET /api/memory/:path` — read a doc file (path-traversal guarded) |
 | `handleMemoryRecall(store, params)` | `routes/memory.ts` | `GET /api/memory/recall` — semantic claim recall without recording dashboard usage |
-| `handleMemoryProjection(store)` | `routes/memory.ts` | `GET /api/memory/projection` — PCA/KNN projection for the memory cloud view |
+| `handleMemoryProjection(store, params?)` | `routes/memory.ts` | `GET /api/memory/projection` — 3D PCA + spread + KNN projection for the memory galaxy; memoised per claim set, `?refresh=1` rebuilds |
+| `projectClaims(claims, k?, spread?)` | `projection.ts` | PCA to 3D (power iteration + deflation) → separation relaxation → cosine KNN edges |
 
 ## Routes
 
@@ -35,6 +36,7 @@ GET /api/memory             → handleMemoryList
 GET /api/memory/<path>      → handleMemoryRead
 GET /api/memory/recall      → handleMemoryRecall (503 if unavailable)
 GET /api/memory/projection  → handleMemoryProjection (503 if unavailable)
+    ?refresh=1                force a rebuild instead of the memoised result
 ```
 
 ## Key Concepts
@@ -47,6 +49,24 @@ Binds `127.0.0.1`. No CORS headers — same-origin from `public/index.html`. Don
 
 - Logs: `date` must match `^\d{4}-\d{2}-\d{2}$` exactly.
 - Memory: rejects `..` and absolute paths; verifies resolved path stays inside `docs/`.
+
+### Memory galaxy projection
+
+`projection.ts` runs entirely at request time, nothing is persisted:
+
+1. **PCA to 3D** — top-3 principal components via matrix-free power iteration plus
+   deflation (never materialises the 640×640 covariance).
+2. **Spread** — a separation relaxation pushes stars closer than `minSep` apart
+   while KNN edges spring true neighbours back together. Local forces only, so
+   PCA's global arrangement survives; a uniform spatial hash keeps it O(n) per
+   iteration. Deterministic — no RNG, fixed iteration count. (A full UMAP SGD was
+   tried and rejected: near-uniform cosine edge weights let attraction dominate and
+   the corpus collapsed into two pinpoint balls.)
+3. **KNN edges** — cosine over the FULL-dim vectors, not the projection.
+
+Cost is O(n²·d) in the KNN, seconds on a multi-thousand-claim corpus, so the
+serialized body is memoised against a count+id fingerprint of the active claim set.
+`X-Projection-Cache: hit|miss` reports which path served the request.
 
 ### Boot wiring
 

--- a/docs/features/http-dashboard.md
+++ b/docs/features/http-dashboard.md
@@ -13,12 +13,13 @@ Operators running junior on a server have no live view of what's happening: whic
 ```
 src/http/
 ├── server.ts              -- Bun.serve, route table, single fetch handler
+├── projection.ts          -- 3D PCA + spread + KNN for the memory galaxy
 └── routes/
     ├── health.ts          -- uptime + session/agent counters
     ├── sessions.ts        -- list + per-thread detail
     ├── dev-server.ts      -- DevServerManager + DevServerQueue state
     ├── logs.ts            -- tail logs/<date>.log with tag/level filters
-    └── memory.ts          -- list/read docs/**/*.md (parity with Friday)
+    └── memory.ts          -- docs browser + claim recall + galaxy projection
 ```
 
 Bun-native: no router framework, no auth, no CORS. Static `public/index.html` is served at `/` from the same origin as the API, so cross-origin access has no reason to exist.
@@ -44,8 +45,34 @@ Junior is intentionally insecure as a networked product. The dashboard assumes a
 | `GET /api/logs?date=YYYY-MM-DD&tail=N&tag=&level=` | Parsed entries from `logs/<date>.log` |
 | `GET /api/memory` | List of `docs/**/*.md` paths |
 | `GET /api/memory/:path` | Contents of one doc file |
+| `GET /api/memory/recall?query=&tags=&kinds=&repo=&limit=` | Cosine-ranked claims; the route embeds the query, recall never records dashboard usage |
+| `GET /api/memory/projection[?refresh=1]` | `{ points[{id,x,y,z,kind,text,tags,repo,weight,createdAt,lastUsedAt}], edges[{a,b,sim}], facets{tags,kinds,repos} }` |
 
 `OPTIONS *` returns 204 (preflight handler kept for browsers that probe; no CORS headers attached). Unknown paths return JSON `{ error: "not found" }` 404. Handler exceptions log to the `http` tag and return JSON 500 — the bot does not die on a route bug.
+
+## Memory galaxy
+
+The `#memory` view renders the claim corpus as a navigable 3D star field, drawn by
+a hand-rolled perspective renderer on a 2D canvas (no WebGL, no library — the
+dashboard is one static file, and a 3D dependency would mean a build step). Stars
+composite additively, which is order-independent, so the draw loop needs no
+per-frame depth sort; distance reads through size and fog instead.
+
+- **Why 3D.** In 2D, thousands of claims overlap into an unreadable smear no matter
+  how the projection is tuned. Depth plus orbit/zoom gives the corpus somewhere to
+  go, and the server-side spread pass guarantees stars don't sit on top of each
+  other (see [the projection notes](../code_index/http-dashboard.md)).
+- **Navigation.** Drag orbits, wheel zooms, shift-drag pans, click focuses a star
+  and flies to it, double-click resets. The wheel handler is registered
+  non-passive and calls `preventDefault` — otherwise the wheel scrolls the page
+  behind the canvas instead of zooming.
+- **Filtering.** Tag / kind / repo chips (AND across tags) plus a text box that
+  substring-filters as you type and escalates to real semantic recall on ⏎ —
+  the same embedding path an agent's `memory_recall` takes. Matches light up, the
+  rest fade to background dust; `frame` fits the camera to the current match set.
+- **Layout containment.** The view is a fixed-height flex column, and the claim
+  rail scrolls inside itself with `overscroll-behavior: contain`. Without that,
+  a wheel over the rail chains up to `.content` and scrolls the whole dashboard.
 
 ## Configuration
 

--- a/public/index.html
+++ b/public/index.html
@@ -350,18 +350,97 @@
   .run-dot.running { background: rgba(245,158,11,0.8); }
   .run-line { font-family: var(--font-mono); font-size: 11px; color: var(--fg-dim); padding: 2px 0; }
 
-  /* ---------- memory ---------- */
-  .mem-layout { display: grid; grid-template-columns: 1.4fr 1fr; gap: 14px; }
-  @media (max-width: 1000px) { .mem-layout { grid-template-columns: 1fr; } }
-  #memory-canvas { display: block; width: 100%; height: 440px; background: #0a0a0a; border: 1px solid var(--border); border-radius: 12px; cursor: crosshair; }
-  .cloud-legend { display: flex; gap: 16px; margin: 10px 2px 0; }
-  .cloud-legend .lg { display: inline-flex; align-items: center; gap: 6px; color: var(--fg-dim); font-size: 11px; font-family: var(--font-mono); }
-  .cloud-legend .sw { width: 9px; height: 9px; border-radius: 50%; }
-  .claim-row { padding: 10px 16px; border-bottom: 1px solid var(--border-subtle); font-size: 12.5px; }
+  /* ---------- memory galaxy ---------- */
+  /* The galaxy owns the viewport instead of flowing down the page: the canvas
+     must never grow the document, and the claim rail scrolls INSIDE itself.
+     `overscroll-behavior: contain` is the fix for the wheel over the rail
+     chaining up to .content and scrolling the whole dashboard. */
+  #view-memory.active { display: flex; flex-direction: column; height: 100%; max-width: none; padding: 22px 26px 20px; }
+  #view-memory .view-head { margin-bottom: 12px; }
+  .mem-filters { display: flex; flex-direction: column; gap: 8px; margin-bottom: 12px; }
+  .mem-filter-row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+  /* Chip rows scroll inside a two-row cap instead of pushing the galaxy down —
+     with 1200+ tags and a dozen repos, an uncapped wrap eats the viewport. */
+  .mem-filter-row .chips { flex: 1; min-width: 0; max-height: 58px; overflow-y: auto; overscroll-behavior: contain; }
+  #mem-kinds { flex: none; }
+  .mem-filter-row .lbl {
+    font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.12em;
+    text-transform: uppercase; color: var(--fg-faint); width: 42px; flex: none;
+  }
+  .chip.tag { font-family: var(--font-mono); font-size: 10.5px; padding: 3px 9px; }
+  .chip.tag .n { color: var(--fg-faint); margin-left: 5px; }
+  .chip.tag.on .n { color: rgba(255,255,255,0.5); }
+  .chip.tag .x { margin-left: 6px; color: var(--fg-faint); }
+  .chip.tag:hover .x { color: var(--red); }
+
+  .mem-layout { flex: 1; min-height: 0; display: grid; grid-template-columns: minmax(0,1fr) 372px; gap: 14px; }
+  @media (max-width: 1080px) {
+    .mem-layout { grid-template-columns: 1fr; grid-template-rows: minmax(300px, 1.5fr) minmax(190px, 1fr); }
+    .mem-filter-row .chips { max-height: 34px; }
+  }
+
+  .galaxy-wrap {
+    position: relative; min-height: 0; min-width: 0; overflow: hidden;
+    border: 1px solid var(--border); border-radius: 12px;
+    background:
+      radial-gradient(120% 90% at 30% 18%, rgba(0,100,255,0.10), transparent 62%),
+      radial-gradient(90% 80% at 78% 82%, rgba(151,71,255,0.09), transparent 58%),
+      #050507;
+  }
+  #memory-canvas { display: block; width: 100%; height: 100%; cursor: grab; touch-action: none; }
+  #memory-canvas.dragging { cursor: grabbing; }
+  .galaxy-hud {
+    position: absolute; left: 12px; bottom: 10px; right: 12px; pointer-events: none;
+    display: flex; align-items: flex-end; gap: 14px; flex-wrap: wrap;
+    font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-faint);
+  }
+  .galaxy-hud .lg { display: inline-flex; align-items: center; gap: 6px; color: var(--fg-dim); }
+  .galaxy-hud .sw { width: 8px; height: 8px; border-radius: 50%; }
+  .galaxy-hud .hint { margin-left: auto; text-align: right; line-height: 1.7; }
+  .galaxy-tools { position: absolute; right: 12px; top: 10px; display: flex; gap: 6px; }
+  .galaxy-tools .ctrl { background: rgba(8,8,10,0.72); backdrop-filter: blur(4px); }
+  .galaxy-tools .ctrl.on { color: var(--fg); border-color: var(--accent); }
+  .galaxy-status {
+    position: absolute; inset: 0; display: flex; align-items: center; justify-content: center;
+    color: var(--fg-faint); font-family: var(--font-mono); font-size: 12px;
+    pointer-events: none; text-align: center; padding: 0 20px;
+  }
+
+  .mem-rail { display: flex; flex-direction: column; min-height: 0; gap: 10px; }
+  /* flex:1 + height:1px is the grid-safe way to get a scroll box — a max-height
+     here would let the rail push the page instead of scrolling itself. */
+  .mem-scroll { flex: 1; height: 1px; overflow-y: auto; overscroll-behavior: contain; }
+  .mem-rail-head {
+    display: flex; align-items: baseline; gap: 8px;
+    font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.12em;
+    text-transform: uppercase; color: var(--fg-dim);
+  }
+  .mem-rail-head .n { margin-left: auto; color: var(--fg-faint); letter-spacing: 0; }
+
+  /* A long claim must not squash the match list — the card scrolls itself. */
+  #mem-detail { flex: 0 1 auto; min-height: 0; max-height: 45%; overflow-y: auto; overscroll-behavior: contain; }
+  .claim-detail { padding: 14px 16px; background: var(--surface); border: 1px solid var(--border); border-radius: 12px; }
+  .claim-detail .body { font-size: 13px; color: rgba(255,255,255,0.9); margin: 4px 0 8px; }
+  .claim-detail .meta { font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-faint); line-height: 1.8; }
+  .claim-detail .near { margin-top: 8px; border-top: 1px solid var(--border-subtle); padding-top: 8px; }
+  .claim-detail .near .nrow {
+    display: flex; gap: 8px; font-size: 11.5px; color: var(--fg-dim); cursor: pointer;
+    padding: 3px 0; align-items: baseline;
+  }
+  .claim-detail .near .nrow:hover { color: var(--fg); }
+  .claim-detail .near .sim { font-family: var(--font-mono); font-size: 10px; color: var(--fg-faint); flex: none; width: 34px; }
+  .claim-detail .near .t { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+
+  .claim-row { padding: 10px 16px; border-bottom: 1px solid var(--border-subtle); font-size: 12.5px; cursor: pointer; }
   .claim-row:last-child { border-bottom: none; }
-  .claim-row .k { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase; margin-bottom: 2px; }
+  .claim-row:hover { background: rgba(255,255,255,0.03); }
+  .claim-row.on { background: rgba(0,100,255,0.09); box-shadow: inset 2px 0 0 var(--accent); }
+  .claim-row .k { font-family: var(--font-mono); font-size: 9.5px; letter-spacing: 0.1em; text-transform: uppercase; margin-bottom: 2px; display: flex; gap: 8px; }
   .claim-row .k.lesson { color: var(--green); } .claim-row .k.fact { color: var(--accent); } .claim-row .k.situation-claim { color: var(--purple); }
-  .claim-row .tags { color: var(--fg-faint); font-size: 11px; font-family: var(--font-mono); margin-top: 2px; }
+  .claim-row .k .score { margin-left: auto; color: var(--fg-faint); letter-spacing: 0; }
+  .claim-row .tags { color: var(--fg-faint); font-size: 11px; font-family: var(--font-mono); margin-top: 3px; }
+  .claim-row .tags span { cursor: pointer; }
+  .claim-row .tags span:hover { color: var(--accent); }
 
   /* ---------- docs ---------- */
   .docs-layout { display: grid; grid-template-columns: 280px 1fr; gap: 14px; min-height: 500px; }
@@ -504,23 +583,51 @@
     <section class="view" id="view-memory">
       <div class="view-head">
         <h2>Memory</h2>
-        <span class="sub">PCA projection — local neighbourhoods are meaningful, global distances are not</span>
-        <span class="right"><button class="ctrl" id="cloud-refresh" type="button">refresh</button></span>
+        <span class="sub">3D projection — local neighbourhoods are meaningful, global distances are not</span>
+        <span class="right">
+          <input class="search" id="mem-q" type="text" placeholder="filter text · ⏎ semantic recall" autocomplete="off" />
+          <button class="ctrl" id="mem-clear" type="button">clear</button>
+          <button class="ctrl" id="cloud-refresh" type="button">rebuild</button>
+        </span>
       </div>
-      <div class="mem-layout">
-        <div style="position:relative">
-          <canvas id="memory-canvas"></canvas>
-          <div class="cloud-legend">
-            <span class="lg"><span class="sw" style="background:#22c55e"></span>lesson</span>
-            <span class="lg"><span class="sw" style="background:#0064ff"></span>fact</span>
-            <span class="lg"><span class="sw" style="background:#9747ff"></span>situation-claim</span>
-          </div>
-          <div class="tip" id="cloud-tip" style="max-width:320px;white-space:normal"></div>
-          <div class="empty" id="cloud-status" style="position:absolute;top:0;left:0;right:0;text-align:center;padding-top:180px;pointer-events:none">loading…</div>
+
+      <div class="mem-filters">
+        <div class="mem-filter-row">
+          <span class="lbl">kind</span>
+          <div class="chips" id="mem-kinds"></div>
+          <span class="lbl" style="width:auto;margin-left:10px">repo</span>
+          <div class="chips" id="mem-repos"></div>
         </div>
-        <div>
-          <h3 class="sect" style="margin-top:0">Recent claims</h3>
-          <div class="panel" id="claim-list"><div class="empty">load the cloud to see claims</div></div>
+        <div class="mem-filter-row">
+          <span class="lbl">tags</span>
+          <input class="search" id="mem-tag-q" type="text" placeholder="find a tag…" style="width:150px" autocomplete="off" />
+          <div class="chips" id="mem-tags"></div>
+        </div>
+      </div>
+
+      <div class="mem-layout">
+        <div class="galaxy-wrap" id="galaxy-wrap">
+          <canvas id="memory-canvas"></canvas>
+          <div class="galaxy-tools">
+            <button class="ctrl on" id="gal-links" type="button" title="show KNN links">links</button>
+            <button class="ctrl on" id="gal-spin" type="button" title="idle auto-rotate">spin</button>
+            <button class="ctrl" id="gal-frame" type="button" title="frame the current filter">frame</button>
+            <button class="ctrl" id="gal-reset" type="button" title="reset the camera">reset</button>
+          </div>
+          <div class="galaxy-hud">
+            <span class="lg"><span class="sw" style="background:#34d399"></span>lesson</span>
+            <span class="lg"><span class="sw" style="background:#3b82f6"></span>fact</span>
+            <span class="lg"><span class="sw" style="background:#a76eff"></span>situation-claim</span>
+            <span id="gal-stats"></span>
+            <span class="hint">drag orbit · wheel zoom · shift-drag pan<br />click a star to focus</span>
+          </div>
+          <div class="tip" id="cloud-tip" style="max-width:340px;white-space:normal"></div>
+          <div class="galaxy-status" id="cloud-status">loading…</div>
+        </div>
+        <div class="mem-rail">
+          <div id="mem-detail"></div>
+          <div class="mem-rail-head"><span id="mem-rail-title">claims</span><span class="n" id="mem-rail-count"></span></div>
+          <div class="panel mem-scroll" id="claim-list"><div class="empty">loading the galaxy…</div></div>
         </div>
       </div>
     </section>
@@ -655,7 +762,7 @@ let logQuery = "";
 let follow = true;
 let actBuckets = null; // length-24 or null to hide
 let docsLoaded = false;
-let cloudLoaded = false;
+let galaxyLoaded = false;
 let drawerThreadId = null;
 
 /* =================== navigation =================== */
@@ -667,7 +774,7 @@ function show(view) {
   document.querySelectorAll("nav a").forEach((a) => a.classList.toggle("active", a.dataset.view === view));
   const el = $("view-" + view);
   (el || $("view-overview")).classList.add("active");
-  if (view === "memory" && !cloudLoaded) loadCloud();
+  if (view === "memory") { resizeGalaxy(); if (!galaxyLoaded) loadGalaxy(false); }
   if (view === "docs" && !docsLoaded) loadDocsTree();
   if (view === "logs") fetchLogs();
 }
@@ -1353,170 +1460,684 @@ function renderWorkflows() {
   $("wf-list").innerHTML = html;
 }
 
-/* =================== memory cloud =================== */
-const KIND_COLORS = {
-  lesson: "#22c55e",
-  fact: "#0064ff",
-  "situation-claim": "#9747ff",
-};
-const KIND_FALLBACK = "#999999";
-const cloud = {
+/* =================== memory galaxy =================== */
+/* A hand-rolled 3D renderer on a 2D canvas: perspective projection, additive
+   star blending, no WebGL and no library. The dashboard is one static file
+   served by the bot process, so a 3D dependency here would mean a build step.
+   Stars are composited with "lighter", which is order-independent — that is what
+   lets the draw loop skip a per-frame depth sort of the whole corpus. */
+const KINDS = ["lesson", "fact", "situation-claim"];
+const PALETTE = [[52, 211, 153], [59, 130, 246], [167, 110, 255], [150, 150, 150]];
+const ALPHA_STEPS = 8;
+const TAU = Math.PI * 2;
+const MAX_ROWS = 200;
+const kindIdx = (kind) => { const i = KINDS.indexOf(kind); return i < 0 ? 3 : i; };
+const rgba = (c, a) => "rgba(" + c[0] + "," + c[1] + "," + c[2] + "," + a.toFixed(3) + ")";
+const kindColor = (kind) => { const c = PALETTE[kindIdx(kind)]; return "rgb(" + c[0] + "," + c[1] + "," + c[2] + ")"; };
+
+const GAL = {
   canvas: $("memory-canvas"),
+  ctx: null,
   tip: $("cloud-tip"),
   status: $("cloud-status"),
-  screen: [],
-  data: null,
+  points: [],
+  byId: new Map(),
+  neighbors: new Map(),   // id -> [{id, sim}] strongest first
+  edgeA: null, edgeB: null, edgeSim: null,  // KNN edges as index pairs
+  facets: { tags: [], kinds: [], repos: [] },
+  w: 0, h: 0, dpr: 1,
+  sx: null, sy: null, sr: null, sz: null, svis: null, // per-point screen cache
+  buckets: [],
+  cam: { yaw: 0.6, pitch: 0.32, dist: 2.1, tx: 0, ty: 0, tz: 0 },
+  vYaw: 0, vPitch: 0,
+  drag: null,
+  fly: null,
+  lastInput: 0,
+  spinOn: true,
+  linksOn: true,
   hoverId: null,
+  selId: null,
+  filter: { text: "", tags: new Set(), kinds: new Set(), repo: "" },
+  matches: null,     // Set of matching ids, or null when nothing is filtered
+  scores: null,      // id -> semantic recall score, or null
+  tagQuery: "",
+  dirty: true,
 };
-function kindColor(kind) { return KIND_COLORS[kind] || KIND_FALLBACK; }
-function setCloudStatus(text) {
-  if (text) {
-    cloud.status.textContent = text;
-    cloud.status.style.display = "";
-  } else {
-    cloud.status.style.display = "none";
-  }
+
+/* ---------- load ---------- */
+function setGalStatus(text) {
+  GAL.status.textContent = text || "";
+  GAL.status.style.display = text ? "" : "none";
 }
-function drawCloud(data) {
-  cloud.data = data;
-  cloud.hoverId = null;
-  paintCloud();
-  // recent claims from points (newest-ish by order returned)
-  const points = (data && data.points) || [];
-  if (points.length === 0) {
-    $("claim-list").innerHTML = '<div class="empty">No claims with embeddings yet.</div>';
-  } else {
-    const recent = points.slice(-12).reverse();
-    $("claim-list").innerHTML = recent.map((c) =>
-      '<div class="claim-row"><div class="k ' + esc(c.kind) + '">' + esc(c.kind) + "</div>" +
-      '<div style="color:rgba(255,255,255,0.85)">' + esc(c.text) + "</div>" +
-      '<div class="tags">' + (c.tags || []).map(esc).join(" · ") + "</div></div>"
-    ).join("");
-  }
-}
-function paintCloud() {
-  const data = cloud.data || {};
-  const points = data.points || [];
-  const edges = data.edges || [];
-  const canvas = cloud.canvas;
-  const dpr = window.devicePixelRatio || 1;
-  const cssW = canvas.clientWidth || 800;
-  const cssH = canvas.clientHeight || 440;
-  canvas.width = Math.round(cssW * dpr);
-  canvas.height = Math.round(cssH * dpr);
-  const ctx = canvas.getContext("2d");
-  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-  ctx.clearRect(0, 0, cssW, cssH);
-  cloud.screen = [];
-  if (points.length === 0) {
-    setCloudStatus("No claims with embeddings yet.");
-    return;
-  }
-  setCloudStatus(null);
-  const pad = 28;
-  let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
-  for (const p of points) {
-    if (p.x < minX) minX = p.x;
-    if (p.x > maxX) maxX = p.x;
-    if (p.y < minY) minY = p.y;
-    if (p.y > maxY) maxY = p.y;
-  }
-  const spanX = maxX - minX || 1;
-  const spanY = maxY - minY || 1;
-  const toScreen = (p) => ({
-    sx: points.length === 1 ? cssW / 2 : pad + ((p.x - minX) / spanX) * (cssW - 2 * pad),
-    sy: points.length === 1 ? cssH / 2 : pad + ((p.y - minY) / spanY) * (cssH - 2 * pad),
-  });
-  const pos = new Map();
-  for (const p of points) pos.set(p.id, toScreen(p));
-  ctx.lineWidth = 1;
-  for (const e of edges) {
-    const a = pos.get(e.a);
-    const b = pos.get(e.b);
-    if (!a || !b) continue;
-    const touchesHover = cloud.hoverId != null && (e.a === cloud.hoverId || e.b === cloud.hoverId);
-    const baseAlpha = Math.max(0.05, Math.min(0.3, (e.sim || 0) * 0.32));
-    const alpha = touchesHover ? Math.min(0.7, baseAlpha + 0.4) : baseAlpha;
-    ctx.strokeStyle = "rgba(0,100,255," + alpha.toFixed(3) + ")";
-    ctx.beginPath();
-    ctx.moveTo(a.sx, a.sy);
-    ctx.lineTo(b.sx, b.sy);
-    ctx.stroke();
-  }
-  for (const p of points) {
-    const s = pos.get(p.id);
-    const isHover = p.id === cloud.hoverId;
-    if (isHover) {
-      ctx.strokeStyle = "rgba(255,255,255,0.85)";
-      ctx.lineWidth = 1.5;
-      ctx.beginPath();
-      ctx.arc(s.sx, s.sy, 7, 0, Math.PI * 2);
-      ctx.stroke();
-    }
-    ctx.fillStyle = kindColor(p.kind);
-    ctx.beginPath();
-    ctx.arc(s.sx, s.sy, isHover ? 4.5 : 3.5, 0, Math.PI * 2);
-    ctx.fill();
-    cloud.screen.push({ sx: s.sx, sy: s.sy, point: p });
-  }
-}
-function cloudHover(evt) {
-  const rect = cloud.canvas.getBoundingClientRect();
-  const mx = evt.clientX - rect.left;
-  const my = evt.clientY - rect.top;
-  let best = null;
-  let bestD = 100;
-  for (const item of cloud.screen) {
-    const dx = item.sx - mx;
-    const dy = item.sy - my;
-    const d = dx * dx + dy * dy;
-    if (d < bestD) { bestD = d; best = item; }
-  }
-  const nextHover = best ? best.point.id : null;
-  if (nextHover !== cloud.hoverId) {
-    cloud.hoverId = nextHover;
-    paintCloud();
-  }
-  if (!best) { cloud.tip.style.display = "none"; return; }
-  const p = best.point;
-  const tags = (p.tags || []).length
-    ? '<div style="color:var(--fg-dim);margin-top:4px">' + p.tags.map(esc).join(", ") + "</div>"
-    : "";
-  cloud.tip.innerHTML =
-    '<div style="color:' + kindColor(p.kind) + ';font-size:10px;text-transform:uppercase;letter-spacing:0.1em;margin-bottom:4px">' +
-    esc(p.kind) + "</div><div>" + esc(p.text) + "</div>" + tags;
-  cloud.tip.style.display = "block";
-  const wrap = cloud.canvas.parentElement.getBoundingClientRect();
-  let tx = best.sx + 12;
-  let ty = best.sy + 12;
-  if (tx + 330 > wrap.width) tx = best.sx - cloud.tip.offsetWidth - 12;
-  cloud.tip.style.left = Math.max(0, tx) + "px";
-  cloud.tip.style.top = Math.max(0, ty) + "px";
-}
-function cloudLeave() {
-  cloud.tip.style.display = "none";
-  if (cloud.hoverId != null) {
-    cloud.hoverId = null;
-    paintCloud();
-  }
-}
-async function loadCloud() {
-  setCloudStatus("loading…");
-  const res = await safeFetch("/api/memory/projection");
-  cloudLoaded = true;
+
+async function loadGalaxy(force) {
+  setGalStatus(force ? "rebuilding the projection…" : "projecting the claim space…");
+  const res = await safeFetch("/api/memory/projection" + (force ? "?refresh=1" : ""));
+  galaxyLoaded = true;
   if (!res.ok) {
-    setCloudStatus("Failed to load projection.");
+    setGalStatus("Failed to load the projection.");
     $("claim-list").innerHTML = '<div class="empty">Failed to load claims.</div>';
     return;
   }
-  drawCloud(res.data);
+  ingestGalaxy(res.data);
 }
-cloud.canvas.addEventListener("mousemove", cloudHover);
-cloud.canvas.addEventListener("mouseleave", cloudLeave);
-$("cloud-refresh").addEventListener("click", loadCloud);
-if (window.ResizeObserver) {
-  new ResizeObserver(() => { if (cloud.data) paintCloud(); }).observe(cloud.canvas);
+
+function ingestGalaxy(data) {
+  const points = (data && data.points) || [];
+  GAL.points = points;
+  GAL.byId = new Map(points.map((p) => [p.id, p]));
+  GAL.idxById = new Map(points.map((p, i) => [p.id, i]));
+  GAL.facets = (data && data.facets) || { tags: [], kinds: [], repos: [] };
+  GAL.selId = null;
+  GAL.hoverId = null;
+
+  // Precompute a lowercase haystack per claim so the text filter is a single
+  // substring test per point instead of rebuilding strings on every keystroke.
+  for (const p of points) {
+    p.hay = (p.text + " " + (p.tags || []).join(" ") + " " + (p.repo || "")).toLowerCase();
+  }
+
+  const edges = (data && data.edges) || [];
+  const index = new Map(points.map((p, i) => [p.id, i]));
+  GAL.edgeA = new Int32Array(edges.length);
+  GAL.edgeB = new Int32Array(edges.length);
+  GAL.edgeSim = new Float32Array(edges.length);
+  GAL.neighbors = new Map();
+  let m = 0;
+  for (const e of edges) {
+    const ai = index.get(e.a);
+    const bi = index.get(e.b);
+    if (ai === undefined || bi === undefined) continue;
+    GAL.edgeA[m] = ai; GAL.edgeB[m] = bi; GAL.edgeSim[m] = e.sim; m += 1;
+    pushNeighbor(e.a, e.b, e.sim);
+    pushNeighbor(e.b, e.a, e.sim);
+  }
+  GAL.edgeCount = m;
+  for (const list of GAL.neighbors.values()) list.sort((a, b) => b.sim - a.sim);
+
+  const n = points.length;
+  GAL.sx = new Float32Array(n);
+  GAL.sy = new Float32Array(n);
+  GAL.sr = new Float32Array(n);
+  GAL.sz = new Float32Array(n);
+  GAL.svis = new Uint8Array(n);
+  GAL.buckets = [];
+  for (let i = 0; i < PALETTE.length * ALPHA_STEPS; i += 1) GAL.buckets.push([]);
+
+  setGalStatus(n ? null : "No claims with embeddings yet.");
+  resetView(false);
+  renderKindChips();
+  renderRepoChips();
+  renderTagPicker();
+  applyFilter();
 }
+
+function pushNeighbor(from, to, sim) {
+  const list = GAL.neighbors.get(from);
+  if (list) list.push({ id: to, sim });
+  else GAL.neighbors.set(from, [{ id: to, sim }]);
+}
+
+/* ---------- camera ---------- */
+const clampPitch = (p) => Math.max(-1.45, Math.min(1.45, p));
+
+function resetView(animate) {
+  const goal = { tx: 0, ty: 0, tz: 0, dist: 2.1 };
+  if (animate) flyTo(goal);
+  else { Object.assign(GAL.cam, goal, { yaw: 0.6, pitch: 0.32 }); GAL.dirty = true; }
+}
+
+function flyTo(goal, ms) {
+  const cam = GAL.cam;
+  GAL.fly = {
+    start: performance.now(), dur: ms || 620,
+    from: { tx: cam.tx, ty: cam.ty, tz: cam.tz, dist: cam.dist },
+    to: { tx: goal.tx, ty: goal.ty, tz: goal.tz, dist: goal.dist == null ? cam.dist : goal.dist },
+  };
+}
+
+/** Fit the camera around whatever the filter currently matches. */
+function frameMatches() {
+  const list = matchedPoints();
+  if (!list.length) return;
+  let cx = 0, cy = 0, cz = 0;
+  for (const p of list) { cx += p.x; cy += p.y; cz += p.z; }
+  cx /= list.length; cy /= list.length; cz /= list.length;
+  let radius = 0;
+  for (const p of list) {
+    const d = Math.hypot(p.x - cx, p.y - cy, p.z - cz);
+    if (d > radius) radius = d;
+  }
+  flyTo({ tx: cx, ty: cy, tz: cz, dist: Math.max(0.45, radius * 2.1 + 0.35) });
+}
+
+function stepCamera(now) {
+  const cam = GAL.cam;
+  let moved = false;
+
+  if (GAL.fly) {
+    const f = GAL.fly;
+    const t = Math.min(1, (now - f.start) / f.dur);
+    const e = t < 0.5 ? 2 * t * t : 1 - Math.pow(-2 * t + 2, 2) / 2; // easeInOutQuad
+    cam.tx = f.from.tx + (f.to.tx - f.from.tx) * e;
+    cam.ty = f.from.ty + (f.to.ty - f.from.ty) * e;
+    cam.tz = f.from.tz + (f.to.tz - f.from.tz) * e;
+    cam.dist = f.from.dist + (f.to.dist - f.from.dist) * e;
+    if (t >= 1) GAL.fly = null;
+    moved = true;
+  } else if (!GAL.drag && (Math.abs(GAL.vYaw) > 2e-5 || Math.abs(GAL.vPitch) > 2e-5)) {
+    // Release inertia — the galaxy keeps drifting after a flick, then settles.
+    cam.yaw += GAL.vYaw;
+    cam.pitch = clampPitch(cam.pitch + GAL.vPitch);
+    GAL.vYaw *= 0.93;
+    GAL.vPitch *= 0.93;
+    moved = true;
+  }
+
+  if (GAL.spinOn && !GAL.drag && !GAL.fly && now - GAL.lastInput > 2500) {
+    cam.yaw += 0.0011;
+    moved = true;
+  }
+  if (moved) GAL.dirty = true;
+}
+
+function galaxyFrame(now) {
+  requestAnimationFrame(galaxyFrame);
+  if (!GAL.points.length || currentView() !== "memory") return;
+  stepCamera(now);
+  if (GAL.dirty) { paintGalaxy(); GAL.dirty = false; }
+}
+
+/* ---------- render ---------- */
+function resizeGalaxy() {
+  const wrap = $("galaxy-wrap");
+  if (!wrap) return;
+  const rect = wrap.getBoundingClientRect();
+  GAL.w = Math.max(1, Math.round(rect.width));
+  GAL.h = Math.max(1, Math.round(rect.height));
+  GAL.dpr = window.devicePixelRatio || 1;
+  GAL.canvas.width = Math.round(GAL.w * GAL.dpr);
+  GAL.canvas.height = Math.round(GAL.h * GAL.dpr);
+  GAL.dirty = true;
+}
+
+function paintGalaxy() {
+  if (!GAL.ctx) GAL.ctx = GAL.canvas.getContext("2d");
+  const ctx = GAL.ctx;
+  const { w, h, points, cam } = GAL;
+  const n = points.length;
+  ctx.setTransform(GAL.dpr, 0, 0, GAL.dpr, 0, 0);
+  ctx.clearRect(0, 0, w, h);
+  if (!n || !w) return;
+
+  const cy = Math.cos(cam.yaw), sy = Math.sin(cam.yaw);
+  const cp = Math.cos(cam.pitch), sp = Math.sin(cam.pitch);
+  const focal = Math.min(w, h) * 0.85;
+  const ox = w / 2, oy = h / 2;
+  const matches = GAL.matches;
+
+  for (let i = 0; i < n; i += 1) {
+    const p = points[i];
+    const px = p.x - cam.tx, py = p.y - cam.ty, pz = p.z - cam.tz;
+    const rx = px * cy - pz * sy;
+    const rzy = px * sy + pz * cy;
+    const ry = py * cp - rzy * sp;
+    const rz = py * sp + rzy * cp + cam.dist;
+    if (rz <= 0.04) { GAL.svis[i] = 0; continue; }
+    const f = focal / rz;
+    const x = ox + rx * f;
+    const y = oy - ry * f;
+    GAL.sx[i] = x; GAL.sy[i] = y; GAL.sz[i] = rz;
+    // Size carries both weight (how much the claim has earned) and depth.
+    const base = 1.05 + Math.min(1.8, Math.max(0, p.weight)) * 0.7;
+    GAL.sr[i] = Math.max(0.55, Math.min(16, base * (cam.dist / rz)));
+    GAL.svis[i] = x > -40 && x < w + 40 && y > -40 && y < h + 40 ? 1 : 0;
+  }
+
+  // Links behind the stars, in two passes: one faint ambient web (a single flat
+  // alpha — per-edge alpha would mean a stroke call per edge) and a bright pass
+  // for whatever is hovered or selected, which is the one you actually read.
+  const focusId = GAL.hoverId != null ? GAL.hoverId : GAL.selId;
+  if (GAL.edgeCount) {
+    ctx.lineWidth = 1;
+    if (GAL.linksOn) {
+      ctx.strokeStyle = "rgba(120,170,255,0.055)";
+      ctx.beginPath();
+      for (let e = 0; e < GAL.edgeCount; e += 1) {
+        const a = GAL.edgeA[e], b = GAL.edgeB[e];
+        if (!GAL.svis[a] || !GAL.svis[b]) continue;
+        if (matches && !(matches.has(points[a].id) && matches.has(points[b].id))) continue;
+        ctx.moveTo(GAL.sx[a], GAL.sy[a]);
+        ctx.lineTo(GAL.sx[b], GAL.sy[b]);
+      }
+      ctx.stroke();
+    }
+    if (focusId != null) {
+      ctx.strokeStyle = "rgba(160,200,255,0.62)";
+      ctx.lineWidth = 1.2;
+      ctx.beginPath();
+      for (let e = 0; e < GAL.edgeCount; e += 1) {
+        const a = GAL.edgeA[e], b = GAL.edgeB[e];
+        if (points[a].id !== focusId && points[b].id !== focusId) continue;
+        if (!GAL.svis[a] || !GAL.svis[b]) continue;
+        ctx.moveTo(GAL.sx[a], GAL.sy[a]);
+        ctx.lineTo(GAL.sx[b], GAL.sy[b]);
+      }
+      ctx.stroke();
+    }
+  }
+
+  // Stars, batched by (kind, alpha bucket). Additive blending is commutative, so
+  // no depth sort is needed — distance reads through size and fog alone.
+  for (const bucket of GAL.buckets) bucket.length = 0;
+  for (let i = 0; i < n; i += 1) {
+    if (!GAL.svis[i]) continue;
+    const p = points[i];
+    const fog = Math.max(0.07, Math.min(0.62, 1.05 - GAL.sz[i] / (cam.dist * 1.5)));
+    let alpha = fog;
+    let r = GAL.sr[i];
+    if (matches && !matches.has(p.id)) { alpha *= 0.16; r *= 0.7; }
+    else if (matches) {
+      alpha = Math.min(0.95, alpha + 0.3);
+      r *= 1.25;
+      if (GAL.scores) {
+        // Rank shows up as brightness when a semantic query is driving the view.
+        const s = GAL.scores.get(p.id) || 0;
+        r *= 1 + Math.min(1, s / (GAL.topScore || 1)) * 0.5;
+      }
+    }
+    // Quantise alpha into buckets so each (kind, alpha) pair is one fill call.
+    // The bucket paints at its midpoint alpha, so the quantisation is unbiased.
+    const slot = Math.max(0, Math.min(ALPHA_STEPS - 1, Math.floor(alpha * ALPHA_STEPS)));
+    GAL.buckets[kindIdx(p.kind) * ALPHA_STEPS + slot].push(GAL.sx[i], GAL.sy[i], r);
+  }
+  ctx.globalCompositeOperation = "lighter";
+  for (let b = 0; b < GAL.buckets.length; b += 1) {
+    const arr = GAL.buckets[b];
+    if (!arr.length) continue;
+    ctx.fillStyle = rgba(PALETTE[Math.floor(b / ALPHA_STEPS)], ((b % ALPHA_STEPS) + 0.5) / ALPHA_STEPS);
+    ctx.beginPath();
+    for (let i = 0; i < arr.length; i += 3) {
+      ctx.moveTo(arr[i] + arr[i + 2], arr[i + 1]);
+      ctx.arc(arr[i], arr[i + 1], arr[i + 2], 0, TAU);
+    }
+    ctx.fill();
+  }
+  ctx.globalCompositeOperation = "source-over";
+
+  drawMarker(ctx, GAL.hoverId, 0.5);
+  drawMarker(ctx, GAL.selId, 1);
+  updateGalStats();
+}
+
+function drawMarker(ctx, id, strength) {
+  if (id == null) return;
+  const p = GAL.byId.get(id);
+  if (!p) return;
+  const i = GAL.idxById.get(id);
+  if (i === undefined || !GAL.svis[i]) return;
+  const x = GAL.sx[i], y = GAL.sy[i];
+  const r = Math.max(7, GAL.sr[i] + 5);
+  const color = PALETTE[kindIdx(p.kind)];
+  const glow = ctx.createRadialGradient(x, y, 0, x, y, r * 3);
+  glow.addColorStop(0, rgba(color, 0.5 * strength));
+  glow.addColorStop(1, rgba(color, 0));
+  ctx.fillStyle = glow;
+  ctx.beginPath();
+  ctx.arc(x, y, r * 3, 0, TAU);
+  ctx.fill();
+  ctx.strokeStyle = "rgba(255,255,255," + (0.45 + 0.45 * strength).toFixed(2) + ")";
+  ctx.lineWidth = strength > 0.9 ? 1.5 : 1;
+  ctx.beginPath();
+  ctx.arc(x, y, r, 0, TAU);
+  ctx.stroke();
+}
+
+function updateGalStats() {
+  const shown = GAL.matches ? GAL.matches.size : GAL.points.length;
+  const text = shown + " / " + GAL.points.length + " stars · " + (GAL.edgeCount || 0) + " links";
+  if (text === GAL.statsText) return; // paints run at 60fps; the DOM write must not
+  GAL.statsText = text;
+  $("gal-stats").textContent = text;
+}
+
+/* ---------- picking / hover ---------- */
+function pickAt(evt) {
+  const rect = GAL.canvas.getBoundingClientRect();
+  const mx = evt.clientX - rect.left;
+  const my = evt.clientY - rect.top;
+  let bestI = -1;
+  let bestScore = Infinity;
+  for (let i = 0; i < GAL.points.length; i += 1) {
+    if (!GAL.svis[i]) continue;
+    const reach = Math.max(10, GAL.sr[i] + 6);
+    const d = Math.hypot(GAL.sx[i] - mx, GAL.sy[i] - my);
+    if (d > reach) continue;
+    // Closest to the pointer wins; near-ties break toward the star nearest the camera.
+    const score = d / reach + GAL.sz[i] * 0.02;
+    if (score < bestScore) { bestScore = score; bestI = i; }
+  }
+  return bestI < 0 ? null : GAL.points[bestI];
+}
+
+function hoverAt(evt) {
+  const hit = pickAt(evt);
+  const id = hit ? hit.id : null;
+  if (id !== GAL.hoverId) { GAL.hoverId = id; GAL.dirty = true; }
+  if (!hit) { GAL.tip.style.display = "none"; return; }
+  const tags = (hit.tags || []).length
+    ? '<div style="color:var(--fg-faint);margin-top:5px">' + hit.tags.map(esc).join(" · ") + "</div>"
+    : "";
+  GAL.tip.innerHTML =
+    '<div style="color:' + kindColor(hit.kind) + ';font-size:9.5px;text-transform:uppercase;letter-spacing:0.12em;margin-bottom:4px">' +
+    esc(hit.kind) + (hit.repo ? " · " + esc(hit.repo) : "") + "</div>" +
+    '<div style="color:var(--fg)">' + esc(clip(hit.text, 240)) + "</div>" + tags;
+  GAL.tip.style.display = "block";
+  const i = GAL.idxById.get(hit.id);
+  let tx = GAL.sx[i] + 14;
+  let ty = GAL.sy[i] + 14;
+  if (tx + GAL.tip.offsetWidth > GAL.w) tx = GAL.sx[i] - GAL.tip.offsetWidth - 14;
+  if (ty + GAL.tip.offsetHeight > GAL.h) ty = GAL.h - GAL.tip.offsetHeight - 8;
+  GAL.tip.style.left = Math.max(0, tx) + "px";
+  GAL.tip.style.top = Math.max(0, ty) + "px";
+}
+
+const clip = (s, max) => (s && s.length > max ? s.slice(0, max - 1) + "…" : s || "");
+
+function selectClaim(id, fly) {
+  GAL.selId = id;
+  GAL.dirty = true;
+  const p = id && GAL.byId.get(id);
+  if (p && fly) flyTo({ tx: p.x, ty: p.y, tz: p.z, dist: Math.min(GAL.cam.dist, 1.15) });
+  renderDetail();
+  markSelectedRow();
+}
+
+/* ---------- filters ---------- */
+function pointMatches(p) {
+  const f = GAL.filter;
+  if (f.kinds.size && !f.kinds.has(p.kind)) return false;
+  if (f.repo && p.repo !== f.repo) return false;
+  for (const tag of f.tags) if (!p.tags.includes(tag)) return false;
+  if (GAL.scores) return GAL.scores.has(p.id);
+  if (f.text && !p.hay.includes(f.text)) return false;
+  return true;
+}
+
+function filterActive() {
+  const f = GAL.filter;
+  return !!(f.text || f.repo || f.tags.size || f.kinds.size || GAL.scores);
+}
+
+function matchedPoints() {
+  return GAL.matches ? GAL.points.filter((p) => GAL.matches.has(p.id)) : GAL.points;
+}
+
+function applyFilter(frame) {
+  GAL.matches = filterActive()
+    ? new Set(GAL.points.filter(pointMatches).map((p) => p.id))
+    : null;
+  GAL.dirty = true;
+  renderRail();
+  renderTagPicker();
+  if (frame) frameMatches();
+}
+
+/** Semantic recall — the server embeds the query, exactly like agent recall. */
+async function semanticSearch() {
+  const q = $("mem-q").value.trim();
+  if (!q) { GAL.scores = null; GAL.filter.text = ""; applyFilter(); return; }
+  setGalStatus("embedding the query…");
+  const params = new URLSearchParams({ query: q, limit: "150" });
+  if (GAL.filter.tags.size) params.set("tags", [...GAL.filter.tags].join(","));
+  if (GAL.filter.kinds.size) params.set("kinds", [...GAL.filter.kinds].join(","));
+  if (GAL.filter.repo) params.set("repo", GAL.filter.repo);
+  const res = await safeFetch("/api/memory/recall?" + params.toString());
+  setGalStatus(null);
+  if (!res.ok) { setGalStatus("Recall failed."); return; }
+  const results = res.data.results || [];
+  GAL.scores = new Map(results.map((r) => [r.id, r.score]));
+  GAL.topScore = results.length ? Math.max(...results.map((r) => r.score || 0)) : 1;
+  applyFilter(true);
+}
+
+/* ---------- rail ---------- */
+function renderRail() {
+  const list = matchedPoints().slice();
+  if (GAL.scores) list.sort((a, b) => (GAL.scores.get(b.id) || 0) - (GAL.scores.get(a.id) || 0));
+  else list.sort((a, b) => (b.lastUsedAt || b.createdAt || 0) - (a.lastUsedAt || a.createdAt || 0));
+
+  $("mem-rail-title").textContent = GAL.scores ? "recall ranking" : filterActive() ? "matches" : "recently used";
+  $("mem-rail-count").textContent = list.length > MAX_ROWS
+    ? "showing " + MAX_ROWS + " of " + list.length
+    : list.length + (GAL.points.length && !filterActive() ? " claims" : " matched");
+
+  if (!list.length) {
+    $("claim-list").innerHTML = '<div class="empty">' +
+      (GAL.points.length ? "Nothing matches these filters." : "No claims with embeddings yet.") + "</div>";
+    return;
+  }
+  $("claim-list").innerHTML = list.slice(0, MAX_ROWS).map((p) => {
+    const score = GAL.scores ? '<span class="score">' + (GAL.scores.get(p.id) || 0).toFixed(3) + "</span>" : "";
+    const tags = (p.tags || []).length
+      ? '<div class="tags">' + p.tags.map((t) => '<span data-tag="' + esc(t) + '">' + esc(t) + "</span>").join(" · ") + "</div>"
+      : "";
+    return '<div class="claim-row' + (p.id === GAL.selId ? " on" : "") + '" data-claim="' + esc(p.id) + '">' +
+      '<div class="k ' + esc(p.kind) + '">' + esc(p.kind) + (p.repo ? " · " + esc(p.repo) : "") + score + "</div>" +
+      '<div style="color:rgba(255,255,255,0.85)">' + esc(clip(p.text, 260)) + "</div>" + tags + "</div>";
+  }).join("");
+  markSelectedRow();
+}
+
+function markSelectedRow() {
+  document.querySelectorAll("#claim-list .claim-row").forEach((row) => {
+    row.classList.toggle("on", row.dataset.claim === GAL.selId);
+  });
+}
+
+function renderDetail() {
+  const p = GAL.selId && GAL.byId.get(GAL.selId);
+  if (!p) { $("mem-detail").innerHTML = ""; return; }
+  const near = (GAL.neighbors.get(p.id) || []).slice(0, 5).map((nb) => {
+    const t = GAL.byId.get(nb.id);
+    return t
+      ? '<div class="nrow" data-claim="' + esc(t.id) + '"><span class="sim">' + nb.sim.toFixed(2) +
+        '</span><span class="t" style="color:' + kindColor(t.kind) + '">▪</span>' +
+        '<span class="t">' + esc(clip(t.text, 90)) + "</span></div>"
+      : "";
+  }).join("");
+  $("mem-detail").innerHTML =
+    '<div class="claim-detail">' +
+    '<div style="font-family:var(--font-mono);font-size:9.5px;letter-spacing:0.12em;text-transform:uppercase;color:' + kindColor(p.kind) + '">' +
+    esc(p.kind) + (p.repo ? " · " + esc(p.repo) : "") + "</div>" +
+    '<div class="body">' + esc(p.text) + "</div>" +
+    ((p.tags || []).length
+      ? '<div class="tags" style="font-family:var(--font-mono);font-size:11px;color:var(--fg-faint);margin-bottom:6px">' +
+        p.tags.map((t) => '<span data-tag="' + esc(t) + '" style="cursor:pointer">' + esc(t) + "</span>").join(" · ") + "</div>"
+      : "") +
+    '<div class="meta">weight ' + (p.weight || 0).toFixed(2) +
+    " · created " + ago(p.createdAt) + " ago" +
+    " · used " + (p.lastUsedAt ? ago(p.lastUsedAt) + " ago" : "never") + "</div>" +
+    (near ? '<div class="near"><div class="meta" style="margin-bottom:4px">nearest in the full space</div>' + near + "</div>" : "") +
+    "</div>";
+}
+
+/* ---------- filter chips ---------- */
+function renderKindChips() {
+  $("mem-kinds").innerHTML = (GAL.facets.kinds || []).map((k) =>
+    '<span class="chip tag' + (GAL.filter.kinds.has(k.value) ? " on" : "") + '" data-kind="' + esc(k.value) + '">' +
+    '<span style="color:' + kindColor(k.value) + '">▪</span> ' + esc(k.value) + '<span class="n">' + k.count + "</span></span>"
+  ).join("") || '<span class="faint" style="font-size:11px">—</span>';
+}
+
+function renderRepoChips() {
+  const repos = (GAL.facets.repos || []).slice(0, 8);
+  $("mem-repos").innerHTML = repos.map((r) =>
+    '<span class="chip tag' + (GAL.filter.repo === r.value ? " on" : "") + '" data-repo="' + esc(r.value) + '">' +
+    esc(r.value) + '<span class="n">' + r.count + "</span></span>"
+  ).join("") || '<span class="faint" style="font-size:11px">none tagged</span>';
+}
+
+function renderTagPicker() {
+  const q = GAL.tagQuery;
+  const selected = [...GAL.filter.tags].map((t) =>
+    '<span class="chip tag on" data-tag-off="' + esc(t) + '">' + esc(t) + '<span class="x">✕</span></span>'
+  ).join("");
+  // Counts are recomputed against the CURRENT matches, so tag chips narrow as you
+  // drill in and dead-end combinations are visibly zero-count (and dropped).
+  const pool = matchedPoints();
+  const counts = new Map();
+  for (const p of pool) for (const t of p.tags) counts.set(t, (counts.get(t) || 0) + 1);
+  const list = (GAL.facets.tags || [])
+    .filter((t) => !GAL.filter.tags.has(t.value) && (!q || t.value.toLowerCase().includes(q)) && counts.has(t.value))
+    .map((t) => ({ value: t.value, count: counts.get(t.value) }))
+    .sort((a, b) => b.count - a.count)
+    .slice(0, q ? 40 : 16);
+  $("mem-tags").innerHTML = selected + list.map((t) =>
+    '<span class="chip tag" data-tag="' + esc(t.value) + '">' + esc(t.value) + '<span class="n">' + t.count + "</span></span>"
+  ).join("");
+}
+
+/* ---------- events ---------- */
+GAL.canvas.addEventListener("pointerdown", (e) => {
+  GAL.canvas.setPointerCapture(e.pointerId);
+  GAL.canvas.classList.add("dragging");
+  GAL.drag = { x: e.clientX, y: e.clientY, pan: e.shiftKey || e.button === 1, moved: 0 };
+  GAL.vYaw = 0; GAL.vPitch = 0; GAL.fly = null;
+  GAL.lastInput = performance.now();
+  GAL.tip.style.display = "none";
+});
+
+GAL.canvas.addEventListener("pointermove", (e) => {
+  if (!GAL.drag) { hoverAt(e); return; }
+  const dx = e.clientX - GAL.drag.x;
+  const dy = e.clientY - GAL.drag.y;
+  GAL.drag.x = e.clientX; GAL.drag.y = e.clientY;
+  GAL.drag.moved += Math.abs(dx) + Math.abs(dy);
+  if (GAL.drag.pan) panCamera(dx, dy);
+  else {
+    GAL.vYaw = -dx * 0.005;
+    GAL.vPitch = -dy * 0.005;
+    GAL.cam.yaw += GAL.vYaw;
+    GAL.cam.pitch = clampPitch(GAL.cam.pitch + GAL.vPitch);
+  }
+  GAL.lastInput = performance.now();
+  GAL.dirty = true;
+});
+
+GAL.canvas.addEventListener("pointerup", (e) => {
+  const drag = GAL.drag;
+  GAL.drag = null;
+  GAL.canvas.classList.remove("dragging");
+  GAL.lastInput = performance.now();
+  if (drag && drag.moved > 6) return; // it was a rotate/pan, not a click
+  const hit = pickAt(e);
+  selectClaim(hit ? hit.id : null, !!hit);
+});
+
+GAL.canvas.addEventListener("pointerleave", () => {
+  GAL.tip.style.display = "none";
+  if (GAL.hoverId != null) { GAL.hoverId = null; GAL.dirty = true; }
+});
+
+GAL.canvas.addEventListener("dblclick", () => { resetView(true); GAL.lastInput = performance.now(); });
+
+// Non-passive so preventDefault sticks: without it the wheel scrolls the whole
+// dashboard behind the galaxy instead of zooming it.
+GAL.canvas.addEventListener("wheel", (e) => {
+  e.preventDefault();
+  const delta = e.deltaMode === 1 ? e.deltaY * 16 : e.deltaY;
+  GAL.cam.dist = Math.max(0.18, Math.min(14, GAL.cam.dist * Math.exp(delta * 0.0013)));
+  GAL.fly = null;
+  GAL.lastInput = performance.now();
+  GAL.dirty = true;
+}, { passive: false });
+
+/** Pan by moving the orbit target along the camera's own right/up axes. */
+function panCamera(dx, dy) {
+  const cam = GAL.cam;
+  const cy = Math.cos(cam.yaw), sy = Math.sin(cam.yaw);
+  const cp = Math.cos(cam.pitch), sp = Math.sin(cam.pitch);
+  const scale = cam.dist / (Math.min(GAL.w, GAL.h) * 0.85);
+  const rightX = cy, rightY = 0, rightZ = -sy;
+  const upX = -sy * sp, upY = cp, upZ = -cy * sp;
+  cam.tx -= (rightX * dx - upX * dy) * scale;
+  cam.ty -= (rightY * dx - upY * dy) * scale;
+  cam.tz -= (rightZ * dx - upZ * dy) * scale;
+}
+
+$("cloud-refresh").addEventListener("click", () => loadGalaxy(true));
+$("gal-reset").addEventListener("click", () => { resetView(true); GAL.lastInput = performance.now(); });
+$("gal-frame").addEventListener("click", () => { frameMatches(); GAL.lastInput = performance.now(); });
+$("gal-links").addEventListener("click", (e) => {
+  GAL.linksOn = !GAL.linksOn;
+  e.currentTarget.classList.toggle("on", GAL.linksOn);
+  GAL.dirty = true;
+});
+$("gal-spin").addEventListener("click", (e) => {
+  GAL.spinOn = !GAL.spinOn;
+  e.currentTarget.classList.toggle("on", GAL.spinOn);
+});
+
+$("mem-q").addEventListener("input", (e) => {
+  // Typing goes back to instant substring filtering; ⏎ escalates to embeddings.
+  GAL.scores = null;
+  GAL.filter.text = e.target.value.trim().toLowerCase();
+  applyFilter();
+});
+$("mem-q").addEventListener("keydown", (e) => {
+  if (e.key === "Enter") { e.preventDefault(); semanticSearch(); }
+});
+$("mem-clear").addEventListener("click", () => {
+  $("mem-q").value = "";
+  $("mem-tag-q").value = "";
+  GAL.filter = { text: "", tags: new Set(), kinds: new Set(), repo: "" };
+  GAL.scores = null;
+  GAL.tagQuery = "";
+  renderKindChips();
+  renderRepoChips();
+  applyFilter();
+  resetView(true);
+});
+$("mem-tag-q").addEventListener("input", (e) => {
+  GAL.tagQuery = e.target.value.trim().toLowerCase();
+  renderTagPicker();
+});
+
+$("mem-tags").addEventListener("click", (e) => {
+  const off = e.target.closest("[data-tag-off]");
+  if (off) { GAL.filter.tags.delete(off.dataset.tagOff); applyFilter(); return; }
+  const on = e.target.closest("[data-tag]");
+  if (on) { GAL.filter.tags.add(on.dataset.tag); applyFilter(); }
+});
+$("mem-kinds").addEventListener("click", (e) => {
+  const chip = e.target.closest("[data-kind]");
+  if (!chip) return;
+  const kind = chip.dataset.kind;
+  if (GAL.filter.kinds.has(kind)) GAL.filter.kinds.delete(kind);
+  else GAL.filter.kinds.add(kind);
+  renderKindChips();
+  applyFilter();
+});
+$("mem-repos").addEventListener("click", (e) => {
+  const chip = e.target.closest("[data-repo]");
+  if (!chip) return;
+  GAL.filter.repo = GAL.filter.repo === chip.dataset.repo ? "" : chip.dataset.repo;
+  renderRepoChips();
+  applyFilter();
+});
+
+for (const container of [$("claim-list"), $("mem-detail")]) {
+  container.addEventListener("click", (e) => {
+    const tag = e.target.closest("[data-tag]");
+    if (tag) { GAL.filter.tags.add(tag.dataset.tag); applyFilter(); return; }
+    const row = e.target.closest("[data-claim]");
+    if (row) selectClaim(row.dataset.claim, true);
+  });
+}
+
+if (window.ResizeObserver) new ResizeObserver(resizeGalaxy).observe($("galaxy-wrap"));
+requestAnimationFrame(galaxyFrame);
 
 /* =================== docs =================== */
 async function loadDocsTree() {

--- a/src/http/projection.ts
+++ b/src/http/projection.ts
@@ -1,19 +1,35 @@
 /**
- * 2D projection of the claim embedding space for the dashboard's "memory cloud"
- * debug view. Everything here is computed AT RENDER TIME from the raw vectors and
- * is NOT stored — it is exploration, not a precise map.
+ * 3D projection of the claim embedding space for the dashboard's "memory galaxy"
+ * view. Everything here is computed AT RENDER TIME from the raw vectors and is
+ * NOT stored — it is exploration, not a precise map.
  *
- * IMPORTANT CAVEAT (surfaced in the UI too): projecting a 640-dim space to 2D
- * with PCA preserves the directions of greatest variance, but it DISTORTS. Local
+ * IMPORTANT CAVEAT (surfaced in the UI too): projecting a 640-dim space to 3D
+ * preserves the directions of greatest variance, but it DISTORTS. Local
  * neighbourhoods (which points sit near which) are meaningful; absolute positions
  * and global distances are NOT. Two clusters far apart on screen may be close in
  * the full space, and vice-versa. Read the KNN edges, not the coordinates.
  *
- * Implementation is dependency-free: PCA's top-2 principal components are found
- * by matrix-free power iteration (the dominant eigenvector of the covariance,
- * computed as Xᵀ(Xv) without ever materialising the 640×640 covariance matrix),
- * then deflation for the second component. For the claim corpus (low thousands of
- * 640-dim vectors, per memory-system-v3.md §6.2) this is a sub-second compute.
+ * Two stages, both dependency-free:
+ *
+ *  1. PCA to 3D. The top-3 principal components are found by matrix-free power
+ *     iteration (the dominant eigenvector of the covariance, computed as Xᵀ(Xv)
+ *     without ever materialising the 640×640 covariance matrix), then deflation
+ *     for the second and third. For the claim corpus (low thousands of 640-dim
+ *     vectors, per memory-system-v3.md §6.2) this is a sub-second compute.
+ *
+ *  2. A spread pass. Raw PCA alone packs thousands of claims into a dense blob —
+ *     the top-3 components explain only a slice of a 640-dim corpus, so distinct
+ *     topics land on top of each other and the core becomes an unreadable smear.
+ *     `spreadLayout` fixes that VISUAL collapse without inventing structure: it
+ *     pushes overlapping stars apart to a minimum separation while KNN edges act
+ *     as springs holding true neighbours together. Both forces are short-range,
+ *     so PCA's global arrangement survives. Fully deterministic — the same corpus
+ *     always yields the same galaxy.
+ *
+ * Tried and rejected: a full UMAP SGD (attract along the KNN graph, repel by
+ * negative sampling) on this corpus. Its cosine-weighted KNN edges are nearly
+ * uniform in strength, so attraction dominated and 2.6k claims collapsed into two
+ * pinpoint balls — worse convergence than the PCA blob it replaced.
  */
 
 export interface ClaimVec {
@@ -22,15 +38,24 @@ export interface ClaimVec {
   text: string;
   tags: string[];
   vector: Float32Array;
+  repo?: string | null;
+  weight?: number;
+  createdAt?: number;
+  lastUsedAt?: number | null;
 }
 
 export interface ProjectionPoint {
   id: string;
   x: number;
   y: number;
+  z: number;
   kind: string;
   text: string;
   tags: string[];
+  repo: string | null;
+  weight: number;
+  createdAt: number | null;
+  lastUsedAt: number | null;
 }
 
 export interface ProjectionEdge {
@@ -44,12 +69,47 @@ export interface ProjectionResult {
   edges: ProjectionEdge[];
 }
 
+/** Layout knobs — exposed for tests, not for callers to tune per-request. */
+export interface SpreadOptions {
+  iterations: number;
+  /**
+   * Minimum star separation, as a multiple of the nominal uniform spacing
+   * (`2 / ∛n` in the [-1,1] cube). This is the whole point of the pass: below it,
+   * stars are pushed apart until they are individually visible.
+   */
+  minSepScale: number;
+  /**
+   * How far a KNN neighbour may drift before its spring pulls back, as a multiple
+   * of the separation floor. Must stay > 1 or the springs fight the floor.
+   */
+  edgeSlack: number;
+  /** Per-iteration step damping. Below 1 to avoid oscillation between the two forces. */
+  damping: number;
+}
+
+const DEFAULT_SPREAD: SpreadOptions = {
+  iterations: 80,
+  // 0.55 is the empirical middle: high enough that the dense core stops being an
+  // unclickable smear, low enough that PCA's lobes and the gaps between them
+  // survive. Push it toward 1 and the corpus flattens into a uniform ball.
+  minSepScale: 0.55,
+  edgeSlack: 2.2,
+  damping: 0.55,
+};
+
 /**
- * Project claims to 2D via PCA and compute KNN edges (cosine, default k=5).
+ * Project claims to 3D via PCA + spread, and compute KNN edges (cosine, k=5).
  * Guards the 0–1 claim case gracefully: points collapse to the origin and there
  * are no edges (the store may be near-empty pre-migration).
+ *
+ * Pass `spread: false` to get the raw PCA coordinates (used by tests that assert
+ * on PCA structure itself).
  */
-export function projectClaims(input: ClaimVec[], k = 5): ProjectionResult {
+export function projectClaims(
+  input: ClaimVec[],
+  k = 5,
+  spread: boolean | Partial<SpreadOptions> = true,
+): ProjectionResult {
   // Guard a mixed-dim corpus (e.g. mid model-change rebuild, before re-embed):
   // PCA/KNN require a uniform dimension. Project the dominant (modal) dim only;
   // off-dim vectors are dropped from the cloud rather than producing NaN coords.
@@ -62,10 +122,7 @@ export function projectClaims(input: ClaimVec[], k = 5): ProjectionResult {
 
   const n = claims.length;
   if (n <= 1) {
-    return {
-      points: claims.map((c) => ({ id: c.id, x: 0, y: 0, kind: c.kind, text: c.text, tags: c.tags })),
-      edges: [],
-    };
+    return { points: claims.map((c) => toPoint(c, 0, 0, 0)), edges: [] };
   }
 
   const dim = modalDim;
@@ -81,25 +138,65 @@ export function projectClaims(input: ClaimVec[], k = 5): ProjectionResult {
     return row;
   });
 
-  // Top-2 principal components by power iteration + deflation.
+  // Top-3 principal components by power iteration + deflation.
   const pc1 = powerIteration(centered, dim);
   deflate(centered, pc1);
   const pc2 = powerIteration(centered, dim);
+  deflate(centered, pc2);
+  const pc3 = powerIteration(centered, dim);
 
-  // Project the (now deflated) original-centred data. Recompute centred rows so
-  // the projection uses the full variance, not the deflated residual.
-  const points: ProjectionPoint[] = claims.map((c) => {
+  // Project the ORIGINAL centred data (not the deflated residual) so each axis
+  // carries the full variance along its component.
+  const coords = new Float64Array(n * 3);
+  for (let idx = 0; idx < n; idx += 1) {
+    const v = claims[idx].vector;
     let x = 0;
     let y = 0;
+    let z = 0;
     for (let i = 0; i < dim; i += 1) {
-      const v = c.vector[i] - mean[i];
-      x += v * pc1[i];
-      y += v * pc2[i];
+      const c = v[i] - mean[i];
+      x += c * pc1[i];
+      y += c * pc2[i];
+      z += c * pc3[i];
     }
-    return { id: c.id, x, y, kind: c.kind, text: c.text, tags: c.tags };
-  });
+    coords[idx * 3] = x;
+    coords[idx * 3 + 1] = y;
+    coords[idx * 3 + 2] = z;
+  }
 
-  return { points, edges: knnEdges(claims, k) };
+  const edges = knnEdges(claims, k);
+
+  normalizeToUnitCube(coords, n);
+  if (spread !== false) {
+    const index = new Map<string, number>();
+    for (let i = 0; i < n; i += 1) index.set(claims[i].id, i);
+    spreadLayout(coords, n, edges, index, {
+      ...DEFAULT_SPREAD,
+      ...(typeof spread === "object" ? spread : {}),
+    });
+    normalizeToUnitCube(coords, n);
+  }
+
+  const points = claims.map((c, i) =>
+    toPoint(c, coords[i * 3], coords[i * 3 + 1], coords[i * 3 + 2]),
+  );
+  return { points, edges };
+}
+
+function toPoint(c: ClaimVec, x: number, y: number, z: number): ProjectionPoint {
+  return {
+    id: c.id,
+    x,
+    y,
+    z,
+    kind: c.kind,
+    text: c.text,
+    tags: c.tags,
+    repo: c.repo ?? null,
+    weight: typeof c.weight === "number" ? c.weight : 1,
+    createdAt: c.createdAt ?? null,
+    lastUsedAt: c.lastUsedAt ?? null,
+  };
 }
 
 /**
@@ -148,9 +245,169 @@ function normalizeInPlace(v: Float64Array): number {
   return norm;
 }
 
+/** Recentre on the origin and rescale so the widest axis spans [-1, 1]. */
+function normalizeToUnitCube(coords: Float64Array, n: number): void {
+  let cx = 0;
+  let cy = 0;
+  let cz = 0;
+  for (let i = 0; i < n; i += 1) {
+    cx += coords[i * 3];
+    cy += coords[i * 3 + 1];
+    cz += coords[i * 3 + 2];
+  }
+  cx /= n; cy /= n; cz /= n;
+
+  let maxAbs = 0;
+  for (let i = 0; i < n; i += 1) {
+    coords[i * 3] -= cx;
+    coords[i * 3 + 1] -= cy;
+    coords[i * 3 + 2] -= cz;
+    for (let a = 0; a < 3; a += 1) {
+      const v = Math.abs(coords[i * 3 + a]);
+      if (v > maxAbs) maxAbs = v;
+    }
+  }
+  if (maxAbs === 0) return;
+  for (let i = 0; i < n * 3; i += 1) coords[i] /= maxAbs;
+}
+
+/**
+ * Separation relaxation over the PCA initialisation. Two short-range forces,
+ * iterated until the cloud stops overlapping itself:
+ *
+ *  - REPEL: any two stars closer than `minSep` are pushed apart to exactly that
+ *    distance. This is the fix for "the memories converge into each other" — with
+ *    thousands of claims, raw PCA piles most of the corpus into a dense core where
+ *    individual stars are unclickable and unreadable.
+ *  - ATTRACT: a KNN edge stretched past `minSep * edgeSlack` pulls back, so true
+ *    neighbours stay adjacent while the repulsion inflates everything else.
+ *
+ * Both forces are LOCAL, so PCA's global arrangement survives — this de-densifies
+ * the map, it does not re-derive it. Repulsion pairs come from a uniform spatial
+ * hash rebuilt each iteration (cell = minSep, so only the 27 surrounding cells can
+ * hold a colliding star), which is what keeps this O(n) per iteration instead of
+ * O(n²). Deterministic: no RNG, fixed iteration count.
+ */
+function spreadLayout(
+  coords: Float64Array,
+  n: number,
+  edges: ProjectionEdge[],
+  index: Map<string, number>,
+  opts: SpreadOptions,
+): void {
+  if (n < 3) return;
+
+  // Nominal spacing if the n points were spread uniformly across the [-1,1] cube.
+  const spacing = 2 / Math.cbrt(n);
+  const minSep = spacing * opts.minSepScale;
+  const edgeMax = minSep * opts.edgeSlack;
+  const cell = minSep;
+
+  // Resolve edges to index pairs once, outside the iteration loop.
+  const ea = new Int32Array(edges.length);
+  const eb = new Int32Array(edges.length);
+  let m = 0;
+  for (const e of edges) {
+    const ai = index.get(e.a);
+    const bi = index.get(e.b);
+    if (ai === undefined || bi === undefined) continue;
+    ea[m] = ai;
+    eb[m] = bi;
+    m += 1;
+  }
+
+  const buckets = new Map<string, number[]>();
+
+  for (let iter = 0; iter < opts.iterations; iter += 1) {
+    buckets.clear();
+    for (let i = 0; i < n; i += 1) {
+      const key = cellKey(coords[i * 3], coords[i * 3 + 1], coords[i * 3 + 2], cell);
+      const bucket = buckets.get(key);
+      if (bucket) bucket.push(i);
+      else buckets.set(key, [i]);
+    }
+
+    for (let i = 0; i < n; i += 1) {
+      const a = i * 3;
+      const gx = Math.floor(coords[a] / cell);
+      const gy = Math.floor(coords[a + 1] / cell);
+      const gz = Math.floor(coords[a + 2] / cell);
+      for (let ox = -1; ox <= 1; ox += 1) {
+        for (let oy = -1; oy <= 1; oy += 1) {
+          for (let oz = -1; oz <= 1; oz += 1) {
+            const bucket = buckets.get(`${gx + ox},${gy + oy},${gz + oz}`);
+            if (!bucket) continue;
+            for (const j of bucket) {
+              // Each unordered pair is resolved once, by its lower index.
+              if (j <= i) continue;
+              separate(coords, a, j * 3, minSep, opts.damping, i, j);
+            }
+          }
+        }
+      }
+    }
+
+    for (let e = 0; e < m; e += 1) {
+      const a = ea[e] * 3;
+      const b = eb[e] * 3;
+      const dx = coords[b] - coords[a];
+      const dy = coords[b + 1] - coords[a + 1];
+      const dz = coords[b + 2] - coords[a + 2];
+      const d = Math.sqrt(dx * dx + dy * dy + dz * dz);
+      if (d <= edgeMax || d < 1e-12) continue;
+      // Pull each end halfway to the slack limit; damping keeps it from
+      // oscillating against the repulsion that just ran.
+      const f = (((d - edgeMax) / d) * 0.5 * opts.damping);
+      coords[a] += dx * f;
+      coords[a + 1] += dy * f;
+      coords[a + 2] += dz * f;
+      coords[b] -= dx * f;
+      coords[b + 1] -= dy * f;
+      coords[b + 2] -= dz * f;
+    }
+  }
+}
+
+/** Push two overlapping stars apart along their separating axis, in-place. */
+function separate(
+  coords: Float64Array,
+  a: number,
+  b: number,
+  minSep: number,
+  damping: number,
+  ai: number,
+  bi: number,
+): void {
+  let dx = coords[b] - coords[a];
+  let dy = coords[b + 1] - coords[a + 1];
+  let dz = coords[b + 2] - coords[a + 2];
+  let d = Math.sqrt(dx * dx + dy * dy + dz * dz);
+  if (d >= minSep) return;
+  if (d < 1e-12) {
+    // Exactly coincident (duplicate embeddings): separate along an axis derived
+    // from the index pair, so the split is deterministic but not always the same
+    // direction for every collided pair.
+    dx = ((ai % 3) - 1) || 1;
+    dy = ((bi % 3) - 1) || 1;
+    dz = (((ai + bi) % 3) - 1) || 1;
+    d = Math.sqrt(dx * dx + dy * dy + dz * dz);
+  }
+  const f = ((minSep - d) / d) * 0.5 * damping;
+  coords[a] -= dx * f;
+  coords[a + 1] -= dy * f;
+  coords[a + 2] -= dz * f;
+  coords[b] += dx * f;
+  coords[b + 1] += dy * f;
+  coords[b + 2] += dz * f;
+}
+
+function cellKey(x: number, y: number, z: number, cell: number): string {
+  return `${Math.floor(x / cell)},${Math.floor(y / cell)},${Math.floor(z / cell)}`;
+}
+
 /**
  * KNN edges by cosine over the FULL-dim vectors (not the projection — the whole
- * point is that the 2D distances lie). Vectors are unit-normalised once so cosine
+ * point is that the 3D distances lie). Vectors are unit-normalised once so cosine
  * is a dot product. Edges are undirected and de-duplicated; `sim` is the cosine.
  */
 function knnEdges(claims: ClaimVec[], k: number): ProjectionEdge[] {

--- a/src/http/routes/memory.test.ts
+++ b/src/http/routes/memory.test.ts
@@ -56,8 +56,12 @@ describe("memory HTTP routes", () => {
       const response = await handleMemoryProjection(store);
       expect(response.status).toBe(200);
       const body = (await response.json()) as {
-        points: Array<{ id: string; x: number; y: number; kind: string; text: string; tags: string[] }>;
+        points: Array<{
+          id: string; x: number; y: number; z: number; kind: string; text: string;
+          tags: string[]; repo: string | null; weight: number;
+        }>;
         edges: Array<{ a: string; b: string; sim: number }>;
+        facets: { tags: Array<{ value: string; count: number }>; kinds: Array<{ value: string; count: number }> };
       };
 
       expect(body.points).toHaveLength(5);
@@ -66,10 +70,18 @@ describe("memory HTTP routes", () => {
       for (const p of body.points) {
         expect(Number.isFinite(p.x)).toBe(true);
         expect(Number.isFinite(p.y)).toBe(true);
+        // The galaxy view needs a third axis — a 2D projection would collapse it.
+        expect(Number.isFinite(p.z)).toBe(true);
         expect(p.kind).toBe("fact");
         expect(Array.isArray(p.tags)).toBe(true);
         expect(typeof p.text).toBe("string");
+        expect(typeof p.weight).toBe("number");
       }
+
+      // Facets drive the filter chips; they must count the projected points.
+      expect(body.facets.kinds).toEqual([{ value: "fact", count: 5 }]);
+      expect(body.facets.tags).toHaveLength(5);
+      expect(body.facets.tags.every((t) => t.count === 1)).toBe(true);
 
       expect(body.edges.length).toBeGreaterThan(0);
       for (const e of body.edges) {
@@ -107,14 +119,42 @@ describe("memory HTTP routes", () => {
       const response = await handleMemoryProjection(store);
       expect(response.status).toBe(200);
       const body = (await response.json()) as {
-        points: Array<{ id: string; x: number; y: number }>;
+        points: Array<{ id: string; x: number; y: number; z: number }>;
         edges: unknown[];
       };
       expect(body.points).toHaveLength(1);
       expect(body.points[0].id).toBe("solo");
       expect(body.points[0].x).toBe(0);
       expect(body.points[0].y).toBe(0);
+      expect(body.points[0].z).toBe(0);
       expect(body.edges).toEqual([]);
+    });
+  });
+
+  it("serves a cache hit for an unchanged claim set, and rebuilds on ?refresh=1", async () => {
+    await withStore(async (store) => {
+      await seedClaim(store, "c1", [1, 0, 0, 0, 0, 0, 0, 0]);
+      await seedClaim(store, "c2", [0, 1, 0, 0, 0, 0, 0, 0]);
+      await seedClaim(store, "c3", [0, 0, 1, 0, 0, 0, 0, 0]);
+
+      const first = await handleMemoryProjection(store);
+      expect(first.headers.get("X-Projection-Cache")).toBe("miss");
+      const firstBody = await first.text();
+
+      const second = await handleMemoryProjection(store);
+      expect(second.headers.get("X-Projection-Cache")).toBe("hit");
+      expect(await second.text()).toBe(firstBody);
+
+      const forced = await handleMemoryProjection(store, new URLSearchParams({ refresh: "1" }));
+      expect(forced.headers.get("X-Projection-Cache")).toBe("miss");
+      // The layout is deterministic, so a rebuild of the same corpus is identical.
+      expect(await forced.text()).toBe(firstBody);
+
+      // A new claim changes the signature, so the next read must recompute.
+      await seedClaim(store, "c4", [0, 0, 0, 1, 0, 0, 0, 0]);
+      const afterWrite = await handleMemoryProjection(store);
+      expect(afterWrite.headers.get("X-Projection-Cache")).toBe("miss");
+      expect((await afterWrite.json()).points).toHaveLength(4);
     });
   });
 });

--- a/src/http/routes/memory.ts
+++ b/src/http/routes/memory.ts
@@ -93,16 +93,82 @@ export async function handleMemoryRecall(
 }
 
 /**
- * 2D projection of the claim embedding space for the "memory cloud" debug view.
- * PCA (top-2 components) + KNN edges (k=5, cosine) computed at render time from
- * the raw vectors — nothing here is stored. The projection distorts: local
- * neighbourhoods are meaningful, global distances are not. The 0–1 claim guard
- * lives in projectClaims().
+ * 3D projection of the claim embedding space for the "memory galaxy" view.
+ * PCA (top-3 components) + a spread pass + KNN edges (k=5, cosine), all computed
+ * at render time from the raw vectors — nothing here is stored. The projection
+ * distorts: local neighbourhoods are meaningful, global distances are not. The
+ * 0–1 claim guard lives in projectClaims().
+ *
+ * The compute is a few seconds on a multi-thousand-claim corpus (KNN is O(n²d)),
+ * so the result is memoised against a signature of the claim set. Claims only
+ * change on a consolidation write, so a stale-free cache is just "recompute when
+ * the id set or count changes"; `?refresh=1` forces a rebuild regardless.
  */
-export async function handleMemoryProjection(store: MemoryStore): Promise<Response> {
+let projectionCache: { signature: string; body: string } | null = null;
+
+export async function handleMemoryProjection(
+  store: MemoryStore,
+  params?: URLSearchParams,
+): Promise<Response> {
   const claims = await store.exportClaimVectors();
+  const signature = claimSignature(claims);
+
+  if (params?.get("refresh") !== "1" && projectionCache?.signature === signature) {
+    return jsonBody(projectionCache.body, true);
+  }
+
   const { points, edges } = projectClaims(claims, 5);
-  return Response.json({ points, edges });
+  const body = JSON.stringify({ points, edges, facets: buildFacets(points) });
+  projectionCache = { signature, body };
+  return jsonBody(body, false);
+}
+
+function jsonBody(body: string, cached: boolean): Response {
+  return new Response(body, {
+    headers: { "Content-Type": "application/json", "X-Projection-Cache": cached ? "hit" : "miss" },
+  });
+}
+
+/**
+ * Cheap order-independent fingerprint of the active claim set: count plus an
+ * XOR-fold of per-id hashes. An edit that rewrites a claim's text without
+ * changing ids won't bust it — acceptable for a debug view with a manual
+ * `?refresh=1`, and far cheaper than hashing every 640-dim vector.
+ */
+function claimSignature(claims: Array<{ id: string }>): string {
+  let fold = 0;
+  for (const claim of claims) {
+    let h = 2166136261;
+    for (let i = 0; i < claim.id.length; i += 1) {
+      h ^= claim.id.charCodeAt(i);
+      h = Math.imul(h, 16777619);
+    }
+    fold = (fold ^ h) >>> 0;
+  }
+  return `${claims.length}:${fold.toString(16)}`;
+}
+
+/** Tag / kind / repo counts so the UI can build filter chips without a scan. */
+function buildFacets(points: Array<{ kind: string; tags: string[]; repo: string | null }>): {
+  tags: Array<{ value: string; count: number }>;
+  kinds: Array<{ value: string; count: number }>;
+  repos: Array<{ value: string; count: number }>;
+} {
+  const tags = new Map<string, number>();
+  const kinds = new Map<string, number>();
+  const repos = new Map<string, number>();
+  for (const point of points) {
+    kinds.set(point.kind, (kinds.get(point.kind) ?? 0) + 1);
+    if (point.repo) repos.set(point.repo, (repos.get(point.repo) ?? 0) + 1);
+    for (const tag of point.tags) tags.set(tag, (tags.get(tag) ?? 0) + 1);
+  }
+  return { tags: sortFacet(tags), kinds: sortFacet(kinds), repos: sortFacet(repos) };
+}
+
+function sortFacet(counts: Map<string, number>): Array<{ value: string; count: number }> {
+  return [...counts.entries()]
+    .map(([value, count]) => ({ value, count }))
+    .sort((a, b) => b.count - a.count || a.value.localeCompare(b.value));
 }
 
 function csv(value: string | null): string[] | undefined {

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -96,7 +96,7 @@ export function startHttpServer(deps: HttpServerDeps): void {
           return await handleMemoryRecall(memoryStore, url.searchParams);
         } else if (url.pathname === "/api/memory/projection") {
           if (!memoryStore) return Response.json({ error: "memory store not available" }, { status: 503 });
-          return await handleMemoryProjection(memoryStore);
+          return await handleMemoryProjection(memoryStore, url.searchParams);
         } else if (url.pathname === "/api/memory") {
           return await handleMemoryList();
         } else if (url.pathname.startsWith("/api/memory/")) {

--- a/src/memory/sqlite.ts
+++ b/src/memory/sqlite.ts
@@ -333,6 +333,9 @@ export class SqliteMemoryStore implements MemoryStore {
         repo: row.repo,
         tags: row.tags ? (JSON.parse(row.tags) as string[]) : [],
         vector,
+        weight: row.weight ?? 1,
+        createdAt: row.created_at,
+        lastUsedAt: row.last_used_at,
       });
     }
     return out;

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -167,6 +167,10 @@ export interface ClaimVectorExport {
   repo: string | null;
   tags: string[];
   vector: Float32Array;
+  /** Value signal — the galaxy view sizes/brightens a star by it. */
+  weight: number;
+  createdAt: number;
+  lastUsedAt: number | null;
 }
 
 // --- memory v3: decay / forgetting (§7.1) ---------------------------------


### PR DESCRIPTION
## Why

The memory view rendered ~2.6k claims as a static 2D PCA scatter in a fixed 440px canvas with no zoom, so the corpus converged into an unreadable smear. The claim rail also had no scroll container of its own — a wheel over it scrolled the entire dashboard.

## What changed

**Server — `src/http/projection.ts`, `src/http/routes/memory.ts`**

- PCA now projects to **3D** (top-3 principal components via power iteration + deflation).
- New **separation relaxation** over the PCA init: stars closer than a minimum separation are pushed apart, while KNN edges spring true neighbours back together. Both forces are short-range, so PCA's global arrangement survives — this de-densifies the map, it does not re-derive it. A uniform spatial hash keeps it O(n) per iteration; no RNG, so the same corpus always yields the same galaxy.
  - A full **UMAP SGD was tried and rejected**: the cosine-weighted KNN edges are near-uniform in strength, so attraction dominated and the corpus collapsed into two pinpoint balls — worse than the blob it replaced. Recorded in the file header so nobody re-runs the experiment.
- Points carry `z`, `repo`, `weight`, `createdAt`, `lastUsedAt`; the response adds `facets` (tag/kind/repo counts) for the filter chips.
- The KNN is O(n²·d) — ~4.5s on the current corpus — so the serialized body is **memoised** against a count+id fingerprint of the active claim set. `?refresh=1` forces a rebuild; `X-Projection-Cache: hit|miss` says which path served the request.

**UI — `public/index.html`**

- Hand-rolled perspective renderer on canvas 2D — no WebGL, no library (the dashboard is one static file; a 3D dependency would mean a build step). Stars composite additively, which is order-independent, so the draw loop needs no per-frame depth sort; distance reads through size and fog.
- **Navigation:** drag orbits with release inertia, wheel zooms, shift-drag pans, click focuses a star and flies to it, double-click resets, idle auto-spin, plus `links` / `frame` / `reset` controls.
- **Querying, the way an agent recalls:** tag chips (AND across tags, counts recomputed against the live match set so dead-end combinations disappear), kind and repo chips, a tag search across the full tag list, and a text box that substring-filters as you type and escalates to real embedding recall on ⏎. Matches light up, everything else fades to background dust; the rail ranks by score, and the detail card links to a claim's nearest neighbours in the full 640-dim space.
- **Scroll fix:** the view is a fixed-height flex column, the rail scrolls inside itself with `overscroll-behavior: contain`, and the wheel handler is registered non-passive with `preventDefault`.

## Verification

- `bun run typecheck` and `bun test` green (1647 pass, 0 fail), two consecutive clean passes.
- New route tests cover the 3D contract, facets, and cache hit / miss / `?refresh=1`.
- Driven in a headless browser at 1600×950, 1280×720 and 1000×800: wheel over the canvas zooms with `document` and `.content` scrollTop staying at 0; wheel over the rail scrolls only the rail; page overflow is 0 at every size; tag/text/semantic filters, selection fly-to and the neighbour list all behave; no console errors; 60fps+ with 2617 stars and 9195 links.

## Docs

`docs/features/http-dashboard.md` and `docs/code_index/http-dashboard.md` updated with the galaxy behaviour, the projection pipeline, and the new endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7ggnvGhmhJhFhUBSXfizb