### PR TITLE
feat: add pipeline control plane and onboarding agent

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@playwright/mcp": "^0.0.70",
         "@slack/bolt": "^4.3.0",
         "@types/qrcode-terminal": "^0.12.2",
-        "baileys": "^7.0.0-rc13",
+        "baileys": "^7.0.0-rc14",
         "cron-parser": "^5.5.0",
         "proper-lockfile": "^4.1.2",
         "qrcode-terminal": "^0.12.0",
@@ -193,7 +193,7 @@
 
     "axios": ["axios@1.14.0", "", { "dependencies": { "follow-redirects": "^1.15.11", "form-data": "^4.0.5", "proxy-from-env": "^2.1.0" } }, "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ=="],
 
-    "baileys": ["baileys@7.0.0-rc13", "", { "dependencies": { "@cacheable/node-cache": "^1.4.0", "@hapi/boom": "^9.1.3", "async-mutex": "^0.5.0", "libsignal": "^6.0.0", "lru-cache": "^11.1.0", "music-metadata": "^11.12.3", "p-queue": "^9.0.0", "pino": "^9.6", "protobufjs": "^7.5.6", "whatsapp-rust-bridge": "0.5.4", "ws": "^8.13.0" }, "peerDependencies": { "audio-decode": "^2.1.3", "jimp": "^1.6.1", "link-preview-js": "^3.0.0", "sharp": "*" }, "optionalPeers": ["audio-decode", "jimp", "link-preview-js"] }, "sha512-v8k74K8B5R7WNYGa26MyJAYEu3Wc4BSuK01QaK8lr30lhE8Nga31nWNu8KN0NDDt+Fsvkq4SQFFI8Q13ghjKmA=="],
+    "baileys": ["baileys@7.0.0-rc14", "", { "dependencies": { "@cacheable/node-cache": "^1.4.0", "@hapi/boom": "^9.1.3", "async-mutex": "^0.5.0", "libsignal": "^6.0.0", "lru-cache": "^11.1.0", "music-metadata": "^11.12.3", "p-queue": "^9.0.0", "pino": "^9.6", "protobufjs": "^7.5.6", "whatsapp-rust-bridge": "0.5.4", "ws": "^8.13.0" }, "peerDependencies": { "audio-decode": "^2.1.3", "jimp": "^1.6.1", "link-preview-js": "^3.0.0", "sharp": "*" }, "optionalPeers": ["audio-decode", "jimp", "link-preview-js"] }, "sha512-pewtrljhWx5JTUBvvkXZz1fL3JPiwzjBsnhx/DWf2LWBx1cZNH7J/sF22xDehba5mySWUQU4a1Pwt7lWARUxaA=="],
 
     "body-parser": ["body-parser@2.2.2", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.3", "http-errors": "^2.0.0", "iconv-lite": "^0.7.0", "on-finished": "^2.4.1", "qs": "^6.14.1", "raw-body": "^3.0.1", "type-is": "^2.0.1" } }, "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA=="],
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@playwright/mcp": "^0.0.70",
     "@slack/bolt": "^4.3.0",
     "@types/qrcode-terminal": "^0.12.2",
-    "baileys": "^7.0.0-rc13",
+    "baileys": "^7.0.0-rc14",
     "cron-parser": "^5.5.0",
     "proper-lockfile": "^4.1.2",
     "qrcode-terminal": "^0.12.0",

--- a/public/index.html
+++ b/public/index.html
@@ -1574,6 +1574,7 @@ let idleTtlMs = null;
 let workflows = [];
 let workflowErrors = [];
 let pipelines = [];
+let openPipelineCount = 0;
 const pipelineDetails = new Map();
 const pipelineDetailErrors = new Set();
 let pipelineDetailLoadingId = null;
@@ -1779,8 +1780,11 @@ function renderSidebar() {
   setNavCount("nav-ds", running, "");
   const enabled = workflows.filter((w) => w.enabled).length;
   setNavCount("nav-wf", enabled, "");
-  const openPipelines = pipelines.filter((run) => run.status !== "terminal").length;
-  setNavCount("nav-pipelines", openPipelines, openPipelines > 0 ? "hot" : "");
+  setNavCount(
+    "nav-pipelines",
+    openPipelineCount,
+    openPipelineCount > 0 ? "hot" : "",
+  );
 
   // Static side-foot DOM — only update text nodes (live-toggle keeps one listener).
   $("sf-version").textContent = health ? String(health.version || "—") : "—";
@@ -4094,6 +4098,7 @@ function applyPipelineListResponse(response) {
   if (response.ok) {
     pipelineFetchError = null;
     const nextPipelines = response.data.pipelines || [];
+    openPipelineCount = Number(response.data.openCount) || 0;
     for (const run of nextPipelines) {
       const detail = pipelineDetails.get(run.id);
       if (detail && detail.updatedAt !== run.updatedAt) pipelineDetails.delete(run.id);

--- a/public/index.html
+++ b/public/index.html
@@ -350,6 +350,270 @@
   .run-dot.running { background: rgba(245,158,11,0.8); }
   .run-line { font-family: var(--font-mono); font-size: 11px; color: var(--fg-dim); padding: 2px 0; }
 
+  /* ---------- pipeline dispatch map ---------- */
+  #view-pipelines.active {
+    position: relative;
+    display: block;
+    height: 100%;
+    max-width: none;
+    padding: 0;
+    overflow: hidden;
+    background: #030407;
+  }
+  #view-pipelines .view-head {
+    position: absolute;
+    inset: 0 0 auto;
+    z-index: 8;
+    min-height: calc(76 * var(--baseline-font));
+    margin: 0;
+    padding: calc(18 * var(--baseline-font)) calc(26 * var(--baseline-font)) calc(28 * var(--baseline-font));
+    background: linear-gradient(180deg, rgba(3,4,7,.98) 52%, rgba(3,4,7,0));
+    pointer-events: none;
+  }
+  #view-pipelines .view-head .right,
+  #view-pipelines .view-head button,
+  #view-pipelines .view-head select { pointer-events: auto; }
+  .pipeline-layout { position: absolute; inset: 0; overflow: hidden; }
+  .pipeline-stage {
+    position: absolute;
+    inset: 0 calc(400 * var(--baseline-font)) 0 0;
+    overflow: hidden;
+    background:
+      radial-gradient(circle at 38% 48%, rgba(0,100,255,.085), transparent 42%),
+      #030407;
+  }
+  #pipeline-canvas {
+    display: block;
+    width: 100%;
+    height: 100%;
+    cursor: grab;
+    touch-action: none;
+  }
+  #pipeline-canvas.dragging { cursor: grabbing; }
+  .pipeline-node-layer {
+    position: absolute;
+    inset: 0;
+    z-index: 3;
+    overflow: hidden;
+    pointer-events: none;
+  }
+  .pipeline-node-card {
+    position: absolute;
+    width: calc(190 * var(--baseline-font));
+    min-height: calc(78 * var(--baseline-font));
+    padding: calc(11 * var(--baseline-font)) calc(12 * var(--baseline-font)) calc(10 * var(--baseline-font)) calc(22 * var(--baseline-font));
+    border: 1px solid var(--node-color, #999);
+    border-radius: calc(10 * var(--baseline-font));
+    background: rgba(7,10,17,.97);
+    color: #fff;
+    text-align: left;
+    transform-origin: center;
+    pointer-events: auto;
+    cursor: pointer;
+    contain: layout paint style;
+    will-change: transform;
+  }
+  .pipeline-node-card::before {
+    content: "";
+    position: absolute;
+    left: calc(8 * var(--baseline-font));
+    top: calc(10 * var(--baseline-font));
+    bottom: calc(10 * var(--baseline-font));
+    width: calc(4 * var(--baseline-font));
+    border-radius: calc(4 * var(--baseline-font));
+    background: var(--node-color, #999);
+  }
+  .pipeline-node-card:hover,
+  .pipeline-node-card.selected {
+    background: rgba(11,20,38,.98);
+    box-shadow: 0 0 0 1px var(--node-color, #999);
+  }
+  .pipeline-node-card .node-title {
+    display: block;
+    overflow: hidden;
+    font-family: Gilroy-SemiBold, var(--font-sans);
+    font-size: calc(12 * var(--baseline-font));
+    line-height: 1.25;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .pipeline-node-card .node-status {
+    display: block;
+    margin-top: calc(4 * var(--baseline-font));
+    font-family: var(--font-mono);
+    font-size: calc(8.5 * var(--baseline-font));
+    letter-spacing: .05em;
+    color: var(--node-color, #999);
+    text-transform: uppercase;
+  }
+  .pipeline-node-card .node-subtitle {
+    display: -webkit-box;
+    overflow: hidden;
+    margin-top: calc(6 * var(--baseline-font));
+    font-family: Gilroy-Regular, var(--font-sans);
+    font-size: calc(9.5 * var(--baseline-font));
+    line-height: 1.35;
+    color: rgba(255,255,255,.76);
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+  .pipeline-node-card .node-meta {
+    display: block;
+    overflow: hidden;
+    margin-top: calc(6 * var(--baseline-font));
+    font-family: var(--font-mono);
+    font-size: calc(7.5 * var(--baseline-font));
+    color: rgba(255,255,255,.4);
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .pipeline-tools {
+    position: absolute;
+    z-index: 6;
+    top: calc(88 * var(--baseline-font));
+    left: calc(26 * var(--baseline-font));
+    display: flex;
+    gap: calc(6 * var(--baseline-font));
+  }
+  .pipeline-tools .ctrl {
+    background: rgba(5,7,12,.92);
+  }
+  .pipeline-hud {
+    position: absolute;
+    z-index: 5;
+    left: calc(26 * var(--baseline-font));
+    right: calc(414 * var(--baseline-font));
+    bottom: calc(20 * var(--baseline-font));
+    display: flex;
+    align-items: center;
+    gap: calc(14 * var(--baseline-font));
+    pointer-events: none;
+    font-family: var(--font-mono);
+    font-size: calc(9.5 * var(--baseline-font));
+    color: var(--fg-faint);
+  }
+  .pipeline-hud .legend { display: inline-flex; align-items: center; gap: calc(6 * var(--baseline-font)); color: var(--fg-dim); }
+  .pipeline-hud .sw { width: calc(7 * var(--baseline-font)); height: calc(7 * var(--baseline-font)); border-radius: 50%; }
+  .pipeline-hud .hint { margin-left: auto; text-align: right; line-height: 1.7; }
+  .pipeline-status {
+    position: absolute;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    padding: calc(20 * var(--baseline-font));
+    pointer-events: none;
+    color: var(--fg-faint);
+    font-family: var(--font-mono);
+    font-size: calc(11 * var(--baseline-font));
+    text-align: center;
+  }
+  .pipeline-rail {
+    position: absolute;
+    z-index: 7;
+    top: calc(86 * var(--baseline-font));
+    right: calc(20 * var(--baseline-font));
+    bottom: calc(20 * var(--baseline-font));
+    width: calc(372 * var(--baseline-font));
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    gap: calc(10 * var(--baseline-font));
+    padding: calc(12 * var(--baseline-font));
+    border: 1px solid rgba(113,116,121,.25);
+    border-radius: calc(12 * var(--baseline-font));
+    background: rgba(6,6,8,.94);
+  }
+  .pipeline-summary {
+    flex: none;
+    padding: calc(13 * var(--baseline-font));
+    border: 1px solid rgba(112,157,255,.18);
+    border-radius: calc(10 * var(--baseline-font));
+    background: linear-gradient(135deg, rgba(0,100,255,.1), rgba(255,255,255,.025));
+  }
+  .pipeline-summary .eyebrow,
+  .pipeline-detail .eyebrow {
+    font-family: var(--font-mono);
+    font-size: calc(8.5 * var(--baseline-font));
+    letter-spacing: .14em;
+    text-transform: uppercase;
+    color: #82acff;
+  }
+  .pipeline-summary .title { margin-top: calc(5 * var(--baseline-font)); font-family: Gilroy-SemiBold, var(--font-sans); font-size: calc(14 * var(--baseline-font)); }
+  .pipeline-summary .meta,
+  .pipeline-detail .meta { margin-top: calc(6 * var(--baseline-font)); font-family: var(--font-mono); font-size: calc(9.5 * var(--baseline-font)); color: var(--fg-dim); line-height: 1.8; }
+  .pipeline-detail {
+    flex: 0 1 auto;
+    max-height: 42%;
+    overflow-y: auto;
+    padding: calc(13 * var(--baseline-font));
+    border: 1px solid var(--border);
+    border-radius: calc(10 * var(--baseline-font));
+    background: var(--surface);
+  }
+  .chat-close {
+    float: right;
+    margin: calc(-3 * var(--baseline-font)) calc(-3 * var(--baseline-font)) 0 calc(8 * var(--baseline-font));
+    border: 1px solid var(--border-subtle);
+    border-radius: calc(6 * var(--baseline-font));
+    background: rgba(255,255,255,.05);
+    color: var(--fg-dim);
+    font-family: var(--font-mono);
+    font-size: calc(8.5 * var(--baseline-font));
+    padding: calc(3 * var(--baseline-font)) calc(7 * var(--baseline-font));
+    cursor: pointer;
+  }
+  .chat-close:hover { color: var(--fg); border-color: rgba(79,140,255,.38); }
+  .pipeline-detail .objective { margin-top: calc(6 * var(--baseline-font)); font-size: calc(12 * var(--baseline-font)); color: rgba(255,255,255,.9); line-height: 1.45; }
+  .agent-chat { margin-top: calc(10 * var(--baseline-font)); display: flex; flex-direction: column; gap: calc(8 * var(--baseline-font)); }
+  .chat-entry {
+    padding: calc(9 * var(--baseline-font)) calc(10 * var(--baseline-font));
+    border: 1px solid rgba(255,255,255,.08);
+    border-radius: calc(8 * var(--baseline-font));
+    background: rgba(255,255,255,.035);
+  }
+  .chat-entry.out {
+    margin-left: calc(18 * var(--baseline-font));
+    border-color: rgba(79,140,255,.22);
+    background: rgba(0,100,255,.07);
+  }
+  .chat-entry.in { margin-right: calc(18 * var(--baseline-font)); }
+  .chat-entry .who {
+    display: flex;
+    gap: calc(7 * var(--baseline-font));
+    font-family: var(--font-mono);
+    font-size: calc(8.5 * var(--baseline-font));
+    color: #82acff;
+    text-transform: uppercase;
+    letter-spacing: .08em;
+  }
+  .chat-entry .who time { margin-left: auto; color: var(--fg-faint); letter-spacing: 0; }
+  .chat-entry .message { margin-top: calc(5 * var(--baseline-font)); font-size: calc(11 * var(--baseline-font)); line-height: 1.45; color: rgba(255,255,255,.86); }
+  .chat-entry .result { margin-top: calc(5 * var(--baseline-font)); font-family: var(--font-mono); font-size: calc(8.5 * var(--baseline-font)); color: var(--fg-dim); }
+  .pipeline-rail-head {
+    display: flex;
+    align-items: baseline;
+    font-family: var(--font-mono);
+    font-size: calc(9 * var(--baseline-font));
+    letter-spacing: .13em;
+    text-transform: uppercase;
+    color: var(--fg-dim);
+  }
+  .pipeline-rail-head span:last-child { margin-left: auto; color: var(--fg-faint); letter-spacing: 0; }
+  .pipeline-runs { flex: 1; height: 1px; overflow-y: auto; overscroll-behavior: contain; }
+  .pipeline-run {
+    padding: calc(10 * var(--baseline-font)) calc(12 * var(--baseline-font));
+    border-bottom: 1px solid var(--border-subtle);
+    cursor: pointer;
+    transition: background .15s ease-in-out;
+  }
+  .pipeline-run:last-child { border-bottom: 0; }
+  .pipeline-run:hover { background: rgba(255,255,255,.035); }
+  .pipeline-run.on { background: rgba(0,100,255,.1); box-shadow: inset 2px 0 #0064ff; }
+  .pipeline-run .top { display: flex; align-items: center; gap: calc(8 * var(--baseline-font)); }
+  .pipeline-run .name { font-family: Gilroy-SemiBold, var(--font-sans); font-size: calc(11.5 * var(--baseline-font)); }
+  .pipeline-run .phase { margin-top: calc(3 * var(--baseline-font)); font-family: var(--font-mono); font-size: calc(9 * var(--baseline-font)); color: var(--fg-dim); }
+  .pipeline-run .count { margin-left: auto; font-family: var(--font-mono); font-size: calc(9 * var(--baseline-font)); color: var(--fg-faint); }
+
   /* ---------- memory galaxy ---------- */
   /* The galaxy owns the viewport instead of flowing down the page: the canvas
      must never grow the document, and the claim rail scrolls INSIDE itself.
@@ -824,7 +1088,7 @@
     .brand, .side-foot, nav::before { display: none; }
     nav {
       display: grid;
-      grid-template-columns: repeat(7, 1fr);
+      grid-template-columns: repeat(8, 1fr);
       gap: calc(2 * var(--baseline-font));
     }
     nav a {
@@ -871,6 +1135,37 @@
     .log-line { grid-template-columns: calc(64 * var(--baseline-font)) calc(45 * var(--baseline-font)) 1fr; }
     .log-line .msg { grid-column: 1 / -1; padding-bottom: calc(4 * var(--baseline-font)); }
     .ds-grid { grid-template-columns: 1fr; }
+    #view-pipelines .view-head {
+      min-height: calc(92 * var(--baseline-font));
+      padding: calc(14 * var(--baseline-font)) calc(14 * var(--baseline-font)) calc(20 * var(--baseline-font));
+    }
+    #view-pipelines .view-head .sub { display: none; }
+    #view-pipelines .view-head .right { width: auto; margin: 0 0 0 auto; }
+    .pipeline-tools { top: calc(96 * var(--baseline-font)); left: calc(10 * var(--baseline-font)); }
+    .pipeline-stage {
+      top: calc(78 * var(--baseline-font));
+      right: 0;
+      bottom: calc(35vh + 22 * var(--baseline-font));
+    }
+    .pipeline-hud { left: calc(12 * var(--baseline-font)); right: calc(12 * var(--baseline-font)); bottom: calc(10 * var(--baseline-font)); }
+    .pipeline-hud .hint { display: none; }
+    .pipeline-rail {
+      top: auto;
+      left: calc(12 * var(--baseline-font));
+      right: calc(12 * var(--baseline-font));
+      bottom: calc(12 * var(--baseline-font));
+      width: auto;
+      height: 35vh;
+      padding: calc(10 * var(--baseline-font));
+    }
+    .pipeline-rail.chat-open .pipeline-summary,
+    .pipeline-rail.chat-open .pipeline-rail-head,
+    .pipeline-rail.chat-open .pipeline-runs { display: none; }
+    .pipeline-rail.chat-open .pipeline-detail {
+      display: block !important;
+      max-height: none;
+      flex: 1;
+    }
     #view-memory .view-head {
       min-height: calc(92 * var(--baseline-font));
       padding: calc(14 * var(--baseline-font)) calc(14 * var(--baseline-font)) calc(20 * var(--baseline-font));
@@ -944,6 +1239,7 @@
       <a href="#logs" data-view="logs"><span class="ico">▤</span>Logs<span class="count err" id="nav-logs" style="display:none"></span></a>
       <a href="#devservers" data-view="devservers"><span class="ico">▶</span>Dev Servers<span class="count" id="nav-ds" style="display:none"></span></a>
       <a href="#workflows" data-view="workflows"><span class="ico">↻</span>Workflows<span class="count" id="nav-wf" style="display:none"></span></a>
+      <a href="#pipelines" data-view="pipelines"><span class="ico">◇</span>Pipelines<span class="count hot" id="nav-pipelines" style="display:none"></span></a>
       <a href="#memory" data-view="memory"><span class="ico">✦</span>Memory</a>
       <a href="#docs" data-view="docs"><span class="ico">¶</span>Docs</a>
     </nav>
@@ -1056,9 +1352,57 @@
       <div class="panel" id="wf-list"><div class="empty">loading…</div></div>
     </section>
 
+    <!-- ================= PIPELINES ================= -->
+    <section class="view" id="view-pipelines">
+      <div class="view-head" data-index="06">
+        <h2>Pipeline dispatches</h2>
+        <span class="sub">durable agent handoffs · live control-plane flow</span>
+        <span class="right">
+          <select class="ctrl" id="pipeline-kind" aria-label="Filter pipelines by type">
+            <option value="">all types</option>
+            <option value="product">product</option>
+            <option value="bug">bug</option>
+          </select>
+          <select class="ctrl" id="pipeline-filter" aria-label="Filter pipelines by status">
+            <option value="">all statuses</option>
+            <option value="active">active</option>
+            <option value="waiting">waiting</option>
+            <option value="needs-human">needs human</option>
+            <option value="terminal">terminal</option>
+          </select>
+          <button class="ctrl" id="pipeline-refresh" type="button">refresh</button>
+        </span>
+      </div>
+      <div class="pipeline-layout">
+        <div class="pipeline-stage" id="pipeline-stage">
+          <canvas id="pipeline-canvas"></canvas>
+          <div class="pipeline-node-layer" id="pipeline-node-layer"></div>
+          <div class="pipeline-tools">
+            <button class="ctrl" id="pipeline-fit" type="button">fit flow</button>
+            <button class="ctrl" id="pipeline-reset" type="button">reset view</button>
+          </div>
+          <div class="pipeline-hud">
+            <span class="legend"><span class="sw" style="background:#4f8cff"></span>active</span>
+            <span class="legend"><span class="sw" style="background:#22c55e"></span>completed</span>
+            <span class="legend"><span class="sw" style="background:#f59e0b"></span>waiting</span>
+            <span class="legend"><span class="sw" style="background:#ff3b3b"></span>failed</span>
+            <span class="hint">drag orbit · wheel zoom · shift-drag pan<br />select a node for dispatch detail</span>
+          </div>
+          <div class="tip" id="pipeline-tip" style="max-width:300px;white-space:normal"></div>
+          <div class="pipeline-status" id="pipeline-status">loading pipeline control plane…</div>
+        </div>
+        <div class="pipeline-rail" role="complementary" aria-label="Pipeline runs">
+          <div class="pipeline-summary" id="pipeline-summary"></div>
+          <div class="pipeline-detail" id="pipeline-detail" style="display:none"></div>
+          <div class="pipeline-rail-head"><span>all runs</span><span id="pipeline-count">—</span></div>
+          <div class="panel pipeline-runs" id="pipeline-runs"><div class="empty">loading…</div></div>
+        </div>
+      </div>
+    </section>
+
     <!-- ================= MEMORY ================= -->
     <section class="view" id="view-memory">
-      <div class="view-head" data-index="06">
+      <div class="view-head" data-index="07">
         <h2>Memory</h2>
         <span class="sub">3D projection — local neighbourhoods are meaningful, global distances are not</span>
         <span class="right">
@@ -1111,7 +1455,7 @@
 
     <!-- ================= DOCS ================= -->
     <section class="view" id="view-docs">
-      <div class="view-head" data-index="07">
+      <div class="view-head" data-index="08">
         <h2>Docs</h2>
         <span class="sub">read-only browser over docs/**/*.md</span>
       </div>
@@ -1205,15 +1549,16 @@ function pendingCount(v) {
 function isErrorSession(s) {
   return s.status === "error" || !!(s.lastError);
 }
-async function fetchJson(path) {
-  const res = await fetch(path);
+async function fetchJson(path, init) {
+  const res = await fetch(path, init);
   if (!res.ok) throw new Error(path + " " + res.status);
   return await res.json();
 }
-async function safeFetch(path) {
+async function safeFetch(path, init) {
   try {
-    return { ok: true, data: await fetchJson(path) };
+    return { ok: true, data: await fetchJson(path, init) };
   } catch (err) {
+    if (err?.name === "AbortError") return { ok: false, aborted: true, error: err, data: null };
     console.error("fetch failed", path, err);
     return { ok: false, error: err, data: null };
   }
@@ -1228,6 +1573,15 @@ let devServers = [];
 let idleTtlMs = null;
 let workflows = [];
 let workflowErrors = [];
+let pipelines = [];
+const pipelineDetails = new Map();
+const pipelineDetailErrors = new Set();
+let pipelineDetailLoadingId = null;
+let pipelineDetailAbortController = null;
+let pipelineFetchError = null;
+let pipelineFetchGeneration = 0;
+let selectedPipelineId = null;
+let renderedPipelineListSignature = null;
 let logEntries = [];
 let logErrorCount = 0;
 let logFetchError = null;
@@ -1252,6 +1606,11 @@ function show(view) {
   document.querySelectorAll("nav a").forEach((a) => a.classList.toggle("active", a.dataset.view === view));
   const el = $("view-" + view);
   (el || $("view-overview")).classList.add("active");
+  if (view === "pipelines") {
+    resizePipeline();
+    if (pipelines.length) renderPipelines();
+    invalidatePipeline();
+  }
   if (view === "memory") { resizeGalaxy(); if (!galaxyLoaded) loadGalaxy(false); }
   if (view === "docs" && !docsLoaded) loadDocsTree();
   if (view === "logs") fetchLogs();
@@ -1420,6 +1779,8 @@ function renderSidebar() {
   setNavCount("nav-ds", running, "");
   const enabled = workflows.filter((w) => w.enabled).length;
   setNavCount("nav-wf", enabled, "");
+  const openPipelines = pipelines.filter((run) => run.status !== "terminal").length;
+  setNavCount("nav-pipelines", openPipelines, openPipelines > 0 ? "hot" : "");
 
   // Static side-foot DOM — only update text nodes (live-toggle keeps one listener).
   $("sf-version").textContent = health ? String(health.version || "—") : "—";
@@ -1937,6 +2298,848 @@ function renderWorkflows() {
   }
   $("wf-list").innerHTML = html;
 }
+
+/* =================== pipeline dispatch map =================== */
+const PIPELINE_COLORS = {
+  active: 0x4f8cff, pending: 0x4f8cff, leased: 0x4f8cff,
+  completed: 0x22c55e, delivered: 0x22c55e,
+  waiting: 0xf59e0b, "needs-human": 0xf59e0b,
+  failed: 0xff3b3b, dead: 0xff3b3b,
+  cancelled: 0x666666, terminal: 0x999999,
+};
+const PIPE = {
+  canvas: $("pipeline-canvas"), renderer: null, scene: null, camera: null,
+  group: null, nodeElements: [], nodePositions: new Map(),
+  nodeLayer: $("pipeline-node-layer"), nodesNeedProject: false,
+  packets: [], selectedNodeId: null,
+  runId: null, signature: null, layoutMode: null,
+  lastFrameAt: 0, needsRender: true, frameRequest: null,
+  worker: null, layoutRequestId: 0, layoutResolvers: new Map(),
+  buildGeneration: 0, buildingSignature: null,
+  width: 1, height: 1, target: new THREE.Vector3(),
+  yaw: 0, pitch: 0, distance: 14, desiredDistance: 14,
+  drag: null,
+};
+const pipelineColor = (status) => PIPELINE_COLORS[status] || 0x999999;
+
+function ensurePipelineRenderer() {
+  if (PIPE.renderer) return;
+  PIPE.renderer = new THREE.WebGLRenderer({
+    canvas: PIPE.canvas, antialias: true, alpha: true, powerPreference: "high-performance",
+  });
+  const firefox = navigator.userAgent.includes("Firefox/");
+  PIPE.renderer.setPixelRatio(Math.min(window.devicePixelRatio || 1, firefox ? 1 : 1.25));
+  PIPE.renderer.outputColorSpace = THREE.SRGBColorSpace;
+  PIPE.renderer.shadowMap.enabled = false;
+  PIPE.scene = new THREE.Scene();
+  PIPE.camera = new THREE.PerspectiveCamera(38, 1, 0.1, 2000);
+  updatePipelineCamera();
+}
+
+function ensurePipelineWorker() {
+  if (PIPE.worker) return PIPE.worker;
+  const worker = new Worker("/assets/pipeline-worker.js");
+  worker.addEventListener("message", (event) => {
+    const pending = PIPE.layoutResolvers.get(event.data?.id);
+    if (!pending) return;
+    PIPE.layoutResolvers.delete(event.data.id);
+    if (event.data.error) pending.reject(new Error(event.data.error));
+    else pending.resolve(event.data.result);
+  });
+  worker.addEventListener("error", (event) => {
+    const error = new Error(event.message || "Pipeline layout worker failed");
+    for (const pending of PIPE.layoutResolvers.values()) pending.reject(error);
+    PIPE.layoutResolvers.clear();
+    PIPE.worker = null;
+  });
+  PIPE.worker = worker;
+  return worker;
+}
+
+function requestPipelineLayout(run) {
+  const id = ++PIPE.layoutRequestId;
+  const input = {
+    runId: run.id,
+    vertical: PIPE.width < 600,
+    assignments: (run.assignments || []).map((assignment) => ({
+      id: assignment.id,
+      parentAssignmentId: assignment.parentAssignmentId,
+      sourceAgent: assignment.sourceAgent,
+      targetAgent: assignment.targetAgent,
+      createdAt: assignment.createdAt,
+    })),
+  };
+  return new Promise((resolve, reject) => {
+    PIPE.layoutResolvers.set(id, { resolve, reject });
+    ensurePipelineWorker().postMessage({ id, input });
+  });
+}
+
+function disposePipelineObject(object) {
+  object.traverse((child) => {
+    if (child.geometry) child.geometry.dispose();
+    const materials = Array.isArray(child.material) ? child.material : [child.material];
+    for (const material of materials) {
+      if (!material) continue;
+      if (material.map) material.map.dispose();
+      material.dispose();
+    }
+  });
+}
+
+function makePipelineCardElement(node, selected) {
+  const color = "#" + pipelineColor(node.status).toString(16).padStart(6, "0");
+  const element = document.createElement("button");
+  element.type = "button";
+  element.className = "pipeline-node-card" + (selected ? " selected" : "");
+  element.dataset.pipelineNodeId = node.id;
+  element.style.setProperty("--node-color", color);
+  element.innerHTML =
+    '<span class="node-title">' + esc(node.title) + "</span>" +
+    '<span class="node-status">' + esc(String(node.status).toUpperCase()) + "</span>" +
+    '<span class="node-subtitle">' + esc(node.subtitle || "") + "</span>" +
+    '<span class="node-meta">' + esc(node.meta || "") + "</span>";
+  return element;
+}
+
+function makePipelineLaneLabel(agent) {
+  const canvas = document.createElement("canvas");
+  canvas.width = 420;
+  canvas.height = 80;
+  const ctx = canvas.getContext("2d");
+  ctx.font = "600 28px 'DM Mono', ui-monospace, monospace";
+  ctx.fillStyle = "rgba(130,172,255,.9)";
+  ctx.fillText(String(agent).toUpperCase() + " LANE", 12, 48);
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.colorSpace = THREE.SRGBColorSpace;
+  const label = new THREE.Mesh(
+    new THREE.PlaneGeometry(2.1, 0.4),
+    new THREE.MeshBasicMaterial({
+      map: texture,
+      transparent: true,
+      depthWrite: false,
+      side: THREE.DoubleSide,
+    }),
+  );
+  return label;
+}
+
+function addPipelineSwimlanes(nodes, positions) {
+  if (PIPE.width < 600) return;
+  const assignmentNodes = nodes.filter((node) => node.type === "assignment");
+  const agents = [...new Set(assignmentNodes.map((node) => node.assignment.targetAgent))];
+  const xValues = [...positions.values()].map((position) => position.x);
+  const minX = Math.min(...xValues) - 1.8;
+  const maxX = Math.max(...xValues) + 1.8;
+  const width = maxX - minX;
+  for (const agent of agents) {
+    const node = assignmentNodes.find((candidate) => candidate.assignment.targetAgent === agent);
+    const y = positions.get(node.id).y;
+    const band = new THREE.Mesh(
+      new THREE.PlaneGeometry(width, 1.55),
+      new THREE.MeshBasicMaterial({
+        color: 0x4f8cff,
+        transparent: true,
+        opacity: 0.035,
+        depthWrite: false,
+        side: THREE.DoubleSide,
+      }),
+    );
+    band.position.set((minX + maxX) / 2, y, -0.5);
+    PIPE.group.add(band);
+    const borderGeometry = new THREE.BufferGeometry().setFromPoints([
+      new THREE.Vector3(minX, y - 0.78, -0.47),
+      new THREE.Vector3(maxX, y - 0.78, -0.47),
+      new THREE.Vector3(minX, y + 0.78, -0.47),
+      new THREE.Vector3(maxX, y + 0.78, -0.47),
+    ]);
+    PIPE.group.add(new THREE.LineSegments(
+      borderGeometry,
+      new THREE.LineBasicMaterial({ color: 0x4f8cff, transparent: true, opacity: 0.15 }),
+    ));
+    const label = makePipelineLaneLabel(agent);
+    label.position.set(minX + 1.1, y + 0.57, -0.42);
+    PIPE.group.add(label);
+  }
+}
+
+function addPipelineSurface(positions) {
+  const values = [...positions.values()];
+  if (!values.length) return;
+  const minX = Math.min(...values.map((position) => position.x)) - 5;
+  const maxX = Math.max(...values.map((position) => position.x)) + 5;
+  const minY = Math.min(...values.map((position) => position.y)) - 4;
+  const maxY = Math.max(...values.map((position) => position.y)) + 4;
+  const width = Math.max(18, maxX - minX);
+  const height = Math.max(14, maxY - minY);
+  const centerX = (minX + maxX) / 2;
+  const centerY = (minY + maxY) / 2;
+  const surface = new THREE.Mesh(
+    new THREE.PlaneGeometry(width, height),
+    new THREE.MeshBasicMaterial({
+      color: 0x030407,
+    }),
+  );
+  surface.position.set(centerX, centerY, -0.72);
+  PIPE.group.add(surface);
+
+  const grid = [];
+  const step = width > 120 ? 2 : 1;
+  for (let x = Math.ceil(minX / step) * step; x <= maxX; x += step) {
+    grid.push(x, minY, -0.68, x, maxY, -0.68);
+  }
+  for (let y = Math.ceil(minY / step) * step; y <= maxY; y += step) {
+    grid.push(minX, y, -0.68, maxX, y, -0.68);
+  }
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute("position", new THREE.Float32BufferAttribute(grid, 3));
+  PIPE.group.add(new THREE.LineSegments(
+    geometry,
+    new THREE.LineBasicMaterial({ color: 0x27354f, transparent: true, opacity: 0.16 }),
+  ));
+}
+
+function pipelineNodeFromAssignment(run, assignment, layoutNode) {
+  if (!assignment) {
+    return {
+      ...layoutNode,
+      type: "run",
+      run,
+      title: run.kind + " pipeline",
+      subtitle: run.phase,
+      meta: run.ownerAgent + " · v" + run.stateVersion,
+      status: run.status,
+    };
+  }
+  return {
+    ...layoutNode,
+    type: "assignment",
+    assignment,
+    title: assignment.targetAgent,
+    subtitle: assignment.objective,
+    meta: assignment.sourceAgent + " → " + assignment.targetAgent,
+    status: assignment.status,
+  };
+}
+
+function nextPipelineBuildFrame() {
+  return new Promise((resolve) => requestAnimationFrame(resolve));
+}
+
+async function buildPipelineItems(items, generation, perFrame, build) {
+  let index = 0;
+  while (index < items.length) {
+    await nextPipelineBuildFrame();
+    if (generation !== PIPE.buildGeneration) return false;
+    const deadline = performance.now() + 7;
+    let built = 0;
+    while (
+      index < items.length &&
+      built < perFrame &&
+      (built === 0 || performance.now() < deadline)
+    ) {
+      build(items[index]);
+      index += 1;
+      built += 1;
+    }
+  }
+  return true;
+}
+
+function frameLargePipeline(layout) {
+  const { minX, maxX, minY, maxY } = layout.bounds;
+  PIPE.target.set(
+    minX + Math.min(16, Math.max(0, (maxX - minX) / 2)),
+    (minY + maxY) / 2,
+    0,
+  );
+  PIPE.yaw = -0.18;
+  PIPE.pitch = 0.1;
+  PIPE.desiredDistance = Math.min(30, Math.max(18, (maxY - minY) * 1.35));
+  PIPE.distance = PIPE.desiredDistance;
+  updatePipelineCamera();
+  invalidatePipeline();
+}
+
+async function buildPipelineScene(run, preserveCamera = false) {
+  const signature = pipelineSignature(run);
+  const generation = ++PIPE.buildGeneration;
+  PIPE.buildingSignature = signature;
+  $("pipeline-status").textContent =
+    (run.assignments || []).length > 24
+      ? "Laying out large pipeline off the main thread…"
+      : "Laying out pipeline…";
+  ensurePipelineRenderer();
+  let layout;
+  try {
+    layout = await requestPipelineLayout(run);
+  } catch (error) {
+    if (generation === PIPE.buildGeneration) {
+      PIPE.buildingSignature = null;
+      $("pipeline-status").textContent = "Failed to lay out pipeline: " + error.message;
+    }
+    return;
+  }
+  if (generation !== PIPE.buildGeneration) return;
+  if (PIPE.group) {
+    PIPE.scene.remove(PIPE.group);
+    disposePipelineObject(PIPE.group);
+  }
+  PIPE.group = new THREE.Group();
+  PIPE.scene.add(PIPE.group);
+  PIPE.nodeElements = [];
+  PIPE.nodeLayer.style.visibility = "hidden";
+  PIPE.nodeLayer.replaceChildren();
+  PIPE.packets = [];
+  PIPE.runId = run.id;
+  PIPE.layoutMode = PIPE.width < 600 ? "vertical" : "horizontal";
+  const assignments = new Map(
+    (run.assignments || []).map((assignment) => [assignment.id, assignment]),
+  );
+  const nodes = layout.nodes.map((node) =>
+    pipelineNodeFromAssignment(run, assignments.get(node.id), node)
+  );
+  const positions = new Map(
+    layout.nodes.map((node) => [node.id, new THREE.Vector3(node.x, node.y, node.z)]),
+  );
+  PIPE.nodePositions = positions;
+  addPipelineSurface(positions);
+  addPipelineSwimlanes(nodes, positions);
+  const nodesBuilt = await buildPipelineItems(nodes, generation, 12, (node) => {
+    const element = makePipelineCardElement(node, PIPE.selectedNodeId === node.id);
+    PIPE.nodeLayer.append(element);
+    PIPE.nodeElements.push(element);
+  });
+  if (!nodesBuilt) return;
+  const edgeNodes = nodes.filter((node) => node.type === "assignment");
+  const edgesBuilt = await buildPipelineItems(edgeNodes, generation, 10, (node) => {
+    addPipelineEdge(
+      positions.get(node.fromId),
+      positions.get(node.id),
+      node.assignment,
+    );
+  });
+  if (!edgesBuilt) return;
+  PIPE.signature = signature;
+  PIPE.buildingSignature = null;
+  if (!preserveCamera) {
+    if (nodes.length > 24 && PIPE.width >= 600) frameLargePipeline(layout);
+    else fitPipeline();
+  }
+  PIPE.nodeLayer.style.visibility = "";
+  PIPE.nodesNeedProject = true;
+  invalidatePipeline();
+  paintPipelineDetail(run);
+  $("pipeline-status").textContent = "";
+}
+
+function clearPipelineScene() {
+  PIPE.buildGeneration += 1;
+  PIPE.buildingSignature = null;
+  if (!PIPE.group) return;
+  PIPE.scene.remove(PIPE.group);
+  disposePipelineObject(PIPE.group);
+  PIPE.group = null;
+  PIPE.nodeElements = [];
+  PIPE.nodePositions = new Map();
+  PIPE.nodeLayer.replaceChildren();
+  PIPE.nodeLayer.style.visibility = "";
+  PIPE.packets = [];
+  PIPE.runId = null;
+  PIPE.signature = null;
+  invalidatePipeline();
+}
+
+function addPipelineEdge(from, to, assignment) {
+  if (!from || !to) return;
+  const vertical = PIPE.width < 600;
+  const start = from.clone().add(vertical
+    ? new THREE.Vector3(0, -0.61, -0.02)
+    : new THREE.Vector3(1.48, 0, -0.02));
+  const end = to.clone().add(vertical
+    ? new THREE.Vector3(0, 0.61, -0.02)
+    : new THREE.Vector3(-1.48, 0, -0.02));
+  const mid = start.clone().lerp(end, 0.5);
+  if (vertical) mid.x += (end.x - start.x) * 0.08;
+  else mid.y += (end.y - start.y) * 0.08;
+  const curve = new THREE.QuadraticBezierCurve3(start, mid, end);
+  const color = pipelineColor(assignment.dispatch?.status || assignment.status);
+  PIPE.group.add(new THREE.Line(
+    new THREE.BufferGeometry().setFromPoints(curve.getPoints(20)),
+    new THREE.LineBasicMaterial({ color, transparent: true, opacity: assignment.dispatch ? 0.62 : 0.28 }),
+  ));
+  const arrow = new THREE.Mesh(
+    new THREE.ConeGeometry(0.1, 0.28, 8),
+    new THREE.MeshBasicMaterial({ color, transparent: true, opacity: 0.8 }),
+  );
+  arrow.position.copy(curve.getPoint(0.95));
+  arrow.quaternion.setFromUnitVectors(new THREE.Vector3(0, 1, 0), curve.getTangent(0.95).normalize());
+  PIPE.group.add(arrow);
+  if (["pending", "leased"].includes(assignment.dispatch?.status)) {
+    const packet = new THREE.Mesh(
+      new THREE.SphereGeometry(0.075, 8, 6),
+      new THREE.MeshBasicMaterial({ color }),
+    );
+    PIPE.group.add(packet);
+    PIPE.packets.push({
+      mesh: packet, curve, offset: hashUnit(assignment.id),
+      speed: 0.18,
+    });
+  }
+}
+
+function hashUnit(value) {
+  let hash = 0;
+  for (const char of String(value)) hash = ((hash << 5) - hash + char.charCodeAt(0)) | 0;
+  return Math.abs(hash % 1000) / 1000;
+}
+
+function pipelineSignature(run) {
+  return JSON.stringify([
+    run.id, run.phase, run.status, run.stateVersion,
+    (run.assignments || []).map((assignment) => [
+      assignment.id, assignment.parentAssignmentId, assignment.status,
+      assignment.updatedAt, assignment.dispatch?.status, assignment.dispatch?.attempts,
+    ]),
+  ]);
+}
+
+function renderPipelines() {
+  $("pipeline-count").textContent = pipelines.length + " runs";
+  if (!pipelines.some((run) => run.id === selectedPipelineId)) {
+    selectedPipelineId = pipelines[0]?.id || null;
+    PIPE.selectedNodeId = null;
+  }
+  const listSignature = selectedPipelineId + "|" + pipelines.map((run) => {
+    const detail = pipelineDetails.get(run.id);
+    return [run.id, run.phase, run.status, run.updatedAt, detail?.updatedAt || 0].join(":");
+  }).join("|");
+  if (listSignature !== renderedPipelineListSignature) {
+    renderedPipelineListSignature = listSignature;
+    $("pipeline-runs").innerHTML = pipelines.length
+      ? pipelines.map((run) => {
+        const detail = pipelineDetails.get(run.id);
+        const open = (detail?.assignments || []).filter((assignment) =>
+          ["pending", "leased", "waiting"].includes(assignment.status)
+        ).length;
+        return '<div class="pipeline-run' + (run.id === selectedPipelineId ? " on" : "") +
+          '" data-pipeline-id="' + esc(run.id) + '">' +
+          '<div class="top"><span class="name">' + esc(run.kind) + " · " + esc(shortId(run.id)) +
+          '</span><span class="count">' +
+          (detail ? open + " open" : esc(run.status)) + "</span></div>" +
+          '<div class="phase">' + esc(run.phase) + " · " + esc(run.status) + " · " + ago(run.updatedAt) + " ago</div></div>";
+        }).join("")
+      : '<div class="empty">' +
+        (pipelineFetchError ? "Failed to load pipelines." : "No pipeline runs yet. Agent dispatches will appear here.") +
+        "</div>";
+  }
+  const summary = pipelines.find((candidate) => candidate.id === selectedPipelineId);
+  if (!summary) {
+    $("pipeline-summary").innerHTML =
+      '<div class="eyebrow">control plane</div><div class="title">No pipeline runs</div>' +
+      '<div class="meta">Start a durable agent pipeline to see its dispatch graph.</div>';
+    $("pipeline-detail").style.display = "none";
+    $("pipeline-status").textContent = pipelineFetchError
+      ? "Failed to load pipeline control plane." : "No pipeline dispatches to map yet.";
+    clearPipelineScene();
+    return;
+  }
+  const run = pipelineDetails.get(summary.id);
+  if (!run) {
+    paintPipelineSummary(summary);
+    if (PIPE.runId !== summary.id) clearPipelineScene();
+    if (currentView() === "pipelines") void loadPipelineDetail(summary.id);
+    return;
+  }
+  if (currentView() !== "pipelines") {
+    paintPipelineDetail(run);
+    return;
+  }
+  const signature = pipelineSignature(run);
+  if (PIPE.runId !== run.id || !PIPE.group) {
+    if (PIPE.buildingSignature !== signature) void buildPipelineScene(run);
+  } else if (PIPE.signature !== signature) {
+    if (PIPE.buildingSignature !== signature) void buildPipelineScene(run, true);
+  }
+  else paintPipelineDetail(run);
+}
+
+function paintPipelineSummary(run) {
+  $("pipeline-summary").innerHTML =
+    '<div class="eyebrow">' + esc(run.kind || "pipeline") + " · " + esc(run.status || "loading") + "</div>" +
+    '<div class="title">' + esc(run.phase || "Loading flow") + "</div>" +
+    '<div class="meta">owner ' + esc(run.ownerAgent || "—") + "<br />thread " +
+    esc(shortId(run.threadId || run.id)) +
+    (run.repoRefs?.length ? "<br />repos " + esc(run.repoRefs.join(", ")) : "") +
+    "</div>";
+  $("pipeline-detail").style.display = "none";
+  $("pipeline-status").textContent = pipelineDetailLoadingId === run.id
+    ? "Loading selected pipeline…"
+    : pipelineDetailErrors.has(run.id)
+      ? "Failed to load selected pipeline. Use refresh to retry."
+      : "Select this run to load its dispatch flow.";
+}
+
+async function loadPipelineDetail(runId, force = false) {
+  if (!runId || pipelineDetailLoadingId === runId) return;
+  if (!force && pipelineDetailErrors.has(runId)) return;
+  if (!force && pipelineDetails.has(runId)) return;
+  pipelineDetailAbortController?.abort();
+  const controller = new AbortController();
+  pipelineDetailAbortController = controller;
+  pipelineDetailErrors.delete(runId);
+  pipelineDetailLoadingId = runId;
+  const summary = pipelines.find((candidate) => candidate.id === runId);
+  if (selectedPipelineId === runId && summary) paintPipelineSummary(summary);
+  const response = await safeFetch(
+    "/api/pipelines/" + encodeURIComponent(runId),
+    { signal: controller.signal },
+  );
+  if (controller.signal.aborted) return;
+  if (pipelineDetailAbortController === controller) pipelineDetailAbortController = null;
+  if (pipelineDetailLoadingId === runId) pipelineDetailLoadingId = null;
+  if (response.ok && response.data.pipeline) {
+    pipelineDetails.delete(runId);
+    pipelineDetails.set(runId, response.data.pipeline);
+    while (pipelineDetails.size > 4) {
+      const oldestId = pipelineDetails.keys().next().value;
+      if (oldestId === selectedPipelineId) {
+        const selected = pipelineDetails.get(oldestId);
+        pipelineDetails.delete(oldestId);
+        pipelineDetails.set(oldestId, selected);
+        continue;
+      }
+      pipelineDetails.delete(oldestId);
+    }
+  } else if (selectedPipelineId === runId) {
+    pipelineDetailErrors.add(runId);
+    $("pipeline-status").textContent = "Failed to load selected pipeline.";
+  }
+  if (selectedPipelineId === runId) renderPipelines();
+}
+
+function paintPipelineDetail(run) {
+  const open = (run.assignments || []).filter((assignment) =>
+    ["pending", "leased", "waiting"].includes(assignment.status)
+  ).length;
+  const transitions = (run.transitions || []).slice(-4);
+  $("pipeline-summary").innerHTML =
+    '<div class="eyebrow">' + esc(run.kind) + " · " + esc(run.status) + "</div>" +
+    '<div class="title">' + esc(run.phase) + "</div>" +
+    '<div class="meta">owner ' + esc(run.ownerAgent) + " · " +
+    (run.assignments || []).length + " dispatches · " + open + " open<br />" +
+    "thread " + esc(shortId(run.threadId)) +
+    (run.repoRefs?.length ? "<br />repos " + esc(run.repoRefs.join(", ")) : "") +
+    (transitions.length ? "<br />phase trail " + esc(transitions.map((item) => item.toPhase).join(" → ")) : "") +
+    "</div>";
+  const selectedAssignment = (run.assignments || []).find(
+    (assignment) => assignment.id === PIPE.selectedNodeId,
+  );
+  const node = PIPE.selectedNodeId === "run:" + run.id
+    ? pipelineNodeFromAssignment(run, null, { id: PIPE.selectedNodeId })
+    : selectedAssignment
+      ? pipelineNodeFromAssignment(run, selectedAssignment, {
+        id: selectedAssignment.id,
+      })
+      : null;
+  const detail = $("pipeline-detail");
+  const rail = detail.closest(".pipeline-rail");
+  if (!node) {
+    rail.classList.remove("chat-open");
+    detail.style.display = "none";
+    detail.innerHTML = "";
+    return;
+  }
+  detail.style.display = "";
+  if (node.type === "run") {
+    rail.classList.remove("chat-open");
+    detail.innerHTML =
+      '<div class="eyebrow">selected run</div><div class="objective">' + esc(run.kind) +
+      " pipeline is " + esc(run.status) + " in " + esc(run.phase) + ".</div>" +
+      '<div class="meta">created ' + ago(run.createdAt) + " ago<br />updated " + ago(run.updatedAt) +
+      " ago<br />state version " + esc(run.stateVersion) + "</div>";
+    return;
+  }
+  const assignment = node.assignment;
+  const agent = assignment.targetAgent;
+  const conversation = agentConversation(run, agent);
+  rail.classList.add("chat-open");
+  detail.innerHTML =
+    '<button class="chat-close" type="button" data-close-agent-chat>close</button>' +
+    '<div class="eyebrow">agent chat · ' + esc(agent) + "</div>" +
+    '<div class="meta">' + conversation.length + " durable message" +
+    (conversation.length === 1 ? "" : "s") + " across this run</div>" +
+    '<div class="agent-chat">' +
+    (conversation.length
+      ? conversation.map(renderAgentMessage).join("")
+      : '<div class="empty">No durable messages recorded for this agent.</div>') +
+    "</div>";
+}
+
+function agentConversation(run, agent) {
+  const entries = [];
+  for (const assignment of run.assignments || []) {
+    if (assignment.targetAgent === agent) {
+      entries.push({
+        direction: "in",
+        from: assignment.sourceAgent,
+        to: agent,
+        message: assignment.objective,
+        result: "assignment · " + assignment.status +
+          (assignment.dispatch ? " · dispatch " + assignment.dispatch.status : ""),
+        at: assignment.createdAt,
+      });
+      for (const outcome of assignment.outcomes || []) {
+        const checks = (outcome.checks || []).length
+          ? " · checks " + outcome.checks.map((check) => check.name + ":" + check.status).join(", ")
+          : "";
+        const blockers = (outcome.blockers || []).length
+          ? " · blockers " + outcome.blockers.map((blocker) => blocker.kind).join(", ")
+          : "";
+        entries.push({
+          direction: "out",
+          from: agent,
+          to: "pipeline",
+          message: outcome.reason,
+          result: outcome.action + " · " + outcome.status + checks + blockers,
+          at: outcome.createdAt,
+        });
+      }
+    }
+    if (assignment.sourceAgent === agent && assignment.targetAgent !== agent) {
+      entries.push({
+        direction: "out",
+        from: agent,
+        to: assignment.targetAgent,
+        message: assignment.objective,
+        result: "handoff · " + assignment.status,
+        at: assignment.createdAt,
+      });
+    }
+  }
+  return entries.sort((a, b) => a.at - b.at);
+}
+
+function renderAgentMessage(entry) {
+  return '<div class="chat-entry ' + entry.direction + '">' +
+    '<div class="who"><span>' + esc(entry.from) + " → " + esc(entry.to) +
+    "</span><time>" + ago(entry.at) + " ago</time></div>" +
+    '<div class="message">' + esc(entry.message) + "</div>" +
+    '<div class="result">' + esc(entry.result) + "</div></div>";
+}
+
+$("pipeline-runs").addEventListener("click", (event) => {
+  const row = event.target.closest("[data-pipeline-id]");
+  if (!row) return;
+  if (selectedPipelineId === row.dataset.pipelineId) return;
+  pipelineDetailAbortController?.abort();
+  pipelineDetailAbortController = null;
+  pipelineDetailLoadingId = null;
+  selectedPipelineId = row.dataset.pipelineId;
+  PIPE.selectedNodeId = null;
+  pipelineDetailErrors.delete(selectedPipelineId);
+  if (currentView() === "pipelines") renderPipelines();
+});
+$("pipeline-detail").addEventListener("click", (event) => {
+  if (!event.target.closest("[data-close-agent-chat]")) return;
+  PIPE.selectedNodeId = null;
+  const run = pipelineDetails.get(selectedPipelineId);
+  if (run) paintPipelineDetail(run);
+});
+$("pipeline-filter").addEventListener("change", () => refreshPipelineControlPlane());
+$("pipeline-kind").addEventListener("change", () => refreshPipelineControlPlane());
+$("pipeline-refresh").addEventListener("click", () => {
+  if (selectedPipelineId) {
+    pipelineDetails.delete(selectedPipelineId);
+    pipelineDetailErrors.delete(selectedPipelineId);
+  }
+  refreshPipelineControlPlane();
+});
+$("pipeline-fit").addEventListener("click", () => fitPipeline());
+$("pipeline-reset").addEventListener("click", () => {
+  PIPE.yaw = 0;
+  PIPE.pitch = 0;
+  fitPipeline();
+});
+
+function fitPipeline() {
+  if (!PIPE.group || !PIPE.nodeElements.length) return;
+  PIPE.group.updateWorldMatrix(true, true);
+  const box = new THREE.Box3().setFromObject(PIPE.group);
+  const center = box.getCenter(new THREE.Vector3());
+  const size = box.getSize(new THREE.Vector3());
+  PIPE.target.copy(center);
+  PIPE.yaw = PIPE.width < 600 ? -0.12 : -0.22;
+  PIPE.pitch = PIPE.width < 600 ? 0.07 : 0.13;
+  const halfFov = THREE.MathUtils.degToRad(PIPE.camera.fov * 0.5);
+  const verticalFit = size.y * 0.5 / Math.tan(halfFov);
+  const horizontalFit = size.x * 0.5 / (Math.tan(halfFov) * PIPE.camera.aspect);
+  PIPE.desiredDistance = Math.max(8, verticalFit, horizontalFit) * 1.16;
+  PIPE.distance = PIPE.desiredDistance;
+  updatePipelineCamera();
+  invalidatePipeline();
+}
+
+function updatePipelineCamera() {
+  if (!PIPE.camera) return;
+  const cosPitch = Math.cos(PIPE.pitch);
+  PIPE.camera.position.set(
+    PIPE.target.x + Math.sin(PIPE.yaw) * cosPitch * PIPE.distance,
+    PIPE.target.y + Math.sin(PIPE.pitch) * PIPE.distance,
+    PIPE.target.z + Math.cos(PIPE.yaw) * cosPitch * PIPE.distance,
+  );
+  PIPE.camera.lookAt(PIPE.target);
+  PIPE.nodesNeedProject = true;
+}
+
+function projectPipelineNodes() {
+  if (!PIPE.camera || !PIPE.nodeElements.length) return;
+  PIPE.camera.updateMatrixWorld();
+  const focalLength = PIPE.height /
+    (2 * Math.tan(THREE.MathUtils.degToRad(PIPE.camera.fov * 0.5)));
+  const projected = new THREE.Vector3();
+  const view = new THREE.Vector3();
+  for (const element of PIPE.nodeElements) {
+    const position = PIPE.nodePositions.get(element.dataset.pipelineNodeId);
+    if (!position) continue;
+    projected.copy(position).project(PIPE.camera);
+    view.copy(position).applyMatrix4(PIPE.camera.matrixWorldInverse);
+    const visible = projected.z >= -1 && projected.z <= 1 && view.z < 0 &&
+      projected.x >= -1.3 && projected.x <= 1.3 &&
+      projected.y >= -1.3 && projected.y <= 1.3;
+    if (!visible) {
+      element.style.display = "none";
+      continue;
+    }
+    element.style.display = "";
+    const x = (projected.x * 0.5 + 0.5) * PIPE.width;
+    const y = (-projected.y * 0.5 + 0.5) * PIPE.height;
+    const baseWidth = element._pipelineBaseWidth ||
+      (element._pipelineBaseWidth = element.offsetWidth || 190);
+    const scale = Math.max(0.2, Math.min(1.6, (3 * focalLength / -view.z) / baseWidth));
+    element.style.transform =
+      "translate3d(" + x.toFixed(1) + "px," + y.toFixed(1) +
+      "px,0) translate(-50%,-50%) scale(" + scale.toFixed(3) + ")";
+    element.style.zIndex = String(Math.max(1, Math.round(10000 + view.z * 10)));
+  }
+  PIPE.nodesNeedProject = false;
+}
+
+function invalidatePipeline() {
+  PIPE.needsRender = true;
+  if (PIPE.frameRequest == null && currentView() === "pipelines") {
+    PIPE.frameRequest = requestAnimationFrame(pipelineFrame);
+  }
+}
+
+function resizePipeline() {
+  ensurePipelineRenderer();
+  const rect = $("pipeline-stage").getBoundingClientRect();
+  if (!rect.width || !rect.height) return;
+  PIPE.width = rect.width;
+  PIPE.height = rect.height;
+  PIPE.renderer.setSize(rect.width, rect.height, false);
+  PIPE.camera.aspect = rect.width / rect.height;
+  PIPE.camera.updateProjectionMatrix();
+  PIPE.nodesNeedProject = true;
+  invalidatePipeline();
+  const nextMode = rect.width < 600 ? "vertical" : "horizontal";
+  if (PIPE.group && PIPE.layoutMode && PIPE.layoutMode !== nextMode) {
+    const run = pipelineDetails.get(selectedPipelineId);
+    if (run) void buildPipelineScene(run);
+  }
+}
+
+PIPE.canvas.addEventListener("pointerdown", (event) => {
+  PIPE.drag = {
+    x: event.clientX, y: event.clientY, startX: event.clientX, startY: event.clientY,
+    yaw: PIPE.yaw, pitch: PIPE.pitch, target: PIPE.target.clone(),
+    pan: event.shiftKey || event.button === 2,
+  };
+  PIPE.canvas.setPointerCapture(event.pointerId);
+  PIPE.canvas.classList.add("dragging");
+});
+PIPE.canvas.addEventListener("pointermove", (event) => {
+  if (PIPE.drag) {
+    const dx = event.clientX - PIPE.drag.x;
+    const dy = event.clientY - PIPE.drag.y;
+    if (PIPE.drag.pan) {
+      const scale = PIPE.distance / Math.max(PIPE.height, 1) * 1.4;
+      const right = new THREE.Vector3(1, 0, 0).applyQuaternion(PIPE.camera.quaternion);
+      const up = new THREE.Vector3(0, 1, 0).applyQuaternion(PIPE.camera.quaternion);
+      PIPE.target.copy(PIPE.drag.target).addScaledVector(right, -dx * scale).addScaledVector(up, dy * scale);
+    } else {
+      PIPE.yaw = PIPE.drag.yaw - dx * 0.005;
+      PIPE.pitch = Math.max(-1.15, Math.min(1.15, PIPE.drag.pitch + dy * 0.004));
+    }
+    updatePipelineCamera();
+    invalidatePipeline();
+    return;
+  }
+  PIPE.canvas.style.cursor = "grab";
+});
+PIPE.canvas.addEventListener("pointerup", (event) => {
+  if (!PIPE.drag) return;
+  const moved = Math.hypot(event.clientX - PIPE.drag.startX, event.clientY - PIPE.drag.startY);
+  PIPE.drag = null;
+  PIPE.canvas.classList.remove("dragging");
+  if (moved < 5) {
+    PIPE.selectedNodeId = null;
+    for (const element of PIPE.nodeElements) element.classList.remove("selected");
+    const run = pipelineDetails.get(selectedPipelineId);
+    if (run) paintPipelineDetail(run);
+  }
+});
+PIPE.canvas.addEventListener("pointercancel", () => {
+  PIPE.drag = null;
+  PIPE.canvas.classList.remove("dragging");
+});
+PIPE.canvas.addEventListener("contextmenu", (event) => event.preventDefault());
+PIPE.canvas.addEventListener("wheel", (event) => {
+  event.preventDefault();
+  PIPE.desiredDistance = Math.max(4.5, Math.min(60, PIPE.desiredDistance * Math.exp(event.deltaY * 0.001)));
+  invalidatePipeline();
+}, { passive: false });
+
+PIPE.nodeLayer.addEventListener("click", (event) => {
+  const card = event.target.closest("[data-pipeline-node-id]");
+  if (!card) return;
+  PIPE.selectedNodeId = card.dataset.pipelineNodeId;
+  for (const element of PIPE.nodeElements) {
+    element.classList.toggle("selected", element === card);
+  }
+  const run = pipelineDetails.get(selectedPipelineId);
+  if (run) paintPipelineDetail(run);
+});
+
+function pipelineFrame(now) {
+  PIPE.frameRequest = null;
+  if (!PIPE.renderer || document.hidden || currentView() !== "pipelines") return;
+  if (now - PIPE.lastFrameAt < 50) {
+    invalidatePipeline();
+    return;
+  }
+  const cameraMoving = Math.abs(PIPE.desiredDistance - PIPE.distance) > 0.002;
+  if (!PIPE.needsRender && !cameraMoving && PIPE.packets.length === 0) return;
+  PIPE.lastFrameAt = now;
+  if (cameraMoving) {
+    PIPE.distance += (PIPE.desiredDistance - PIPE.distance) * 0.14;
+    updatePipelineCamera();
+  }
+  for (const packet of PIPE.packets) {
+    const progress = (now * 0.001 * packet.speed + packet.offset) % 1;
+    packet.mesh.position.copy(packet.curve.getPoint(progress));
+    packet.mesh.scale.setScalar(0.8 + Math.sin(now * 0.008 + packet.offset * 10) * 0.18);
+  }
+  if (PIPE.nodesNeedProject) projectPipelineNodes();
+  PIPE.renderer.render(PIPE.scene, PIPE.camera);
+  PIPE.needsRender = false;
+  if (cameraMoving || PIPE.packets.length > 0) invalidatePipeline();
+}
+if (window.ResizeObserver) new ResizeObserver(resizePipeline).observe($("pipeline-stage"));
+document.addEventListener("visibilitychange", () => {
+  if (!document.hidden) invalidatePipeline();
+});
 
 /* =================== memory galaxy =================== */
 /* The server owns semantic layout (PCA + spread + KNN); Three.js owns the
@@ -2877,13 +4080,51 @@ async function refreshDayLogs() {
 }
 
 /* =================== poll loop =================== */
+function pipelineListPath() {
+  const pipelineStatus = $("pipeline-filter").value;
+  const pipelineKind = $("pipeline-kind").value;
+  const pipelineParams = new URLSearchParams();
+  if (pipelineStatus) pipelineParams.set("status", pipelineStatus);
+  if (pipelineKind) pipelineParams.set("kind", pipelineKind);
+  return "/api/pipelines" +
+    (pipelineParams.size ? "?" + pipelineParams.toString() : "");
+}
+
+function applyPipelineListResponse(response) {
+  if (response.ok) {
+    pipelineFetchError = null;
+    const nextPipelines = response.data.pipelines || [];
+    for (const run of nextPipelines) {
+      const detail = pipelineDetails.get(run.id);
+      if (detail && detail.updatedAt !== run.updatedAt) pipelineDetails.delete(run.id);
+    }
+    pipelines = nextPipelines;
+  } else {
+    pipelineFetchError = response.error || true;
+  }
+}
+
+async function refreshPipelineControlPlane() {
+  const generation = ++pipelineFetchGeneration;
+  const response = await safeFetch(pipelineListPath());
+  if (generation !== pipelineFetchGeneration) return;
+  applyPipelineListResponse(response);
+  renderSidebar();
+  renderPipelines();
+  if (!response.ok && pipelines.length === 0) {
+    $("pipeline-status").textContent = "Failed to load pipeline control plane.";
+    $("pipeline-runs").innerHTML = '<div class="empty">Failed to load pipelines.</div>';
+  }
+}
+
 async function refreshMain() {
-  // 2s tick: health + sessions + dev-server + workflows only (no unbounded log scans).
-  const [h, s, d, w] = await Promise.all([
+  const pipelineGeneration = ++pipelineFetchGeneration;
+  const [h, s, d, w, p] = await Promise.all([
     safeFetch("/api/health"),
     safeFetch("/api/sessions"),
     safeFetch("/api/dev-server"),
     safeFetch("/api/workflows"),
+    safeFetch(pipelineListPath()),
   ]);
 
   if (h.ok) health = h.data;
@@ -2897,6 +4138,7 @@ async function refreshMain() {
     workflows = w.data.workflows || [];
     workflowErrors = w.data.errors || [];
   }
+  if (pipelineGeneration === pipelineFetchGeneration) applyPipelineListResponse(p);
 
   lastRefreshAt = Date.now();
   renderSidebar();
@@ -2904,6 +4146,7 @@ async function refreshMain() {
   renderThreads();
   renderDevServers();
   renderWorkflows();
+  if (currentView() === "pipelines") renderPipelines();
   // panel-level errors when first load fails
   if (!s.ok && sessions.length === 0) {
     $("th-list").innerHTML = '<div class="empty">Failed to load sessions.</div>';
@@ -2915,13 +4158,19 @@ async function refreshMain() {
   if (!w.ok && workflows.length === 0) {
     $("wf-list").innerHTML = '<div class="empty">Failed to load workflows.</div>';
   }
+  if (!p.ok && pipelines.length === 0) {
+    $("pipeline-status").textContent = "Failed to load pipeline control plane.";
+    $("pipeline-runs").innerHTML = '<div class="empty">Failed to load pipelines.</div>';
+  }
   if (!h.ok && !health) {
     $("ov-stats").innerHTML = '<div class="empty">Failed to load health.</div>';
   }
 }
 
+let tickInFlight = false;
 async function tick() {
-  if (!live) return;
+  if (!live || tickInFlight) return;
+  tickInFlight = true;
   try {
     await refreshMain();
     if (currentView() === "logs" && follow) {
@@ -2929,6 +4178,8 @@ async function tick() {
     }
   } catch (err) {
     console.error("poll tick failed", err);
+  } finally {
+    tickInFlight = false;
   }
 }
 

--- a/public/pipeline-worker.js
+++ b/public/pipeline-worker.js
@@ -1,0 +1,95 @@
+"use strict";
+
+function buildLayout(input) {
+  const runNodeId = "run:" + input.runId;
+  const assignments = [...input.assignments].sort((a, b) =>
+    a.createdAt - b.createdAt || a.id.localeCompare(b.id)
+  );
+  const assignmentIds = new Set(assignments.map((assignment) => assignment.id));
+  const agents = [...new Set(assignments.map((assignment) => assignment.targetAgent))];
+  const laneByAgent = new Map(agents.map((agent, index) => [agent, index]));
+  const latestByAgent = new Map();
+  const depthById = new Map([[runNodeId, 0]]);
+  const occupiedLaneSlots = new Set();
+  const laneGap = input.vertical ? 3.25 : 1.95;
+  const laneHeight = Math.max(0, (agents.length - 1) * laneGap);
+  const nodes = [{
+    id: runNodeId,
+    type: "run",
+    depth: 0,
+    fromId: null,
+    x: 0,
+    y: input.vertical ? 0 : laneHeight / 2 + 2.15,
+    z: 0,
+  }];
+
+  for (const assignment of assignments) {
+    const explicitParent = assignment.parentAssignmentId &&
+        assignmentIds.has(assignment.parentAssignmentId)
+      ? assignment.parentAssignmentId
+      : null;
+    const inferredParent = latestByAgent.get(assignment.sourceAgent) || null;
+    const fromId = explicitParent || inferredParent || runNodeId;
+    const lane = laneByAgent.get(assignment.targetAgent) || 0;
+    let depth = (depthById.get(fromId) || 0) + 1;
+    while (occupiedLaneSlots.has(lane + ":" + depth)) depth += 1;
+    occupiedLaneSlots.add(lane + ":" + depth);
+    nodes.push({
+      id: assignment.id,
+      type: "assignment",
+      depth,
+      fromId,
+      x: input.vertical ? 0 : depth * 4,
+      y: input.vertical ? -depth * 1.8 : laneHeight / 2 - lane * laneGap,
+      z: Math.sin((lane + 1) * 1.7) * 0.34,
+    });
+    depthById.set(assignment.id, depth);
+    latestByAgent.set(assignment.targetAgent, assignment.id);
+  }
+
+  if (input.vertical) {
+    const columns = new Map();
+    for (const node of nodes) {
+      const column = columns.get(node.depth);
+      if (column) column.push(node);
+      else columns.set(node.depth, [node]);
+    }
+    for (const [depth, column] of columns) {
+      column.sort((a, b) => a.id.localeCompare(b.id));
+      const total = (column.length - 1) * 3.25;
+      column.forEach((node, index) => {
+        node.x = total / 2 - index * 3.25;
+        node.y = -depth * 1.8;
+        node.z = column.length > 1
+          ? (index - (column.length - 1) / 2) * 0.72
+          : Math.sin(depth * 0.75) * 0.14;
+      });
+    }
+  }
+
+  const xs = nodes.map((node) => node.x);
+  const ys = nodes.map((node) => node.y);
+  return {
+    nodes,
+    agents,
+    bounds: {
+      minX: Math.min(...xs),
+      maxX: Math.max(...xs),
+      minY: Math.min(...ys),
+      maxY: Math.max(...ys),
+    },
+  };
+}
+
+self.onmessage = (event) => {
+  const { id, input } = event.data || {};
+  if (!id || !input) return;
+  try {
+    self.postMessage({ id, result: buildLayout(input) });
+  } catch (error) {
+    self.postMessage({
+      id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+};

--- a/src/agents/capabilities.ts
+++ b/src/agents/capabilities.ts
@@ -141,6 +141,7 @@ export function isReadOnlyRole(
   if (!manifest) return false;
   return (
     manifest.mutationPolicy === "none" ||
+    manifest.permissionIntent === "mcp-only" ||
     manifest.permissionIntent === "read-only" ||
     manifest.permissionIntent === "no-tools"
   );

--- a/src/agents/capabilities.ts
+++ b/src/agents/capabilities.ts
@@ -111,6 +111,19 @@ export function canEditProductCode(
   ) && canMutateWorkspace(agent);
 }
 
+/**
+ * Whether an agent must run inside a Junior-managed repository worktree.
+ * Unknown agents fail closed. Orchestrators, planners, and repo-less utility
+ * agents operate only against their explicitly granted control-plane tools.
+ */
+export function requiresManagedWorktree(
+  agent: string | AgentManifest | null | undefined,
+): boolean {
+  const manifest = manifestOf(agent);
+  if (!manifest) return true;
+  return !["orchestrator", "planner", "utility"].includes(manifest.role);
+}
+
 export function mutationPolicyOf(
   agent: string | AgentManifest | null | undefined,
 ): MutationPolicy | null {

--- a/src/agents/loader.test.ts
+++ b/src/agents/loader.test.ts
@@ -64,13 +64,13 @@ describe("loadAgentDefinition", () => {
     expect(def!.permissions.mcp).toContain("mongodb");
   });
 
-  it("loads onboard-member as repo-less with read-only MongoDB access", async () => {
+  it("loads onboard-member as repo-less with MCP-only MongoDB access", async () => {
     const def = await loadAgentDefinition(
       path.join(agentsOrgDir, "onboard-member.md"),
     );
 
     expect(def).not.toBeNull();
-    expect(def!.permissions.intent).toBe("read-only");
+    expect(def!.permissions.intent).toBe("mcp-only");
     expect(def!.permissions.mcp).toContain("mongodb");
     expect(def!.permissions.tools).toContain("mcp__mongodb__find");
     expect(def!.context.workspace).toBe(false);

--- a/src/agents/loader.test.ts
+++ b/src/agents/loader.test.ts
@@ -7,6 +7,7 @@ const agentsDir = path.resolve(
   import.meta.dir,
   "../../.claude/agents",
 );
+const agentsOrgDir = path.resolve(import.meta.dir, "../../agents-org");
 
 describe("loadAgentDefinition", () => {
   it("loads an existing .md file (build.md)", async () => {
@@ -61,6 +62,18 @@ describe("loadAgentDefinition", () => {
     expect(def).not.toBeNull();
     expect(def!.permissions.mcp).toContain("slack-bot");
     expect(def!.permissions.mcp).toContain("mongodb");
+  });
+
+  it("loads onboard-member as repo-less with read-only MongoDB access", async () => {
+    const def = await loadAgentDefinition(
+      path.join(agentsOrgDir, "onboard-member.md"),
+    );
+
+    expect(def).not.toBeNull();
+    expect(def!.permissions.intent).toBe("read-only");
+    expect(def!.permissions.mcp).toContain("mongodb");
+    expect(def!.permissions.tools).toContain("mcp__mongodb__find");
+    expect(def!.context.workspace).toBe(false);
   });
 
   it("parses typed permission frontmatter", async () => {

--- a/src/agents/loader.ts
+++ b/src/agents/loader.ts
@@ -27,6 +27,7 @@ export interface AgentContextProfile {
 }
 
 export type AgentPermissionIntent =
+  | "mcp-only"
   | "read-only"
   | "normal"
   | "human-gated"
@@ -169,6 +170,7 @@ function parsePermissionIntent(value: string | undefined): AgentPermissionIntent
   const normalized = value.trim().toLowerCase();
   if (
     normalized === "read-only" ||
+    normalized === "mcp-only" ||
     normalized === "normal" ||
     normalized === "human-gated" ||
     normalized === "utility" ||

--- a/src/agents/manifest.ts
+++ b/src/agents/manifest.ts
@@ -36,7 +36,8 @@ export type AgentRole =
   | "planner"
   | "builder"
   | "reviewer"
-  | "reproducer";
+  | "reproducer"
+  | "utility";
 
 /**
  * Mutation authority for product code / external systems.
@@ -60,6 +61,7 @@ export type AgentCapability =
   | "github-review-read"
   | "github-review-comment"
   | "browser-read"
+  | "mongodb-read"
   | "pipeline-artifact-write"
   | "pipeline-run-start"
   | "worktree-verify"
@@ -122,6 +124,7 @@ const ORCHESTRATOR_HANDOFF: HandoffPolicy = {
     "frontend",
     "review",
     "reproducer",
+    "onboard-member",
     "human",
   ],
   mayReturnTo: [],
@@ -287,5 +290,23 @@ export const TRUSTED_AGENT_CATALOG: readonly AgentManifest[] = [
       maxParallel: 1,
     },
     trustSource: "junior",
+  },
+  {
+    name: "onboard-member",
+    lifecycle: "persistent",
+    role: "utility",
+    capabilities: [
+      "mongodb-read",
+      "pipeline-artifact-write",
+    ],
+    // Production discovery only. Execution remains independently human-gated.
+    mutationPolicy: "none",
+    permissionIntent: "read-only",
+    handoffPolicy: {
+      mayDelegateTo: ["orchestrator", "human"],
+      mayReturnTo: ["orchestrator"],
+      maxParallel: 0,
+    },
+    trustSource: "agents-org",
   },
 ] as const;

--- a/src/agents/manifest.ts
+++ b/src/agents/manifest.ts
@@ -23,6 +23,7 @@
 
 /** Matches `AgentPermissionIntent` in loader.ts — kept local to avoid cycles. */
 export type CatalogPermissionIntent =
+  | "mcp-only"
   | "read-only"
   | "normal"
   | "human-gated"
@@ -301,7 +302,7 @@ export const TRUSTED_AGENT_CATALOG: readonly AgentManifest[] = [
     ],
     // Production discovery only. Execution remains independently human-gated.
     mutationPolicy: "none",
-    permissionIntent: "read-only",
+    permissionIntent: "mcp-only",
     handoffPolicy: {
       mayDelegateTo: ["orchestrator", "human"],
       mayReturnTo: ["orchestrator"],

--- a/src/agents/provider-parity.test.ts
+++ b/src/agents/provider-parity.test.ts
@@ -84,6 +84,7 @@ describe("provider parity — catalog permissions", () => {
         "default",
         "frontend",
         "lead",
+        "onboard-member",
         "pm",
         "reproducer",
         "review",
@@ -180,6 +181,7 @@ describe("provider parity — handoff graph vs canDispatch", () => {
       "frontend",
       "review",
       "reproducer",
+      "onboard-member",
     ];
     for (const orch of ["default", "lead", "junior"] as const) {
       for (const worker of workers) {

--- a/src/agents/registry.test.ts
+++ b/src/agents/registry.test.ts
@@ -6,6 +6,7 @@ import {
   hasCapability,
   hasHumanGatedCapability,
   isReadOnlyRole,
+  requiresManagedWorktree,
 } from "./capabilities.ts";
 import { resolveEffectivePermissionIntent } from "./loader.ts";
 import { TRUSTED_AGENT_CATALOG } from "./manifest.ts";
@@ -33,6 +34,7 @@ describe("trusted agent catalog", () => {
         "default",
         "frontend",
         "lead",
+        "onboard-member",
         "pm",
         "reproducer",
         "review",
@@ -59,11 +61,14 @@ describe("trusted agent catalog", () => {
       "reproducer",
       "default",
       "lead",
+      "onboard-member",
     ]) {
       const manifest = resolveAgentManifest(name);
       expect(manifest).not.toBeNull();
       expect(manifest!.name).toBe(name);
-      expect(manifest!.trustSource).toBe("junior");
+      expect(manifest!.trustSource).toBe(
+        name === "onboard-member" ? "agents-org" : "junior",
+      );
       expect(manifest!.lifecycle).toBe("persistent");
       expect(manifest!.permissionIntent).toBeTruthy();
     }
@@ -120,6 +125,7 @@ describe("handoff graph", () => {
       expect(registryAllowsHandoff(orch, "build")).toBe(true);
       expect(registryAllowsHandoff(orch, "review")).toBe(true);
       expect(registryAllowsHandoff(orch, "pm")).toBe(true);
+      expect(registryAllowsHandoff(orch, "onboard-member")).toBe(true);
       expect(registryAllowsHandoff(orch, "human")).toBe(true);
     }
   });
@@ -185,6 +191,12 @@ describe("capabilities", () => {
     expect(canEditProductCode("pm")).toBe(false);
     expect(canWritePipelineArtifacts("pm")).toBe(true);
     expect(canWritePipelineArtifacts("review")).toBe(true);
+    expect(isReadOnlyRole("onboard-member")).toBe(true);
+    expect(hasCapability("onboard-member", "mongodb-read")).toBe(true);
+    expect(canEditProductCode("onboard-member")).toBe(false);
+    expect(requiresManagedWorktree("onboard-member")).toBe(false);
+    expect(requiresManagedWorktree("build")).toBe(true);
+    expect(requiresManagedWorktree("unknown-agent")).toBe(true);
   });
 
   it("never grants independently human-gated capabilities", () => {

--- a/src/agents/registry.ts
+++ b/src/agents/registry.ts
@@ -21,7 +21,8 @@ export type OrchestratorContext = "support" | "default";
 
 /** Restrictiveness rank — higher is more restrictive. */
 const INTENT_RESTRICTIVENESS: Record<CatalogPermissionIntent, number> = {
-  "no-tools": 4,
+  "no-tools": 5,
+  "mcp-only": 4,
   "read-only": 3,
   "human-gated": 2,
   utility: 1,

--- a/src/claude/policy.test.ts
+++ b/src/claude/policy.test.ts
@@ -279,6 +279,7 @@ describe("mapClaudeRunPolicy", () => {
       "Read",
       "mcp__slack-bot__pipeline_get_state",
       "mcp__slack-bot__pipeline_report_outcome",
+      "mcp__slack-bot__pipeline_write_artifact",
       "mcp__slack-bot__agent_dispatch",
     ]);
     expect(policy.disallowedTools).toContain("Write");

--- a/src/claude/policy.ts
+++ b/src/claude/policy.ts
@@ -109,6 +109,7 @@ export function mapClaudeRunPolicy(options: {
       ? [
           "mcp__slack-bot__pipeline_get_state",
           "mcp__slack-bot__pipeline_report_outcome",
+          "mcp__slack-bot__pipeline_write_artifact",
         ]
       : []),
     ...(hasCapability(agentName, "dispatch")
@@ -124,6 +125,22 @@ export function mapClaudeRunPolicy(options: {
   ].filter((root): root is string => Boolean(root));
   const mayInspect = hasCapability(agentName, "worktree-verify");
   const hasRegisteredWorktreeCwd = worktreeRoots.includes(cwd);
+
+  if (intent === "mcp-only") {
+    return {
+      permissionMode: "default",
+      allowedTools: [...new Set([...declaredTools, ...capabilityTools])]
+        .filter((tool) => tool.startsWith("mcp__")),
+      disallowedTools: [
+        "Read",
+        "Glob",
+        "Grep",
+        ...NO_TOOLS_DISALLOWED,
+        ...PROVIDER_NATIVE_FANOUT_DISALLOWED,
+      ],
+      addDirs: [],
+    };
+  }
 
   if (intent === "read-only") {
     if (mayInspect) {

--- a/src/codex-app-server/config.test.ts
+++ b/src/codex-app-server/config.test.ts
@@ -81,6 +81,22 @@ describe("buildCodexMcpConfig", () => {
       },
     });
   });
+
+  it("injects the read-only MongoDB proxy from a trusted agent capability", () => {
+    const session = createSession("t", "c");
+    session.activeAgentName = "onboard-member";
+    session.agentPermissions = { intent: "read-only", mcp: [], tools: [] };
+
+    expect(buildCodexMcpConfig(makeConfig(), session, true)).toMatchObject({
+      mongodb: {
+        transport: "http",
+        url: expect.stringContaining(
+          "http://localhost:3456/mcp/mongodb?agent=onboard-member&channel=c&thread=t",
+        ),
+      },
+      "slack-bot": expect.any(Object),
+    });
+  });
 });
 
 describe("buildCodexConfigToml", () => {

--- a/src/codex-app-server/policy.ts
+++ b/src/codex-app-server/policy.ts
@@ -47,6 +47,15 @@ export function mapCodexRunPolicy(options: {
     ...Object.values(session.worktreePaths ?? {}),
   ].filter((root): root is string => Boolean(root));
 
+  if (intent === "mcp-only") {
+    return {
+      approvalPolicy: "never",
+      sandbox: "read-only",
+      sandboxPolicy: { type: "readOnly" },
+      mcpAllowed: !session.cwd,
+    };
+  }
+
   if (intent === "read-only" || intent === "no-tools") {
     if (
       intent === "read-only" &&

--- a/src/http/routes/pipelines.test.ts
+++ b/src/http/routes/pipelines.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from "bun:test";
+import { InMemoryPipelineStore } from "../../pipelines/store/memory.ts";
+import type { AssignmentCreate, PipelineRun } from "../../pipelines/types.ts";
+import { handlePipelines } from "./pipelines.ts";
+
+describe("handlePipelines", () => {
+  it("projects recent runs as assignment dispatch flows", async () => {
+    const store = new InMemoryPipelineStore();
+    const run = makeRun();
+    const root = makeAssignment(run.id, "root", null, "system", "build");
+    const child = makeAssignment(run.id, "child", root.id, "build", "review");
+
+    await store.createRunWithAssignment({
+      run,
+      assignment: root,
+      outbox: [{
+        id: "dispatch-root",
+        runId: run.id,
+        assignmentId: root.id,
+        eventType: "assignment.dispatch",
+        payload: {},
+        idempotencyKey: "dispatch-root",
+        status: "delivered",
+      }],
+    });
+    const outcomeReceipt = await store.recordOutcomeTransaction({
+      outcome: {
+        assignmentId: root.id,
+        expectedRunVersion: 1,
+        action: "continue_self",
+        status: "progress",
+        reason: "The implementation handoff is ready.",
+        evidenceRefs: ["e1"],
+        artifactRefs: [],
+        blockers: [],
+        checks: [],
+        progressFingerprint: "architecture-ready",
+      },
+      actorType: "agent",
+      actorId: "build",
+      idempotencyKey: "architecture-ready",
+      toPhase: "aggregate-verification",
+    });
+    expect(outcomeReceipt.status).toBe("accepted");
+    await store.createAssignmentWithOutbox({
+      assignment: child,
+      outbox: {
+        id: "dispatch-child",
+        runId: run.id,
+        assignmentId: child.id,
+        eventType: "assignment.dispatch",
+        payload: {},
+        idempotencyKey: "dispatch-child",
+        status: "pending",
+      },
+    });
+
+    const indexResponse = await handlePipelines(store, new URLSearchParams());
+    const indexBody = await indexResponse.json() as {
+      pipelines: Array<{ id: string; assignments?: unknown[] }>;
+    };
+    expect(indexBody.pipelines).toEqual([
+      expect.objectContaining({ id: run.id }),
+    ]);
+    expect(indexBody.pipelines[0]!.assignments).toBeUndefined();
+
+    const response = await handlePipelines(
+      store,
+      new URLSearchParams(),
+      run.id,
+    );
+    expect(response.status).toBe(200);
+    const body = await response.json() as {
+      pipeline: {
+        id: string;
+        assignments: Array<{
+          id: string;
+          parentAssignmentId: string | null;
+          dispatch: { status: string } | null;
+          outcomes: Array<{ reason: string }>;
+        }>;
+        transitions: Array<{
+          id: string;
+          sequence: number;
+          fromPhase: string;
+          toPhase: string;
+          actorType: string;
+          actorId: string;
+          occurredAt: number;
+        }>;
+      };
+    };
+
+    expect(body.pipeline.id).toBe(run.id);
+    expect(body.pipeline.assignments).toHaveLength(2);
+    expect(body.pipeline.assignments[0]!.dispatch?.status).toBe("delivered");
+    expect(body.pipeline.assignments[0]!.outcomes).toEqual([
+      expect.objectContaining({
+        reason: "The implementation handoff is ready.",
+      }),
+    ]);
+    expect(body.pipeline.assignments[1]).toMatchObject({
+      id: "child",
+      parentAssignmentId: "root",
+      dispatch: { status: "pending" },
+    });
+    expect(body.pipeline.transitions).toEqual([
+      expect.objectContaining({
+        sequence: 1,
+        fromPhase: "building",
+        toPhase: "aggregate-verification",
+        actorType: "agent",
+        actorId: "build",
+      }),
+    ]);
+  });
+
+  it("returns all runs and filters product and bug pipelines", async () => {
+    const store = new InMemoryPipelineStore();
+    for (let index = 0; index < 55; index += 1) {
+      const run = makeRun(
+        `run-${index}`,
+        index,
+        index % 2 === 0 ? "product" : "bug",
+      );
+      await store.createRunWithAssignment({
+        run,
+        assignment: makeAssignment(run.id, `asg-${index}`, null, "system", "default"),
+      });
+    }
+
+    const allResponse = await handlePipelines(store, new URLSearchParams());
+    const allBody = await allResponse.json() as {
+      pipelines: Array<{ kind: string }>;
+    };
+    expect(allBody.pipelines).toHaveLength(55);
+
+    const bugResponse = await handlePipelines(
+      store,
+      new URLSearchParams("kind=bug"),
+    );
+    const bugBody = await bugResponse.json() as {
+      pipelines: Array<{ kind: string }>;
+    };
+    expect(bugBody.pipelines).toHaveLength(27);
+    expect(bugBody.pipelines.every((run) => run.kind === "bug")).toBe(true);
+  });
+
+  it("returns 404 for a missing pipeline detail", async () => {
+    const response = await handlePipelines(
+      new InMemoryPipelineStore(),
+      new URLSearchParams(),
+      "missing",
+    );
+    expect(response.status).toBe(404);
+  });
+});
+
+function makeRun(
+  id = "run-1",
+  updatedAt = 2,
+  kind: PipelineRun["kind"] = "product",
+): PipelineRun {
+  const base = {
+    id,
+    definitionVersion: 1,
+    channelId: "C123",
+    threadId: `thread-${id}`,
+    status: "active" as const,
+    ownerAgent: kind === "bug" ? "debug" : kind === "default" ? "default" : "build",
+    repoRefs: ["junior"],
+    acceptanceCriteria: [],
+    artifactRefs: [],
+    blockerRefs: [],
+    activeAttemptId: null,
+    stateVersion: 1,
+    deadlineAt: null,
+    terminalOutcome: null,
+    terminalReason: null,
+    createdAt: 1,
+    updatedAt,
+  };
+  if (kind === "bug") return { ...base, kind: "bug", phase: "intake", ownerAgent: "debug" };
+  if (kind === "default") {
+    return { ...base, kind: "default", phase: "working", ownerAgent: "default" };
+  }
+  return { ...base, kind: "product", phase: "building" };
+}
+
+function makeAssignment(
+  runId: string,
+  id: string,
+  parentAssignmentId: string | null,
+  sourceAgent: string,
+  targetAgent: string,
+): AssignmentCreate {
+  return {
+    id,
+    runId,
+    parentAssignmentId,
+    sourceAgent,
+    sourceSlackUserId: null,
+    targetAgent,
+    objective: `${targetAgent} objective`,
+    contextRefs: [],
+    artifactRefs: [],
+    acceptanceCriteria: [],
+    mutationScope: [],
+    dependsOn: [],
+    attempt: 1,
+    attemptId: null,
+    candidateRevisionDigest: null,
+    deadlineAt: null,
+    idempotencyKey: `assignment-${id}`,
+  };
+}

--- a/src/http/routes/pipelines.test.ts
+++ b/src/http/routes/pipelines.test.ts
@@ -58,11 +58,13 @@ describe("handlePipelines", () => {
     const indexResponse = await handlePipelines(store, new URLSearchParams());
     const indexBody = await indexResponse.json() as {
       pipelines: Array<{ id: string; assignments?: unknown[] }>;
+      openCount: number;
     };
     expect(indexBody.pipelines).toEqual([
       expect.objectContaining({ id: run.id }),
     ]);
     expect(indexBody.pipelines[0]!.assignments).toBeUndefined();
+    expect(indexBody.openCount).toBe(1);
 
     const response = await handlePipelines(
       store,

--- a/src/http/routes/pipelines.ts
+++ b/src/http/routes/pipelines.ts
@@ -1,0 +1,159 @@
+import type { PipelineStore } from "../../pipelines/store/interface.ts";
+import type {
+  Assignment,
+  PipelineOutboxRecord,
+  PipelineRun,
+  StoredOutcome,
+} from "../../pipelines/types.ts";
+
+const RUN_STATUSES = new Set(["active", "waiting", "needs-human", "terminal"]);
+const RUN_KINDS = new Set(["default", "product", "bug"]);
+
+export async function handlePipelines(
+  store: PipelineStore,
+  params: URLSearchParams,
+  runId?: string,
+): Promise<Response> {
+  if (runId) {
+    const run = await store.getRun(runId);
+    if (!run) return Response.json({ error: "pipeline not found" }, { status: 404 });
+    return Response.json({ pipeline: await projectPipeline(store, run) });
+  }
+
+  const rawStatus = params.get("status");
+  const status = rawStatus && RUN_STATUSES.has(rawStatus)
+    ? rawStatus as PipelineRun["status"]
+    : undefined;
+  const rawKind = params.get("kind");
+  const kind = rawKind && RUN_KINDS.has(rawKind)
+    ? rawKind as PipelineRun["kind"]
+    : undefined;
+
+  const runs = await store.listRuns({ status, kind });
+  const pipelines = runs.map(projectRun);
+
+  return Response.json({ pipelines });
+}
+
+async function projectPipeline(store: PipelineStore, run: PipelineRun) {
+  const [assignments, events, outbox] = await Promise.all([
+    store.listAssignments(run.id),
+    store.listEvents(run.id),
+    store.listOutbox(run.id),
+  ]);
+  const dispatchByAssignment = latestDispatches(outbox);
+  const outcomesByAssignment = new Map(
+    await Promise.all(
+      assignments.map(async (assignment) => [
+        assignment.id,
+        await store.listOutcomes(assignment.id),
+      ] as const),
+    ),
+  );
+
+  return {
+    ...projectRun(run),
+    assignments: assignments
+      .sort((a, b) => a.createdAt - b.createdAt)
+      .map((assignment) =>
+        projectAssignment(
+          assignment,
+          dispatchByAssignment.get(assignment.id),
+          outcomesByAssignment.get(assignment.id) ?? [],
+        )
+      ),
+    transitions: events
+      .filter((event) =>
+        event.fromPhase !== null &&
+        event.toPhase !== null &&
+        event.fromPhase !== event.toPhase
+      )
+      .map((event) => ({
+        id: event.id,
+        sequence: event.sequence,
+        fromPhase: event.fromPhase,
+        toPhase: event.toPhase,
+        actorType: event.actorType,
+        actorId: event.actorId,
+        occurredAt: event.occurredAt,
+      })),
+  };
+}
+
+function projectRun(run: PipelineRun) {
+  return {
+    id: run.id,
+    kind: run.kind,
+    channelId: run.channelId,
+    threadId: run.threadId,
+    phase: run.phase,
+    status: run.status,
+    ownerAgent: run.ownerAgent,
+    repoRefs: run.repoRefs,
+    activeAttemptId: run.activeAttemptId,
+    stateVersion: run.stateVersion,
+    terminalOutcome: run.terminalOutcome,
+    terminalReason: run.terminalReason,
+    createdAt: run.createdAt,
+    updatedAt: run.updatedAt,
+  };
+}
+
+function projectAssignment(
+  assignment: Assignment,
+  dispatch: PipelineOutboxRecord | undefined,
+  outcomes: StoredOutcome[],
+) {
+  return {
+    id: assignment.id,
+    parentAssignmentId: assignment.parentAssignmentId,
+    sourceAgent: assignment.sourceAgent,
+    targetAgent: assignment.targetAgent,
+    status: assignment.status,
+    objective: assignment.objective,
+    attempt: assignment.attempt,
+    attemptId: assignment.attemptId,
+    dependsOn: assignment.dependsOn,
+    createdAt: assignment.createdAt,
+    updatedAt: assignment.updatedAt,
+    outcomes: outcomes.map((outcome) => ({
+      id: outcome.id,
+      action: outcome.action,
+      status: outcome.status,
+      reason: outcome.reason,
+      blockers: outcome.blockers,
+      checks: outcome.checks,
+      createdAt: outcome.createdAt,
+    })),
+    dispatch: dispatch
+      ? {
+          status: dispatch.status,
+          attempts: dispatch.attempts,
+          availableAt: dispatch.availableAt,
+          deliveredAt: dispatch.deliveredAt,
+          lastError: dispatch.lastError,
+        }
+      : null,
+  };
+}
+
+function latestDispatches(
+  outbox: PipelineOutboxRecord[],
+): Map<string, PipelineOutboxRecord> {
+  const result = new Map<string, PipelineOutboxRecord>();
+  for (const record of outbox) {
+    if (
+      !record.assignmentId ||
+      !["assignment.dispatch", "assignment.continue", "assignment.resume"].includes(
+        record.eventType,
+      )
+    ) {
+      continue;
+    }
+    const current = result.get(record.assignmentId);
+    if (!current || record.createdAt > current.createdAt) {
+      result.set(record.assignmentId, record);
+    }
+  }
+  return result;
+}

--- a/src/http/routes/pipelines.ts
+++ b/src/http/routes/pipelines.ts
@@ -29,27 +29,29 @@ export async function handlePipelines(
     ? rawKind as PipelineRun["kind"]
     : undefined;
 
-  const runs = await store.listRuns({ status, kind });
+  const [runs, openCount] = await Promise.all([
+    store.listRuns({ status, kind, limit: 100 }),
+    store.countOpenRuns(),
+  ]);
   const pipelines = runs.map(projectRun);
 
-  return Response.json({ pipelines });
+  return Response.json({ pipelines, openCount });
 }
 
 async function projectPipeline(store: PipelineStore, run: PipelineRun) {
-  const [assignments, events, outbox] = await Promise.all([
+  const [assignments, events, outbox, outcomes] = await Promise.all([
     store.listAssignments(run.id),
     store.listEvents(run.id),
     store.listOutbox(run.id),
+    store.listOutcomesForRun(run.id),
   ]);
   const dispatchByAssignment = latestDispatches(outbox);
-  const outcomesByAssignment = new Map(
-    await Promise.all(
-      assignments.map(async (assignment) => [
-        assignment.id,
-        await store.listOutcomes(assignment.id),
-      ] as const),
-    ),
-  );
+  const outcomesByAssignment = new Map<string, StoredOutcome[]>();
+  for (const outcome of outcomes) {
+    const grouped = outcomesByAssignment.get(outcome.assignmentId) ?? [];
+    grouped.push(outcome);
+    outcomesByAssignment.set(outcome.assignmentId, grouped);
+  }
 
   return {
     ...projectRun(run),

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -15,12 +15,14 @@ import type { DevServerQueue } from "../lifecycle/dev-server-queue.ts";
 import type { WorkflowRegistry } from "../workflows/registry.ts";
 import type { WorkflowStore } from "../workflows/store.ts";
 import type { MemoryStore } from "../memory/store.ts";
+import type { PipelineStore } from "../pipelines/store/interface.ts";
 import { handleHealth } from "./routes/health.ts";
 import { handleSessions, handleSessionDetail } from "./routes/sessions.ts";
 import { handleLogs } from "./routes/logs.ts";
 import { handleMemoryList, handleMemoryProjection, handleMemoryRead, handleMemoryRecall } from "./routes/memory.ts";
 import { handleDevServers } from "./routes/dev-server.ts";
 import { handleWorkflows } from "./routes/workflows.ts";
+import { handlePipelines } from "./routes/pipelines.ts";
 import { log } from "../logger.ts";
 
 const PUBLIC_DIR = path.resolve(import.meta.dir, "../../public");
@@ -35,6 +37,7 @@ export interface HttpServerDeps {
   workflowRegistry: WorkflowRegistry;
   workflowStore: WorkflowStore;
   memoryStore?: MemoryStore;
+  pipelineStore: PipelineStore;
 }
 
 export function startHttpServer(deps: HttpServerDeps): void {
@@ -47,6 +50,7 @@ export function startHttpServer(deps: HttpServerDeps): void {
     workflowRegistry,
     workflowStore,
     memoryStore,
+    pipelineStore,
   } = deps;
 
   const server = Bun.serve({
@@ -95,6 +99,19 @@ export function startHttpServer(deps: HttpServerDeps): void {
           return new Response("Three.js runtime not found", { status: 404 });
         }
 
+        if (url.pathname === "/assets/pipeline-worker.js") {
+          const file = Bun.file(path.join(PUBLIC_DIR, "pipeline-worker.js"));
+          if (await file.exists()) {
+            return new Response(file, {
+              headers: {
+                "Content-Type": "text/javascript; charset=utf-8",
+                "Cache-Control": "no-cache",
+              },
+            });
+          }
+          return new Response("Pipeline worker not found", { status: 404 });
+        }
+
         if (url.pathname === "/api/health") {
           return await handleHealth(store, config, startedAt);
         } else if (url.pathname === "/api/sessions") {
@@ -108,6 +125,13 @@ export function startHttpServer(deps: HttpServerDeps): void {
           return await handleDevServers(devServerManager, devServerQueue, repos);
         } else if (url.pathname === "/api/workflows") {
           return await handleWorkflows(workflowRegistry, workflowStore);
+        } else if (url.pathname === "/api/pipelines") {
+          return await handlePipelines(pipelineStore, url.searchParams);
+        } else if (url.pathname.startsWith("/api/pipelines/")) {
+          const runId = decodeURIComponent(
+            url.pathname.slice("/api/pipelines/".length),
+          );
+          return await handlePipelines(pipelineStore, url.searchParams, runId);
         } else if (url.pathname === "/api/logs") {
           return await handleLogs(url.searchParams);
         } else if (url.pathname === "/api/memory/recall") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -699,6 +699,7 @@ setInterval(() => {
         workflowRegistry,
         workflowStore,
         memoryStore,
+        pipelineStore,
       });
     } catch (err) {
       log.error(

--- a/src/mcp/mongodb-proxy.test.ts
+++ b/src/mcp/mongodb-proxy.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "bun:test";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { SlackMcpRunContext } from "./context.ts";
+import { createMongoProxyServer } from "./mongodb-proxy.ts";
+
+const RUN_CONTEXT: SlackMcpRunContext = {
+  agent: "thinker",
+  channel: "C01",
+  threadId: "thread-1",
+  signed: true,
+};
+
+describe("MongoDB MCP read-only proxy", () => {
+  it("mirrors backend schemas and forwards nested filter arguments", async () => {
+    const calls: Array<{ name: string; arguments?: Record<string, unknown> }> = [];
+    const backendClient = {
+      async listTools() {
+        return {
+          tools: [
+            {
+              name: "find",
+              description: "Run a find query against a MongoDB collection",
+              inputSchema: {
+                type: "object" as const,
+                properties: {
+                  connectionId: { type: "string" },
+                  database: { type: "string" },
+                  collection: { type: "string" },
+                  filter: {
+                    type: "object",
+                    additionalProperties: true,
+                  },
+                },
+                required: ["connectionId", "database", "collection"],
+              },
+            },
+            {
+              name: "insert-many",
+              inputSchema: { type: "object" as const },
+            },
+          ],
+        };
+      },
+      async callTool(request: { name: string; arguments?: Record<string, unknown> }) {
+        calls.push(request);
+        return {
+          content: [{ type: "text" as const, text: "ok" }],
+        };
+      },
+    };
+    const server = createMongoProxyServer(
+      RUN_CONTEXT,
+      async () => ({ client: backendClient as never }),
+    );
+    const client = new Client({ name: "mongo-proxy-test", version: "0.1.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      const { tools } = await client.listTools();
+      expect(tools.map((tool) => tool.name)).toEqual(["find"]);
+      expect(tools[0]?.inputSchema).toMatchObject({
+        properties: {
+          database: { type: "string" },
+          filter: {
+            type: "object",
+            additionalProperties: true,
+          },
+        },
+      });
+
+      const filter = {
+        status: { $in: ["active", "trial"] },
+        createdAt: { $gte: { $date: "2026-07-01T00:00:00.000Z" } },
+      };
+      const result = await client.callTool({
+        name: "find",
+        arguments: {
+          connectionId: "preconfigured",
+          database: "app",
+          collection: "members",
+          filter,
+        },
+      });
+
+      expect(result.isError).not.toBe(true);
+      expect(calls).toEqual([{
+        name: "find",
+        arguments: {
+          connectionId: "preconfigured",
+          database: "app",
+          collection: "members",
+          filter,
+        },
+      }]);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it("does not expose or call write tools returned by the backend", async () => {
+    let called = false;
+    const backendClient = {
+      async listTools() {
+        return {
+          tools: [{
+            name: "delete-many",
+            inputSchema: { type: "object" as const },
+          }],
+        };
+      },
+      async callTool() {
+        called = true;
+        return { content: [{ type: "text" as const, text: "unexpected" }] };
+      },
+    };
+    const server = createMongoProxyServer(
+      RUN_CONTEXT,
+      async () => ({ client: backendClient as never }),
+    );
+    const client = new Client({ name: "mongo-proxy-test", version: "0.1.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      expect((await client.listTools()).tools).toEqual([]);
+      const result = await client.callTool({
+        name: "delete-many",
+        arguments: {},
+      });
+      expect(result.isError).toBe(true);
+      expect(called).toBe(false);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});

--- a/src/mcp/mongodb-proxy.ts
+++ b/src/mcp/mongodb-proxy.ts
@@ -2,13 +2,15 @@ import { resolve } from "node:path";
 import type { IncomingMessage, ServerResponse } from "node:http";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
-import { z } from "zod";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  type CallToolResult,
+} from "@modelcontextprotocol/sdk/types.js";
 import { log } from "../logger.ts";
 import { parseSlackMcpRunContext, type SlackMcpRunContext } from "./context.ts";
-import { registerTool } from "./register-tool.ts";
 
 const MONGODB_PROXY_IDLE_TTL_MS = Number(process.env.MONGODB_MCP_PROXY_IDLE_TTL_MS ?? "600000");
 const MONGODB_PROXY_REQUEST_TIMEOUT_MS = Number(process.env.MONGODB_MCP_PROXY_REQUEST_TIMEOUT_MS ?? "120000");
@@ -26,6 +28,9 @@ interface MongoBackend {
   transport: StdioClientTransport;
 }
 
+type MongoBackendClient = Pick<Client, "callTool" | "listTools">;
+type MongoBackendProvider = () => Promise<{ client: MongoBackendClient }>;
+
 let backend: Promise<MongoBackend> | null = null;
 let idleTimer: ReturnType<typeof setTimeout> | null = null;
 
@@ -34,8 +39,7 @@ export async function handleMongoMcpRequest(
   res: ServerResponse,
 ): Promise<void> {
   const runContext = parseSlackMcpRunContext(req.url);
-  const mcpServer = new McpServer({ name: "mongodb", version: "0.1.0" });
-  registerMongoProxyTools(mcpServer, runContext);
+  const mcpServer = createMongoProxyServer(runContext);
 
   const transport = new StreamableHTTPServerTransport({
     sessionIdGenerator: undefined,
@@ -43,6 +47,57 @@ export async function handleMongoMcpRequest(
 
   await mcpServer.connect(transport);
   await transport.handleRequest(req, res);
+}
+
+/**
+ * Mirror the backend's current tool contracts instead of replacing them with a
+ * generic record schema. Strict MCP clients reject legitimate Mongo arguments
+ * (including nested `filter` objects) when tools/list declares no properties.
+ * The allowlist remains local so upstream additions can never expand access.
+ */
+export function createMongoProxyServer(
+  runContext: SlackMcpRunContext | null,
+  backendProvider: MongoBackendProvider = getMongoBackend,
+): Server {
+  const server = new Server(
+    { name: "mongodb", version: "0.1.0" },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    const { client } = await backendProvider();
+    armIdleTimer();
+    const { tools } = await client.listTools();
+    return {
+      tools: tools.filter((tool) => isAllowedMongoTool(tool.name)),
+    };
+  });
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+    if (!isAllowedMongoTool(name)) {
+      return mongoProxyError(`tool "${name}" is not available through the read-only proxy.`);
+    }
+    if (!runContext) {
+      return mongoProxyError("MongoDB MCP run context missing; refused to proxy request.");
+    }
+
+    try {
+      const { client } = await backendProvider();
+      armIdleTimer();
+      return await client.callTool(
+        { name, arguments: args },
+        undefined,
+        { timeout: MONGODB_PROXY_REQUEST_TIMEOUT_MS },
+      ) as CallToolResult;
+    } catch (err) {
+      return mongoProxyError(
+        `MongoDB MCP proxy error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  });
+
+  return server;
 }
 
 export async function closeMongoMcpBackend(): Promise<void> {
@@ -56,50 +111,18 @@ export async function closeMongoMcpBackend(): Promise<void> {
   await transport?.close().catch(() => undefined);
 }
 
-function registerMongoProxyTools(
-  server: McpServer,
-  runContext: SlackMcpRunContext | null,
-): void {
-  for (const name of MONGODB_TOOL_NAMES) {
-    registerTool(
-      server,
-      name,
-      {
-        description: `Proxy to Junior's shared read-only MongoDB MCP backend (${name}).`,
-        inputSchema: z.record(z.string(), z.unknown()),
-      },
-      async (args) => {
-        if (!runContext) {
-          return {
-            isError: true,
-            content: [{
-              type: "text" as const,
-              text: "Error: MongoDB MCP run context missing; refused to proxy request.",
-            }],
-          };
-        }
+function isAllowedMongoTool(name: string): name is typeof MONGODB_TOOL_NAMES[number] {
+  return (MONGODB_TOOL_NAMES as readonly string[]).includes(name);
+}
 
-        try {
-          const { client } = await getMongoBackend();
-          armIdleTimer();
-          const result = await client.callTool(
-            { name, arguments: args },
-            undefined,
-            { timeout: MONGODB_PROXY_REQUEST_TIMEOUT_MS },
-          );
-          return result as CallToolResult;
-        } catch (err) {
-          return {
-            isError: true,
-            content: [{
-              type: "text" as const,
-              text: `MongoDB MCP proxy error: ${err instanceof Error ? err.message : String(err)}`,
-            }],
-          };
-        }
-      },
-    );
-  }
+function mongoProxyError(message: string): CallToolResult {
+  return {
+    isError: true,
+    content: [{
+      type: "text",
+      text: `Error: ${message}`,
+    }],
+  };
 }
 
 function getMongoBackend(): Promise<MongoBackend> {

--- a/src/mcp/slack-server.ts
+++ b/src/mcp/slack-server.ts
@@ -1535,7 +1535,7 @@ export function registerTools(server: McpServer, runContext: SlackMcpRunContext 
         path: z.string().describe("Relative path under the run artifact directory"),
         content: z.string().describe("File contents"),
         run_id: z.string().optional(),
-        assignment_id: z.string().optional(),
+        assignment_id: z.string(),
       },
     },
     async (args) => {

--- a/src/pipelines/store/interface.ts
+++ b/src/pipelines/store/interface.ts
@@ -36,7 +36,10 @@ export interface PipelineStore {
   listRuns(filter?: {
     status?: PipelineRun["status"];
     kind?: PipelineRun["kind"];
+    limit?: number;
   }): Promise<PipelineRun[]>;
+  /** Global non-terminal count, independent of dashboard filters. */
+  countOpenRuns(): Promise<number>;
 
   /**
    * Atomically create a run + initial assignment (and optional seed events).
@@ -116,6 +119,8 @@ export interface PipelineStore {
   listGates(attemptId: string): Promise<PipelineGate[]>;
 
   listOutcomes(assignmentId: string): Promise<StoredOutcome[]>;
+  /** Batch dashboard projection for every assignment belonging to a run. */
+  listOutcomesForRun(runId: string): Promise<StoredOutcome[]>;
 
   // -------------------------------------------------------------------------
   // GitHub resource tracking (Phase 5 shadow — no wakes)

--- a/src/pipelines/store/interface.ts
+++ b/src/pipelines/store/interface.ts
@@ -32,6 +32,11 @@ export interface PipelineStore {
   createRun(run: PipelineRun): Promise<void>;
   getRun(id: string): Promise<PipelineRun | undefined>;
   getRunByThread(threadId: string): Promise<PipelineRun | undefined>;
+  /** Read-only dashboard projection, newest activity first. */
+  listRuns(filter?: {
+    status?: PipelineRun["status"];
+    kind?: PipelineRun["kind"];
+  }): Promise<PipelineRun[]>;
 
   /**
    * Atomically create a run + initial assignment (and optional seed events).

--- a/src/pipelines/store/memory.test.ts
+++ b/src/pipelines/store/memory.test.ts
@@ -295,6 +295,8 @@ describe("InMemoryPipelineStore", () => {
     expect((await store.listRuns({ kind: "bug" })).map((run) => run.id)).toEqual([
       "bug-run-1",
     ]);
+    expect(await store.listRuns({ limit: 2 })).toHaveLength(2);
+    expect(await store.countOpenRuns()).toBe(3);
   });
 
   it("is idempotent on assignment idempotency keys", async () => {

--- a/src/pipelines/store/memory.test.ts
+++ b/src/pipelines/store/memory.test.ts
@@ -3,6 +3,7 @@ import { fakeClock } from "../../time/clock.ts";
 import { InMemoryPipelineStore } from "./memory.ts";
 import {
   makeAssignmentCreate,
+  makeBugRun,
   makeDefaultPromotionInput,
   makeDefaultRun,
   makeProductRun,
@@ -278,6 +279,22 @@ describe("InMemoryPipelineStore", () => {
     await store.createRun(run);
     expect((await store.getRun("run-1"))?.phase).toBe("building");
     expect((await store.getRunByThread("T1"))?.id).toBe("run-1");
+  });
+
+  it("lists every run newest-first and filters by pipeline kind", async () => {
+    const store = new InMemoryPipelineStore(fakeClock(1000));
+    await store.createRun(makeProductRun({ updatedAt: 1_000 }));
+    await store.createRun(makeBugRun({ updatedAt: 2_000 }));
+    await store.createRun(makeDefaultRun({ updatedAt: 3_000 }));
+
+    expect((await store.listRuns()).map((run) => run.kind)).toEqual([
+      "default",
+      "bug",
+      "product",
+    ]);
+    expect((await store.listRuns({ kind: "bug" })).map((run) => run.id)).toEqual([
+      "bug-run-1",
+    ]);
   });
 
   it("is idempotent on assignment idempotency keys", async () => {

--- a/src/pipelines/store/memory.ts
+++ b/src/pipelines/store/memory.ts
@@ -90,6 +90,7 @@ export class InMemoryPipelineStore implements PipelineStore {
   async listRuns(filter?: {
     status?: PipelineRun["status"];
     kind?: PipelineRun["kind"];
+    limit?: number;
   }): Promise<PipelineRun[]> {
     return [...this.runs.values()]
       .filter((run) =>
@@ -97,7 +98,12 @@ export class InMemoryPipelineStore implements PipelineStore {
         (!filter?.kind || run.kind === filter.kind)
       )
       .sort((a, b) => b.updatedAt - a.updatedAt)
+      .slice(0, filter?.limit ?? 100)
       .map(cloneRun);
+  }
+
+  async countOpenRuns(): Promise<number> {
+    return [...this.runs.values()].filter((run) => run.status !== "terminal").length;
   }
 
   async createRunWithAssignment(input: {
@@ -834,6 +840,17 @@ export class InMemoryPipelineStore implements PipelineStore {
 
   async listOutcomes(assignmentId: string): Promise<StoredOutcome[]> {
     return (this.outcomes.get(assignmentId) ?? []).map((o) => ({ ...o }));
+  }
+
+  async listOutcomesForRun(runId: string): Promise<StoredOutcome[]> {
+    const assignmentIds = new Set(
+      [...this.assignments.values()]
+        .filter((assignment) => assignment.runId === runId)
+        .map((assignment) => assignment.id),
+    );
+    return [...this.outcomes.entries()]
+      .filter(([assignmentId]) => assignmentIds.has(assignmentId))
+      .flatMap(([, outcomes]) => outcomes.map((outcome) => ({ ...outcome })));
   }
 
   // -------------------------------------------------------------------------

--- a/src/pipelines/store/memory.ts
+++ b/src/pipelines/store/memory.ts
@@ -87,6 +87,19 @@ export class InMemoryPipelineStore implements PipelineStore {
     this.runsByThread.set(run.threadId, run.id);
   }
 
+  async listRuns(filter?: {
+    status?: PipelineRun["status"];
+    kind?: PipelineRun["kind"];
+  }): Promise<PipelineRun[]> {
+    return [...this.runs.values()]
+      .filter((run) =>
+        (!filter?.status || run.status === filter.status) &&
+        (!filter?.kind || run.kind === filter.kind)
+      )
+      .sort((a, b) => b.updatedAt - a.updatedAt)
+      .map(cloneRun);
+  }
+
   async createRunWithAssignment(input: {
     run: PipelineRun;
     assignment: AssignmentCreate;

--- a/src/pipelines/store/sqlite.test.ts
+++ b/src/pipelines/store/sqlite.test.ts
@@ -102,6 +102,8 @@ describe("SqlitePipelineStore", () => {
         .map((run) => run.id),
     ).toEqual(["bug-run-1"]);
     expect(await store.listRuns({ kind: "product", status: "waiting" })).toEqual([]);
+    expect(await store.listRuns({ limit: 2 })).toHaveLength(2);
+    expect(await store.countOpenRuns()).toBe(3);
   });
 
   it("is idempotent on assignment idempotency keys", async () => {

--- a/src/pipelines/store/sqlite.test.ts
+++ b/src/pipelines/store/sqlite.test.ts
@@ -6,6 +6,7 @@ import { fakeClock } from "../../time/clock.ts";
 import { SqlitePipelineStore } from "./sqlite.ts";
 import {
   makeAssignmentCreate,
+  makeBugRun,
   makeDefaultPromotionInput,
   makeDefaultRun,
   makeProductRun,
@@ -84,6 +85,23 @@ describe("SqlitePipelineStore", () => {
     const asg = await store.getAssignment("asg-1");
     expect(asg?.targetAgent).toBe("build");
     expect((await store.getRunByThread("T1"))?.id).toBe("run-1");
+  });
+
+  it("lists every run newest-first with combinable kind and status filters", async () => {
+    await store.createRun(makeProductRun({ updatedAt: 1_000 }));
+    await store.createRun(makeBugRun({ updatedAt: 2_000, status: "waiting" }));
+    await store.createRun(makeDefaultRun({ updatedAt: 3_000 }));
+
+    expect((await store.listRuns()).map((run) => run.kind)).toEqual([
+      "default",
+      "bug",
+      "product",
+    ]);
+    expect(
+      (await store.listRuns({ kind: "bug", status: "waiting" }))
+        .map((run) => run.id),
+    ).toEqual(["bug-run-1"]);
+    expect(await store.listRuns({ kind: "product", status: "waiting" })).toEqual([]);
   });
 
   it("is idempotent on assignment idempotency keys", async () => {

--- a/src/pipelines/store/sqlite.ts
+++ b/src/pipelines/store/sqlite.ts
@@ -1658,6 +1658,49 @@ export class SqlitePipelineStore implements PipelineStore {
     return result.changes;
   }
 
+  async listRuns(filter?: {
+    status?: PipelineRun["status"];
+    kind?: PipelineRun["kind"];
+  }): Promise<PipelineRun[]> {
+    if (filter?.status && filter.kind) {
+      return this.db
+        .query<RunRow, [string, string]>(
+          `SELECT * FROM pipeline_runs
+           WHERE status = ? AND kind = ?
+           ORDER BY updated_at DESC`,
+        )
+        .all(filter.status, filter.kind)
+        .map(runFromRow);
+    }
+    if (filter?.status) {
+      return this.db
+        .query<RunRow, [string]>(
+          `SELECT * FROM pipeline_runs
+           WHERE status = ?
+           ORDER BY updated_at DESC`,
+        )
+        .all(filter.status)
+        .map(runFromRow);
+    }
+    if (filter?.kind) {
+      return this.db
+        .query<RunRow, [string]>(
+          `SELECT * FROM pipeline_runs
+           WHERE kind = ?
+           ORDER BY updated_at DESC`,
+        )
+        .all(filter.kind)
+        .map(runFromRow);
+    }
+    return this.db
+      .query<RunRow, []>(
+        `SELECT * FROM pipeline_runs
+         ORDER BY updated_at DESC`,
+      )
+      .all()
+      .map(runFromRow);
+  }
+
   async listTerminalRuns(filter?: {
     updatedBefore?: number;
   }): Promise<PipelineRun[]> {

--- a/src/pipelines/store/sqlite.ts
+++ b/src/pipelines/store/sqlite.ts
@@ -313,6 +313,18 @@ export class SqlitePipelineStore implements PipelineStore {
       CREATE INDEX IF NOT EXISTS idx_pipeline_runs_thread
       ON pipeline_runs (thread_id)
     `);
+    this.db.run(`
+      CREATE INDEX IF NOT EXISTS idx_pipeline_runs_updated
+      ON pipeline_runs (updated_at DESC)
+    `);
+    this.db.run(`
+      CREATE INDEX IF NOT EXISTS idx_pipeline_runs_status_updated
+      ON pipeline_runs (status, updated_at DESC)
+    `);
+    this.db.run(`
+      CREATE INDEX IF NOT EXISTS idx_pipeline_runs_kind_status_updated
+      ON pipeline_runs (kind, status, updated_at DESC)
+    `);
 
     this.db.run(`
       CREATE TABLE IF NOT EXISTS pipeline_attempts (
@@ -1661,44 +1673,60 @@ export class SqlitePipelineStore implements PipelineStore {
   async listRuns(filter?: {
     status?: PipelineRun["status"];
     kind?: PipelineRun["kind"];
+    limit?: number;
   }): Promise<PipelineRun[]> {
+    const limit = Math.max(1, Math.min(filter?.limit ?? 100, 500));
     if (filter?.status && filter.kind) {
       return this.db
-        .query<RunRow, [string, string]>(
+        .query<RunRow, [string, string, number]>(
           `SELECT * FROM pipeline_runs
            WHERE status = ? AND kind = ?
-           ORDER BY updated_at DESC`,
+           ORDER BY updated_at DESC
+           LIMIT ?`,
         )
-        .all(filter.status, filter.kind)
+        .all(filter.status, filter.kind, limit)
         .map(runFromRow);
     }
     if (filter?.status) {
       return this.db
-        .query<RunRow, [string]>(
+        .query<RunRow, [string, number]>(
           `SELECT * FROM pipeline_runs
            WHERE status = ?
-           ORDER BY updated_at DESC`,
+           ORDER BY updated_at DESC
+           LIMIT ?`,
         )
-        .all(filter.status)
+        .all(filter.status, limit)
         .map(runFromRow);
     }
     if (filter?.kind) {
       return this.db
-        .query<RunRow, [string]>(
+        .query<RunRow, [string, number]>(
           `SELECT * FROM pipeline_runs
            WHERE kind = ?
-           ORDER BY updated_at DESC`,
+           ORDER BY updated_at DESC
+           LIMIT ?`,
         )
-        .all(filter.kind)
+        .all(filter.kind, limit)
         .map(runFromRow);
     }
     return this.db
-      .query<RunRow, []>(
+      .query<RunRow, [number]>(
         `SELECT * FROM pipeline_runs
-         ORDER BY updated_at DESC`,
+         ORDER BY updated_at DESC
+         LIMIT ?`,
       )
-      .all()
+      .all(limit)
       .map(runFromRow);
+  }
+
+  async countOpenRuns(): Promise<number> {
+    return this.db
+      .query<{ count: number }, []>(
+        `SELECT COUNT(*) AS count
+         FROM pipeline_runs
+         WHERE status != 'terminal'`,
+      )
+      .get()!.count;
   }
 
   async listTerminalRuns(filter?: {
@@ -1981,6 +2009,19 @@ export class SqlitePipelineStore implements PipelineStore {
          ORDER BY created_at ASC`,
       )
       .all(assignmentId)
+      .map(outcomeFromRow);
+  }
+
+  async listOutcomesForRun(runId: string): Promise<StoredOutcome[]> {
+    return this.db
+      .query<OutcomeRow, [string]>(
+        `SELECT o.*
+         FROM pipeline_outcomes o
+         INNER JOIN pipeline_assignments a ON a.id = o.assignment_id
+         WHERE a.run_id = ?
+         ORDER BY o.created_at ASC`,
+      )
+      .all(runId)
       .map(outcomeFromRow);
   }
 

--- a/src/pipelines/tools-artifact.test.ts
+++ b/src/pipelines/tools-artifact.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "bun:test";
+import { rmSync } from "node:fs";
+import { resolve } from "node:path";
+import { InMemoryPipelineStore } from "./store/memory.ts";
+import {
+  makeAssignmentCreate,
+  makeProductRun,
+} from "./store/test-helpers.ts";
+import {
+  pipelineWriteArtifact,
+  type PipelineToolRuntime,
+  type ToolTextResult,
+} from "./tools.ts";
+
+function body(result: ToolTextResult): Record<string, unknown> {
+  return JSON.parse(result.content[0]?.text ?? "{}") as Record<string, unknown>;
+}
+
+describe("pipeline_write_artifact authorization", () => {
+  it("allows onboard-member to write its own assignment artifact", async () => {
+    const store = new InMemoryPipelineStore();
+    const runId = `run-onboard-artifact-${crypto.randomUUID()}`;
+    const assignmentId = `assignment-onboard-${crypto.randomUUID()}`;
+    const foreignAssignmentId =
+      `assignment-onboard-foreign-${crypto.randomUUID()}`;
+    const run = makeProductRun({
+      id: runId,
+      channelId: "C-ONBOARD",
+      threadId: "1700000000.100",
+      ownerAgent: "default",
+    });
+    await store.createRun(run);
+    await store.createAssignment(makeAssignmentCreate({
+      id: assignmentId,
+      runId,
+      targetAgent: "onboard-member",
+    }));
+    const runtime: PipelineToolRuntime = {
+      store,
+      runtimeMode: "active",
+      githubTrackingEnabled: false,
+    };
+    const artifactRoot = `data/pipelines/${runId}`;
+
+    try {
+      const result = body(await pipelineWriteArtifact(runtime, {
+        agent: "onboard-member",
+        channel: run.channelId,
+        threadId: run.threadId,
+        messageTs: "1700000000.101",
+        runId,
+        assignmentId,
+        dispatchKey: "onboard-artifact",
+        signed: true,
+      }, {
+        run_id: runId,
+        assignment_id: assignmentId,
+        path: "onboarding-packet.md",
+        content: "# approved packet\n",
+      }));
+
+      expect(result.ok).toBe(true);
+      expect(result.artifactRef).toBe(
+        `${artifactRoot}/onboarding-packet.md`,
+      );
+
+      const foreign = body(await pipelineWriteArtifact(runtime, {
+        agent: "onboard-member",
+        channel: run.channelId,
+        threadId: run.threadId,
+        messageTs: "1700000000.101",
+        runId,
+        assignmentId: foreignAssignmentId,
+        dispatchKey: "onboard-artifact",
+        signed: true,
+      }, {
+        run_id: runId,
+        assignment_id: assignmentId,
+        path: "foreign.md",
+        content: "must not be written\n",
+      }));
+      expect(foreign.ok).toBe(false);
+      expect(foreign.reason).toBe(
+        "assignment does not match authenticated assignment context",
+      );
+    } finally {
+      rmSync(resolve(process.cwd(), artifactRoot), {
+        recursive: true,
+        force: true,
+      });
+    }
+  });
+});

--- a/src/pipelines/tools-dispatch.test.ts
+++ b/src/pipelines/tools-dispatch.test.ts
@@ -171,6 +171,59 @@ describe("durable agent_dispatch", () => {
     expect(await store.listAssignments(started.run.id)).toHaveLength(1);
   });
 
+  it("dispatches the repo-less onboarding agent without repository refs", async () => {
+    const store = new InMemoryPipelineStore();
+    const sessions = new InMemorySessionStore();
+    const started = await createDefaultRun(
+      { store },
+      {
+        channelId: CHANNEL,
+        threadId: THREAD,
+        objective: "check whether a user needs onboarding",
+        messageTs: "1700000000.106",
+        targetAgent: "default",
+      },
+    );
+    const session = createSession(THREAD, CHANNEL);
+    session.activePipelineInvocation = {
+      runId: started.run.id,
+      assignmentId: started.assignment.id,
+      dispatchKey: "repo-less-onboarding",
+      outcomeCountAtDispatch: 0,
+      retryCount: 0,
+    };
+    await sessions.set(THREAD, session);
+
+    const result = body(await pipelineDispatchAgent({
+      store,
+      sessionStore: sessions,
+      runtimeMode: "active",
+      githubTrackingEnabled: false,
+    }, {
+      agent: "default",
+      channel: CHANNEL,
+      threadId: THREAD,
+      runId: started.run.id,
+      assignmentId: started.assignment.id,
+      dispatchKey: "repo-less-onboarding",
+      signed: true,
+    }, {
+      target_agent: "onboard-member",
+      objective: "Read current membership state and prepare the gated plan",
+      mode: "delegate",
+      reason: "The onboarding agent has read-only MongoDB access",
+      idempotency_key: "dispatch-onboarding",
+    }));
+
+    expect(result.ok).toBe(true);
+    expect(await store.getAssignment(result.targetAssignmentId as string))
+      .toMatchObject({
+        targetAgent: "onboard-member",
+        mutationScope: ["pipeline-artifact"],
+      });
+    expect((await store.getRun(started.run.id))?.repoRefs).toEqual([]);
+  });
+
   it("binds a missing repository and resumes a needs-human run atomically", async () => {
     const store = new InMemoryPipelineStore();
     const sessions = new InMemorySessionStore();

--- a/src/pipelines/tools.ts
+++ b/src/pipelines/tools.ts
@@ -10,11 +10,9 @@ import {
   canWritePipelineArtifacts,
   checkCapability,
   isReadOnlyRole,
+  requiresManagedWorktree,
 } from "../agents/capabilities.ts";
-import {
-  canonicalAgentName,
-  resolveAgentManifest,
-} from "../agents/registry.ts";
+import { canonicalAgentName } from "../agents/registry.ts";
 import { canDispatch } from "../support/agents.ts";
 import {
   slackMcpAgentForSession,
@@ -776,9 +774,7 @@ export async function pipelineDispatchAgent(
       );
     }
   }
-  const targetRole = resolveAgentManifest(target)?.role;
-  const targetRequiresWorktree =
-    targetRole !== "orchestrator" && targetRole !== "planner";
+  const targetRequiresWorktree = requiresManagedWorktree(target);
   if (targetRequiresWorktree && effectiveRepoRefs.length === 0) {
     return textResult(
       {

--- a/src/pipelines/tools.ts
+++ b/src/pipelines/tools.ts
@@ -391,7 +391,10 @@ function authorizeAssignmentAction(
   run: PipelineRun,
   assignment: Assignment,
   agent: string,
-  opts: { requireWriteCapable?: boolean } = {},
+  opts: {
+    requireWriteCapable?: boolean;
+    requireOwnAssignmentForReadOnly?: boolean;
+  } = {},
 ): string | null {
   if (assignment.runId !== run.id) {
     return "assignment does not belong to run";
@@ -411,6 +414,14 @@ function authorizeAssignmentAction(
 
   if (!ownsAssignment && !isOrch) {
     return `agent "${agent}" is not authorized for assignment target "${assignment.targetAgent}"`;
+  }
+
+  if (
+    opts.requireOwnAssignmentForReadOnly &&
+    isReadOnlyRole(caller) &&
+    !ownsAssignment
+  ) {
+    return `read-only agent "${agent}" cannot write artifacts for another assignment`;
   }
 
   if (opts.requireWriteCapable) {
@@ -1004,11 +1015,20 @@ export async function pipelineWriteArtifact(
   if (!assignment) {
     return textResult({ ok: false, reason: "assignment not found" }, true);
   }
+  if (runContext.assignmentId !== assignment.id) {
+    return textResult(
+      {
+        ok: false,
+        reason: "assignment does not match authenticated assignment context",
+      },
+      true,
+    );
+  }
   const authFailure = authorizeAssignmentAction(
     run,
     assignment,
     runContext.agent,
-    { requireWriteCapable: true },
+    { requireOwnAssignmentForReadOnly: true },
   );
   if (authFailure) {
     return textResult({ ok: false, reason: authFailure }, true);

--- a/src/runners/mcp-config.ts
+++ b/src/runners/mcp-config.ts
@@ -31,6 +31,9 @@ export function allowedMcpServers(session: ThreadSession): Set<McpServerName> {
   ) {
     allowed.add("slack-bot");
   }
+  if (hasCapability(agent, "mongodb-read")) {
+    allowed.add("mongodb");
+  }
   return allowed;
 }
 

--- a/src/runners/policy.test.ts
+++ b/src/runners/policy.test.ts
@@ -171,7 +171,11 @@ describe("compileOpenCodePermission", () => {
     expect(permission["mcp__mongodb__list-collections"]).toBe("allow");
     expect(permission["mcp__mongodb__collection-schema"]).toBe("allow");
     expect(permission["mcp__mongodb__update-one"]).not.toBe("allow");
+    expect(permission["mcp__slack-bot__pipeline_write_artifact"]).toBe("allow");
     expect(permission["mcp__*"]).toBe("deny");
+    expect(permission.read).toBe("deny");
+    expect(permission.glob).toBe("deny");
+    expect(permission.grep).toBe("deny");
     expect(permission.bash).toBe("deny");
   });
 
@@ -245,13 +249,26 @@ describe("provider permission compilation matrix", () => {
     // Review / reproducer: hard read-only where enforceable. Both use Claude
     // default mode so the trusted pipeline-control MCP allowlist can settle
     // assignments; repository mutations remain explicitly denied.
-    for (const name of ["review", "reproducer", "onboard-member"] as const) {
+    for (const name of ["review", "reproducer"] as const) {
       const row = byName.get(name)!;
       expect(row.intent).toBe("read-only");
       expect(row.claudePermissionMode).toBe("default");
       expect(row.codexSandbox).toBe("read-only");
       expect(row.openCode).toMatchObject({ edit: "deny", write: "deny" });
     }
+
+    const onboarding = byName.get("onboard-member")!;
+    expect(onboarding.intent).toBe("mcp-only");
+    expect(onboarding.claudePermissionMode).toBe("default");
+    expect(onboarding.codexSandbox).toBe("read-only");
+    expect(onboarding.openCode).toMatchObject({
+      read: "deny",
+      glob: "deny",
+      grep: "deny",
+      bash: "deny",
+      "mcp__*": "deny",
+      "mcp__slack-bot__pipeline_write_artifact": "allow",
+    });
 
     // PM / architect: human-gated. Codex gets a read-only jail — with
     // workspace-write + on-request, ordinary edits never trigger an approval,

--- a/src/runners/policy.test.ts
+++ b/src/runners/policy.test.ts
@@ -159,6 +159,22 @@ describe("compileOpenCodePermission", () => {
     expect(permission["mcp__*"]).toBe("deny");
   });
 
+  it("allows only read operations on MongoDB for the onboarding agent", () => {
+    const permission = compileOpenCodePermission({
+      subject: {
+        activeAgentName: "onboard-member",
+        agentPermissions: { intent: "read-only", mcp: [], tools: [] },
+      },
+    }) as Record<string, string>;
+
+    expect(permission["mcp__mongodb__find"]).toBe("allow");
+    expect(permission["mcp__mongodb__list-collections"]).toBe("allow");
+    expect(permission["mcp__mongodb__collection-schema"]).toBe("allow");
+    expect(permission["mcp__mongodb__update-one"]).not.toBe("allow");
+    expect(permission["mcp__*"]).toBe("deny");
+    expect(permission.bash).toBe("deny");
+  });
+
   it("asks on mutating tools for human-gated roles", () => {
     const permission = compileOpenCodePermission({
       subject: {
@@ -229,7 +245,7 @@ describe("provider permission compilation matrix", () => {
     // Review / reproducer: hard read-only where enforceable. Both use Claude
     // default mode so the trusted pipeline-control MCP allowlist can settle
     // assignments; repository mutations remain explicitly denied.
-    for (const name of ["review", "reproducer"] as const) {
+    for (const name of ["review", "reproducer", "onboard-member"] as const) {
       const row = byName.get(name)!;
       expect(row.intent).toBe("read-only");
       expect(row.claudePermissionMode).toBe("default");

--- a/src/runners/policy.ts
+++ b/src/runners/policy.ts
@@ -115,6 +115,14 @@ export function compileOpenCodePermission(options: {
       ? {
           "mcp__slack-bot__pipeline_get_state": "allow",
           "mcp__slack-bot__pipeline_report_outcome": "allow",
+          "mcp__slack-bot__pipeline_write_artifact": "allow",
+        }
+      : {}),
+    ...(hasCapability(agentName, "mongodb-read")
+      ? {
+          "mcp__mongodb__find": "allow",
+          "mcp__mongodb__list-collections": "allow",
+          "mcp__mongodb__collection-schema": "allow",
         }
       : {}),
     ...(hasCapability(agentName, "dispatch")
@@ -147,6 +155,30 @@ export function compileOpenCodePermission(options: {
     };
   }
 
+  if (intent === "mcp-only") {
+    const declaredMcpPermissions = Object.fromEntries(
+      (options.subject.agentPermissions?.tools ?? [])
+        .filter((tool) => tool.startsWith("mcp__"))
+        .map((tool) => [tool, "allow"]),
+    );
+    return {
+      read: "deny",
+      glob: "deny",
+      grep: "deny",
+      list: "deny",
+      edit: "deny",
+      write: "deny",
+      bash: "deny",
+      task: "deny",
+      "*": "deny",
+      // OpenCode resolves permission patterns last-match-wins. The wildcard
+      // denial must precede the exact trusted MCP grants.
+      "mcp__*": "deny",
+      ...declaredMcpPermissions,
+      ...capabilityPermissions,
+    };
+  }
+
   if (intent === "read-only") {
     return {
       read: "allow",
@@ -172,9 +204,9 @@ export function compileOpenCodePermission(options: {
         : "deny",
       task: "deny",
       // Explicit read-safe MCP surface only — never blanket mcp__*.
+      "mcp__*": "deny",
       ...READ_SAFE_MCP_PERMISSIONS,
       ...capabilityPermissions,
-      "mcp__*": "deny",
     };
   }
 

--- a/src/runners/policy.ts
+++ b/src/runners/policy.ts
@@ -71,6 +71,9 @@ export function resolveRunPermissionIntent(
  * Mutating Slack/memory/dispatch tools are NOT included.
  */
 export const READ_SAFE_MCP_PERMISSIONS: Record<string, string> = {
+  "mcp__mongodb__find": "allow",
+  "mcp__mongodb__list-collections": "allow",
+  "mcp__mongodb__collection-schema": "allow",
   "mcp__slack-bot__slack_read_thread": "allow",
   "mcp__slack-bot__slack_read_channel": "allow",
   "mcp__slack-bot__slack_search": "allow",
@@ -297,6 +300,7 @@ export const CATALOG_ROLE_NAMES = [
   "frontend",
   "review",
   "reproducer",
+  "onboard-member",
 ] as const;
 
 /**

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -801,6 +801,64 @@ describe("SessionManager", () => {
     });
   });
 
+  it("keeps a stale-cwd onboarding cold start isolated from repo agent definitions", async () => {
+    const resolvedSessions: ThreadSession[] = [];
+    manager.agentRouter = {
+      resolveAgent: mock(async (runSession: ThreadSession) => {
+        resolvedSessions.push(runSession);
+        return null;
+      }),
+      composeSystemPrompt: mock(async () => null),
+    } as unknown as NonNullable<typeof manager.agentRouter>;
+
+    const existing = createSession("thread-1", "C123");
+    existing.targetRepo = "junior";
+    existing.worktreePath = "/tmp/stale-worktree";
+    existing.worktreePaths = { junior: "/tmp/stale-worktree" };
+    existing.cwd = "/tmp/stale-cwd";
+    existing.agentSessions["onboard-member"] = {
+      agentName: "onboard-member",
+      provider: "claude",
+      sessionId: "legacy-onboarding-session",
+      sessionCwd: "/tmp/stale-worktree",
+      status: "idle",
+      pendingMessages: [],
+      lastActivity: Date.now(),
+      pid: null,
+    };
+    await store.set(existing.threadId, existing);
+
+    await manager.handleAgentMessage(
+      makeEvent({ text: "continue the membership check" }),
+      "onboard-member",
+    );
+    await waitFor(() => mockSpawnFn.mock.calls.length === 1);
+
+    expect(resolvedSessions).toHaveLength(1);
+    expect(resolvedSessions[0]).toMatchObject({
+      targetRepo: null,
+      worktreePath: null,
+      worktreePaths: {},
+      cwd: null,
+      sessionId: null,
+    });
+    expect(mockSpawnFn.mock.calls[0]![0]).toMatchObject({
+      targetRepo: null,
+      worktreePath: null,
+      worktreePaths: {},
+      cwd: null,
+      sessionId: null,
+    });
+    // Invocation isolation must not erase worktree state needed by later
+    // build/review assignments on the durable thread.
+    expect(await store.get("thread-1")).toMatchObject({
+      targetRepo: "junior",
+      worktreePath: "/tmp/stale-worktree",
+      worktreePaths: { junior: "/tmp/stale-worktree" },
+      cwd: "/tmp/stale-cwd",
+    });
+  });
+
   it("preserves durable worktree affinity when a repo-less utility idle-resumes", async () => {
     const idleHandle = createIdleOpencodeHandle("ses-onboard", 12345);
     const retryHandle = createCompletingOpencodeHandle("ses-onboard", 67890);

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -763,6 +763,103 @@ describe("SessionManager", () => {
     expect(runSession.worktreePaths).toEqual(paths);
   });
 
+  it("keeps the onboarding agent repo-less outside a pipeline", async () => {
+    const createWorktree = mock(async () => "/tmp/should-not-be-created");
+    manager.worktreeManager = {
+      createWorktree,
+      getWorktreePath: () => "/tmp/should-not-be-created",
+      worktreeExists: mock(async () => false),
+      getBranchName: () => "slack/thread-1",
+    } as unknown as WorktreeManager;
+
+    const existing = createSession("thread-1", "C123");
+    existing.targetRepo = "junior";
+    existing.worktreePath = "/tmp/stale-worktree";
+    existing.worktreePaths = { junior: "/tmp/stale-worktree" };
+    existing.cwd = "/tmp/stale-cwd";
+    await store.set(existing.threadId, existing);
+
+    await manager.handleAgentMessage(
+      makeEvent({ text: "check membership state" }),
+      "onboard-member",
+    );
+    await waitFor(() => mockSpawnFn.mock.calls.length === 1);
+
+    expect(createWorktree).not.toHaveBeenCalled();
+    expect(mockSpawnFn.mock.calls[0]![0]).toMatchObject({
+      targetRepo: null,
+      worktreePath: null,
+      worktreePaths: {},
+      cwd: null,
+    });
+  });
+
+  it("does not provision or inherit worktrees for the repo-less onboarding agent", async () => {
+    const pipelineStore = new InMemoryPipelineStore();
+    await pipelineStore.createRun(
+      makeProductRun({
+        id: "run-onboard-member",
+        threadId: "thread-1",
+        repoRefs: ["GrowthX-Club/junior", "GrowthX-Club/frontend"],
+      }),
+    );
+    await pipelineStore.createAssignment(
+      makeAssignmentCreate({
+        id: "assignment-onboard-member",
+        runId: "run-onboard-member",
+        targetAgent: "onboard-member",
+      }),
+    );
+    manager.pipelineStore = pipelineStore;
+
+    const createWorktree = mock(async () => "/tmp/should-not-be-created");
+    manager.worktreeManager = {
+      createWorktree,
+      getWorktreePath: () => "/tmp/should-not-be-created",
+      worktreeExists: mock(async () => false),
+      getBranchName: () => "slack/thread-1",
+    } as unknown as WorktreeManager;
+
+    const existing = createSession("thread-1", "C123");
+    existing.activePipelineRunId = "run-onboard-member";
+    existing.activePipelineKind = "product";
+    existing.targetRepo = "junior";
+    existing.worktreePath = "/tmp/stale-worktree";
+    existing.worktreePaths = { junior: "/tmp/stale-worktree" };
+    existing.cwd = "/tmp/stale-cwd";
+    await store.set(existing.threadId, existing);
+
+    await manager.handleAgentMessage(
+      makeEvent({
+        text: "check the member state using read-only MongoDB",
+        pipelineInvocation: {
+          runId: "run-onboard-member",
+          assignmentId: "assignment-onboard-member",
+          dispatchKey: "dispatch-onboard-member",
+          outcomeCountAtDispatch: 0,
+          retryCount: 0,
+        },
+      }),
+      "onboard-member",
+    );
+    await waitFor(() => mockSpawnFn.mock.calls.length === 1);
+
+    expect(createWorktree).not.toHaveBeenCalled();
+    const runSession = mockSpawnFn.mock.calls[0]![0];
+    expect(runSession.targetRepo).toBeNull();
+    expect(runSession.worktreePath).toBeNull();
+    expect(runSession.worktreePaths).toEqual({});
+    expect(runSession.cwd).toBeNull();
+    // Repo-less routing is invocation-local: do not erase worktrees that a
+    // later build/review assignment on the same pipeline still needs.
+    expect(await store.get("thread-1")).toMatchObject({
+      targetRepo: "junior",
+      worktreePath: "/tmp/stale-worktree",
+      worktreePaths: { junior: "/tmp/stale-worktree" },
+      cwd: "/tmp/stale-cwd",
+    });
+  });
+
   it("coalesces concurrent fan-out setup for the same pipeline worktree", async () => {
     const pipelineStore = new InMemoryPipelineStore();
     await pipelineStore.createRun(

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -541,7 +541,7 @@ describe("SessionManager", () => {
         status: "blocked",
         reason: "Need the user's decision",
         evidenceRefs: [],
-        artifactRefs: [],
+        artifactRefs: ["pipeline-artifact:onboarding-packet.md"],
         blockers: [],
         checks: [],
         progressFingerprint: "wait:user-decision",
@@ -572,7 +572,14 @@ describe("SessionManager", () => {
     expect(child).toBeDefined();
     expect(child?.parentAssignmentId).toBe(invocation?.assignmentId);
     expect(child?.status).toBe("pending");
+    expect(child?.artifactRefs).toContain(
+      "pipeline-artifact:onboarding-packet.md",
+    );
     expect(mockSpawnFn.mock.calls[1][1]).toContain("use option B");
+    expect(mockSpawnFn.mock.calls[1][1]).toContain("Need the user's decision");
+    expect(mockSpawnFn.mock.calls[1][1]).toContain(
+      "pipeline-artifact:onboarding-packet.md",
+    );
     expect(mockSpawnFn.mock.calls[1][1]).toContain(child!.id);
   });
 
@@ -792,6 +799,73 @@ describe("SessionManager", () => {
       worktreePaths: {},
       cwd: null,
     });
+  });
+
+  it("preserves durable worktree affinity when a repo-less utility idle-resumes", async () => {
+    const idleHandle = createIdleOpencodeHandle("ses-onboard", 12345);
+    const retryHandle = createCompletingOpencodeHandle("ses-onboard", 67890);
+    const handles = [idleHandle, retryHandle];
+    mockSpawnFn = mock(() => handles.shift()!);
+    manager = createTestManager(store, cloneConfig({
+      runner: { provider: "opencode" },
+      opencode: {
+        ...testConfig.opencode,
+        continuityEnabled: true,
+      },
+      session: {
+        ...testConfig.session,
+        idleTimeoutMs: 5,
+        maxIdleInterrupts: 1,
+      },
+    }));
+
+    const existing = createSession("thread-1", "C123");
+    existing.targetRepo = "junior";
+    existing.worktreePath = "/tmp/durable-worktree";
+    existing.worktreePaths = { junior: "/tmp/durable-worktree" };
+    existing.cwd = "/tmp/durable-cwd";
+    await store.set(existing.threadId, existing);
+
+    await manager.handleAgentMessage(
+      makeEvent({ text: "check membership state" }),
+      "onboard-member",
+    );
+    await waitFor(() => mockSpawnFn.mock.calls.length === 2);
+
+    expect(mockSpawnFn.mock.calls[1]![0]).toMatchObject({
+      targetRepo: null,
+      worktreePath: null,
+      worktreePaths: {},
+      cwd: null,
+    });
+    expect(await store.get("thread-1")).toMatchObject({
+      targetRepo: "junior",
+      worktreePath: "/tmp/durable-worktree",
+      worktreePaths: { junior: "/tmp/durable-worktree" },
+      cwd: "/tmp/durable-cwd",
+      idleInterruptCount: 1,
+    });
+
+    retryHandle._complete("resumed", "ses-onboard");
+  });
+
+  it("fails closed when Codex app-server cannot enforce MCP-only isolation", async () => {
+    manager = createTestManager(store, cloneConfig({
+      runner: { provider: "codex-app-server" },
+    }));
+    const errors = mock((_session: ThreadSession, _error: string | null) => {});
+    manager.onError = errors;
+
+    await manager.handleAgentMessage(
+      makeEvent({ text: "check membership state" }),
+      "onboard-member",
+    );
+    await waitFor(() => errors.mock.calls.length === 1);
+
+    expect(mockSpawnFn).not.toHaveBeenCalled();
+    expect(errors.mock.calls[0]![1]).toContain(
+      "cannot enforce MCP-only tool isolation",
+    );
   });
 
   it("does not provision or inherit worktrees for the repo-less onboarding agent", async () => {

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -1,4 +1,6 @@
 import type { App } from "@slack/bolt";
+import { mkdirSync } from "node:fs";
+import { resolve } from "node:path";
 import type { Config, RepoConfig } from "../config.ts";
 import type { RunnerEvent, RunnerProvider, SpawnHandle, SpawnResult, SpawnRunnerFn } from "../runners/types.ts";
 import type {
@@ -65,7 +67,11 @@ import {
   isDuplicateSlackToolResponse,
   prepareSlackResponse,
 } from "../slack/formatting.ts";
-import { DEFAULT_CONTEXT_PROFILE, type AgentContextProfile } from "../agents/loader.ts";
+import {
+  DEFAULT_CONTEXT_PROFILE,
+  resolveEffectivePermissionIntent,
+  type AgentContextProfile,
+} from "../agents/loader.ts";
 import { downloadSlackFiles, sanitizeFileName } from "../slack/files.ts";
 import { log as _log } from "../logger.ts";
 import { inferReviewRepo } from "../worktree/review-routing.ts";
@@ -1756,7 +1762,7 @@ export class SessionManager {
       // cwd fallback: only used when no worktree exists. With the always-worktree
       // policy above, this only fires for read-only/discussion threads with no
       // targetRepo — never inside the shared origin repo.
-      const targetRepoCwd: string | undefined = session.worktreePath
+      let targetRepoCwd: string | undefined = session.worktreePath
         ? undefined
         : targetRepo?.path;
 
@@ -1764,6 +1770,22 @@ export class SessionManager {
       // the newly registered isolated checkout on this same turn.
       let runSession = this.buildRunSession(session, agentName, agentIdentity);
       let provider = sessionProvider(runSession, this.config);
+      const permissionIntent = resolveEffectivePermissionIntent(
+        runSession.agentPermissions,
+        runSession.activeAgentName ?? runSession.agentType,
+      );
+      if (permissionIntent === "mcp-only") {
+        if (provider === "codex-app-server") {
+          throw new Error(
+            `Provider ${provider} cannot enforce MCP-only tool isolation for ${agentName}; use claude, opencode, or opencode-sdk`,
+          );
+        }
+        targetRepoCwd = resolve(
+          import.meta.dirname ?? ".",
+          `../../data/runtime-agents/${agentName}`,
+        );
+        mkdirSync(targetRepoCwd, { recursive: true });
+      }
       const invocationCwd = resolveRunnerCwd(runSession, targetRepoCwd);
       if (
         runSession.sessionId &&
@@ -2259,12 +2281,29 @@ export class SessionManager {
           (isTopLevel ? session.sessionId : agentSession?.sessionId) &&
           session.idleInterruptCount < maxIdleInterrupts
         ) {
-          session.idleInterruptCount++;
+          const nextIdleInterruptCount = session.idleInterruptCount + 1;
+          const durableSession = await this.mutateSession(
+            session.threadId,
+            (fresh) => {
+              if (this.handles.get(handleKey) !== attemptHandle) {
+                throw new RunOwnershipChangedError();
+              }
+              fresh.idleInterruptCount = nextIdleInterruptCount;
+            },
+          );
+          session = pipelineRole === "utility"
+            ? {
+                ...durableSession,
+                cwd: null,
+                targetRepo: null,
+                worktreePath: null,
+                worktreePaths: {},
+              }
+            : durableSession;
           _log.warn(
             "session",
             `idle-resume attempt=${session.idleInterruptCount}/${maxIdleInterrupts} thread=${session.threadId} agent=${agentName} provider=${provider}`,
           );
-          await this.store.set(session.threadId, session);
 
           const continuePrompt = [
             `The previous turn was interrupted after ${this.config.session.idleTimeoutMs / 1000}s with no runner events.`,
@@ -3485,7 +3524,32 @@ export class SessionManager {
           .sort((a, b) => b.updatedAt - a.updatedAt)[0];
         if (!assignment) {
           const parent = [...assignments].sort((a, b) => b.updatedAt - a.updatedAt)[0];
+          const parentOutcomes = parent
+            ? await this.pipelineStore.listOutcomes(parent.id)
+            : [];
+          const latestParentOutcome = parentOutcomes.at(-1);
           const assignmentId = crypto.randomUUID();
+          const humanObjective = event.text.trim() ||
+            "Continue from the latest human input";
+          const recoveryContext = parent
+            ? [
+                humanObjective,
+                "",
+                "<durable-human-gate-context>",
+                `parent_assignment_id: ${parent.id}`,
+                `parent_objective: ${parent.objective}`,
+                `context_refs: ${JSON.stringify(parent.contextRefs)}`,
+                `artifact_refs: ${JSON.stringify([
+                  ...parent.artifactRefs,
+                  ...(latestParentOutcome?.artifactRefs ?? []),
+                ])}`,
+                `latest_outcome_reason: ${latestParentOutcome?.reason ?? ""}`,
+                `latest_outcome_checks: ${JSON.stringify(
+                  latestParentOutcome?.checks ?? [],
+                )}`,
+                "</durable-human-gate-context>",
+              ].join("\n")
+            : humanObjective;
           assignment = await this.pipelineStore.createAssignmentWithOutbox({
             assignment: {
               id: assignmentId,
@@ -3494,9 +3558,18 @@ export class SessionManager {
               sourceAgent: "human",
               sourceSlackUserId: event.isSelfBot ? null : event.user,
               targetAgent: durableTarget,
-              objective: event.text.trim() || "Continue from the latest human input",
-              contextRefs: ["control-branch:human-input", `source-message:${event.ts}`],
-              artifactRefs: [],
+              objective: recoveryContext,
+              contextRefs: [
+                ...(parent?.contextRefs ?? []),
+                "control-branch:human-input",
+                `source-message:${event.ts}`,
+              ],
+              artifactRefs: [
+                ...new Set([
+                  ...(parent?.artifactRefs ?? []),
+                  ...(latestParentOutcome?.artifactRefs ?? []),
+                ]),
+              ],
               acceptanceCriteria: active.acceptanceCriteria,
               mutationScope:
                 durableTarget === "build" || durableTarget === "frontend"

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -1567,13 +1567,7 @@ export class SessionManager {
         // Repo-less agents must not inherit the thread's prior repository
         // affinity. Keep this invocation-only so another assignment in the
         // same pipeline can still use the durable managed worktrees.
-        session = {
-          ...session,
-          cwd: null,
-          targetRepo: null,
-          worktreePath: null,
-          worktreePaths: {},
-        };
+        session = this.projectInvocationSession(session, pipelineRole);
       }
 
       if (
@@ -1802,10 +1796,14 @@ export class SessionManager {
           agentName,
           staleSessionId,
         );
-        session = invalidation.session;
+        const durableSession = invalidation.session;
         agentSession = isTopLevel
           ? null
-          : this.getOrCreateAgentSession(session, agentName);
+          : this.getOrCreateAgentSession(durableSession, agentName);
+        // Provider-session invalidation reloads the durable thread row. Reapply
+        // invocation-only isolation before resolving policy or agent
+        // definitions so a stale cwd cannot restore repository trust.
+        session = this.projectInvocationSession(durableSession, pipelineRole);
         runSession = this.buildRunSession(session, agentName, agentIdentity);
         provider = sessionProvider(runSession, this.config);
         if (invalidation.invalidated) {
@@ -2291,15 +2289,7 @@ export class SessionManager {
               fresh.idleInterruptCount = nextIdleInterruptCount;
             },
           );
-          session = pipelineRole === "utility"
-            ? {
-                ...durableSession,
-                cwd: null,
-                targetRepo: null,
-                worktreePath: null,
-                worktreePaths: {},
-              }
-            : durableSession;
+          session = this.projectInvocationSession(durableSession, pipelineRole);
           _log.warn(
             "session",
             `idle-resume attempt=${session.idleInterruptCount}/${maxIdleInterrupts} thread=${session.threadId} agent=${agentName} provider=${provider}`,
@@ -3686,6 +3676,25 @@ export class SessionManager {
   private idleResumeEnabled(provider: RunnerProvider): boolean {
     if (provider === "opencode") return this.config.opencode.continuityEnabled;
     return provider !== "opencode-sdk" && provider !== "codex-app-server";
+  }
+
+  /**
+   * Remove repository affinity from repo-less utility invocations without
+   * mutating the durable thread row. This projection must be applied after
+   * every store reload, including provider-session invalidation and retries.
+   */
+  private projectInvocationSession(
+    session: ThreadSession,
+    pipelineRole: string | undefined,
+  ): ThreadSession {
+    if (pipelineRole !== "utility") return session;
+    return {
+      ...session,
+      cwd: null,
+      targetRepo: null,
+      worktreePath: null,
+      worktreePaths: {},
+    };
   }
 
   private buildRunSession(

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -15,6 +15,7 @@ import type {
 } from "./types.ts";
 import type { AgentRouter } from "../agents/router.ts";
 import { resolveAgentManifest } from "../agents/registry.ts";
+import { requiresManagedWorktree } from "../agents/capabilities.ts";
 import type { WorktreeManager } from "../worktree/manager.ts";
 import type { PipelineStore } from "../pipelines/store/interface.ts";
 import {
@@ -1551,7 +1552,29 @@ export class SessionManager {
           )
         : undefined;
 
-      if (activePipelineRun && pipelineInvocation) {
+      const pipelineRole = resolveAgentManifest(agentName)?.role;
+      if (pipelineRole === "utility") {
+        _log.info(
+          "manager",
+          `workspace.skip thread=${session.threadId} run=${activePipelineRun?.id ?? "-"} assignment=${pipelineInvocation?.assignmentId ?? "-"} agent=${agentName} reason=repo-less-agent`,
+        );
+        // Repo-less agents must not inherit the thread's prior repository
+        // affinity. Keep this invocation-only so another assignment in the
+        // same pipeline can still use the durable managed worktrees.
+        session = {
+          ...session,
+          cwd: null,
+          targetRepo: null,
+          worktreePath: null,
+          worktreePaths: {},
+        };
+      }
+
+      if (
+        activePipelineRun &&
+        pipelineInvocation &&
+        pipelineRole !== "utility"
+      ) {
         // Durable repo refs, not a developer checkout or stale session cwd,
         // define the pipeline workspace. Provision every referenced repo so
         // fan-out agents can collaborate through the injected path map. Plain
@@ -3852,11 +3875,7 @@ export class SessionManager {
 }
 
 function pipelineAgentRequiresWorktree(agentName: string): boolean {
-  const role = resolveAgentManifest(agentName)?.role;
-  // Unknown roles fail closed. Trusted orchestrators and planners can perform
-  // repo-less discovery/control-plane work; every execution/review role needs
-  // a target repository and a Junior-managed worktree.
-  return role !== "orchestrator" && role !== "planner";
+  return requiresManagedWorktree(agentName);
 }
 
 const defaultSpawnRunnerForRuntime: SpawnRunnerFn =


### PR DESCRIPTION
## Summary
- expose durable pipeline runs through a filterable API and live dispatch dashboard
- add a repo-less, read-only onboarding agent with schema-preserving MongoDB proxy access
- keep production onboarding execution human-gated; depends on GrowthX-Club/junior-private-agents#16

## Test plan
- [x] Run `bun run typecheck` twice
- [x] Run focused pipeline, session, agent, runner, and MongoDB proxy tests (269 passed)
- [x] Run the full test suite (1841 passed, 4 model-download tests skipped)
- [x] Run `bun run build` twice and `git diff --check`