### PR TITLE
fix: increase worklog workflow timeout

### DIFF
--- a/docs/features/dynamic-workflows.md
+++ b/docs/features/dynamic-workflows.md
@@ -66,7 +66,7 @@ permissions:
 runner:
   provider: default
   agentName: lead
-  timeoutMs: 300000
+  timeoutMs: 1200000
   idleTimeoutMs: 300000
   maxIdleInterrupts: 3
 concurrency: skip

--- a/workflows/worklog.workflow.md
+++ b/workflows/worklog.workflow.md
@@ -23,7 +23,7 @@ permissions:
 runner:
   provider: default
   agentName: default
-  timeoutMs: 300000
+  timeoutMs: 1200000
 concurrency: skip
 ---
 


### PR DESCRIPTION
## Summary
- Increase the worklog workflow hard timeout from 5 minutes to 20 minutes so repository and GitHub activity collection can complete reliably.
- Keep the dynamic workflow documentation in sync with the deployed configuration.

## Test plan
- [x] `bun test src/workflows/definition.test.ts src/workflows/registry.test.ts`