### PR TITLE
fix: preserve Codex prompts and scope pipeline context

### DIFF
--- a/.claude/agents/build.md
+++ b/.claude/agents/build.md
@@ -1,7 +1,7 @@
 ---
 name: build
 description: Backend engineer. Use for building features, fixing bugs, refactoring code.
-tools: Read, Edit, Write, Bash, Grep, Glob, Agent, mcp__slack-bot__memory_recall
+tools: Read, Edit, Write, Bash, Grep, Glob, mcp__slack-bot__memory_recall
 permissions.intent: normal
 common: core,building-philosophy,pipeline-outcome
 context.threadHistory: true
@@ -18,7 +18,13 @@ You're the hands-on engineer. You take specs and turn them into working code. Pr
 
 Interrogate the spec before touching code. If the prompt doesn't answer "which files does this touch," say what's missing and ask -- don't guess and start editing. A raw note dump is not a green light to build.
 
-Recall memory before starting (task query + repo `entity_refs` like `gx-backend:repo`) and again on an unfamiliar entity or a surprise — per the core memory contract.
+Use the assignment's recalled context at intake; do not repeat the orchestrator's initial recall. Recall again only for an unfamiliar entity or a surprise that the assignment does not cover.
+
+Start from the assignment's file/symbol anchors. Do not repeat repository-wide
+discovery already performed by the orchestrator. Read the named ranges and
+their direct references first; broaden only when types, callers, tests, or
+runtime evidence show that another file is involved. Approximate line numbers
+are navigation hints, not authority over the current file contents.
 
 **Authority (one gate, not two).** A direct user or assignment ask to `build` / `fix` / `implement` a scoped change authorizes ordinary workspace work — do not invent a second go-word gate. Escalate or re-confirm only when: mock/design sign-off is being treated as build approval, the ask expands past the stated scope, product intent is still ambiguous, or the action is destructive/external/production/credential-bearing. A correction to your plan is not blanket permission to keep expanding.
 
