### PR TITLE
docs: memory + task-route proposals (3 design docs)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -61,6 +61,17 @@ The remaining indexes are listed by module in `docs/code_index/`.
 
 ## Historical and proposal documents
 
+Active proposals (designed, not implemented):
+
+- [Task routes](features/task-routes.md): a per-task path through a codebase —
+  entry point, order, and tooling dead ends — with write-time fingerprinting,
+  ripgrep-only verification, auto-repair, and usage-weighted decay.
+- [Pre-recall synthesis](features/pre-recall-synthesis.md): move the LLM call
+  after recall, add success telemetry, and signal turn start with a reaction.
+- [Claim dedup write guard](features/claim-dedup-write-guard.md): the 0.92
+  similarity gate lives in one caller; move it to the store write path, merge
+  instead of dropping, and backfill the existing near-duplicates.
+
 Feature files with an explicit `Historical`, `Proposal`, `Future`, or
 `Superseded` status are retained as design history. In particular, the older
 Codex runner plans, associative-memory designs, and pre-v3 memory plans are

--- a/docs/features/claim-dedup-write-guard.md
+++ b/docs/features/claim-dedup-write-guard.md
@@ -1,0 +1,222 @@
+# Claim dedup: move the guard into the write path
+
+> **Status: Proposal.** The defect is measured against the live corpus
+> (`data/memory.db`, 2621 embedded claims) and the current code; the fix is not
+> implemented. Measurements taken at commit `905621a`.
+
+## Problem
+
+Semantic dedup exists, is tested, and is bypassed by most of the writers.
+
+`consolidateSession` embeds each draft claim and drops it when it sits within
+`DEFAULT_DEDUP_THRESHOLD = 0.92` cosine of an existing claim or of another draft
+in the same batch (`src/memory/consolidation/consolidate.ts:24,149-150`). That
+works. But the check lives in *that caller*, not in the store, and there are four
+callers of `upsertClaim`:
+
+| Caller | Deduped? |
+|---|---|
+| `consolidation/consolidate.ts:168` | **yes** — 0.92 cosine gate |
+| `mcp/slack-server.ts:1854` (`memory_add`) | no |
+| `memory/cli.ts:65` (`add-lesson` / `add-fact`) | no |
+| `memory/cli.ts:222` (`add-claim`) | no |
+| `memory/migrate-v3.ts:209` (one-shot) | no — acceptable, historical |
+
+`memory_add` derives its id with `claimIdFromText(text)`, so re-adding *byte
+identical* text upserts in place. That is exact-match dedup, not semantic: a
+one-word edit produces a different id and a new row.
+
+### Measured effect
+
+Near-duplicate rate across the 2621 embedded claims (all pairs, cosine over the
+full 640-dim vectors):
+
+| Threshold | Claims with a twin |
+|---|---|
+| ≥ 0.95 | 0 (0.0%) |
+| ≥ 0.92 *(the gate)* | small |
+| ≥ 0.90 | 432 (16.5%) |
+| ≥ 0.85 | 769 (29.3%) |
+
+The closest surviving pair is **0.9425** — above the gate, so it cannot have
+arrived through consolidation. The two texts differ by one word:
+
+```
+A: `command <tool>` is the escape hatch when a wrapper alias/hook is silently rewriting your invocation
+B: `command <tool>` is the escape hatch when a wrapper alias/hook is rewriting your invocation
+```
+
+Corpus growth, for context: 2631 active claims in a **60-day-old** corpus, 765 of
+them added in the last 7 days (~109/day, accelerating). [Memory v3
+§6.2](memory-system-v3.md) assumes "dedup-on-write keeps it at *distinct-knowledge*
+size, so it plateaus in the low thousands." No plateau is visible yet.
+
+### Why this is a recall-quality bug before it is a storage bug
+
+With ~30% of claims carrying a near-twin at 0.85, a `limit: 5` recall returns
+fewer than five *distinct* ideas. Observed live while checking for duplicates
+before adding a lesson: six results came back, five of which were paraphrases of
+one "audit scope before documentation work" lesson. Four of six slots wasted.
+
+This is also why the fix is not a vector index. Scan latency is 12.2ms p50 at this
+corpus size, of which only ~3ms is cosine — well inside [§6.2's](memory-system-v3.md)
+rung-1 budget. A faster index would return the redundant results faster.
+
+### Why the gap is invisible
+
+`consolidation/consolidate.test.ts:269` — *"dedups near-identical claim drafts and
+claims near an existing stored claim"* — passes. A green test on the one guarded
+path is exactly what makes the three unguarded paths read as covered. Worth a
+comment on that test when the guard moves, so the next reader does not draw the
+same inference.
+
+## Shape of the fix
+
+### Guard at the chokepoint
+
+Move the similarity check to where every writer already funnels: the store's
+claim-write path. Two of the three ungated call sites embed the text immediately
+before calling `upsertClaim` (`slack-server.ts:1851`, `cli.ts:64`), so the vector
+the guard needs is already in hand.
+
+#### A vector must exist for the guard to run
+
+`cli.ts:222` (`add-claim`) is the exception: `--embedding` is optional and the
+call writes `embedding: embedding ? new Float32Array(embedding) : null`. A
+cosine guard has nothing to compare for those rows, and the store **cannot embed
+its way out** — memory v3 is explicit that the store never embeds, callers embed
+at the boundary (`recallMemory`'s contract, `slack-server.ts:1764-1767`).
+
+So the invariant has to be enforced at the type/CLI level, not inferred:
+
+- An ordinary claim insert **requires** a non-null `embedding`. `upsertClaim`
+  rejects an insert that has neither an embedding nor an explicit bypass, rather
+  than silently storing an unguardable, unrecallable row. (A claim with no
+  embedding is already invisible to cosine-only recall — the guard gap and the
+  recall gap are the same defect.)
+- `add-claim` without `--embedding` either embeds via the provider before
+  calling the store, or fails with a message naming `--skip-dedup`.
+
+#### Existing-id writes need patch semantics, not a free pass
+
+An earlier draft of this document said an existing id "must always write through,
+regardless of its neighbours". That is wrong twice over.
+
+**It erases value metadata.** `ON CONFLICT(id) DO UPDATE` sets
+`helpful_count = excluded.helpful_count`, `unhelpful_count = excluded.…`, and
+`weight = excluded.weight` (`sqlite.ts:183-185`), while those fields are optional
+on `ClaimInput` and default to `0`/`1.0` (`sqlite.ts:201`). Any caller that
+re-writes a claim by id without restating them — `add-lesson` and `memory_add`
+both do — **silently resets accumulated weight to 1.0 and both counters to zero**.
+That is a live defect today, independent of dedup, and it destroys exactly the
+value signal the merge path below is meant to accumulate. Fix it in the same
+change: update only the columns the caller actually supplied, using
+`COALESCE(excluded.col, claim.col)` semantics for the value fields.
+
+**It can still create a duplicate.** An update whose *text* changed materially is
+a new claim wearing an old id, and it can land inside the threshold of a
+different existing claim. Re-run the neighbour scan on any update where the text
+changed, excluding the row's own id from the candidate set.
+
+#### Bypass for restore paths
+
+`migrate-v3.ts` and any future backup restore must write historical rows
+verbatim: a `skipDedup?: boolean` on `ClaimInput`, set only by those callers, and
+the same flag waives the embedding requirement above.
+
+#### Scope and winner selection
+
+The candidate scan is not "the whole corpus". Merging across scopes changes what
+other sessions can recall, so compatibility is part of the invariant:
+
+- **Kind:** same `kind` only, matching the cut list below.
+- **Repo:** a claim merges only into a claim with the *same* `repo` value.
+  Never merge a repo-specific claim into a global (`repo IS NULL`) one — that
+  would leak a repo's convention into every other repo's recall — and never merge
+  a global claim down into a repo-specific one, which would narrow knowledge that
+  currently applies everywhere. Cross-scope near-duplicates are reported, not
+  merged.
+
+When several neighbours exceed the threshold, the winner is deterministic:
+highest `weight`, then oldest `created_at`, then lowest `id`. Ties resolved any
+other way make the outcome depend on row order, which makes the sweep
+non-reproducible.
+
+The scan and the merge run in **one transaction**, so a concurrent writer cannot
+insert a near-duplicate between the check and the write.
+
+### Merge, don't drop
+
+Consolidation currently *skips* a near-duplicate draft. Silently discarding it
+loses a real signal: the same claim being independently derived twice is evidence
+it matters. On a near-duplicate hit, bump the surviving claim instead —
+`helpful_count` and `weight`, and refresh `last_used_at`. That feeds the existing
+decay contract (`archiveStaleClaims` is "stale **and** low-value"), so repeated
+rediscovery makes a claim harder to fade rather than a no-op.
+
+The response should say which happened — `{ id, action: "inserted" | "merged",
+mergedInto? }` — so a caller (and the Stop hook) can tell the difference between
+"stored" and "already knew that".
+
+### Threshold
+
+432 claims sit in the `[0.90, 0.92)` band, immediately under the current gate.
+Lowering to 0.90 is the obvious move but should not be done blind: sample that
+band and judge whether the pairs are genuinely the same claim. The "audit scope"
+cluster suggests they are, but a threshold that merges distinct lessons is a
+worse failure than one that keeps a few twins — a merged-away claim is
+recoverable only from provenance.
+
+Make it configurable (`MEMORY_DEDUP_THRESHOLD`, default unchanged at 0.92 until
+the band is sampled) so the change is a config move, not a code move.
+
+### Cost
+
+The guard costs one corpus scan per write: ~12ms at today's size, the same
+measurement as recall. Writes are rare and off the turn's critical path, so this
+is the cheap side of the pipeline to spend on — the same reasoning that puts
+route fingerprinting at write time in [task routes](task-routes.md).
+
+## Backfill
+
+The 432 existing near-duplicates need an offline sweep, not a hot-path fix:
+
+- Cluster claims at the chosen threshold, keep the highest-`weight` member as
+  representative, sum `helpful_count` into it.
+- **Archive, never delete** (`active = 0`), matching the claim decay contract —
+  the collapsed rows stay as provenance.
+- Ship it as a workflow under `workflows/` alongside the existing memory
+  consolidation job, dry-run by default like `migrate-v3.ts`.
+
+## Verification
+
+Re-run the all-pairs histogram after the guard and the sweep. Success is: **no
+pair above the threshold among `active = 1` claims that share a dedup scope**
+(same `kind`, same `repo`), and the `[threshold-0.02, threshold)` band shrinking
+rather than growing week over week.
+
+The scoping matters — the criterion cannot be "no pair anywhere in the corpus",
+because the sweep archives duplicates rather than deleting them, so their rows
+(and their vectors) stay in the table by design. A global measurement would fail
+permanently against its own success condition.
+
+Add the near-duplicate rate to `memoryHealth()` so it is a standing metric
+instead of a one-off measurement — without it, the next regression is as
+invisible as this one was.
+
+## Dependencies
+
+- [Memory v3](memory-system-v3.md) — the claim store, `upsertClaim`, the decay
+  contract this reuses, and §6.2's scan-vs-index ladder.
+- [Dynamic workflows](dynamic-workflows.md) — where the backfill sweep runs.
+- [MCP server](mcp-server.md) — `memory_add`, one of the ungated writers.
+
+## Cut list (true v2)
+
+- A vector index. Measured unnecessary at this corpus size, and orthogonal to
+  the redundancy problem.
+- LLM-judged duplicate detection. Cosine at a tuned threshold is cheap and
+  auditable; escalate only if sampling shows the threshold cannot separate
+  genuine twins from distinct claims.
+- Cross-kind dedup (a `lesson` merging into a `fact`). Same-kind only until
+  there is evidence the corpus needs it.

--- a/docs/features/pre-recall-synthesis.md
+++ b/docs/features/pre-recall-synthesis.md
@@ -1,0 +1,189 @@
+# Pre-recall: synthesis placement, telemetry, and the turn-start signal
+
+> **Status: Proposal.** The defects described are real and verified against the
+> current code and logs; the fixes are not implemented. `src/memory/pre-recall.ts`
+> is unchanged as of commit 0a24cdf.
+
+## Problem
+
+Pre-recall exists to keep useless spam out of the working agent's context and to
+merge several recalled claims into something usable. It currently does neither,
+and it costs 15 seconds of dead air per turn when it fails.
+
+Three separate defects, each small and independently fixable.
+
+### 1. The LLM is on the wrong end of the pipeline
+
+`createPreRecall` (`src/memory/pre-recall.ts:72`) spends its one LLM call on
+**query extraction** from the inbound Slack message, then recalls top-3 per query,
+dedupes by claim id, and emits `- ${claim.text}` lines verbatim into a
+`<pre-recall>` block (lines 112-140). That is a dedupe-and-list. There is no merge
+and no summarization anywhere in the file — `extractRecallQueries` is the only
+model call.
+
+So the budget is spent on the unbounded half. An arbitrary Slack message has no
+ceiling on complexity, which is why a 15s timeout is unsizeable; and on expiry the
+function returns `null`, so the turn gets **zero** memory. Synthesis is the bounded
+half: N retrieved claims of known size, a predictable prompt, and a meaningful
+partial result to fall back to.
+
+### 2. There is no denominator
+
+`pre-recall.ts` contains exactly one log call — a `_log.warn` inside the catch
+(line 144). Success is silent. The logs therefore show:
+
+```
+2026-07-24   28 timeouts
+2026-07-23   61
+2026-07-22   33
+                  186 total across all retained logs
+```
+
+with per-day totals identical to per-day `pre-recall` line counts, which *reads*
+as a 100% failure rate and is not evidence of one. Nobody can currently tell
+whether pre-recall is broken or merely degraded, and no threshold change is
+measurable. Fix the telemetry before tuning the number.
+
+### 3. The dead air is invisible
+
+The call site is a blocking `await` immediately before the runner spawns
+(`src/session/manager.ts:1932-1941`). A timeout is 15 seconds during which the
+thread shows nothing at all — indistinguishable from the bot ignoring the message.
+
+## Shape of the fix
+
+### Query derivation without a subprocess
+
+Drop `extractRecallQueries`. Embed the raw message directly with the existing
+provider — milliseconds, no subprocess, no timeout. Optional cheap keyword
+expansion (repo name, thread agent) stays non-LLM.
+
+This is the piece where the earlier "just embed the message" suggestion was
+wrong *as a whole answer*: it gets retrieval right and drops curation. Curation
+moves to the next stage, where it belongs.
+
+### Synthesis after recall
+
+One bounded LLM call over the retrieved claim set, producing the merged
+`<pre-recall>` block:
+
+| Outcome | Emitted |
+|---|---|
+| Synthesis returns | merged, deduplicated summary |
+| Synthesis times out | **top-K raw claims** (today's behaviour) |
+| Retrieval returns nothing | `null`, as today |
+
+Worst case becomes strictly better than the current worst case of nothing.
+
+**What this does and does not fix.** It does not remove blocking latency: the
+call is still a subprocess awaited before the runner spawns
+(`session/manager.ts:1932-1941`), still under `PRE_RECALL_TIMEOUT_MS`. What
+changes is that the budget now covers a *sizeable* input and there is something
+to emit when it expires. Latency relief comes from the turn-start signal below
+and from dropping the extraction subprocess, not from synthesis.
+
+**"Bounded" has to be enforced, not assumed.** Claim text has no length ceiling
+in the schema, so N claims is not a bounded prompt on its own. The synthesis
+stage needs explicit caps: max candidates (start at the recall limit), max
+characters per claim before truncation, and a total prompt-character ceiling
+that drops the lowest-scoring candidates when exceeded. Without those three, the
+"predictable timeout" argument does not hold.
+
+Config: reuse `PRE_RECALL_TIMEOUT_MS` for the synthesis call; its meaning changes
+from "extraction budget" to "synthesis budget" and it becomes affordable to raise,
+because a fallback now exists.
+
+### Usage must be recorded after synthesis, not at retrieval
+
+`recallMemory` calls `recallClaims` without passing `recordUsage`
+(`slack-server.ts:1804-1808`), so it takes the default `true` and bumps
+`last_used_at` on **every candidate at retrieval time** — before anything decides
+whether the claim was useful.
+
+That is wrong today and gets worse under this design, because synthesis exists
+precisely to discard most candidates. Filtered-out spam would be marked fresh on
+every turn it is retrieved, and `archiveStaleClaims` ("stale **and** low-value")
+would never fade it. The claims that most need to decay are the ones a filter
+keeps rejecting.
+
+So:
+
+- Candidate retrieval passes `recordUsage: false`.
+- Synthesis returns the ids of the claims that actually **contributed** to the
+  emitted block.
+- Only those ids get marked used, in one call after synthesis.
+- On the timeout fallback, mark the top-K that were actually emitted — nothing
+  else.
+
+This makes `last_used_at` mean "this claim reached an agent's prompt", which is
+what the decay contract assumes it means.
+
+### Telemetry
+
+Log the success path: queries derived, candidates recalled, claims after
+synthesis, elapsed ms, and whether the fallback fired. One `log.info` per
+pre-recall attempt makes both the rate and the value measurable. Ship this
+**first** — it is three lines and everything else is unverifiable without it.
+
+### Turn-start signal
+
+Users need to see that a turn is being processed. Two options were considered:
+
+- **A Slack message per turn** ("recalling…"). Rejected as the default: this is
+  exactly the thread noise the lead was tuned to avoid, and it fires on every
+  turn including fast ones.
+- **A reaction** (chosen). The established pattern in this codebase —
+  `this.onReaction?.(event, "eyes")` (`src/session/manager.ts:344`) via
+  `SlackResponder.addReaction` (`src/slack/responder.ts:354`). Add on turn start,
+  clear when the runner posts. Instant, zero new messages.
+
+**Removal plumbing does not exist yet.** `SlackResponder` wraps only
+`reactions.add` (`responder.ts:354-360`); there is no `removeReaction`. This
+proposal needs it, plus a clear-on-every-terminal-path rule, or the thread
+accumulates permanent "working" markers that are worse than no signal at all:
+
+| Terminal path | Reaction cleared |
+|---|---|
+| Runner posts a response | yes |
+| Runner spawn failure | yes |
+| Turn timeout / hard kill | yes |
+| Cancellation (`!stop`, driver interrupt) | yes |
+| Response suppressed (`NO_SLACK_MESSAGE`, silent lead turn) | yes |
+
+The suppressed-response case is the easy one to miss and the most common on lead
+turns, which default to silent. Clearing belongs in the same `finally` that
+already tears down the turn, not at each individual exit.
+
+Reversible if the reaction proves too subtle: gate a message on elapsed time so
+it only posts when pre-turn work exceeds ~3s and fast turns stay silent.
+
+Wire the signal at the **turn level, not inside pre-recall**. Once synthesis is
+placed correctly the pre-recall latency largely disappears, so the signal is
+really about slow turns generally; wiring it into the recall path would cover
+only one cause.
+
+## Dependencies
+
+- [Memory v3](memory-system-v3.md) — `recallClaims`, the embedding provider, and
+  the `recordUsage` contract (pre-recall is production recall and *should* record).
+- [Session management](session-management.md) — the call site and the turn
+  lifecycle the signal hangs off.
+- [Slack event handler](slack-event-handler.md) — reaction add/remove plumbing.
+
+## Configuration
+
+```
+PRE_RECALL_ENABLED=false        # unchanged; still opt-in
+PRE_RECALL_RUNNER=claude        # now used for synthesis, not extraction
+PRE_RECALL_MODEL=              # unchanged
+PRE_RECALL_TIMEOUT_MS=15000    # now the synthesis budget, with a real fallback
+```
+
+## Cut list (true v2)
+
+- Streaming the synthesized block into the prompt as it generates. The block is
+  small; a bounded call plus fallback is enough.
+- Per-agent synthesis prompts. One prompt until there is evidence roles need
+  different framings.
+- Caching synthesis by message similarity. Measure the hit rate first — with the
+  telemetry above, that becomes answerable.

--- a/docs/features/task-routes.md
+++ b/docs/features/task-routes.md
@@ -1,0 +1,414 @@
+# Task Routes
+
+> **Status: Proposal.** Nothing here is implemented. No `src/routes/` module,
+> `task_route` table, or `route_fetch` / `route_save` tool exists yet. Measurements
+> and file references are current as of commit 0a24cdf; the design is not an
+> implementation contract until it ships.
+
+## Problem
+
+Agents re-pay the cost of *locating* code on every task. Reasoning is not the
+expensive part; finding the entry point is.
+
+Concrete measurement, from the session that built the dashboard memory galaxy:
+before the first edit, the agent read five server files and grepped
+`public/index.html` four separate times to find the CSS block, the HTML section,
+the JS block, and the shared helpers — then burned three attempts discovering
+that the Chrome extension was unavailable and local Playwright needed an explicit
+`executablePath`. None of that is recoverable today. The next agent asked to add
+a filter to that same view starts from zero.
+
+**Who has this problem:** every dispatched agent, every pipeline stage, and the
+orchestrator deciding what to hand them.
+**What happens today:** ~10-15 tool calls of rediscovery per task, and tooling
+dead ends are re-hit verbatim.
+**"Finally" moment:** an agent asks "has anyone done this kind of task on this
+feature before?" and gets back five verified steps and one "don't bother trying
+X" instead of a blank page.
+
+## What a route is — and is not
+
+A route is an **ordered path through a codebase for one kind of task**, plus the
+dead ends worth skipping. It is deliberately narrow: a route answers "where do I
+start and in what order", not "what exists".
+
+| | Owns | Example |
+|---|---|---|
+| `docs/code_index/<module>.md` | Exhaustive symbol → file inventory | every handler in `src/http/routes/` |
+| Claims (memory v3) | Generalizable prose lessons, semantically recalled | "put the expensive step where input is bounded" |
+| **Task route** | **Entry point, order, and gotchas for one task-kind on one feature** | **"adding a filter to the dashboard memory view"** |
+
+Hard rule: **≤8 steps.** Longer than that and you have written a code index, so
+write a code index and have the route point at it. A route that restates the
+index is worse than no route, because two maps that disagree is worse than one
+stale map.
+
+Tooling dead ends get equal billing with file paths. "The Chrome extension is not
+connected; use `node_modules/.bin/playwright` with `executablePath` pointed at
+`~/Library/Caches/ms-playwright/chromium_headless_shell-*`" is pure rediscovery
+cost and belongs in the route.
+
+## Shape
+
+```
+src/routes/                     -- task routes (distinct from src/http/routes/)
+├── store/
+│   ├── interface.ts            -- TaskRouteStore
+│   ├── factory.ts              -- createTaskRouteStore(config)
+│   ├── sqlite.ts               -- SqliteTaskRouteStore (shares MEMORY_DB_PATH)
+│   └── memory.ts               -- in-memory (tests)
+├── anchors.ts                  -- fingerprint + verify (ripgrep only)
+├── freshness.ts                -- git-scoped staleness + auto-archive rules
+└── tools.ts                    -- route_fetch / route_save MCP handlers
+```
+
+### Why not a new claim kind
+
+The earlier proposal was a `task-route` claim kind. Reading the schema, that is
+wrong on two counts:
+
+1. A claim is **one atomic text** plus one embedding (`src/memory/types.ts`,
+   `ClaimInput`). A route is structured — ordered steps, each with anchors,
+   fingerprints, and usage counters. Forcing it into `claim.text` throws away
+   exactly the structure the verification pass needs.
+2. `claim.kind` carries a SQL `CHECK` constraint
+   (`src/memory/sqlite.ts:650`). SQLite cannot `ALTER` a CHECK, so a new kind
+   means a table rebuild — the codebase already carries one such migration
+   (`ensureMemoryNodeAllowsClaim`) and its comment explains the cost.
+
+New tables in the same DB need neither, and give up nothing in retrieval —
+routes are searched directly, by exact key first and by an embedding on the
+route's *task description* second. See [Retrieval](#retrieval--routes-are-searched-directly).
+
+### Schema
+
+```sql
+CREATE TABLE IF NOT EXISTS task_route (
+  id             TEXT PRIMARY KEY,
+  repo           TEXT NOT NULL,       -- 'junior', 'gx-backend', ...
+  feature        TEXT NOT NULL,       -- 'dashboard-memory-view'
+  task_kind      TEXT NOT NULL,       -- 'add-ui-surface' | 'add-endpoint' | 'debug-*'
+  task_desc      TEXT NOT NULL,       -- natural language, embedded for recall
+  embedding      BLOB, embed_model TEXT, dim INTEGER,
+  verified_sha   TEXT NOT NULL,       -- commit the anchors were resolved against
+  fetch_count    INTEGER DEFAULT 0,
+  repair_count   INTEGER DEFAULT 0,
+  created_at     INTEGER NOT NULL,
+  last_used_at   INTEGER,
+  active         INTEGER DEFAULT 1    -- archived, never deleted
+);
+
+CREATE TABLE IF NOT EXISTS task_route_step (
+  route_id       TEXT NOT NULL,
+  ord            INTEGER NOT NULL,
+  note           TEXT NOT NULL,       -- why this step, one sentence
+  path           TEXT,                -- NULL for pure tooling notes
+  symbol         TEXT,                -- function/const/section-marker
+  decl_pattern   TEXT,                -- regex that located the declaration
+  sig_hash       TEXT,                -- hash of the declaration line
+  block_hash     TEXT,                -- hash of the enclosing block
+  expects_ref    TEXT,                -- "this file should still reference X"
+  touch_count    INTEGER DEFAULT 0,   -- times a fetcher actually opened it
+  PRIMARY KEY (route_id, ord)
+);
+```
+
+```sql
+CREATE UNIQUE INDEX IF NOT EXISTS task_route_identity
+  ON task_route (repo, feature, task_kind);
+```
+
+That index is load-bearing, not decoration. "Unique by convention" is not an
+invariant — a concurrent or interrupted `route_save` would insert a second active
+route for the same identity and defeat the single-route guarantee outright. With
+the constraint in place, `route_save` is a real `INSERT … ON CONFLICT(repo,
+feature, task_kind) DO UPDATE` inside one transaction with its step rows, so a
+save is atomic or it did not happen.
+
+Five half-stale routes for the same task is worse than none, because the reader
+cannot tell which to trust — the same discipline the lessons hook gets from
+recall-before-add.
+
+Note the interaction with archival: archived routes (`active = 0`) still occupy
+the identity. Either scope the index to active rows (a partial index) or have
+`route_save` revive and overwrite the archived row rather than insert alongside
+it. The latter is simpler and keeps one row per identity forever.
+
+## Anchors: expensive at write, free at read
+
+The governing constraint is that **there is no warm language server to lean on**.
+An LSP owned by the operator's VS Code is unreachable from Junior's process, and
+dev servers are opt-in and unset for most pipeline runs — so any fast tier
+conditioned on "a server is warm" would silently never activate.
+
+Measured alternative (ripgrep 15.1.0, gx-backend, 5031 TS files):
+
+| Operation | Time |
+|---|---|
+| Resolve one symbol's declaration repo-wide | **15ms** |
+| Full declaration scan (17.5k decls, 1351 files) | 21ms |
+
+At that cost a symbol index is a net negative: `ctags`/`gtags` add a second
+source of staleness that must be rebuilt, to accelerate a lookup that was already
+free. GNU global's one unique capability is a global reference index, and routes
+do not need it — **a route names both ends of every edge it records**, so
+"does `server.ts` still reference `handleMemoryProjection`" is a single-file grep,
+not a repo-wide question. (Worth stealing from ctags without adopting it: it
+anchors on a search *pattern*, not a line number. `decl_pattern` is that idea.)
+
+So the split is:
+
+- **`route_save` (write, no latency pressure):** resolve each symbol, record
+  `decl_pattern`, `sig_hash`, `block_hash`, and stamp `verified_sha`.
+- **`route_fetch` (read, hot):** compare stored fingerprints against disk. No
+  index, no daemon, no warmth to check. Milliseconds.
+
+### Verification tiers
+
+Cheapest first; every tier is grep- or git-cost, so all of them always run.
+
+| Tier | Check | Yields |
+|---|---|---|
+| 0 | path exists; `git log <verified_sha>..HEAD -- <route paths>` | `untouched` — nothing changed, route is fresh regardless of age |
+| 1 | `symbol` present in `path`; `sig_hash` / `block_hash` match | `ok` / `drifted` |
+| 2 | `decl_pattern` search repo-wide when tier 1 fails | `moved:<newpath>` / `gone` |
+| 3 | `expects_ref` still present in the named file | `edge-broken` |
+
+Freshness is scoped to **the route's own paths**, never wall-clock. A route
+written a year ago to a module nobody has touched is perfectly good; one written
+last week to a file refactored twice since is garbage. Age is not the signal;
+change is.
+
+The response reports **which tier answered each step**. `verified: fingerprint`
+is stronger evidence than `verified: path-only`, and the reading agent needs that
+to calibrate. This annotation is the point: an unverified route produces
+confidently-wrong work with no error signal, which is the exact failure mode
+[CLAUDE.md](../../CLAUDE.md) principle 1 warns about. The annotation *is* the
+error signal.
+
+### Which git state — save and verify must agree
+
+An earlier draft had `route_save` stamp "the repo HEAD" and `route_fetch` verify
+against "the default worktree after a fetch". Those are two different trees, and
+the mismatch breaks the design in the common case.
+
+`route_save` fires at the end of a turn, from the Stop hook — which usually means
+**an unmerged feature worktree**. Anchors resolved there may not exist on the
+default branch at all, so the very first `route_fetch` would report them `gone`,
+or worse, auto-repair them against whichever tree it happened to read. A `git
+fetch` also does not advance a checked-out branch, so "after a fetch" does not
+make a stale working copy current.
+
+The resolution, in order of preference:
+
+1. **One canonical ref for both operations:** `origin/<default-branch>` — the
+   remote-tracking ref, which `git fetch` *does* advance, read with
+   `git show <ref>:<path>` / `git grep <ref>` rather than from the working tree.
+   This removes the working copy from the picture entirely, so a dirty checkout,
+   a feature branch, or a half-finished rebase cannot influence verification.
+2. **Save only what exists on that ref.** At `route_save`, resolve each anchor
+   against `origin/<default-branch>`, not the local worktree. Anchors that
+   resolve only in the unmerged branch are recorded as `pending`, and the route
+   is not activated until a later fetch finds them on the canonical ref.
+3. **Or defer the save.** The alternative is to run `route_save` post-merge, from
+   the merge/PR path rather than the Stop hook. Cleaner semantics, weaker
+   capture — the agent that knew which files mattered is long gone by then.
+
+Option 1 plus `pending` anchors is the recommendation: it keeps capture at the
+moment the knowledge exists, without letting unmerged state masquerade as
+verified. `verified_sha` then means "the canonical ref this was checked against",
+which is also what makes `git log <verified_sha>..<ref> -- <paths>` a meaningful
+freshness query.
+
+If the repo is not present on the box, or the canonical ref cannot be resolved,
+steps report `unknown` — never `ok`.
+
+## Tools
+
+Both go to the **working agent**. The recall agent gets neither: which files
+mattered is not inferrable from a transcript — a consolidator sees what was read
+but not which reads were dead ends, and only the agent that did the work knows
+the difference. Placing them here also keeps routes entirely outside the
+pre-recall budget (see [pre-recall synthesis](pre-recall-synthesis.md)).
+
+Neither tool calls an LLM. The intelligence is in the caller.
+
+### `route_fetch`
+
+```
+route_fetch(repo, task: string, feature?: string, task_kind?: string)
+  → { route_id, task_desc, verified_sha, drift: "untouched"|"N commits",
+      steps: [{ ord, note, path, symbol, status, resolved_path?, verified_by }],
+      confidence: { ok: n, drifted: n, moved: n, gone: n } }
+```
+
+Side effect: increments `fetch_count`, sets `last_used_at`, and auto-repairs (below).
+
+#### Retrieval — routes are searched directly
+
+The separate table costs nothing in search capability, because the `claim` table
+has no search machinery to borrow. `recallClaims`
+(`src/memory/sqlite.ts:255-277`) is a SQL `WHERE` for the scalar filters, then
+**cosine computed in TypeScript** over deserialized `embedding` BLOBs, sorted and
+sliced. There is no vector index and no SQLite vector extension anywhere in the
+schema. Any table carrying an `embedding BLOB` gets identical retrieval by
+reusing roughly twenty lines. This is a deliberate, documented choice, not an
+oversight — [memory v3 §6.2](memory-system-v3.md) lays out the scaling ladder and
+records why LanceDB and pgvector were rejected at this corpus size.
+
+Lookup is two-stage, most precise first:
+
+1. **Exact** — `(repo, feature, task_kind)` when the caller knows them. This is
+   the common case, because the orchestrator dispatching the task already knows
+   all three.
+2. **Semantic** — cosine over `task_desc` embeddings, filtered to `repo`, and to
+   `feature` when given.
+
+Scale makes the performance question moot: the corpus is one route per
+`(repo, feature, task_kind)` — dozens to low hundreds — against the 2617 claims
+already scanned linearly on every recall today.
+
+#### Why not reach routes *through* a claim
+
+The alternative is a two-hop: recall a claim, have it point at a route, then read
+the route. Rejected on four counts:
+
+- **Wrong matcher.** Claim recall ranks prose by semantic similarity. Route
+  lookup is primarily an exact match on three known keys. A two-hop forces the
+  precise question through the fuzzy matcher and drops to the fallback path in
+  the case that should have been exact.
+- **A second staleness source.** The pointer-claim is one more artifact to write,
+  keep in sync, and re-verify. Routes already have a decay story; the pointer
+  would need its own.
+- **It reintroduces the budget.** Claims are reached via pre-recall, which is
+  exactly the hot path with a hard timeout that routes were placed outside of.
+- **It is the spam.** A claim whose only content is "there is a route for this"
+  is precisely the useless prose that pre-recall exists to filter out.
+
+The legitimate concern buried in the two-hop idea is *discovery* — an agent that
+doesn't know a route exists never calls `route_fetch`. That is an adoption
+problem, solved by making the fetch a standing step 0 in the agent definitions
+(see below), not by chaining retrieval through a second store.
+
+### `route_save`
+
+```
+route_save(repo, feature, task_kind, task_desc,
+           steps: [{ note, path?, symbol?, expects_ref? }])
+  → { route_id, resolved: n, unresolved: [...] }
+```
+
+Resolves and fingerprints every step against `origin/<default-branch>` (see
+[which git state](#which-git-state--save-and-verify-must-agree)), stamps
+`verified_sha` with that ref's commit, and upserts on the unique
+`(repo, feature, task_kind)` identity inside one transaction with its step rows.
+Rejects >8 steps — that cap is the feature, not a limitation.
+
+### `route_report_usage`
+
+```
+route_report_usage(route_id, used_ords: number[])
+  → { ok: true }
+```
+
+Explicit, because **Junior cannot observe an agent's file reads**. `route_fetch`
+returns suggestions and never learns what happened next; nothing in the runner
+boundary reports which paths a subagent opened. Without this call the
+`touch_count` column has no writer and usage-weighted pruning is a fiction.
+
+The caller is the agent that fetched the route, reporting at the end of its task
+which steps it actually used. That is one more thing an agent must remember to
+do, so the honest fallback if adoption is poor: **drop touch-based
+promotion/pruning from v1** and keep only the repair/archive signals, which are
+observable without cooperation. Better a smaller mechanism that works than a
+counter that stays zero and quietly prunes nothing.
+
+## Self-healing and decay
+
+**Auto-repair.** When tier 2 resolves a moved symbol, `route_fetch` rewrites
+`path`, re-fingerprints, bumps `verified_sha`, and increments `repair_count` — no
+agent involvement. Ordinary refactors are the single biggest cause of map decay,
+and this makes routes survive them for free. A route then only dies when the
+*concept* disappears, not when the code moves.
+
+**Usage-weighted pruning** *(gated on adoption)*. Steps never reported used
+across N fetches are noise and get dropped; steps consistently reported get
+promoted, so the route self-prunes toward the minimum useful set instead of
+growing into the inventory this design exists to avoid. This depends entirely on
+agents calling [`route_report_usage`](#route_report_usage) — the signal is
+*reported*, never inferred, because Junior cannot see an agent's filesystem
+reads. Ship the pruning rule only once the reports are actually arriving;
+until then `touch_count` stays informational and nothing is pruned on it.
+
+**Archival, never deletion** — matching the claim decay contract
+(`archiveStaleClaims`: archive, keep provenance). A route flips `active = 0` when
+a majority of steps are `gone`/`edge-broken` **and** no repair has landed across N
+fetches. That is the graceful end: it fades because it stopped being both useful
+and true, not because it got old.
+
+Do **not** collapse this to a single staleness scalar. A route 90% fresh whose
+*entry point* moved is worse than one 60% fresh with a valid entry point. Report
+per-step status; if an aggregate is shown, weight it by `touch_count`.
+
+## Adoption
+
+A tool an agent must remember to call gets called never. Two wiring changes:
+
+- `route_fetch` becomes a standing step 0 in the orchestrator and builder agent
+  definitions for any task touching a known feature area.
+- `route_save` gets a Stop-hook nudge alongside the lessons hook, with a
+  comparable bar: only when the task crossed ≥2 modules or hit a tooling dead end.
+  Most turns still write nothing.
+
+## Worked example
+
+What this session would have saved, as a route:
+
+```
+repo=junior feature=dashboard-memory-view task_kind=add-ui-surface
+1. public/index.html is one ~1700-line static file — CSS block, HTML sections and
+   all JS in one <script>. Grep its section-marker comments; never read it whole.
+2. Shared helpers at the top of the script: $, esc, safeFetch, ago, show().
+   Reuse — do not redefine.
+3. Server flow: route table in src/http/server.ts → handler in
+   src/http/routes/<name>.ts → pure compute in src/http/projection.ts.
+4. A new UI field means extending BOTH ClaimVectorExport (src/memory/types.ts)
+   and exportClaimVectors (src/memory/sqlite.ts).
+5. DEAD END: the Chrome extension is not connected. Verify with local Playwright,
+   executablePath ~/Library/Caches/ms-playwright/chromium_headless_shell-*.
+6. Page globals are script-scoped, not on window — drive them from Playwright
+   with string-form page.evaluate("GAL.points.length").
+```
+
+Six lines against roughly a dozen tool calls and three failed attempts.
+
+## Dependencies
+
+- [Memory v3](memory-system-v3.md) — the SQLite DB (`MEMORY_DB_PATH`), the
+  embedding provider reused for `task_desc`, and the archive-never-delete decay
+  contract this mirrors.
+- [MCP server](mcp-server.md) — where `route_fetch` / `route_save` are registered.
+- [Agent definitions](agent-definitions.md) — the standing step-0 wiring.
+- [Worktree manager](worktree-manager.md) — resolving a repo's default worktree
+  for verification.
+
+## Open questions
+
+- **Cross-repo routes.** A bug-pipeline task spans gx-backend and gx-client-next.
+  One route with a `repo` per step, or two linked routes? Leaning per-step repo.
+- **Who owns `task_kind`?** A free-text field drifts into synonyms
+  (`add-ui` / `add-ui-surface` / `new-ui`). Probably a small closed vocabulary
+  validated at write, extended deliberately.
+- **Bootstrapping.** Routes are worthless until some exist. Backfilling from
+  existing `docs/code_index/*` is tempting but produces exactly the inventory-
+  shaped routes this design rejects. Prefer earning them from real tasks.
+
+## Cut list (true v2)
+
+- LSP / ctags / gtags integration. Measured unnecessary; revisit only if a
+  concrete check appears that ripgrep provably cannot answer.
+- A global reference index. Routes name both endpoints.
+- Any long-lived per-repo indexing process.
+- Route editing UI. Auto-repair plus `route_save` overwrite is the edit path.
+- Cross-agent route sharing/merging. One route per `(repo, feature, task_kind)`,
+  last writer wins.


### PR DESCRIPTION
Design docs only — no runtime change. Each carries a **Status: Proposal** banner and all three are indexed in `docs/README.md`.

### `task-routes.md`
A per-task path through a codebase — entry point, order, and tooling dead ends — as a new memory type distinct from claims and code indexes. Write-time ripgrep fingerprinting, process-free read-time verification, auto-repair on refactors, usage-weighted decay.

Records the rejected alternatives with measurements: a warm language server is unreachable from a server process (the operator's editor owns it, dev servers are opt-in and usually unset), and a symbol index is a net negative when ripgrep resolves a declaration across 5031 TS files in 15ms.

### `pre-recall-synthesis.md`
Pre-recall spends its 15s budget on query *extraction* from an arbitrary Slack message — the unbounded half of the pipeline — and returns `null` on timeout, so the turn gets zero memory. 186 timeouts in the retained logs. Moves the LLM after recall over a bounded claim set with a top-K fallback, adds the missing success telemetry (today only the catch block logs, so there is no denominator), and signals turn start with a reaction rather than a message.

### `claim-dedup-write-guard.md`
The 0.92 similarity gate lives in one of four `upsertClaim` callers, so `memory_add` and the CLI write through unchecked. Measured: 16.5% of the 2621-claim corpus has a near-duplicate at cosine ≥ 0.90, and the closest surviving pair (0.9425) differs by one word. Also documents a live defect — `ON CONFLICT` resets `weight`/`helpful_count`/`unhelpful_count` from `excluded`, so re-saving a claim by id silently zeroes its accumulated value.

---

Implementation branches fork from this once merged, one per doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7ggnvGhmhJhFhUBSXfizb