### PR TITLE
Allow orchestrators to dispatch utility agents

### DIFF
--- a/.claude/agents/default.md
+++ b/.claude/agents/default.md
@@ -11,7 +11,7 @@ operational.lifecycle: persistent
 operational.role: orchestrator
 operational.capabilities: repo-read, repo-write, worktree-mutate, pipeline-artifact-write, pipeline-run-start, dispatch, orchestrate, github-review-read
 operational.mutationPolicy: workspace
-operational.mayDelegateTo: pm, architect, build, frontend, review, reproducer, onboard-member, db-executioner, human
+operational.mayDelegateTo: pm, architect, build, frontend, review, reproducer, onboard-member, db-executioner, admin-account, aws-uploader, feature-metrics, github-access, onboarding, oogway, pnd-populator, human
 operational.mayReturnTo:
 operational.maxParallel: 4
 common: core,orchestrator-dispatch,pipeline-start,pipeline-outcome

--- a/src/agents/provider-parity.test.ts
+++ b/src/agents/provider-parity.test.ts
@@ -79,14 +79,21 @@ describe("provider parity — catalog permissions", () => {
     const names = listCatalogAgents().map((m) => m.name).sort();
     expect(names).toEqual(
       [
+        "admin-account",
         "architect",
+        "aws-uploader",
         "build",
         "db-executioner",
         "default",
+        "feature-metrics",
         "frontend",
+        "github-access",
         "lead",
         "onboard-member",
+        "onboarding",
+        "oogway",
         "pm",
+        "pnd-populator",
         "reproducer",
         "review",
       ].sort(),

--- a/src/agents/provider-parity.test.ts
+++ b/src/agents/provider-parity.test.ts
@@ -182,16 +182,15 @@ describe("provider parity — handoff graph vs canDispatch", () => {
   });
 
   it("orchestrators may fan out to every registered worker", () => {
-    const workers = [
-      "pm",
-      "architect",
-      "build",
-      "frontend",
-      "review",
-      "reproducer",
-      "onboard-member",
-      "db-executioner",
-    ];
+    // Derived from the catalog, not hardcoded: registering an agent flips its
+    // dispatch to fail-closed (see canDispatch's catalog-target branch), so a
+    // new definition that nobody adds to an orchestrator's mayDelegateTo is
+    // silently undispatchable. A hardcoded roster here stays green through
+    // exactly that regression.
+    const workers = listCatalogAgents()
+      .filter((manifest) => manifest.role !== "orchestrator")
+      .map((manifest) => manifest.name);
+    expect(workers.length).toBeGreaterThan(0);
     for (const orch of ["default", "lead", "junior"] as const) {
       for (const worker of workers) {
         expect(canDispatch(orch, worker)).toBe(true);

--- a/src/agents/registry.test.ts
+++ b/src/agents/registry.test.ts
@@ -29,14 +29,21 @@ describe("trusted agent catalog", () => {
     const names = listCatalogAgents().map((m) => m.name).sort();
     expect(names).toEqual(
       [
+        "admin-account",
         "architect",
+        "aws-uploader",
         "build",
         "db-executioner",
         "default",
+        "feature-metrics",
         "frontend",
+        "github-access",
         "lead",
         "onboard-member",
+        "onboarding",
+        "oogway",
         "pm",
+        "pnd-populator",
         "reproducer",
         "review",
       ].sort(),


### PR DESCRIPTION
Companion to [junior-private-agents#20](https://github.com/GrowthX-Club/junior-private-agents/pull/20). **Merge that one first** — the submodule pointer here references its branch commit, and the roster tests fail without those definitions.

## Background

Seven `agents-org` definitions carried no `operational.*` frontmatter, so they compiled into no manifest at all. `requiresManagedWorktree()` fails closed on a null manifest, so Junior provisioned an isolated repo worktree for agents that only ever needed the main checkout. That is what blocked an approved admin-account request: `create_admin_account.ts` reads `DB_STRING` from the gitignored `apps/migrations/.env`, which no worktree has.

## Why this PR exists separately

Registering those agents in the catalog **flips their dispatch to fail-closed**, which would have traded one bug for another. `canDispatch` treats the two cases oppositely:

- A **non-catalog** target is reachable by any orchestrator via the legacy `isPersistentAgent` path.
- Once it declares `operational.enabled`, the *"catalog source with no matching edge: fail closed for catalog targets"* rule at `src/support/agents.ts:220` applies, and `registryAllowsHandoff` requires an explicit edge from the **source's** `mayDelegateTo`.

So adding the manifests alone would have made these agents undispatchable. The seven names are added to `.claude/agents/default.md`, which the `lead` variant aliases.

This failure mode is invisible to typecheck and to the agent's own file — only a `canDispatch` check catches it.

## Changes

- `.claude/agents/default.md` — add the seven utility agents to `operational.mayDelegateTo`
- `src/agents/provider-parity.test.ts`, `src/agents/registry.test.ts` — both assert the exact catalog roster and fail by design on any addition; updated to the new list
- `agents-org` — submodule bump

## Verification

For all seven: `requiresManagedWorktree` false, `canDispatch` true from `default`, `lead`, and `junior`.

Full suite 2032 pass / 0 fail, `bun run typecheck` clean, across two consecutive passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YS3UHRG11Nj7L28Uj6Mmcn