@@ -27,6 +33,8 @@ Recall memory before starting (task query + repo `entity_refs` like `gx-backend:
 - **You own:** edits in the authorized worktree, focused verification, and explicit-path **checkpoint commits** when the assignment authorizes mutation.
 - **Orchestrator owns:** aggregate verification across agents/repos, push/PR create-or-update, phase transitions, and human gates.
 - **Review owns:** read-only findings and a typed verdict — never product-code edits.
+- **Junior owns fan-out:** do not spawn provider-native subagents. Report a
+  scope gap or hand control back through the durable run contract.
 - Do not open or merge PRs unless the assignment or human explicitly asks you to; prefer leaving PR coordination to the orchestrator.
 
 ## Build workflow

--- a/.claude/agents/common/orchestrator-dispatch.md
+++ b/.claude/agents/common/orchestrator-dispatch.md
@@ -6,6 +6,31 @@ Use dispatch to reduce context load and wall-clock time. Do not carry independen
 
 You orchestrate; you don't write the code. Route builds to opus/sonnet subagents or the appropriate persistent worker. Exception: a genuinely single-line/string/config tweak - do that yourself, dispatching it is friction, not delegation.
 
+## Discovery budget and worker handoff
+
+For non-trivial implementation, perform a shallow scoping pass rather than a
+second implementation investigation. Locate the relevant repository, feature
+docs, files, symbols, direct references, and verification commands. Prefer
+code intelligence or narrow searches; do not read whole implementation files
+only to ask the worker to read them again.
+
+Every build/frontend assignment must include:
+
+- objective and acceptance criteria;
+- file paths plus symbols and approximate line ranges, with why each anchor
+  matters;
+- the observed commit SHA;
+- concise evidence already established;
+- authorized scope and explicit do-not-touch boundaries;
+- verification commands or checks.
+
+For a tiny change, name the exact file and intended edit. For a medium feature,
+provide anchors and let the worker choose the implementation within the stated
+boundary. For a major change, provide architectural constraints and outcomes;
+the worker decides whether to edit or create files and must report material
+scope deviations. If you already performed deep diagnosis, pass the findings
+as an evidence capsule so the worker does not repeat discovery.
+
 ## Dispatch decision
 
 Before deep exploration, split the work:

--- a/.claude/agents/common/runtime-environment.md
+++ b/.claude/agents/common/runtime-environment.md
@@ -33,7 +33,10 @@ The active dev config and any production-like fallback paths (e.g. `/etc/hosts` 
 
 ## Available MCP tools
 
-Pre-loaded — do NOT `ToolSearch` for them:
+These tools may be eager or deferred depending on the active provider. Use a
+named tool directly when it is visible. If a required named MCP tool is not in
+the current tool list, use provider-native tool search once to load it; do not
+search again for tools already visible.
 
 - **Slack bot** (HTTP MCP, runs in junior's process): `slack_send_message`, `slack_send_dm`, `slack_read_thread`, `slack_read_channel`, `slack_search`, `slack_search_users`, `slack_upload_file`, `pipeline_get_state`, `pipeline_report_outcome`, `pipeline_start_run`, `agent_dispatch`. Primary write paths for posting to Slack remain `slack_send_message` / `slack_send_dm`; they are audit communication, not execution transport. `agent_dispatch(mode="delegate"|"handoff")` creates the durable assignment transition. Pass `username` + `icon_emoji` per `AGENT_IDENTITIES` so attribution is correct.
 - **MongoDB (read-only)**: `mcp__mongodb__find`, `mcp__mongodb__aggregate`, `mcp__mongodb__count`, `mcp__mongodb__collection-schema`, `mcp__mongodb__list-collections`, `mcp__mongodb__list-databases`. All database reads must use these MCP tools. NEVER inspect `.env` files for database credentials, run `mongosh`/`mongo`, connect through an application driver or scratch script, or use a raw MongoDB URI—even for a read. If MCP cannot perform the query, stop and report the limitation; do not bypass it. NEVER mutate.

--- a/.claude/agents/frontend.md
+++ b/.claude/agents/frontend.md
@@ -1,7 +1,7 @@
 ---
 name: frontend
 description: Frontend engineer. Use for UI work, component building, styling, frontend features.
-tools: Read, Edit, Write, Bash, Grep, Glob, Agent, mcp__slack-bot__memory_recall
+tools: Read, Edit, Write, Bash, Grep, Glob, mcp__slack-bot__memory_recall
 permissions.intent: normal
 common: core,building-philosophy,pipeline-outcome
 context.threadHistory: true
@@ -16,7 +16,12 @@ You build interfaces that feel right. Pixel-perfect when it matters, pragmatic w
 
 ## Before you build
 
-Interrogate the spec: if the prompt doesn't answer "which files does this touch," say what's missing before editing. Recall memory at task start (task query + repo `entity_refs`) and on an unfamiliar component or a surprise — per the core memory contract.
+Interrogate the spec: if the prompt doesn't answer "which files does this touch," say what's missing before editing. Use the assignment's recalled context at intake instead of repeating the orchestrator's initial recall; recall again only for an unfamiliar component or a surprise that the assignment does not cover.
+
+Start from the assignment's file/component anchors. Do not repeat
+repository-wide discovery already performed by the orchestrator. Read the
+named ranges and their direct references first; broaden only when types,
+callers, rendered behavior, tests, or runtime evidence require it.
 
 **Mock means mock.** A "mock"/"mockup" ask is a standalone local HTML artifact for sign-off -- never a live-component edit. Don't push mockups; keep mock copy current with the real product, not a stale paradigm. Mock approval is not build approval.
 
@@ -27,6 +32,8 @@ Interrogate the spec: if the prompt doesn't answer "which files does this touch,
 - **You own:** UI edits in the authorized worktree, focused verification, screenshots when visual, and explicit-path **checkpoint commits** when authorized.
 - **Orchestrator owns:** aggregate verification, push/PR create-or-update, phase transitions, and human gates.
 - **Review owns:** read-only findings and a typed verdict — never product-code edits.
+- **Junior owns fan-out:** do not spawn provider-native subagents. Report a
+  scope gap or hand control back through the durable run contract.
 - Do not open or merge PRs unless the assignment or human explicitly asks you to.
 
 ## Frontend workflow

--- a/docs/code_index/agent-catalog.md
+++ b/docs/code_index/agent-catalog.md
@@ -27,6 +27,10 @@ policy, and verification metadata.
 - `pm`, `architect`, `build`, and `frontend`: catalog roles for planning and
   implementation handoffs. They are not interchangeable persistent Slack
   identities.
+- Junior owns provider-native implementation fan-out. `build` and `frontend`
+  do not receive the `Agent` tool; their assignment starts from Junior's
+  file/symbol/SHA evidence capsule and returns scope gaps through the durable
+  run contract.
 - Private overlay roles are dispatchable only after their identity metadata is
   loaded from `agents-org`.
 

--- a/docs/code_index/agent-catalog.md
+++ b/docs/code_index/agent-catalog.md
@@ -33,7 +33,7 @@ policy, and verification metadata.
   run contract.
 - Runtime policy enforces this across providers: Claude disallows `Agent`,
   OpenCode denies `task` and registers no subagents, and generated Codex config
-  disables multi-agent tools.
+  disables the `multi_agent` feature.
 - Private overlay roles are dispatchable only after their identity metadata is
   loaded from `agents-org`.
 

--- a/docs/code_index/agent-catalog.md
+++ b/docs/code_index/agent-catalog.md
@@ -31,6 +31,9 @@ policy, and verification metadata.
   do not receive the `Agent` tool; their assignment starts from Junior's
   file/symbol/SHA evidence capsule and returns scope gaps through the durable
   run contract.
+- Runtime policy enforces this across providers: Claude disallows `Agent`,
+  OpenCode denies `task` and registers no subagents, and generated Codex config
+  disables multi-agent tools.
 - Private overlay roles are dispatchable only after their identity metadata is
   loaded from `agents-org`.
 

--- a/docs/code_index/codex-app-server.md
+++ b/docs/code_index/codex-app-server.md
@@ -29,6 +29,10 @@ tool/edit/persistence operating contract and is a provider-quality regression.
 The client completes the documented `initialize` → `initialized` handshake
 before starting or resuming a thread.
 
+Generated Codex config sets `[agents].enabled = false`; provider-native
+subagents would bypass Junior's durable assignment, context, and settlement
+contracts.
+
 Codex continuity is provider-native and optional. Durable session, workflow,
 pipeline, and artifact state remains authoritative when a process or provider
 connection is restarted.

--- a/docs/code_index/codex-app-server.md
+++ b/docs/code_index/codex-app-server.md
@@ -22,6 +22,13 @@ isolated-home, model, and timeout flags are listed in [`.env.example`](../../.en
 The provider receives the same scoped Junior MCP contract as other normal
 worktree-backed runs, subject to per-agent permissions.
 
+Fresh threads preserve Codex's native `baseInstructions`. Junior's provider
+baseline and composed active-agent prompt are additive
+`developerInstructions`; replacing the native base prompt strips Codex's
+tool/edit/persistence operating contract and is a provider-quality regression.
+The client completes the documented `initialize` → `initialized` handshake
+before starting or resuming a thread.
+
 Codex continuity is provider-native and optional. Durable session, workflow,
 pipeline, and artifact state remains authoritative when a process or provider
 connection is restarted.

--- a/docs/code_index/codex-app-server.md
+++ b/docs/code_index/codex-app-server.md
@@ -29,7 +29,7 @@ tool/edit/persistence operating contract and is a provider-quality regression.
 The client completes the documented `initialize` → `initialized` handshake
 before starting or resuming a thread.
 
-Generated Codex config sets `[agents].enabled = false`; provider-native
+Generated Codex config sets `[features].multi_agent = false`; provider-native
 subagents would bypass Junior's durable assignment, context, and settlement
 contracts.
 

--- a/docs/code_index/pre-recall.md
+++ b/docs/code_index/pre-recall.md
@@ -47,4 +47,8 @@ top cosine / top score / claims / fallback / ms.
 `SessionManager.runRunnerWithAgent` awaits `this.preRecall(rawMessage, { repo, agent })`
 immediately before the runner spawns (`src/session/manager.ts`). The turn-progress
 reaction that covers that wait is separate — see
-[session-management](session-management.md).
+[session-management](session-management.md). Compiled typed worker assignments
+skip automatic pre-recall because Junior's handoff carries the selected
+evidence. Junior/lead assignments recall only on their initial dispatch
+(`retryCount === 0`); bounded settlement continuations reuse the
+assignment/provider context.

--- a/docs/code_index/runner-providers.md
+++ b/docs/code_index/runner-providers.md
@@ -23,7 +23,7 @@ and MCP wiring.
 | `spawnOpenCode(...)` | `spawner.ts` | Runs `opencode run --format json`, generates `OPENCODE_CONFIG_CONTENT`, parses events. |
 | `buildOpenCodeArgs(...)` | `args.ts` | Builds fresh/resume CLI args using `--session`, `--dir`, `--agent build`, and attachments; keeps the prompt before `--file` flags so OpenCode does not parse prompt text as file paths. |
 | `buildOpenCodeConfig(...)` | `config.ts` | Generates model, permissions, primary `agent.build`, MCP entries, and subagent entries. |
-| `loadOpenCodeSupportSubagents()` | `support-agents.ts` | Exposes standalone stateless support prompts as generated OpenCode subagents. |
+| `loadOpenCodeSupportSubagents()` | `support-agents.ts` | Loads standalone support prompts for manual/non-Junior consumers; Slack runtime does not register them. |
 | `buildOpenCodeAgentPrompt(...)` | `prompt.ts` | Wraps Junior core + active-agent prompt in the OpenCode provider baseline. |
 | `resolveOpenCodeModel(...)` | `model.ts` | Resolves session/config model to a valid `provider/model` OpenCode ref; runner-specific aliases (`gpt-5.6-sol`, `opus`, ...) fall back to the config default or null (omit `--model`). |
 | `createOpenCodeStreamParser()` / `createOpenCodeEventMapper()` | `parser.ts` | Converts OpenCode JSON events into normalized runner events; captures native `{"type":"error"}` events on `mapper.error`. |
@@ -35,11 +35,8 @@ and MCP wiring.
 - Slack MCP is included for every normal OpenCode run, including the initial
   lead run from Junior root. It is omitted only for explicit `session.cwd`
   utility runs.
-- Generated subagents include only stateless support fetchers:
-  `nr-research`, `sentry-fetch`, `vercel-status`. They are omitted for utility
-  `session.cwd` runs and use a constrained read/search/MCP permission surface.
-- Persistent workers (`reproducer`, `review`) are not generated as
-  OpenCode Task subagents; they are Slack-dispatched persistent sessions.
+- Slack runtime denies OpenCode `task` and registers no provider-native
+  subagents. Junior creates every worker through its durable assignment graph.
 - `opencode-sdk` is the separate OpenCode server/SDK provider. It uses the
   native session abort/attach path and is tested independently from the CLI
   adapter.

--- a/docs/code_index/session-management.md
+++ b/docs/code_index/session-management.md
@@ -98,14 +98,22 @@ Handled in `handleCommand`: `build`, `frontend`, `architect` (set `agentType`, c
 ## Prompt Composition (in `runRunnerWithAgent`)
 
 1. For an active pipeline assignment, resolve every durable repo ref, provision all managed worktrees, and select the primary cwd from review/workstream affinity. Otherwise resolve `targetRepo` and create its worktree when set.
-2. Resolve agent definition + context profile (defaults to all-true)
+2. Resolve agent definition + context profile (defaults to all-true). Typed
+   worker assignments force `threadHistory:false` because their durable
+   assignment envelope is the compiled handoff; Junior/lead and direct worker
+   turns keep their declared history profile.
 3. First turn: `buildPromptPreamble(...)` injects enabled blocks
 4. Resumed turn: just `buildWorkspaceBlock` (cheap safety insurance) if workspace flag is on
 5. `resolveSlackMentions` rewrites `<@U…>` → `@Name (<@U…>)`
 6. Download image files → append paths
 7. `composeSystemPrompt` (common + agent body) + identity block + dispatch-allow block → `session.systemPrompt`
 8. Optional `<persistent-agent-state>` block when `context.agentState` is on
-9. `spawnRunner(runSession, prompt, ..., agentIdentity)` wrapped in `withTimeout`
+9. Optional pre-recall. Compiled typed worker assignments skip it because
+   Junior's handoff owns recall selection. Junior/lead assignments recall on
+   retry `0`; settlement continuations reuse that context.
+10. Emit content-free `prompt-context` telemetry (character count and block
+    presence), then `spawnRunner(runSession, prompt, ..., agentIdentity)`
+    wrapped in `withTimeout`.
 
 ## Concurrency Guards
 

--- a/src/agents/lint.test.ts
+++ b/src/agents/lint.test.ts
@@ -102,6 +102,22 @@ describe("prompt lint", () => {
     });
   });
 
+  describe("Junior owns worker fan-out", () => {
+    it.each(["build", "frontend"])(
+      "%s does not expose the provider-native Agent tool",
+      async (name) => {
+        const content = await Bun.file(
+          path.join(agentsDir, `${name}.md`),
+        ).text();
+        const tools = content.match(/^tools:\s*(.+)$/m)?.[1] ?? "";
+        expect(tools.split(",").map((tool) => tool.trim())).not.toContain(
+          "Agent",
+        );
+        expect(content).toContain("Junior owns fan-out");
+      },
+    );
+  });
+
   describe("all public agents have Done means section", () => {
     it.each(ALL_PUBLIC_AGENTS)("%s.md contains '## Done means'", async (name) => {
       const content = await readAgent(name);

--- a/src/agents/loader.test.ts
+++ b/src/agents/loader.test.ts
@@ -32,7 +32,7 @@ describe("loadAgentDefinition", () => {
       "Backend engineer. Use for building features, fixing bugs, refactoring code.",
     );
     expect(def!.tools).toBe(
-      "Read, Edit, Write, Bash, Grep, Glob, Agent, mcp__slack-bot__memory_recall",
+      "Read, Edit, Write, Bash, Grep, Glob, mcp__slack-bot__memory_recall",
     );
     expect(def!.model).toBeNull();
     expect(def!.common).toEqual([
@@ -50,7 +50,6 @@ describe("loadAgentDefinition", () => {
         "Bash",
         "Grep",
         "Glob",
-        "Agent",
         "mcp__slack-bot__memory_recall",
       ],
     });

--- a/src/claude/policy.test.ts
+++ b/src/claude/policy.test.ts
@@ -60,6 +60,7 @@ describe("mapClaudeRunPolicy", () => {
       "Write",
       "NotebookEdit",
       "Bash",
+      "Agent",
     ]);
     expect(policy.allowedTools).toEqual([]);
     expect(policy.addDirs).toEqual([]);
@@ -79,7 +80,7 @@ describe("mapClaudeRunPolicy", () => {
     // round-trip (default mode) --allowedTools skips the permission prompt,
     // which would bypass the human gate this intent exists for.
     expect(policy.allowedTools).toEqual(["Read"]);
-    expect(policy.disallowedTools).toEqual([]);
+    expect(policy.disallowedTools).toEqual(["Agent"]);
     expect(policy.addDirs).toEqual(["/repo"]);
   });
 
@@ -117,7 +118,23 @@ describe("mapClaudeRunPolicy", () => {
     expect(policy.disallowedTools).toContain("Bash(*DB_STRING*)");
     expect(policy.disallowedTools).toContain("Bash(*.env*)");
     expect(policy.disallowedTools).toContain("Read(**/.env)");
+    expect(policy.disallowedTools).toContain("Agent");
     expect(policy.addDirs).toEqual(["/repo"]);
+  });
+
+  test("denies provider-native fan-out for orchestrators too", () => {
+    const session = createSession("t", "c");
+    session.activeAgentName = "default";
+    session.agentPermissions = {
+      intent: "normal",
+      mcp: ["slack-bot"],
+      tools: ["Read", "Agent", "mcp__slack-bot__agent_dispatch"],
+    };
+
+    const policy = mapClaudeRunPolicy({ config, session, cwd: "/repo" });
+
+    expect(policy.permissionMode).toBe("bypassPermissions");
+    expect(policy.disallowedTools).toContain("Agent");
   });
 
   test("null/unset intent behaves like normal for non-restricted roles", () => {

--- a/src/claude/policy.ts
+++ b/src/claude/policy.ts
@@ -52,6 +52,12 @@ const READ_ONLY_DISALLOWED = [
 const NO_TOOLS_DISALLOWED = ["Edit", "Write", "NotebookEdit", "Bash"];
 
 /**
+ * Junior's durable assignment graph is the only fan-out mechanism. Provider
+ * subagents bypass assignment state, context compilation, and settlement.
+ */
+const PROVIDER_NATIVE_FANOUT_DISALLOWED = ["Agent"];
+
+/**
  * Database access is capability-scoped through the read-only MongoDB MCP.
  * Normal agents otherwise run Bash in bypassPermissions mode, so explicitly
  * block the credential-discovery and direct-client forms seen in production.
@@ -151,7 +157,10 @@ export function mapClaudeRunPolicy(options: {
             ...verificationTools,
           ]),
         ],
-        disallowedTools: [...READ_ONLY_DISALLOWED],
+        disallowedTools: [
+          ...READ_ONLY_DISALLOWED,
+          ...PROVIDER_NATIVE_FANOUT_DISALLOWED,
+        ],
         addDirs: hasRegisteredWorktreeCwd
           ? [...new Set([cwd, ...worktreeRoots])]
           : [],
@@ -167,7 +176,10 @@ export function mapClaudeRunPolicy(options: {
     return {
       permissionMode: capabilityTools.length > 0 ? "default" : "plan",
       allowedTools: [...new Set([...readOnlyDeclaredTools, ...capabilityTools])],
-      disallowedTools: [...READ_ONLY_DISALLOWED],
+      disallowedTools: [
+        ...READ_ONLY_DISALLOWED,
+        ...PROVIDER_NATIVE_FANOUT_DISALLOWED,
+      ],
       addDirs: [],
     };
   }
@@ -176,7 +188,10 @@ export function mapClaudeRunPolicy(options: {
     return {
       permissionMode: "plan",
       allowedTools: [],
-      disallowedTools: [...NO_TOOLS_DISALLOWED],
+      disallowedTools: [
+        ...NO_TOOLS_DISALLOWED,
+        ...PROVIDER_NATIVE_FANOUT_DISALLOWED,
+      ],
       addDirs: [],
     };
   }
@@ -202,7 +217,9 @@ export function mapClaudeRunPolicy(options: {
         ]),
       ],
       disallowedTools:
-        capabilityTools.length > 0 ? [...READ_ONLY_DISALLOWED] : [],
+        capabilityTools.length > 0
+          ? [...READ_ONLY_DISALLOWED, ...PROVIDER_NATIVE_FANOUT_DISALLOWED]
+          : [...PROVIDER_NATIVE_FANOUT_DISALLOWED],
       addDirs: [cwd],
     };
   }
@@ -212,7 +229,10 @@ export function mapClaudeRunPolicy(options: {
     return {
       permissionMode: config.permissionMode,
       allowedTools: declaredTools,
-      disallowedTools: [...DIRECT_DATABASE_ACCESS_DISALLOWED],
+      disallowedTools: [
+        ...DIRECT_DATABASE_ACCESS_DISALLOWED,
+        ...PROVIDER_NATIVE_FANOUT_DISALLOWED,
+      ],
       addDirs: [cwd],
     };
   }
@@ -224,7 +244,10 @@ export function mapClaudeRunPolicy(options: {
   return {
     permissionMode: "bypassPermissions",
     allowedTools: [],
-    disallowedTools: [...DIRECT_DATABASE_ACCESS_DISALLOWED],
+    disallowedTools: [
+      ...DIRECT_DATABASE_ACCESS_DISALLOWED,
+      ...PROVIDER_NATIVE_FANOUT_DISALLOWED,
+    ],
     addDirs: [cwd],
   };
 }

--- a/src/codex-app-server/config.test.ts
+++ b/src/codex-app-server/config.test.ts
@@ -109,7 +109,7 @@ describe("buildCodexConfigToml", () => {
     });
     expect(config).toContain('model_reasoning_effort = "medium"');
     expect(config).toContain('sandbox_mode = "danger-full-access"');
-    expect(config).toContain("[agents]\nenabled = false");
+    expect(config).toContain("[features]\nmulti_agent = false");
   });
 });
 

--- a/src/codex-app-server/config.test.ts
+++ b/src/codex-app-server/config.test.ts
@@ -109,6 +109,7 @@ describe("buildCodexConfigToml", () => {
     });
     expect(config).toContain('model_reasoning_effort = "medium"');
     expect(config).toContain('sandbox_mode = "danger-full-access"');
+    expect(config).toContain("[agents]\nenabled = false");
   });
 });
 

--- a/src/codex-app-server/config.ts
+++ b/src/codex-app-server/config.ts
@@ -102,8 +102,8 @@ export function buildCodexConfigToml(options: {
   lines.push(`approval_policy = ${tomlString(options.approvalPolicy)}`);
   lines.push(`sandbox_mode = ${tomlString(options.sandbox)}`);
   lines.push("");
-  lines.push("[agents]");
-  lines.push("enabled = false");
+  lines.push("[features]");
+  lines.push("multi_agent = false");
   lines.push("");
 
   for (const [name, server] of Object.entries(options.mcp ?? {})) {

--- a/src/codex-app-server/config.ts
+++ b/src/codex-app-server/config.ts
@@ -102,6 +102,9 @@ export function buildCodexConfigToml(options: {
   lines.push(`approval_policy = ${tomlString(options.approvalPolicy)}`);
   lines.push(`sandbox_mode = ${tomlString(options.sandbox)}`);
   lines.push("");
+  lines.push("[agents]");
+  lines.push("enabled = false");
+  lines.push("");
 
   for (const [name, server] of Object.entries(options.mcp ?? {})) {
     lines.push(`[mcp_servers.${tomlBareKey(name)}]`);

--- a/src/codex-app-server/spawner.test.ts
+++ b/src/codex-app-server/spawner.test.ts
@@ -74,6 +74,10 @@ describe("spawnCodexAppServer", () => {
         .map((line) => JSON.parse(line));
       const threadStart = requests.find((request) => request.method === "thread/start");
       const turnStart = requests.find((request) => request.method === "turn/start");
+      expect(threadStart.params).not.toHaveProperty("baseInstructions");
+      expect(threadStart.params.developerInstructions).toContain(
+        "You are Junior running inside Codex",
+      );
       expect(threadStart.params.sandbox).toBe("danger-full-access");
       expect(threadStart.params.sandboxPolicy).toEqual({ type: "dangerFullAccess" });
       expect(turnStart.params.sandboxPolicy).toEqual({ type: "dangerFullAccess" });
@@ -114,6 +118,7 @@ describe("spawnCodexAppServer", () => {
         .map((line) => JSON.parse(line));
       expect(requests.map((request) => request.method)).toEqual([
         "initialize",
+        "initialized",
         "thread/resume",
         "thread/start",
         "turn/start",

--- a/src/codex-app-server/spawner.ts
+++ b/src/codex-app-server/spawner.ts
@@ -298,7 +298,7 @@ function juniorBaselineInstructions(): string {
   return [
     "You are Junior running inside Codex as a Slack-controlled coding agent.",
     "Preserve Junior's Slack session semantics and respond with concise, useful final text.",
-    "Use provider-native subagents only when the task or active Junior agent prompt explicitly asks for delegation or parallel agent work.",
+    "Do not use provider-native subagents. Junior owns fan-out through its durable assignment graph.",
   ].join("\n");
 }
 

--- a/src/codex-app-server/spawner.ts
+++ b/src/codex-app-server/spawner.ts
@@ -110,6 +110,10 @@ export function spawnCodexAppServer(
     });
   };
 
+  const notify = (method: string, params: Record<string, unknown> = {}) => {
+    proc.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`);
+  };
+
   const respond = (id: number, result: Record<string, unknown>) => {
     proc.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`);
   };
@@ -165,6 +169,7 @@ export function spawnCodexAppServer(
           optOutNotificationMethods: [],
         },
       });
+      notify("initialized");
 
       if (session.sessionId) {
         try {
@@ -289,7 +294,7 @@ function codexCompatibleModel(model: string | null): string | null {
   return model;
 }
 
-function baseInstructions(): string {
+function juniorBaselineInstructions(): string {
   return [
     "You are Junior running inside Codex as a Slack-controlled coding agent.",
     "Preserve Junior's Slack session semantics and respond with concise, useful final text.",
@@ -298,7 +303,11 @@ function baseInstructions(): string {
 }
 
 function developerInstructions(session: ThreadSession): string {
-  return session.systemPrompt ?? "Follow the active Junior agent instructions for this Slack thread.";
+  return [
+    juniorBaselineInstructions(),
+    session.systemPrompt ??
+      "Follow the active Junior agent instructions for this Slack thread.",
+  ].join("\n\n");
 }
 
 function inputItems(prompt: string, imagePaths: string[]): Array<Record<string, unknown>> {
@@ -320,7 +329,9 @@ function threadStartParams(options: {
     approvalPolicy: options.policy.approvalPolicy,
     sandbox: options.policy.sandbox,
     sandboxPolicy: options.policy.sandboxPolicy,
-    baseInstructions: baseInstructions(),
+    // Omit baseInstructions so Codex retains its native coding-agent operating
+    // prompt. Junior is an additive developer layer, not a replacement for
+    // Codex's tool, persistence, safety, and editing contract.
     developerInstructions: developerInstructions(options.session),
     ephemeral: false,
     experimentalRawEvents: false,

--- a/src/opencode/config.test.ts
+++ b/src/opencode/config.test.ts
@@ -16,12 +16,12 @@ describe("OpenCode config generation", () => {
     ).toEqual({
       $schema: "https://opencode.ai/config.json",
       model: "openai/gpt-5.1",
-      permission: "allow",
+      permission: { "*": "allow", task: "deny" },
       agent: {
         build: {
           description: "Junior Slack runner",
           mode: "primary",
-          permission: { "*": "allow" },
+          permission: { "*": "allow", task: "deny" },
           prompt: "CUSTOM JUNIOR SYSTEM PROMPT",
         },
       },
@@ -75,7 +75,7 @@ describe("OpenCode config generation", () => {
     expect(config.agent["nr-research"]).toEqual({
       description: "New Relic research",
       mode: "subagent",
-      permission: { "*": "allow" },
+      permission: { "*": "allow", task: "deny" },
       prompt: "Research prompt",
     });
   });
@@ -128,8 +128,11 @@ describe("OpenCode config generation", () => {
       permission: "allow",
     });
 
-    expect(config.permission).toBe("allow");
-    expect(config.agent.build.permission).toEqual({ "*": "allow" });
+    expect(config.permission).toEqual({ "*": "allow", task: "deny" });
+    expect(config.agent.build.permission).toEqual({
+      "*": "allow",
+      task: "deny",
+    });
   });
 
   it("rejects blank agent names", () => {

--- a/src/opencode/config.ts
+++ b/src/opencode/config.ts
@@ -51,15 +51,18 @@ export function buildOpenCodeConfig(
   if (!primaryAgentName) {
     throw new Error("OpenCode agentName is required");
   }
+  const runtimePermission = denyProviderNativeFanout(
+    options.permission ?? "allow",
+  );
 
   const config: OpenCodeGeneratedConfig = {
     $schema: "https://opencode.ai/config.json",
-    permission: options.permission ?? "allow",
+    permission: runtimePermission,
     agent: {
       [primaryAgentName]: {
         description: options.description ?? "Junior Slack runner",
         mode: "primary",
-        permission: toAgentPermissionConfig(options.permission ?? "allow"),
+        permission: toAgentPermissionConfig(runtimePermission),
         prompt: options.agentPrompt,
       },
     },
@@ -81,7 +84,9 @@ export function buildOpenCodeConfig(
       description: subagent.description ?? `Junior support subagent: ${name}`,
       mode: "subagent",
       permission: toAgentPermissionConfig(
-        subagent.permission ?? options.permission ?? "allow",
+        denyProviderNativeFanout(
+          subagent.permission ?? options.permission ?? "allow",
+        ),
       ),
       prompt: subagent.prompt,
     };
@@ -111,4 +116,12 @@ function toAgentPermissionConfig(
     return { "*": permission };
   }
   return permission;
+}
+
+function denyProviderNativeFanout(
+  permission: OpenCodePermissionConfig,
+): OpenCodeAgentPermissionConfig {
+  return typeof permission === "string"
+    ? { "*": permission, task: "deny" }
+    : { ...permission, task: "deny" };
 }

--- a/src/opencode/sdk-provider.ts
+++ b/src/opencode/sdk-provider.ts
@@ -21,7 +21,6 @@ import { compileOpenCodePermission } from "../runners/policy.ts";
 import { OPENCODE_PROVIDER_AGENT, buildOpenCodeAgentPrompt } from "./prompt.ts";
 import { buildOpenCodeConfigContent } from "./config.ts";
 import { resolveOpenCodeModel } from "./model.ts";
-import { loadOpenCodeSupportSubagents } from "./support-agents.ts";
 import { log as _log } from "../logger.ts";
 
 // ---------------------------------------------------------------------------
@@ -153,7 +152,8 @@ export function spawnOpenCodeSdk(
       fallback: config.opencode.permission,
     }),
     mcp: session.cwd ? null : undefined,
-    subagents: session.cwd ? [] : loadOpenCodeSupportSubagents(),
+    // Junior's durable assignment graph owns fan-out.
+    subagents: [],
   });
 
   let sdkSessionId: string | null = null;

--- a/src/opencode/spawner.test.ts
+++ b/src/opencode/spawner.test.ts
@@ -183,7 +183,7 @@ describe("spawnOpenCode", () => {
     expect(parsed.agent["vercel-status"]).toBeUndefined();
   });
 
-  it("exposes stateless support agents to OpenCode Task", async () => {
+  it("does not register provider-native support subagents", async () => {
     const session = createSession("thread-1", "C01");
     session.provider = "opencode";
 
@@ -202,19 +202,11 @@ describe("spawnOpenCode", () => {
     await handle.result;
 
     const parsed = JSON.parse(configContent!);
-    expect(parsed.agent["nr-research"].mode).toBe("subagent");
-    expect(parsed.agent["nr-research"].permission).toEqual({
-      read: "allow",
-      glob: "allow",
-      grep: "allow",
-      edit: "deny",
-      write: "deny",
-      bash: "deny",
-      task: "deny",
-      "mcp__*": "allow",
-    });
-    expect(parsed.agent["sentry-fetch"].mode).toBe("subagent");
-    expect(parsed.agent["vercel-status"].mode).toBe("subagent");
+    expect(parsed.permission.task).toBe("deny");
+    expect(parsed.agent.build.permission.task).toBe("deny");
+    expect(parsed.agent["nr-research"]).toBeUndefined();
+    expect(parsed.agent["sentry-fetch"]).toBeUndefined();
+    expect(parsed.agent["vercel-status"]).toBeUndefined();
     expect(parsed.agent.reproducer).toBeUndefined();
   });
 

--- a/src/opencode/spawner.ts
+++ b/src/opencode/spawner.ts
@@ -7,7 +7,6 @@ import {
   buildOpenCodeConfigContent,
   type OpenCodeMcpConfig,
   type OpenCodePermissionConfig,
-  type OpenCodeSubagentConfig,
 } from "./config.ts";
 import {
   createOpenCodeEventMapper,
@@ -15,7 +14,6 @@ import {
   type OpenCodeEvent,
 } from "./parser.ts";
 import { buildOpenCodeAgentPrompt, OPENCODE_PROVIDER_AGENT } from "./prompt.ts";
-import { loadOpenCodeSupportSubagents } from "./support-agents.ts";
 import { signalProcessTree } from "../lifecycle/process-tree.ts";
 
 export interface OpenCodeEnvContext {
@@ -41,7 +39,6 @@ export interface OpenCodeSpawnerConfig {
   continuityEnabled?: boolean;
   permission?: OpenCodePermissionConfig;
   mcp?: OpenCodeMcpConfig | null;
-  subagents?: OpenCodeSubagentConfig[];
   env?: OpenCodeEnvExtension;
 }
 
@@ -79,9 +76,9 @@ export function spawnOpenCode(
     // Slack MCP even when cwd is Junior's project root so intake can call
     // register_worktree before any worktree exists.
     mcp: session.cwd ? null : config.mcp,
-    subagents: session.cwd
-      ? []
-      : (config.subagents ?? loadOpenCodeSupportSubagents()),
+    // Junior's durable assignment graph owns fan-out. Do not register
+    // provider-native subagents in Slack-controlled runtime config.
+    subagents: [],
   });
   const env = extendOpenCodeEnv(
     {

--- a/src/runners/policy.test.ts
+++ b/src/runners/policy.test.ts
@@ -174,7 +174,7 @@ describe("compileOpenCodePermission", () => {
     });
   });
 
-  it("uses fallback for normal builders", () => {
+  it("preserves the fallback but denies provider-native Task for normal builders", () => {
     expect(
       compileOpenCodePermission({
         subject: {
@@ -183,7 +183,19 @@ describe("compileOpenCodePermission", () => {
         },
         fallback: "allow",
       }),
-    ).toBe("allow");
+    ).toEqual({ "*": "allow", task: "deny" });
+  });
+
+  it("denies provider-native Task for orchestrators", () => {
+    expect(
+      compileOpenCodePermission({
+        subject: {
+          activeAgentName: "default",
+          agentPermissions: { intent: "normal", mcp: [], tools: [] },
+        },
+        fallback: { "*": "allow", edit: "ask" },
+      }),
+    ).toEqual({ "*": "allow", edit: "ask", task: "deny" });
   });
 
   it("hard-denies everything for no-tools", () => {
@@ -243,7 +255,7 @@ describe("provider permission compilation matrix", () => {
       expect(row.claudePermissionMode).toBe("bypassPermissions");
       // Uses configured codex sandbox (workspace-write default).
       expect(row.codexSandbox).toBe("workspace-write");
-      expect(row.openCode).toBe("allow");
+      expect(row.openCode).toEqual({ "*": "allow", task: "deny" });
     }
   });
 

--- a/src/runners/policy.ts
+++ b/src/runners/policy.ts
@@ -195,8 +195,12 @@ export function compileOpenCodePermission(options: {
     };
   }
 
-  // normal, utility, or unset — preserve operator-configured fallback.
-  return fallback;
+  // Normal, utility, or unset preserve the operator fallback except for
+  // provider-native fan-out. Junior's durable assignment graph owns all
+  // delegation so every OpenCode runtime denies Task.
+  return typeof fallback === "string"
+    ? { "*": fallback, task: "deny" }
+    : { ...fallback, task: "deny" };
 }
 
 /** Compile Claude run policy from session + config. */

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -3627,6 +3627,115 @@ describe("SessionManager", () => {
 });
 
 describe("typed pipeline settlement", () => {
+  it("uses compiled assignment context without worker Slack history or recall", async () => {
+    const sessionStore = new InMemorySessionStore();
+    const pipelineStore = new InMemoryPipelineStore(fakeClock(1_000));
+    await pipelineStore.createRun(makeProductRun({
+      phase: "building",
+      repoRefs: ["junior"],
+    }));
+    await pipelineStore.createAssignment(makeAssignmentCreate({
+      id: "asg-context-budget",
+      targetAgent: "build",
+      objective: "implement from scoped anchors",
+      idempotencyKey: "asg-context-budget-key",
+    }));
+    const handles: MockHandle[] = [];
+    const prompts: string[] = [];
+    const manager = new SessionManager(sessionStore, testConfig, (_session, prompt) => {
+      prompts.push(prompt);
+      const handle = createMockHandle();
+      handles.push(handle);
+      return handle;
+    });
+    manager.pipelineStore = pipelineStore;
+    attachExistingPipelineWorktree(manager);
+    let threadHistoryReads = 0;
+    manager.slackApp = {
+      client: {
+        users: {
+          info: async ({ user }: { user: string }) => ({
+            user: { profile: { display_name: user } },
+          }),
+        },
+        conversations: {
+          info: async () => ({ channel: { name: "test" } }),
+          replies: async () => {
+            threadHistoryReads++;
+            return {
+              messages: [
+                { ts: "1", user: "U-A", text: "stale discovery discussion" },
+              ],
+            };
+          },
+        },
+      },
+    } as unknown as App;
+    let recallCalls = 0;
+    (manager as unknown as {
+      preRecall: (
+        message: string,
+        context: { repo: string | null; agent: string },
+      ) => Promise<string | null>;
+    }).preRecall = async () => {
+      recallCalls++;
+      return "<pre-recall>scoped lesson</pre-recall>";
+    };
+
+    await manager.handleAgentMessage(makeEvent({
+      user: "pipeline-internal",
+      text: "<pipeline-assignment>scoped anchors</pipeline-assignment>",
+      dedupeKey: "pipeline-outbox:context-budget",
+      pipelineInvocation: {
+        runId: "run-1",
+        assignmentId: "asg-context-budget",
+        dispatchKey: "context-budget",
+        outcomeCountAtDispatch: 0,
+        retryCount: 0,
+      },
+    }), "build");
+    await waitFor(() => handles.length === 1);
+
+    expect(prompts[0]).toContain("<pipeline-assignment>");
+    expect(prompts[0]).not.toContain("<pre-recall>");
+    expect(prompts[0]).not.toContain("<thread-context>");
+    expect(threadHistoryReads).toBe(0);
+    expect(recallCalls).toBe(0);
+
+    handles[0]!._complete("", "context-budget-session", [], {
+      status: "incomplete",
+      reason: "max_turns",
+      retryable: true,
+    });
+    await waitFor(() => handles.length === 2);
+
+    expect(prompts[1]).not.toContain("<thread-context>");
+    expect(prompts[1]).not.toContain("<pre-recall>");
+    expect(threadHistoryReads).toBe(0);
+    expect(recallCalls).toBe(0);
+
+    const run = (await pipelineStore.getRun("run-1"))!;
+    await pipelineStore.recordOutcomeTransaction({
+      outcome: {
+        assignmentId: "asg-context-budget",
+        expectedRunVersion: run.stateVersion,
+        action: "complete",
+        status: "succeeded",
+        reason: "context budget verified",
+        evidenceRefs: [],
+        artifactRefs: [],
+        blockers: [],
+        checks: [],
+        progressFingerprint: "context-budget-verified",
+      },
+      toPhase: "aggregate-verification",
+      actorType: "system",
+      actorId: "test",
+      idempotencyKey: "context-budget-verified",
+    });
+    handles[1]!._complete("done", "context-budget-session");
+  });
+
   it("repairs an unavailable Claude session without consuming pipeline retries", async () => {
     const sessionStore = new InMemorySessionStore();
     const pipelineStore = new InMemoryPipelineStore(fakeClock(1_000));
@@ -3905,13 +4014,26 @@ describe("typed pipeline settlement", () => {
       return handle;
     });
     manager.pipelineStore = pipelineStore;
-    attachExistingPipelineWorktree(manager);
-    let releaseRecall!: () => void;
-    const recallGate = new Promise<void>((resolve) => { releaseRecall = resolve; });
-    let recallCalls = 0;
-    (manager as unknown as { preRecall: (message: string, context: { repo: string | null }) => Promise<string | null> }).preRecall = async () => {
-      recallCalls++;
-      if (recallCalls === 2) await recallGate;
+    const worktreePath = "/tmp/junior.junior-worktrees/slack-thread-1";
+    let releaseSetup!: () => void;
+    const setupGate = new Promise<void>((resolve) => { releaseSetup = resolve; });
+    let worktreeChecks = 0;
+    manager.worktreeManager = {
+      getWorktreePath: () => worktreePath,
+      worktreeExists: mock(async () => {
+        worktreeChecks++;
+        if (worktreeChecks === 2) await setupGate;
+        return true;
+      }),
+      createWorktree: mock(async () => worktreePath),
+      getBranchName: () => "slack/thread-1",
+    } as unknown as WorktreeManager;
+    (manager as unknown as {
+      preRecall: (
+        message: string,
+        context: { repo: string | null },
+      ) => Promise<string | null>;
+    }).preRecall = async () => {
       return null;
     };
 
@@ -3932,11 +4054,11 @@ describe("typed pipeline settlement", () => {
       reason: "max_turns",
       retryable: true,
     });
-    await waitFor(() => recallCalls === 2);
+    await waitFor(() => worktreeChecks === 2);
     await manager.handleMessage(
       makeEvent({ command: "reset", text: "build", ts: "reset-worker" }),
     );
-    releaseRecall();
+    releaseSetup();
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     expect((await sessionStore.get("thread-1"))?.agentSessions.build).toBeUndefined();
@@ -3962,13 +4084,26 @@ describe("typed pipeline settlement", () => {
       return handle;
     });
     manager.pipelineStore = pipelineStore;
-    attachExistingPipelineWorktree(manager);
-    let releaseRecall!: () => void;
-    const recallGate = new Promise<void>((resolve) => { releaseRecall = resolve; });
-    let recallCalls = 0;
-    (manager as unknown as { preRecall: (message: string, context: { repo: string | null }) => Promise<string | null> }).preRecall = async () => {
-      recallCalls++;
-      if (recallCalls === 2) await recallGate;
+    const worktreePath = "/tmp/junior.junior-worktrees/slack-thread-1";
+    let releaseSetup!: () => void;
+    const setupGate = new Promise<void>((resolve) => { releaseSetup = resolve; });
+    let worktreeChecks = 0;
+    manager.worktreeManager = {
+      getWorktreePath: () => worktreePath,
+      worktreeExists: mock(async () => {
+        worktreeChecks++;
+        if (worktreeChecks === 2) await setupGate;
+        return true;
+      }),
+      createWorktree: mock(async () => worktreePath),
+      getBranchName: () => "slack/thread-1",
+    } as unknown as WorktreeManager;
+    (manager as unknown as {
+      preRecall: (
+        message: string,
+        context: { repo: string | null },
+      ) => Promise<string | null>;
+    }).preRecall = async () => {
       return null;
     };
 
@@ -3989,11 +4124,11 @@ describe("typed pipeline settlement", () => {
       reason: "max_turns",
       retryable: true,
     });
-    await waitFor(() => recallCalls === 2);
+    await waitFor(() => worktreeChecks === 2);
     await manager.handleMessage(
       makeEvent({ command: "reset", text: "all", ts: "reset-lead" }),
     );
-    releaseRecall();
+    releaseSetup();
     await new Promise((resolve) => setTimeout(resolve, 10));
 
     expect(await sessionStore.get("thread-1")).toBeUndefined();

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -1788,8 +1788,18 @@ export class SessionManager {
         ? await this.agentRouter.resolveAgent(runSession)
         : null;
       assertRunOwnership();
-      const contextProfile: AgentContextProfile =
+      const declaredContextProfile: AgentContextProfile =
         agentDefinition?.context ?? DEFAULT_CONTEXT_PROFILE;
+      // A typed worker assignment already carries the durable objective,
+      // acceptance criteria, evidence/artifact refs, and exact causal handoff.
+      // Replaying the Slack conversation beside that contract duplicates
+      // Junior's dispatch context and makes workers reinterpret stale
+      // discussion. Junior/lead and direct worker turns keep their declared
+      // thread-history profile.
+      const usesCompiledWorkerContext = Boolean(pipelineInvocation && !isTopLevel);
+      const contextProfile: AgentContextProfile = usesCompiledWorkerContext
+        ? { ...declaredContextProfile, threadHistory: false }
+        : declaredContextProfile;
 
       // Apply agent-declared model override to the session so the spawner
       // picks it up (session.model ?? config.defaultModel).
@@ -1868,7 +1878,10 @@ export class SessionManager {
             cwd: invocationCwd,
           });
           const isFirstTurn = !resumes;
-          const needsThreadCatchup = !!session.needsThreadCatchup;
+          // Catch-up belongs to the next conversational Junior turn, not to a
+          // typed worker assignment whose prompt is already self-contained.
+          const needsThreadCatchup =
+            !!session.needsThreadCatchup && !usesCompiledWorkerContext;
           if (isFirstTurn || needsThreadCatchup) {
             const preambleProfile: AgentContextProfile = needsThreadCatchup
               ? {
@@ -1974,7 +1987,14 @@ export class SessionManager {
         }
       }
 
-      if (this.preRecall) {
+      let preRecallInjected = false;
+      // Centralize worker-assignment recall in Junior's compiled handoff.
+      // Direct/manual turns keep recall, while orchestrator settlement
+      // continuations reuse the same assignment and provider-native context.
+      const shouldPreRecall =
+        !usesCompiledWorkerContext &&
+        (!pipelineInvocation || pipelineInvocation.retryCount === 0);
+      if (this.preRecall && shouldPreRecall) {
         // Scope recall to the session's repo so another repo's conventions
         // can't inject into this session's prompt.
         const preRecallBlock = await this.preRecall(rawMessage, {
@@ -1984,11 +2004,16 @@ export class SessionManager {
         assertRunOwnership();
         if (preRecallBlock) {
           prompt = `${preRecallBlock}\n\n${prompt}`;
+          preRecallInjected = true;
         }
       }
 
-      // We don't log the prompt to avoid spamming the logs. unless we are debugging it
-      // log.info("prompt", `thread=${session.threadId} cwd=${targetRepoCwd ?? session.worktreePath ?? "junior"}\n--- PROMPT START ---\n${prompt}\n--- PROMPT END ---`);
+      // Log structure and size, never prompt contents. This makes provider and
+      // pipeline token regressions diagnosable without leaking Slack/code text.
+      _log.info(
+        "prompt-context",
+        `thread=${session.threadId} agent=${agentName} provider=${provider} chars=${prompt.length} pipeline=${Boolean(pipelineInvocation)} threadHistory=${prompt.includes("<thread-context>")} preRecall=${preRecallInjected} workspace=${prompt.includes("<workspace>")}`,
+      );
 
       let rawHandle: SpawnHandle;
       if (provider === "claude") {


### PR DESCRIPTION
## Summary
- Compile scoped worker context from Junior's pipeline handoff, centralizing recall and worker fan-out while avoiding duplicate Slack history and provider-native subagents.
- Preserve Codex's native base prompt by layering Junior instructions as developer instructions, and complete the documented `initialize` → `initialized` handshake.
- Add prompt-context telemetry and regression coverage for context budgeting, dispatch boundaries, and Codex startup behavior.

## Test plan
- [x] Run two consecutive clean TypeScript checks (`tsc`)
- [x] Run the full test suite (1810 passed, 4 skipped)
- [x] Run the production build