### PR TITLE
feat: add weekly Slack archive maintenance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -134,6 +134,8 @@ WHATSAPP_AUTH_DIR=data/whatsapp-auth
 # separate database and is never consolidated into Junior memory.
 SLACK_ARCHIVE_ENABLED=false
 SLACK_ARCHIVE_DB_PATH=data/slack-archive.db
+# Weekly full-public-channel sync requires the bot OAuth scope `channels:join`;
+# reinstall the Slack app after granting it so the bot token receives the scope.
 # Comma-separated non-public channel IDs explicitly approved for capture/use.
 # SLACK_ARCHIVE_APPROVED_CHANNEL_IDS=G0123456789,C0987654321
 # Optional default for `bun run slack:archive:import -- --apply`.

--- a/docs/code_index/slack-archive.md
+++ b/docs/code_index/slack-archive.md
@@ -2,7 +2,7 @@
 
 | Symbol | File | Purpose |
 |---|---|---|
-| `SlackArchiveStore` | `src/slack/archive-store.ts` | Standalone SQLite schema, idempotent upserts, FTS/vector hybrid search, thread reads, conversations, checkpoints |
+| `SlackArchiveStore` | `src/slack/archive-store.ts` | Standalone SQLite schema, idempotent upserts, FTS/vector hybrid search, thread reads, conversations, checkpoints, corpus/index revisions |
 | archive types | `src/slack/archive-types.ts` | Canonical messages, files, filters, results, checkpoints |
 | `canonicalizeLiveSlackMessage` | `src/slack/events.ts` | Normalizes live message/edit/delete events before routing guards |
 | `importSlackArchive` | `src/slack/archive-import.ts` | Streams standard Slack export members without extracting the ZIP |

--- a/docs/code_index/slack-archive.md
+++ b/docs/code_index/slack-archive.md
@@ -7,9 +7,11 @@
 | `canonicalizeLiveSlackMessage` | `src/slack/events.ts` | Normalizes live message/edit/delete events before routing guards |
 | `importSlackArchive` | `src/slack/archive-import.ts` | Streams standard Slack export members without extracting the ZIP |
 | `SlackArchiveSync` | `src/slack/archive-sync.ts` | Public/approved Slack API gap repair with history checkpoints and old-thread reply reconciliation |
-| archive CLI | `src/slack/archive-cli.ts` | Dry-run-by-default export import command |
+| `runSlackArchiveMaintenance` | `src/slack/archive-maintenance.ts` | Native weekly Slack sync, pending embedding, and atomic ANN publication |
+| archive CLI | `src/slack/archive-cli.ts` | Dry-run-by-default import, embed, and index commands |
 | `registerSlackArchiveTools` | `src/mcp/slack-archive-tools.ts` | Signed-turn `slack_archive_search` and `slack_archive_thread`, scoped per result to public/approved channels |
 | runtime wiring | `src/index.ts` | Store lifecycle, MCP handle, live event capture |
+| weekly workflow | `workflows/slack-archive-maintenance.workflow.md` | Explicit native-handler schedule and concurrency policy |
 
 The archive database is intentionally separate from `memory.db`; no archive
 table participates in memory consolidation or automatic pre-recall.

--- a/docs/features/slack-archive.md
+++ b/docs/features/slack-archive.md
@@ -52,13 +52,35 @@ checkpoints stay in the top-level-message timestamp domain; `SlackArchiveSync`
 also compares full root metadata with locally archived thread timestamps so it
 can repair missed replies on roots older than the history checkpoint.
 
+### Weekly maintenance
+
+`workflows/slack-archive-maintenance.workflow.md` runs every Sunday at 03:17
+Asia/Kolkata. Its explicit `nativeHandler: slack-archive-maintenance` binding
+executes typed application code directly; it does not invoke an agent or model.
+The native pass:
+
+1. queries Slack's Conversations API for all public channels and explicitly
+   approved non-public channels, joins visible public channels where needed,
+   and closes gaps for messages Junior never saw;
+2. resumes from per-channel checkpoints and repairs replies on older threads;
+3. embeds only new or edited non-empty messages;
+4. atomically rebuilds `data/slack-archive.db.usearch` only when vectors changed
+   or the index is absent; and
+5. records counts and index state in a workflow-run artifact.
+
+The workflow uses `concurrency: skip`, so a slow pass cannot overlap the next
+one. A failed index build leaves the previously published sidecar intact.
+The bot token requires `channels:join` in addition to `channels:read` and
+`channels:history`; after changing Slack OAuth scopes, reinstall the app so the
+new token grant takes effect.
+
 ## Retrieval and security
 
-`slack_archive_search` uses FTS lexical retrieval with optional channel, actor,
-actor-kind, and time filters. The store also supports caller-supplied vectors
-and reciprocal-rank fusion, but importing the full corpus does not generate
-embeddings by default. `slack_archive_thread` reads one exact channel/thread in
-chronological order.
+`slack_archive_search` embeds the query and combines ANN semantic retrieval with
+FTS lexical retrieval, plus optional channel, actor, actor-kind, and time
+filters. Imports do not generate embeddings immediately; the weekly native
+maintenance pass embeds pending rows and republishes the ANN sidecar.
+`slack_archive_thread` reads one exact channel/thread in chronological order.
 
 Both tools require a signed runner turn whose stored session channel is public
 or explicitly approved. Every requested or returned archive channel is checked

--- a/docs/features/slack-archive.md
+++ b/docs/features/slack-archive.md
@@ -69,7 +69,11 @@ The native pass:
 5. records counts and index state in a workflow-run artifact.
 
 The workflow uses `concurrency: skip`, so a slow pass cannot overlap the next
-one. A failed index build leaves the previously published sidecar intact.
+one. When `SLACK_ARCHIVE_ENABLED=false`, its run is recorded as skipped rather
+than failed, preserving the optional-subsystem boundary. A durable corpus
+revision changes when embeddings are added or removed; the matching indexed
+revision advances only after atomic sidecar publication, so edits to empty text
+remove stale vectors and failed builds remain pending for the next run.
 The bot token requires `channels:join` in addition to `channels:read` and
 `channels:history`; after changing Slack OAuth scopes, reinstall the app so the
 new token grant takes effect.

--- a/src/slack/archive-maintenance.test.ts
+++ b/src/slack/archive-maintenance.test.ts
@@ -48,9 +48,47 @@ describe("runSlackArchiveMaintenance", () => {
       rmSync(root, { recursive: true, force: true });
     }
   });
+
+  it("republishes the index when an edit removes an embedding", async () => {
+    const root = mkdtempSync(join(tmpdir(), "junior-slack-maintenance-remove-"));
+    const dbPath = join(root, "archive.db");
+    const indexPath = `${dbPath}.usearch`;
+    let text = "A searchable message";
+    const client = fakeClient(() => text);
+
+    try {
+      await runSlackArchiveMaintenance({
+        client,
+        dbPath,
+        indexPath,
+        dimensions: 4,
+        embedder: new HashingEmbeddingProvider(4),
+      });
+      expect(new SlackArchiveVectorIndex(4, { path: indexPath, load: true }).size).toBe(1);
+
+      text = "";
+      // Backfill observations use wall-clock time for last-write-wins ordering.
+      await Bun.sleep(2);
+      const second = await runSlackArchiveMaintenance({
+        client,
+        dbPath,
+        indexPath,
+        dimensions: 4,
+        embedder: new HashingEmbeddingProvider(4),
+      });
+      expect(second.embedded).toBe(0);
+      expect(second.indexRebuilt).toBe(true);
+      expect(second.indexed).toBe(0);
+      expect(new SlackArchiveVectorIndex(4, { path: indexPath, load: true }).size).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });
 
-function fakeClient(): SlackArchiveClient {
+function fakeClient(
+  text: () => string = () => "A calm rollout needs a rollback checkpoint",
+): SlackArchiveClient {
   return {
     conversations: {
       list: async () => ({
@@ -60,9 +98,7 @@ function fakeClient(): SlackArchiveClient {
       }),
       history: async (args) => ({
         ok: true,
-        messages: args.oldest
-          ? [{ ts: "100.000001", text: "A calm rollout needs a rollback checkpoint", user: "U1" }]
-          : [{ ts: "100.000001", text: "A calm rollout needs a rollback checkpoint", user: "U1" }],
+        messages: [{ ts: "100.000001", text: text(), user: "U1" }],
         response_metadata: { next_cursor: "" },
       }),
       replies: async () => ({ ok: true, messages: [], response_metadata: { next_cursor: "" } }),

--- a/src/slack/archive-maintenance.test.ts
+++ b/src/slack/archive-maintenance.test.ts
@@ -96,7 +96,7 @@ function fakeClient(
         channels: [{ id: "C_PUBLIC", name: "general", is_channel: true, is_member: true }],
         response_metadata: { next_cursor: "" },
       }),
-      history: async (args) => ({
+      history: async () => ({
         ok: true,
         messages: [{ ts: "100.000001", text: text(), user: "U1" }],
         response_metadata: { next_cursor: "" },

--- a/src/slack/archive-maintenance.test.ts
+++ b/src/slack/archive-maintenance.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { HashingEmbeddingProvider } from "../memory/embedding/hashing.ts";
+import { SlackArchiveVectorIndex } from "./archive-vector-index.ts";
+import { runSlackArchiveMaintenance } from "./archive-maintenance.ts";
+import type { SlackArchiveClient } from "./archive-sync.ts";
+
+describe("runSlackArchiveMaintenance", () => {
+  it("syncs Slack directly, embeds pending rows, and republishes only a changed index", async () => {
+    const root = mkdtempSync(join(tmpdir(), "junior-slack-maintenance-"));
+    const dbPath = join(root, "archive.db");
+    const indexPath = `${dbPath}.usearch`;
+    const client = fakeClient();
+    const embedder = new HashingEmbeddingProvider(4);
+
+    try {
+      const first = await runSlackArchiveMaintenance({
+        client,
+        dbPath,
+        indexPath,
+        dimensions: 4,
+        embedder,
+      });
+      expect(first).toMatchObject({
+        channelsSynced: 1,
+        messagesSeen: 1,
+        embedded: 1,
+        remaining: 0,
+        indexed: 1,
+        indexRebuilt: true,
+      });
+      expect(existsSync(indexPath)).toBe(true);
+      expect(new SlackArchiveVectorIndex(4, { path: indexPath, load: true }).size).toBe(1);
+
+      const second = await runSlackArchiveMaintenance({
+        client,
+        dbPath,
+        indexPath,
+        dimensions: 4,
+        embedder,
+      });
+      expect(second.embedded).toBe(0);
+      expect(second.indexed).toBe(1);
+      expect(second.indexRebuilt).toBe(false);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+function fakeClient(): SlackArchiveClient {
+  return {
+    conversations: {
+      list: async () => ({
+        ok: true,
+        channels: [{ id: "C_PUBLIC", name: "general", is_channel: true, is_member: true }],
+        response_metadata: { next_cursor: "" },
+      }),
+      history: async (args) => ({
+        ok: true,
+        messages: args.oldest
+          ? [{ ts: "100.000001", text: "A calm rollout needs a rollback checkpoint", user: "U1" }]
+          : [{ ts: "100.000001", text: "A calm rollout needs a rollback checkpoint", user: "U1" }],
+        response_metadata: { next_cursor: "" },
+      }),
+      replies: async () => ({ ok: true, messages: [], response_metadata: { next_cursor: "" } }),
+    },
+  };
+}

--- a/src/slack/archive-maintenance.ts
+++ b/src/slack/archive-maintenance.ts
@@ -1,0 +1,102 @@
+import { existsSync } from "node:fs";
+import type { EmbeddingProvider } from "../memory/embedding/types.ts";
+import { embedSlackArchive } from "./archive-embed.ts";
+import { buildSlackArchiveVectorIndex } from "./archive-index.ts";
+import { SlackArchiveStore } from "./archive-store.ts";
+import { syncSlackArchive, type SlackArchiveClient } from "./archive-sync.ts";
+
+export interface SlackArchiveMaintenanceOptions {
+  client: SlackArchiveClient;
+  dbPath: string;
+  approvedChannelIds?: ReadonlySet<string>;
+  embedder?: EmbeddingProvider;
+  indexPath?: string;
+  dimensions?: number;
+  embedBatchSize?: number;
+  indexBatchSize?: number;
+}
+
+export interface SlackArchiveMaintenanceReport {
+  channelsSynced: number;
+  messagesSeen: number;
+  embedded: number;
+  staleSkipped: number;
+  remaining: number;
+  indexed: number;
+  indexRebuilt: boolean;
+  dbPath: string;
+  indexPath: string;
+}
+
+/**
+ * Weekly, native archive maintenance. Slack API history closes gaps left by
+ * event delivery; embeddings and the separately persisted ANN index then move
+ * forward as one deployment unit.
+ */
+export async function runSlackArchiveMaintenance(
+  options: SlackArchiveMaintenanceOptions,
+): Promise<SlackArchiveMaintenanceReport> {
+  const dimensions = options.dimensions ?? 640;
+  const indexPath = options.indexPath ?? `${options.dbPath}.usearch`;
+  const store = new SlackArchiveStore(options.dbPath, { vectorDimensions: dimensions });
+  try {
+    const synced = await syncSlackArchive({
+      client: options.client,
+      store,
+      approvedChannelIds: options.approvedChannelIds,
+    });
+    const embedder = options.embedder ?? (await loadLocalEmbedder());
+    const embeddings = await embedSlackArchive({
+      store,
+      provider: embedder,
+      dryRun: false,
+      batchSize: options.embedBatchSize ?? 100,
+    });
+
+    const shouldRebuildIndex = embeddings.embedded > 0 || !existsSync(indexPath);
+    const indexed = shouldRebuildIndex
+      ? buildSlackArchiveVectorIndex({
+          store,
+          indexPath,
+          dimensions,
+          batchSize: options.indexBatchSize ?? 1_000,
+        }).indexed
+      : store.countEmbeddedMessages(dimensions);
+
+    return {
+      channelsSynced: synced.channels,
+      messagesSeen: synced.messages,
+      embedded: embeddings.embedded,
+      staleSkipped: embeddings.staleSkipped,
+      remaining: embeddings.remaining,
+      indexed,
+      indexRebuilt: shouldRebuildIndex,
+      dbPath: options.dbPath,
+      indexPath,
+    };
+  } finally {
+    store.close();
+  }
+}
+
+export function formatSlackArchiveMaintenance(
+  report: SlackArchiveMaintenanceReport,
+): string {
+  return [
+    "Slack archive maintenance complete.",
+    `- channels synced: ${report.channelsSynced}`,
+    `- messages observed: ${report.messagesSeen}`,
+    `- messages embedded: ${report.embedded}`,
+    `- stale embedding writes skipped: ${report.staleSkipped}`,
+    `- embeddings remaining: ${report.remaining}`,
+    `- ANN vectors: ${report.indexed}`,
+    `- ANN index rebuilt: ${report.indexRebuilt ? "yes" : "no (corpus unchanged)"}`,
+    `- database: ${report.dbPath}`,
+    `- index: ${report.indexPath}`,
+  ].join("\n");
+}
+
+async function loadLocalEmbedder(): Promise<EmbeddingProvider> {
+  const { createEmbeddingProvider } = await import("../memory/embedding/factory.ts");
+  return createEmbeddingProvider("local");
+}

--- a/src/slack/archive-maintenance.ts
+++ b/src/slack/archive-maintenance.ts
@@ -53,7 +53,12 @@ export async function runSlackArchiveMaintenance(
       batchSize: options.embedBatchSize ?? 100,
     });
 
-    const shouldRebuildIndex = embeddings.embedded > 0 || !existsSync(indexPath);
+    // The corpus revision changes for both vector additions and removals. The
+    // indexed revision is recorded only after atomic sidecar publication, so a
+    // crash or concurrent write safely leaves another rebuild pending.
+    const corpusRevision = store.getEmbeddingCorpusRevision();
+    const indexedRevision = store.getEmbeddingIndexRevision(dimensions);
+    const shouldRebuildIndex = corpusRevision !== indexedRevision || !existsSync(indexPath);
     const indexed = shouldRebuildIndex
       ? buildSlackArchiveVectorIndex({
           store,
@@ -62,6 +67,7 @@ export async function runSlackArchiveMaintenance(
           batchSize: options.indexBatchSize ?? 1_000,
         }).indexed
       : store.countEmbeddedMessages(dimensions);
+    if (shouldRebuildIndex) store.setEmbeddingIndexRevision(dimensions, corpusRevision);
 
     return {
       channelsSynced: synced.channels,

--- a/src/slack/archive-store.test.ts
+++ b/src/slack/archive-store.test.ts
@@ -50,11 +50,18 @@ describe("SlackArchiveStore", () => {
   });
 
   test("preserves a vector on replay but invalidates it on a text edit", () => {
+    expect(store.getEmbeddingCorpusRevision()).toBe(0);
     store.upsertMessage(message());
+    expect(store.getEmbeddingCorpusRevision()).toBe(1);
     store.upsertMessage(message({ embedding: null, observedAt: 101 }));
+    expect(store.getEmbeddingCorpusRevision()).toBe(1);
     expect([...store.getMessage("C1", "1700000000.000100")!.embedding!]).toEqual([1, 0]);
     store.upsertMessage(message({ text: "edited body", embedding: null, observedAt: 102 }));
     expect(store.getMessage("C1", "1700000000.000100")?.embedding).toBeNull();
+    expect(store.getEmbeddingCorpusRevision()).toBe(2);
+    expect(store.getEmbeddingIndexRevision(2)).toBeNull();
+    store.setEmbeddingIndexRevision(2, 2);
+    expect(store.getEmbeddingIndexRevision(2)).toBe(2);
   });
 
   test("searches FTS5 with channel, actor, and time filters", () => {

--- a/src/slack/archive-store.ts
+++ b/src/slack/archive-store.ts
@@ -34,6 +34,8 @@ const BUSY_TIMEOUT_MS = 5_000;
 const BUSY_RETRY_ATTEMPTS = 5;
 const BUSY_RETRY_BASE_DELAY_MS = 25;
 const FTS_ROWID_MIGRATION = "fts-rowid-v1";
+const EMBEDDING_CORPUS_REVISION = "embedding-corpus-revision";
+const EMBEDDING_INDEX_REVISION_PREFIX = "embedding-index-revision:";
 
 export interface SlackArchiveEmbeddingCandidate {
   channelId: string;
@@ -179,6 +181,12 @@ export class SlackArchiveStore {
           updated_at INTEGER NOT NULL
         )
       `);
+      this.db.run(`
+        CREATE TABLE IF NOT EXISTS slack_archive_metadata (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL
+        )
+      `);
       migrateFtsRowids(this.db);
     });
   }
@@ -196,8 +204,13 @@ export class SlackArchiveStore {
   private writeMessage(input: SlackArchiveMessageInput): SlackArchiveWriteResult {
     const observedAt = input.observedAt ?? Date.now();
     const existing = this.db
-      .query<{ observed_at: number; ingest_source: string }, [string, string]>(
-        "SELECT observed_at, ingest_source FROM slack_archive_message WHERE channel_id = ? AND ts = ?",
+      .query<{
+        observed_at: number;
+        ingest_source: string;
+        text: string;
+        embedding: Uint8Array | null;
+      }, [string, string]>(
+        "SELECT observed_at, ingest_source, text, embedding FROM slack_archive_message WHERE channel_id = ? AND ts = ?",
       )
       .get(input.channelId, input.ts);
     const ingestSource = input.ingestSource ?? "backfill";
@@ -302,6 +315,13 @@ export class SlackArchiveStore {
       });
     } else {
       this.mutableVectorIndex?.remove(messageRow.rowid);
+    }
+    if (
+      (!existing && storedEmbedding) ||
+      (existing?.embedding && !storedEmbedding) ||
+      input.embedding != null
+    ) {
+      this.bumpEmbeddingCorpusRevision();
     }
     return existing ? "updated" : "inserted";
   }
@@ -446,8 +466,53 @@ export class SlackArchiveStore {
       return updated;
     });
     const updated = retrySqliteBusy(() => transaction(updates));
+    if (updated > 0) this.bumpEmbeddingCorpusRevision();
     for (const record of indexed) this.mutableVectorIndex?.upsert(record);
     return updated;
+  }
+
+  getEmbeddingCorpusRevision(): number {
+    return this.getMetadataInteger(EMBEDDING_CORPUS_REVISION) ?? 0;
+  }
+
+  getEmbeddingIndexRevision(dim: number): number | null {
+    return this.getMetadataInteger(`${EMBEDDING_INDEX_REVISION_PREFIX}${dim}`);
+  }
+
+  setEmbeddingIndexRevision(dim: number, revision: number): void {
+    this.setMetadataInteger(`${EMBEDDING_INDEX_REVISION_PREFIX}${dim}`, revision);
+  }
+
+  private bumpEmbeddingCorpusRevision(): void {
+    retrySqliteBusy(() => {
+      this.db.query(`
+        INSERT INTO slack_archive_metadata(key, value) VALUES (?, '1')
+        ON CONFLICT(key) DO UPDATE SET value = CAST(value AS INTEGER) + 1
+      `).run(EMBEDDING_CORPUS_REVISION);
+    });
+  }
+
+  private getMetadataInteger(key: string): number | null {
+    const value = this.db
+      .query<{ value: string }, [string]>(
+        "SELECT value FROM slack_archive_metadata WHERE key = ?",
+      )
+      .get(key)?.value;
+    if (value === undefined) return null;
+    const parsed = Number(value);
+    return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
+  }
+
+  private setMetadataInteger(key: string, value: number): void {
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new Error(`Invalid Slack archive metadata integer: ${value}`);
+    }
+    retrySqliteBusy(() => {
+      this.db.query(`
+        INSERT INTO slack_archive_metadata(key, value) VALUES (?, ?)
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+      `).run(key, String(value));
+    });
   }
 
   upsertConversation(conversation: SlackArchiveConversation): void {

--- a/src/slack/archive-sync.test.ts
+++ b/src/slack/archive-sync.test.ts
@@ -314,10 +314,34 @@ describe("SlackArchiveSync", () => {
     await new SlackArchiveSync({ client, store }).sync();
     expect(historyChannels).toEqual(["C1"]);
   });
+
+  it("joins visible public channels before reading their history", async () => {
+    const calls: string[] = [];
+    const client = fakeClient({
+      list: async () => ({
+        ok: true,
+        channels: [{ id: "C_PUBLIC", name: "general", is_channel: true, is_member: false }],
+        response_metadata: { next_cursor: "" },
+      }),
+      join: async ({ channel }) => {
+        calls.push(`join:${channel}`);
+        return { ok: true };
+      },
+      history: async ({ channel }) => {
+        calls.push(`history:${channel}`);
+        return { ok: true, messages: [], response_metadata: { next_cursor: "" } };
+      },
+    });
+
+    await new SlackArchiveSync({ client, store: new MemoryStore() }).sync();
+
+    expect(calls).toEqual(["join:C_PUBLIC", "history:C_PUBLIC"]);
+  });
 });
 
 function fakeClient(overrides: {
   list?: SlackArchiveClient["conversations"]["list"];
+  join?: SlackArchiveClient["conversations"]["join"];
   history?: SlackArchiveClient["conversations"]["history"];
   replies?: SlackArchiveClient["conversations"]["replies"];
 }): SlackArchiveClient {
@@ -327,6 +351,7 @@ function fakeClient(overrides: {
         ok: true,
         channels: [{ id: "C1", name: "general", is_channel: true }],
       })),
+      ...(overrides.join ? { join: overrides.join } : {}),
       history: overrides.history ?? (async () => ({ ok: true, messages: [] })),
       replies: overrides.replies ?? (async () => ({ ok: true, messages: [] })),
     },

--- a/src/slack/archive-sync.ts
+++ b/src/slack/archive-sync.ts
@@ -39,6 +39,11 @@ export interface SlackConversationResult {
   response_metadata?: SlackCursorMetadata;
 }
 
+export interface SlackJoinResult {
+  ok?: boolean;
+  error?: string;
+}
+
 export interface SlackHistoryResult {
   ok?: boolean;
   error?: string;
@@ -54,6 +59,7 @@ export interface SlackConversation {
   is_group?: boolean;
   is_im?: boolean;
   is_mpim?: boolean;
+  is_member?: boolean;
 }
 
 export interface SlackMessageFile {
@@ -88,6 +94,7 @@ export interface SlackArchiveClient {
       limit: number;
       cursor?: string;
     }): Promise<SlackConversationResult>;
+    join?(args: { channel: string }): Promise<SlackJoinResult>;
     history(args: {
       channel: string;
       limit: number;
@@ -156,6 +163,17 @@ export class SlackArchiveSync {
           conversation.kind === "public_channel" ||
           this.options.approvedChannelIds?.has(conversation.id) === true
         ) {
+          if (conversation.kind === "public_channel" && channel.is_member === false) {
+            if (!this.options.client.conversations.join) {
+              throw new Error(
+                `conversations.join unavailable for public channel ${conversation.id}`,
+              );
+            }
+            const joined = await this.options.client.conversations.join({
+              channel: conversation.id,
+            });
+            assertSlackOk(joined, `conversations.join(${conversation.id})`);
+          }
           yield conversation;
         }
       }

--- a/src/workflows/definition.test.ts
+++ b/src/workflows/definition.test.ts
@@ -140,6 +140,60 @@ describe("validateWorkflowDefinition", () => {
     expect(definition.ownerSlackUserIds).toEqual([]);
     expect(definition.permissions.repos).toBeUndefined();
   });
+
+  it("binds a supported native handler explicitly without an agent runner", () => {
+    const definition = validateWorkflowDefinition({
+      path: "workflows/slack-archive-maintenance.workflow.md",
+      sourceRoot: "public",
+      repos,
+      content: validContent(),
+      body: "Documentation only.",
+      frontmatter: {
+        name: "slack-archive-maintenance",
+        enabled: true,
+        nativeHandler: "slack-archive-maintenance",
+        ownerSlackUserIds: [],
+        triggers: [{ type: "schedule", cron: "17 3 * * 0", timezone: "Asia/Kolkata" }],
+        outputs: [{ type: "docs", path: "data/workflow-runs/slack-archive-maintenance" }],
+        permissions: { tools: ["slack.read", "archive.write", "docs.write"] },
+      },
+    });
+
+    expect(definition.nativeHandler).toBe("slack-archive-maintenance");
+    expect(definition.runner).toBeUndefined();
+  });
+
+  it("rejects unknown native handlers and native-handler plus runner ambiguity", () => {
+    const base = {
+      name: "worklog",
+      enabled: true,
+      ownerSlackUserIds: [],
+      triggers: [{ type: "command", command: "worklog" }],
+      outputs: [{ type: "docs", path: "data/workflow-runs/worklog" }],
+      permissions: { tools: ["docs.write"] },
+    };
+    const validate = (frontmatter: Record<string, unknown>) =>
+      validateWorkflowDefinition({
+        path: "workflows/worklog.workflow.md",
+        sourceRoot: "public",
+        repos,
+        content: validContent(),
+        body: "Documentation only.",
+        frontmatter,
+      });
+
+    expect(() => validate({ ...base, nativeHandler: "run-arbitrary-code" }))
+      .toThrow("Unsupported nativeHandler");
+    expect(() => validate({
+      ...base,
+      nativeHandler: "memory-dedup-sweep",
+      runner: { provider: "default", agentName: "default" },
+    })).toThrow("mutually exclusive");
+    expect(() => validate({
+      ...base,
+      nativeHandler: "slack-archive-maintenance",
+    })).toThrow("requires permissions: slack.read, archive.write");
+  });
 });
 
 function validContent(): string {

--- a/src/workflows/definition.ts
+++ b/src/workflows/definition.ts
@@ -6,6 +6,7 @@ import type { RepoConfig } from "../config.ts";
 import type {
   WorkflowConcurrency,
   WorkflowDefinition,
+  WorkflowNativeHandler,
   WorkflowOutput,
   WorkflowPermissions,
   WorkflowRunnerConfig,
@@ -30,11 +31,23 @@ const SUPPORTED_TOOLS = new Set<WorkflowTool>([
   "git",
   "gh",
   "slack.post",
+  "slack.read",
+  "archive.write",
   "docs.write",
   "memory.read",
   "memory.write",
   "memory.evaluate",
 ]);
+const SUPPORTED_NATIVE_HANDLERS = new Set<WorkflowNativeHandler>([
+  "memory-consolidation",
+  "memory-dedup-sweep",
+  "slack-archive-maintenance",
+]);
+const NATIVE_HANDLER_TOOLS: Record<WorkflowNativeHandler, readonly WorkflowTool[]> = {
+  "memory-consolidation": ["docs.write", "memory.read", "memory.write", "memory.evaluate"],
+  "memory-dedup-sweep": ["docs.write", "memory.read", "memory.evaluate"],
+  "slack-archive-maintenance": ["docs.write", "slack.read", "archive.write"],
+};
 
 export async function loadWorkflowDefinition(
   options: LoadWorkflowDefinitionOptions,
@@ -97,6 +110,13 @@ export function validateWorkflowDefinition(options: {
   const runner = fm.runner == null
     ? undefined
     : parseRunner(objectRecord(fm.runner, "runner"));
+  const nativeHandler = fm.nativeHandler == null
+    ? undefined
+    : parseNativeHandler(stringValue(fm.nativeHandler, "nativeHandler"));
+  if (runner && nativeHandler) {
+    throw new Error("runner and nativeHandler are mutually exclusive");
+  }
+  if (nativeHandler) validateNativeHandlerPermissions(nativeHandler, permissions);
   const fallback = fm.fallback == null
     ? undefined
     : parseFallback(objectRecord(fm.fallback, "fallback"));
@@ -112,6 +132,7 @@ export function validateWorkflowDefinition(options: {
     ownerSlackUserIds,
     triggers,
     outputs,
+    nativeHandler,
     runner,
     permissions,
     fallback,
@@ -121,6 +142,26 @@ export function validateWorkflowDefinition(options: {
     sourcePath: options.path,
     sourceRoot: options.sourceRoot,
   };
+}
+
+function parseNativeHandler(value: string): WorkflowNativeHandler {
+  if (!SUPPORTED_NATIVE_HANDLERS.has(value as WorkflowNativeHandler)) {
+    throw new Error(`Unsupported nativeHandler: ${value}`);
+  }
+  return value as WorkflowNativeHandler;
+}
+
+function validateNativeHandlerPermissions(
+  handler: WorkflowNativeHandler,
+  permissions: WorkflowPermissions,
+): void {
+  const declared = new Set(permissions.tools);
+  const missing = NATIVE_HANDLER_TOOLS[handler].filter((tool) => !declared.has(tool));
+  if (missing.length > 0) {
+    throw new Error(
+      `nativeHandler ${handler} requires permissions: ${missing.join(", ")}`,
+    );
+  }
 }
 
 function parseFrontmatter(content: string, path: string): {

--- a/src/workflows/executor.test.ts
+++ b/src/workflows/executor.test.ts
@@ -92,6 +92,7 @@ describe("WorkflowExecutor", () => {
     const dir = mkdtempSync(join(tmpdir(), "junior-memory-workflow-test-"));
     const definition = workflowDefinition(dir);
     definition.name = "memory-consolidation";
+    definition.nativeHandler = "memory-consolidation";
     definition.triggers = [{ type: "command", command: "memory-consolidation" }];
     definition.outputs = [{ type: "docs", path: join(dir, "memory-consolidation") }];
     definition.permissions.tools = ["docs.write", "memory.read", "memory.write", "memory.evaluate"];
@@ -152,6 +153,7 @@ describe("WorkflowExecutor", () => {
     const dir = mkdtempSync(join(tmpdir(), "junior-dedup-workflow-test-"));
     const definition = workflowDefinition(dir);
     definition.name = "memory-dedup-sweep";
+    definition.nativeHandler = "memory-dedup-sweep";
     definition.triggers = [{ type: "command", command: "memory-dedup-sweep" }];
     definition.outputs = [{ type: "docs", path: join(dir, "memory-dedup-sweep") }];
     definition.permissions.tools = ["docs.write", "memory.read", "memory.evaluate"];
@@ -204,10 +206,59 @@ describe("WorkflowExecutor", () => {
     }
   });
 
+  it("runs Slack archive maintenance natively without spawning an agent", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "junior-slack-archive-workflow-test-"));
+    const definition = workflowDefinition(dir);
+    definition.name = "slack-archive-maintenance";
+    definition.nativeHandler = "slack-archive-maintenance";
+    definition.runner = undefined;
+    definition.outputs = [{ type: "docs", path: join(dir, "slack-archive-maintenance") }];
+    definition.permissions.tools = ["slack.read", "archive.write", "docs.write"];
+    const config = testConfig();
+    config.slackArchive = {
+      enabled: true,
+      dbPath: join(dir, "archive.db"),
+      exportPath: null,
+      approvedChannelIds: [],
+    };
+    const spawn = mock(() => {
+      throw new Error("runner should not be spawned for native archive maintenance");
+    });
+    const executor = new WorkflowExecutor({
+      config,
+      store: new InMemoryWorkflowStore(),
+      slackClient: {} as WebClient,
+      spawn: spawn as never,
+      slackArchiveMaintenance: async () => ({
+        channelsSynced: 12,
+        messagesSeen: 34,
+        embedded: 7,
+        staleSkipped: 0,
+        remaining: 0,
+        indexed: 770_565,
+        indexRebuilt: true,
+        dbPath: config.slackArchive!.dbPath,
+        indexPath: `${config.slackArchive!.dbPath}.usearch`,
+      }),
+      now: () => new Date("2026-08-16T03:17:00+05:30"),
+    });
+
+    try {
+      const result = await executor.run({ definition, reason: "schedule" });
+      expect(spawn).not.toHaveBeenCalled();
+      expect(result.summary).toContain("channels synced: 12");
+      expect(result.summary).toContain("messages embedded: 7");
+      expect(result.summary).toContain("ANN index rebuilt: yes");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("does not spawn a second inspection runner for memory-consolidation (sweep-only)", async () => {
     const dir = mkdtempSync(join(tmpdir(), "junior-memory-sweeponly-test-"));
     const definition = workflowDefinition(dir);
     definition.name = "memory-consolidation";
+    definition.nativeHandler = "memory-consolidation";
     definition.triggers = [{ type: "command", command: "memory-consolidation" }];
     definition.outputs = [{ type: "docs", path: join(dir, "memory-consolidation") }];
     definition.permissions.tools = ["docs.write", "memory.read", "memory.write", "memory.evaluate"];

--- a/src/workflows/executor.test.ts
+++ b/src/workflows/executor.test.ts
@@ -254,6 +254,33 @@ describe("WorkflowExecutor", () => {
     }
   });
 
+  it("records disabled Slack archive maintenance as skipped instead of failed", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "junior-slack-archive-disabled-test-"));
+    const definition = workflowDefinition(dir);
+    definition.name = "slack-archive-maintenance";
+    definition.nativeHandler = "slack-archive-maintenance";
+    definition.runner = undefined;
+    definition.outputs = [{ type: "docs", path: join(dir, "slack-archive-maintenance") }];
+    definition.permissions.tools = ["slack.read", "archive.write", "docs.write"];
+    const store = new InMemoryWorkflowStore();
+    const executor = new WorkflowExecutor({
+      config: testConfig(),
+      store,
+      slackClient: {} as WebClient,
+      now: () => new Date("2026-08-16T03:17:00+05:30"),
+    });
+
+    try {
+      const result = await executor.run({ definition, reason: "schedule" });
+      expect(result.run.status).toBe("skipped");
+      expect(result.summary).toContain("Slack archive is not enabled");
+      expect((await store.getRun(result.run.id))?.status).toBe("skipped");
+      expect(readFileSync(result.run.artifactPath, "utf8")).toContain("Status: skipped");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("does not spawn a second inspection runner for memory-consolidation (sweep-only)", async () => {
     const dir = mkdtempSync(join(tmpdir(), "junior-memory-sweeponly-test-"));
     const definition = workflowDefinition(dir);

--- a/src/workflows/executor.ts
+++ b/src/workflows/executor.ts
@@ -121,7 +121,9 @@ export class WorkflowExecutor {
     let summary = "";
     try {
       if (request.definition.nativeHandler) {
-        summary = await this.runNativeHandler(request.definition.nativeHandler);
+        const nativeResult = await this.runNativeHandler(request.definition.nativeHandler);
+        summary = nativeResult.summary;
+        run.status = nativeResult.status;
       } else if (request.definition.runner) {
         summary = await this.runWithRunner(
           request.definition,
@@ -138,7 +140,7 @@ export class WorkflowExecutor {
           `Workflow ${request.definition.name} ran.`;
       }
 
-      run.status = "success";
+      if (run.status === "running") run.status = "success";
       run.finishedAt = this.now().getTime();
       const body = renderArtifact({
         definition: request.definition,
@@ -411,19 +413,25 @@ export class WorkflowExecutor {
     return formatDedupSweep(report);
   }
 
-  private async runNativeHandler(handler: WorkflowNativeHandler): Promise<string> {
+  private async runNativeHandler(
+    handler: WorkflowNativeHandler,
+  ): Promise<{ summary: string; status: "success" | "skipped" }> {
     const handlers: Record<WorkflowNativeHandler, () => Promise<string>> = {
       "memory-consolidation": () => this.runMemoryConsolidation(),
       "memory-dedup-sweep": () => this.runMemoryDedupSweep(),
       "slack-archive-maintenance": () => this.runSlackArchiveMaintenance(),
     };
-    return handlers[handler]();
+    if (handler === "slack-archive-maintenance" && !this.config.slackArchive?.enabled) {
+      return {
+        status: "skipped",
+        summary: "Skipped Slack archive maintenance: Slack archive is not enabled.",
+      };
+    }
+    return { status: "success", summary: await handlers[handler]() };
   }
 
   private async runSlackArchiveMaintenance(): Promise<string> {
-    if (!this.config.slackArchive?.enabled) {
-      throw new Error("Slack archive is not enabled");
-    }
+    if (!this.config.slackArchive?.enabled) throw new Error("Slack archive is not enabled");
     if (!this.slackClient) throw new Error("Slack client not configured");
     const report = this.slackArchiveMaintenance
       ? await this.slackArchiveMaintenance()

--- a/src/workflows/executor.ts
+++ b/src/workflows/executor.ts
@@ -9,6 +9,7 @@ import { withTimeout } from "../lifecycle/timeout.ts";
 import { log } from "../logger.ts";
 import type {
   WorkflowDefinition,
+  WorkflowNativeHandler,
   WorkflowOutput,
   WorkflowRunnerConfig,
   WorkflowRun,
@@ -31,6 +32,11 @@ import { createProfileStore } from "../memory/profiles/factory.ts";
 import type { ProfileStore } from "../memory/profiles/store.ts";
 import type { EmbeddingProvider } from "../memory/embedding/types.ts";
 import type { ConsolidationInvoke } from "../memory/consolidation/types.ts";
+import {
+  formatSlackArchiveMaintenance,
+  runSlackArchiveMaintenance,
+  type SlackArchiveMaintenanceReport,
+} from "../slack/archive-maintenance.ts";
 
 export const WORKFLOW_UTILITY_CWD = "/tmp/junior-utility";
 const DEFAULT_MAX_IDLE_INTERRUPTS = 3;
@@ -54,6 +60,7 @@ export interface WorkflowExecutorOptions {
     invoke?: ConsolidationInvoke;
     resolvePeople?: PeopleResolver;
   };
+  slackArchiveMaintenance?: () => Promise<SlackArchiveMaintenanceReport>;
 }
 
 export interface WorkflowRunRequest {
@@ -75,6 +82,7 @@ export class WorkflowExecutor {
   private now: () => Date;
   private memoryStore?: MemoryStore;
   private consolidationDeps?: WorkflowExecutorOptions["consolidationDeps"];
+  private slackArchiveMaintenance?: WorkflowExecutorOptions["slackArchiveMaintenance"];
   private activeHandles = new Set<SpawnHandle>();
 
   constructor(options: WorkflowExecutorOptions) {
@@ -85,6 +93,7 @@ export class WorkflowExecutor {
     this.now = options.now ?? (() => new Date());
     this.memoryStore = options.memoryStore;
     this.consolidationDeps = options.consolidationDeps;
+    this.slackArchiveMaintenance = options.slackArchiveMaintenance;
   }
 
   async run(request: WorkflowRunRequest): Promise<WorkflowRunResult> {
@@ -111,18 +120,8 @@ export class WorkflowExecutor {
 
     let summary = "";
     try {
-      if (request.definition.name === "memory-consolidation" && this.memoryStore) {
-        // v3 sweep-only. The consolidation sweep IS the LLM pass — it spawns the
-        // runner per session to derive episodes/profiles/claims (memory v3 §7).
-        // A second inspection-agent pass on top would double the LLM cost and
-        // run a prompt still written for the retired deterministic consolidate().
-        // The sweep's own summary is the workflow artifact.
-        summary = await this.runMemoryConsolidation();
-      } else if (request.definition.name === "memory-dedup-sweep" && this.memoryStore) {
-        // Same reasoning as the consolidation branch: the sweep is the work, and
-        // it is fully deterministic — an agent pass on top would only paraphrase
-        // a report it cannot improve.
-        summary = await this.runMemoryDedupSweep();
+      if (request.definition.nativeHandler) {
+        summary = await this.runNativeHandler(request.definition.nativeHandler);
       } else if (request.definition.runner) {
         summary = await this.runWithRunner(
           request.definition,
@@ -410,6 +409,30 @@ export class WorkflowExecutor {
       threshold: this.config.memory.dedupThreshold,
     });
     return formatDedupSweep(report);
+  }
+
+  private async runNativeHandler(handler: WorkflowNativeHandler): Promise<string> {
+    const handlers: Record<WorkflowNativeHandler, () => Promise<string>> = {
+      "memory-consolidation": () => this.runMemoryConsolidation(),
+      "memory-dedup-sweep": () => this.runMemoryDedupSweep(),
+      "slack-archive-maintenance": () => this.runSlackArchiveMaintenance(),
+    };
+    return handlers[handler]();
+  }
+
+  private async runSlackArchiveMaintenance(): Promise<string> {
+    if (!this.config.slackArchive?.enabled) {
+      throw new Error("Slack archive is not enabled");
+    }
+    if (!this.slackClient) throw new Error("Slack client not configured");
+    const report = this.slackArchiveMaintenance
+      ? await this.slackArchiveMaintenance()
+      : await runSlackArchiveMaintenance({
+          client: this.slackClient,
+          dbPath: this.config.slackArchive.dbPath,
+          approvedChannelIds: new Set(this.config.slackArchive.approvedChannelIds),
+        });
+    return formatSlackArchiveMaintenance(report);
   }
 
   private async postSlack(

--- a/src/workflows/types.ts
+++ b/src/workflows/types.ts
@@ -8,6 +8,10 @@ export type WorkflowRunReason = "schedule" | "command" | "event" | "manual";
 export type WorkflowRunStatus = "running" | "success" | "failed" | "skipped";
 export type WorkflowLastRunStatus = Exclude<WorkflowRunStatus, "running">;
 export type WorkflowConcurrency = "skip" | "parallel";
+export type WorkflowNativeHandler =
+  | "memory-consolidation"
+  | "memory-dedup-sweep"
+  | "slack-archive-maintenance";
 export type WorkflowRunnerProvider =
   | "default"
   | "opencode"
@@ -17,6 +21,8 @@ export type WorkflowTool =
   | "git"
   | "gh"
   | "slack.post"
+  | "slack.read"
+  | "archive.write"
   | "docs.write"
   | "memory.read"
   | "memory.write"
@@ -90,6 +96,8 @@ export interface WorkflowDefinition {
   ownerSlackUserIds: string[];
   triggers: WorkflowTrigger[];
   outputs: WorkflowOutput[];
+  /** Explicit deterministic implementation; mutually exclusive with runner. */
+  nativeHandler?: WorkflowNativeHandler;
   runner?: WorkflowRunnerConfig;
   permissions: WorkflowPermissions;
   fallback?: WorkflowFallback;

--- a/workflows/memory-consolidation.workflow.md
+++ b/workflows/memory-consolidation.workflow.md
@@ -2,6 +2,7 @@
 name: memory-consolidation
 enabled: true
 description: Run the offline v3 consolidation sweep — turn unconsolidated source records into episodes, entity profiles, and semantic claims.
+nativeHandler: memory-consolidation
 ownerSlackUserIds: []
 triggers:
   - type: schedule

--- a/workflows/memory-dedup-sweep.workflow.md
+++ b/workflows/memory-dedup-sweep.workflow.md
@@ -2,6 +2,7 @@
 name: memory-dedup-sweep
 enabled: true
 description: Report claim near-duplicates that predate the write guard — cluster them, name the survivor, and archive nothing until an operator applies it.
+nativeHandler: memory-dedup-sweep
 ownerSlackUserIds: []
 triggers:
   - type: schedule

--- a/workflows/slack-archive-maintenance.workflow.md
+++ b/workflows/slack-archive-maintenance.workflow.md
@@ -1,0 +1,26 @@
+---
+name: slack-archive-maintenance
+enabled: true
+description: Synchronize all public and approved Slack history, embed changed messages, and atomically republish the ANN index.
+nativeHandler: slack-archive-maintenance
+ownerSlackUserIds: []
+triggers:
+  - type: schedule
+    cron: "17 3 * * 0"
+    timezone: Asia/Kolkata
+  - type: command
+    command: slack-archive-maintenance
+outputs:
+  - type: docs
+    path: data/workflow-runs/slack-archive-maintenance
+permissions:
+  tools:
+    - slack.read
+    - archive.write
+    - docs.write
+concurrency: skip
+---
+
+Native implementation: `runSlackArchiveMaintenance()` in
+`src/slack/archive-maintenance.ts`. This body is documentation only and is not
+sent to an agent or model.


### PR DESCRIPTION
## Summary
- Add an explicit typed `nativeHandler` registry for deterministic workflows, with no filename magic or LLM execution, and schedule Slack archive maintenance weekly on Sunday at 03:17 Asia/Kolkata.
- Use the existing bot token to auto-join every visible public channel while preserving the approved-private-channel boundary, then repair checkpoint gaps and older threads, embed pending changes, and atomically rebuild the ANN index only when vectors changed or the index is absent.
- Requires granting the Slack app the `channels:join` OAuth scope and reinstalling it; the current live bot token does not have that scope.

## Test plan
- [x] `bun run typecheck` (two clean serial runs)
- [x] `bun test` (two serial runs: 2001 passed, 4 model-dependent skipped, 0 failed each)