### PR TITLE
feat: prune scoped worktrees after pull request merges

### DIFF
--- a/docs/code_index/github-reconciliation.md
+++ b/docs/code_index/github-reconciliation.md
@@ -35,4 +35,7 @@ only those exact worktrees and retains every normal prune safety gate. The
 workflow runs asynchronously so a long cleanup cannot block GitHub polling;
 its dispatcher coalesces newly merged branches and retries an overlap skip, so
 the workflow's `concurrency: skip` policy prevents overlap without losing a
-merge-triggered cleanup.
+merge-triggered cleanup. Thrown runs are requeued with bounded exponential
+backoff. Repo selection is enforced by an exact case-insensitive comparison of
+the event's `owner/repo` with configured `RepoConfig.githubRepo`; local aliases
+and same-named forks cannot satisfy the match.

--- a/docs/code_index/github-reconciliation.md
+++ b/docs/code_index/github-reconciliation.md
@@ -12,6 +12,7 @@ webhook to keep pipeline state correct.
 | Query builders | `src/github/queries.ts` | Resource/review queries used by reconciliation. |
 | `reconcile*` | `src/github/reconciler.ts` | Fetches external state and applies idempotent internal updates. |
 | Diffing | `src/github/diff.ts` | Compares observed and projected review/resource state. |
+| Merge-prune trigger | `src/github/prune-trigger.ts` | Extracts exact merged PR repo/branch targets for scoped worktree pruning. |
 | Review comments | `src/github/review-comments.ts` | Scopes comments to an exact head SHA and avoids duplicate writes. |
 | Types | `src/github/types.ts` | GitHub resource, review, and reconciliation contracts. |
 
@@ -26,3 +27,12 @@ comment operations; arbitrary GitHub mutation is not part of the contract.
 The pipeline layer consumes reconciled state through typed resources and
 outcomes. Failures are recoverable and must not be treated as proof that the
 external review state changed.
+
+When a reconcile pass observes an `OPEN`/`CLOSED` to `MERGED` transition,
+Junior starts `worktree-prune` with structured trigger context containing the
+PR coordinates, head branch, and head SHA. The event-triggered prune inspects
+only those exact worktrees and retains every normal prune safety gate. The
+workflow runs asynchronously so a long cleanup cannot block GitHub polling;
+its dispatcher coalesces newly merged branches and retries an overlap skip, so
+the workflow's `concurrency: skip` policy prevents overlap without losing a
+merge-triggered cleanup.

--- a/docs/features/dynamic-workflows.md
+++ b/docs/features/dynamic-workflows.md
@@ -172,6 +172,12 @@ used as proof of live work because a hard process exit can leave one behind.
 The scheduler counts active runs per workflow so this remains correct for both
 `skip` and `parallel` concurrency.
 
+System/event callers may attach structured `triggerContext` to a run. The
+executor includes it in the runner's `run` runtime context and the durable run
+artifact. GitHub reconciliation uses this to launch `worktree-prune` for the
+exact repo, branch, and head SHA of newly merged PRs without turning cleanup
+into a repo-bound agent dispatch.
+
 ## Slack Commands
 
 Read commands:

--- a/docs/features/dynamic-workflows.md
+++ b/docs/features/dynamic-workflows.md
@@ -176,7 +176,8 @@ System/event callers may attach structured `triggerContext` to a run. The
 executor includes it in the runner's `run` runtime context and the durable run
 artifact. GitHub reconciliation uses this to launch `worktree-prune` for the
 exact repo, branch, and head SHA of newly merged PRs without turning cleanup
-into a repo-bound agent dispatch.
+into a repo-bound agent dispatch. Event-triggered GitHub runs filter runtime
+repositories by canonical `RepoConfig.githubRepo`, not local repository names.
 
 ## Slack Commands
 

--- a/src/github/diff.test.ts
+++ b/src/github/diff.test.ts
@@ -97,6 +97,10 @@ describe("diffPrSnapshots", () => {
       ctx,
     );
     expect(events.map((e) => e.type)).toEqual(["github.pr.merged"]);
+    expect(events[0]?.next).toMatchObject({
+      headRefName: "feat/x",
+      headRefOid: "aaa111",
+    });
   });
 
   it("emits reopened for closed→open", () => {

--- a/src/github/diff.ts
+++ b/src/github/diff.ts
@@ -90,7 +90,12 @@ export function diffPrSnapshots(
     events.push(
       makeEvent("github.pr.merged", ctx, {
         previous: { state: previous.state, mergedAt: previous.mergedAt },
-        next: { state: next.state, mergedAt: next.mergedAt, headRefOid: next.headRefOid },
+        next: {
+          state: next.state,
+          mergedAt: next.mergedAt,
+          headRefName: next.headRefName,
+          headRefOid: next.headRefOid,
+        },
         fingerprintPart: `merged:${next.mergedAt ?? next.headRefOid}`,
       }),
     );

--- a/src/github/prune-trigger.test.ts
+++ b/src/github/prune-trigger.test.ts
@@ -131,6 +131,42 @@ describe("MergePruneDispatcher", () => {
 
     expect(runs[1]).toEqual(runs[0]);
   });
+
+  it("retries thrown runs with bounded backoff before exhausting the target", async () => {
+    const retries: Array<{ callback: () => void; delayMs: number }> = [];
+    const exhausted: MergedPullRequestPruneTarget[] = [];
+    let runs = 0;
+    const dispatcher = new MergePruneDispatcher({
+      run: async () => {
+        runs += 1;
+        throw new Error("workflow store temporarily unavailable");
+      },
+      retryDelayMs: 100,
+      maxAttempts: 3,
+      scheduleRetry: (callback, delayMs) => {
+        retries.push({ callback, delayMs });
+      },
+      onExhausted: (target) => exhausted.push(target),
+    });
+
+    dispatcher.enqueue([result([event("github.pr.merged")])]);
+    await waitFor(() => retries.length === 1);
+    expect(retries[0]?.delayMs).toBe(100);
+
+    retries[0]?.callback();
+    await waitFor(() => retries.length === 2);
+    expect(retries[1]?.delayMs).toBe(200);
+
+    retries[1]?.callback();
+    await waitFor(() => exhausted.length === 1);
+    expect(runs).toBe(3);
+    expect(exhausted[0]).toMatchObject({
+      owner: "acme",
+      repo: "widgets",
+      number: 42,
+    });
+    expect(retries).toHaveLength(2);
+  });
 });
 
 async function waitFor(predicate: () => boolean): Promise<void> {

--- a/src/github/prune-trigger.test.ts
+++ b/src/github/prune-trigger.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "bun:test";
+import {
+  MergePruneDispatcher,
+  mergedPullRequestPruneTargets,
+  type MergedPullRequestPruneTarget,
+} from "./prune-trigger.ts";
+import type { GitHubSemanticEvent, ShadowPersistResult } from "./types.ts";
+
+function result(events: GitHubSemanticEvent[]): ShadowPersistResult {
+  return {
+    resourceId: "resource-1",
+    events,
+    proposedReductions: [],
+    wakesDelivered: false,
+    associationsTouched: 1,
+  };
+}
+
+function event(
+  type: GitHubSemanticEvent["type"],
+  overrides: Partial<GitHubSemanticEvent> = {},
+): GitHubSemanticEvent {
+  return {
+    type,
+    resourceId: "resource-1",
+    owner: "acme",
+    repo: "widgets",
+    number: 42,
+    observedAt: 1_000,
+    previous: { state: "OPEN" },
+    next: {
+      state: "MERGED",
+      headRefName: "agent/fix-widgets",
+      headRefOid: "abc123",
+    },
+    fingerprint: `resource-1:${type}`,
+    ...overrides,
+  };
+}
+
+describe("mergedPullRequestPruneTargets", () => {
+  it("returns exact repo and branch targets for merge events", () => {
+    expect(
+      mergedPullRequestPruneTargets([
+        result([
+          event("github.pr.checks_changed"),
+          event("github.pr.merged"),
+        ]),
+      ]),
+    ).toEqual([
+      {
+        owner: "acme",
+        repo: "widgets",
+        number: 42,
+        branch: "agent/fix-widgets",
+        headSha: "abc123",
+      },
+    ]);
+  });
+
+  it("deduplicates a PR and ignores incomplete merge events", () => {
+    const merged = event("github.pr.merged");
+    expect(
+      mergedPullRequestPruneTargets([
+        result([merged]),
+        result([
+          merged,
+          event("github.pr.merged", { next: { state: "MERGED" } }),
+        ]),
+      ]),
+    ).toHaveLength(1);
+  });
+});
+
+describe("MergePruneDispatcher", () => {
+  it("serializes targets that arrive during an active prune run", async () => {
+    const runs: MergedPullRequestPruneTarget[][] = [];
+    const releases: Array<() => void> = [];
+    const dispatcher = new MergePruneDispatcher({
+      run: async (targets) => {
+        runs.push([...targets]);
+        await new Promise<void>((resolve) => releases.push(resolve));
+        return { runId: `run-${runs.length}` };
+      },
+    });
+
+    dispatcher.enqueue([result([event("github.pr.merged")])]);
+    await waitFor(() => runs.length === 1);
+    dispatcher.enqueue([
+      result([
+        event("github.pr.merged", {
+          repo: "gadgets",
+          number: 43,
+          next: {
+            state: "MERGED",
+            headRefName: "agent/fix-gadgets",
+            headRefOid: "def456",
+          },
+        }),
+      ]),
+    ]);
+
+    expect(runs).toHaveLength(1);
+    releases[0]?.();
+    await waitFor(() => runs.length === 2);
+    expect(runs[1]?.[0]).toMatchObject({
+      repo: "gadgets",
+      branch: "agent/fix-gadgets",
+    });
+    releases[1]?.();
+  });
+
+  it("retains targets when the workflow scheduler reports an overlap skip", async () => {
+    const runs: MergedPullRequestPruneTarget[][] = [];
+    let retry: (() => void) | undefined;
+    const dispatcher = new MergePruneDispatcher({
+      run: async (targets) => {
+        runs.push([...targets]);
+        return { runId: runs.length === 1 ? "" : "run-2" };
+      },
+      scheduleRetry: (callback) => {
+        retry = callback;
+      },
+    });
+
+    dispatcher.enqueue([result([event("github.pr.merged")])]);
+    await waitFor(() => runs.length === 1);
+    expect(retry).toBeDefined();
+    retry?.();
+    await waitFor(() => runs.length === 2);
+
+    expect(runs[1]).toEqual(runs[0]);
+  });
+});
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt++) {
+    if (predicate()) return;
+    await Bun.sleep(1);
+  }
+  throw new Error("condition was not met");
+}

--- a/src/github/prune-trigger.ts
+++ b/src/github/prune-trigger.ts
@@ -1,0 +1,117 @@
+import type { ShadowPersistResult } from "./types.ts";
+
+export type MergedPullRequestPruneTarget = {
+  owner: string;
+  repo: string;
+  number: number;
+  branch: string;
+  headSha: string;
+};
+
+export type MergePruneRunResult = { runId: string };
+
+export type MergePruneDispatcherOptions = {
+  run: (
+    targets: readonly MergedPullRequestPruneTarget[],
+  ) => Promise<MergePruneRunResult>;
+  retryDelayMs?: number;
+  scheduleRetry?: (callback: () => void, delayMs: number) => void;
+  onRun?: (
+    targets: readonly MergedPullRequestPruneTarget[],
+    result: MergePruneRunResult,
+  ) => void;
+  onError?: (error: unknown) => void;
+};
+
+const DEFAULT_RETRY_DELAY_MS = 30_000;
+
+/**
+ * Collapse newly persisted merge events into the exact PR branches that should
+ * prompt a worktree-prune run. A resource can be associated with several
+ * pipeline runs, so key by GitHub coordinates rather than association count.
+ */
+export function mergedPullRequestPruneTargets(
+  results: readonly ShadowPersistResult[],
+): MergedPullRequestPruneTarget[] {
+  const targets = new Map<string, MergedPullRequestPruneTarget>();
+
+  for (const result of results) {
+    for (const event of result.events) {
+      if (event.type !== "github.pr.merged") continue;
+      const branch = event.next.headRefName;
+      const headSha = event.next.headRefOid;
+      if (!branch || !headSha) continue;
+
+      const target = {
+        owner: event.owner,
+        repo: event.repo,
+        number: event.number,
+        branch,
+        headSha,
+      };
+      targets.set(`${target.owner}/${target.repo}#${target.number}`, target);
+    }
+  }
+
+  return [...targets.values()];
+}
+
+/**
+ * Serialize merge-triggered prune runs. The workflow itself uses
+ * `concurrency: skip`; when another prune already owns the slot, retain the
+ * exact targets and retry instead of silently losing the merge event.
+ */
+export class MergePruneDispatcher {
+  private readonly options: MergePruneDispatcherOptions;
+  private readonly pending = new Map<string, MergedPullRequestPruneTarget>();
+  private draining = false;
+  private retryScheduled = false;
+
+  constructor(options: MergePruneDispatcherOptions) {
+    this.options = options;
+  }
+
+  enqueue(results: readonly ShadowPersistResult[]): number {
+    const targets = mergedPullRequestPruneTargets(results);
+    for (const target of targets) this.addPending(target);
+    if (targets.length > 0) void this.drain();
+    return targets.length;
+  }
+
+  private addPending(target: MergedPullRequestPruneTarget): void {
+    this.pending.set(`${target.owner}/${target.repo}#${target.number}`, target);
+  }
+
+  private async drain(): Promise<void> {
+    if (this.draining || this.retryScheduled || this.pending.size === 0) return;
+    this.draining = true;
+    const targets = [...this.pending.values()];
+    this.pending.clear();
+
+    try {
+      const result = await this.options.run(targets);
+      this.options.onRun?.(targets, result);
+      if (!result.runId) {
+        for (const target of targets) this.addPending(target);
+        this.scheduleRetry();
+      }
+    } catch (error) {
+      this.options.onError?.(error);
+    } finally {
+      this.draining = false;
+      if (!this.retryScheduled && this.pending.size > 0) void this.drain();
+    }
+  }
+
+  private scheduleRetry(): void {
+    if (this.retryScheduled) return;
+    this.retryScheduled = true;
+    const schedule = this.options.scheduleRetry ?? ((callback, delayMs) => {
+      setTimeout(callback, delayMs);
+    });
+    schedule(() => {
+      this.retryScheduled = false;
+      void this.drain();
+    }, this.options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS);
+  }
+}

--- a/src/github/prune-trigger.ts
+++ b/src/github/prune-trigger.ts
@@ -15,15 +15,23 @@ export type MergePruneDispatcherOptions = {
     targets: readonly MergedPullRequestPruneTarget[],
   ) => Promise<MergePruneRunResult>;
   retryDelayMs?: number;
+  maxRetryDelayMs?: number;
+  maxAttempts?: number;
   scheduleRetry?: (callback: () => void, delayMs: number) => void;
   onRun?: (
     targets: readonly MergedPullRequestPruneTarget[],
     result: MergePruneRunResult,
   ) => void;
   onError?: (error: unknown) => void;
+  onExhausted?: (
+    target: MergedPullRequestPruneTarget,
+    error: unknown,
+  ) => void;
 };
 
 const DEFAULT_RETRY_DELAY_MS = 30_000;
+const DEFAULT_MAX_RETRY_DELAY_MS = 15 * 60_000;
+const DEFAULT_MAX_ATTEMPTS = 3;
 
 /**
  * Collapse newly persisted merge events into the exact PR branches that should
@@ -64,6 +72,7 @@ export function mergedPullRequestPruneTargets(
 export class MergePruneDispatcher {
   private readonly options: MergePruneDispatcherOptions;
   private readonly pending = new Map<string, MergedPullRequestPruneTarget>();
+  private readonly failedAttempts = new Map<string, number>();
   private draining = false;
   private retryScheduled = false;
 
@@ -79,7 +88,7 @@ export class MergePruneDispatcher {
   }
 
   private addPending(target: MergedPullRequestPruneTarget): void {
-    this.pending.set(`${target.owner}/${target.repo}#${target.number}`, target);
+    this.pending.set(targetKey(target), target);
   }
 
   private async drain(): Promise<void> {
@@ -94,24 +103,54 @@ export class MergePruneDispatcher {
       if (!result.runId) {
         for (const target of targets) this.addPending(target);
         this.scheduleRetry();
+      } else {
+        for (const target of targets) {
+          this.failedAttempts.delete(targetKey(target));
+        }
       }
     } catch (error) {
       this.options.onError?.(error);
+      let highestFailedAttempt = 0;
+      for (const target of targets) {
+        const key = targetKey(target);
+        const failedAttempt = (this.failedAttempts.get(key) ?? 0) + 1;
+        highestFailedAttempt = Math.max(highestFailedAttempt, failedAttempt);
+        if (failedAttempt < (this.options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS)) {
+          this.failedAttempts.set(key, failedAttempt);
+          this.addPending(target);
+        } else {
+          this.failedAttempts.delete(key);
+          this.options.onExhausted?.(target, error);
+        }
+      }
+      if (this.pending.size > 0) {
+        this.scheduleRetry(highestFailedAttempt);
+      }
     } finally {
       this.draining = false;
       if (!this.retryScheduled && this.pending.size > 0) void this.drain();
     }
   }
 
-  private scheduleRetry(): void {
+  private scheduleRetry(failedAttempt = 0): void {
     if (this.retryScheduled) return;
     this.retryScheduled = true;
     const schedule = this.options.scheduleRetry ?? ((callback, delayMs) => {
       setTimeout(callback, delayMs);
     });
+    const baseDelay = this.options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS;
+    const maxDelay = this.options.maxRetryDelayMs ?? DEFAULT_MAX_RETRY_DELAY_MS;
+    const delayMs = Math.min(
+      baseDelay * 2 ** Math.max(0, failedAttempt - 1),
+      maxDelay,
+    );
     schedule(() => {
       this.retryScheduled = false;
       void this.drain();
-    }, this.options.retryDelayMs ?? DEFAULT_RETRY_DELAY_MS);
+    }, delayMs);
   }
+}
+
+function targetKey(target: MergedPullRequestPruneTarget): string {
+  return `${target.owner}/${target.repo}#${target.number}`;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -212,6 +212,12 @@ const mergePruneDispatcher = new MergePruneDispatcher({
       `merge-triggered worktree-prune failed: ${err instanceof Error ? err.message : String(err)}`,
     );
   },
+  onExhausted: (target, err) => {
+    log.error(
+      "github",
+      `merge-triggered worktree-prune exhausted ${target.owner}/${target.repo}#${target.number}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  },
 });
 const workflowController = new WorkflowController({
   registry: workflowRegistry,

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ import {
 } from "./workflows/store.ts";
 import { createPipelineStore } from "./pipelines/store/factory.ts";
 import { pumpOutbox } from "./pipelines/pump.ts";
+import { MergePruneDispatcher } from "./github/prune-trigger.ts";
 import {
   reconcileStalePipelineAssignments,
   recoverPipelineRuntime,
@@ -182,6 +183,35 @@ const workflowScheduler = new WorkflowScheduler({
   registry: workflowRegistry,
   store: workflowStore,
   executor: workflowExecutor,
+});
+let markWorkflowsReady: () => void = () => undefined;
+const workflowsReady = new Promise<void>((resolveReady) => {
+  markWorkflowsReady = resolveReady;
+});
+const mergePruneDispatcher = new MergePruneDispatcher({
+  run: async (mergedPullRequests) => {
+    await workflowsReady;
+    return workflowScheduler.runNow({
+      name: "worktree-prune",
+      reason: "event",
+      triggerContext: {
+        source: "github.pr.merged",
+        pullRequests: mergedPullRequests,
+      },
+    });
+  },
+  onRun: (targets, result) => {
+    log.info(
+      "github",
+      `merge-triggered worktree-prune prs=${targets.length} run=${result.runId || "queued"}`,
+    );
+  },
+  onError: (err) => {
+    log.warn(
+      "github",
+      `merge-triggered worktree-prune failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  },
 });
 const workflowController = new WorkflowController({
   registry: workflowRegistry,
@@ -482,6 +512,7 @@ const pipelineBoot = (async () => {
               `reconcile examined=${pass.examined} updated=${pass.updated} events=${pass.eventsEmitted} failures=${pass.failures} wakes=${pass.wakesDelivered}`,
             );
           }
+          mergePruneDispatcher.enqueue(pass.results);
         } catch (err) {
           log.warn(
             "github",
@@ -668,6 +699,8 @@ setInterval(() => {
       "workflow",
       `workflow bootstrap failed: ${err instanceof Error ? err.message : String(err)}`,
     );
+  } finally {
+    markWorkflowsReady();
   }
 
   // WhatsApp ingestion (read-only archive). Incoming messages trigger nothing —

--- a/src/workflows/executor.test.ts
+++ b/src/workflows/executor.test.ts
@@ -62,8 +62,11 @@ describe("WorkflowExecutor", () => {
     try {
       const result = await executor.run({
         definition,
-        reason: "manual",
-        actorSlackUserId: "U123ABC",
+        reason: "event",
+        triggerContext: {
+          source: "github.pr.merged",
+          pullRequests: [{ repo: "junior", branch: "agent/test" }],
+        },
       });
 
       expect(result.summary).toContain("Shipped workflow runner");
@@ -72,6 +75,7 @@ describe("WorkflowExecutor", () => {
       expect(captured.prompt).toContain("Collect my PR and commit activity");
       expect(captured.prompt).toContain("\"path\": \"/repo/junior\"");
       expect(captured.prompt).toContain("\"slack.post\"");
+      expect(captured.prompt).toContain("\"source\": \"github.pr.merged\"");
       expect(posts).toEqual([
         {
           channel: "C123ABC",
@@ -80,6 +84,9 @@ describe("WorkflowExecutor", () => {
       ]);
       expect(readFileSync(result.run.artifactPath, "utf8")).toContain(
         "Shipped workflow runner",
+      );
+      expect(readFileSync(result.run.artifactPath, "utf8")).toContain(
+        'Trigger context: {"source":"github.pr.merged"',
       );
       expect((await store.getRun(result.run.id))?.status).toBe("success");
       expect((await store.getRun(result.run.id))?.providerSessionId).toBe("ses-workflow");

--- a/src/workflows/executor.test.ts
+++ b/src/workflows/executor.test.ts
@@ -50,9 +50,24 @@ describe("WorkflowExecutor", () => {
       },
     } as unknown as WebClient;
     const definition = workflowDefinition(dir);
+    const config = testConfig();
+    config.repos = [
+      {
+        name: "widgets-alias",
+        path: "/repo/canonical-widgets",
+        defaultBase: "main",
+        githubRepo: "Acme/Widgets",
+      },
+      {
+        name: "widgets-fork",
+        path: "/repo/fork-widgets",
+        defaultBase: "main",
+        githubRepo: "Other/Widgets",
+      },
+    ];
     const store = new InMemoryWorkflowStore();
     const executor = new WorkflowExecutor({
-      config: testConfig(),
+      config,
       store,
       slackClient,
       spawn,
@@ -65,7 +80,11 @@ describe("WorkflowExecutor", () => {
         reason: "event",
         triggerContext: {
           source: "github.pr.merged",
-          pullRequests: [{ repo: "junior", branch: "agent/test" }],
+          pullRequests: [{
+            owner: "acme",
+            repo: "widgets",
+            branch: "agent/test",
+          }],
         },
       });
 
@@ -73,7 +92,10 @@ describe("WorkflowExecutor", () => {
       expect(captured.session?.cwd).toBe(WORKFLOW_UTILITY_CWD);
       expect(captured.session?.agentType).toBe("default");
       expect(captured.prompt).toContain("Collect my PR and commit activity");
-      expect(captured.prompt).toContain("\"path\": \"/repo/junior\"");
+      expect(captured.prompt).toContain("\"path\": \"/repo/canonical-widgets\"");
+      expect(captured.prompt).toContain("\"githubRepo\": \"Acme/Widgets\"");
+      expect(captured.prompt).not.toContain("/repo/fork-widgets");
+      expect(captured.prompt).not.toContain("Other/Widgets");
       expect(captured.prompt).toContain("\"slack.post\"");
       expect(captured.prompt).toContain("\"source\": \"github.pr.merged\"");
       expect(posts).toEqual([

--- a/src/workflows/executor.ts
+++ b/src/workflows/executor.ts
@@ -67,6 +67,8 @@ export interface WorkflowRunRequest {
   definition: WorkflowDefinition;
   reason: WorkflowRunReason;
   actorSlackUserId?: string | null;
+  /** Structured context supplied by a system/event trigger. */
+  triggerContext?: Record<string, unknown> | null;
 }
 
 export interface WorkflowRunResult {
@@ -133,6 +135,7 @@ export class WorkflowExecutor {
             run,
             repos: this.reposFor(request.definition),
             nativeResult: null,
+            triggerContext: request.triggerContext ?? null,
           }),
         );
       } else {
@@ -146,6 +149,7 @@ export class WorkflowExecutor {
         definition: request.definition,
         run,
         summary,
+        triggerContext: request.triggerContext ?? null,
       });
       await writeArtifact(artifactPath, body);
       const slackMeta = await this.emitOutputs(request.definition, summary);
@@ -162,6 +166,7 @@ export class WorkflowExecutor {
         definition: request.definition,
         run,
         summary: summary || "_Workflow failed before summary generation._",
+        triggerContext: request.triggerContext ?? null,
       });
       await writeArtifact(artifactPath, failureBody).catch(() => undefined);
       await this.store.updateRun(run);
@@ -524,6 +529,7 @@ function renderArtifact(options: {
   definition: WorkflowDefinition;
   run: WorkflowRun;
   summary: string;
+  triggerContext?: Record<string, unknown> | null;
 }): string {
   return [
     `# Workflow Run: ${options.definition.name}`,
@@ -533,6 +539,9 @@ function renderArtifact(options: {
     `Source: ${options.definition.sourcePath}`,
     `Reason: ${options.run.reason}`,
     `Actor: ${options.run.actorSlackUserId ?? "system"}`,
+    options.triggerContext
+      ? `Trigger context: ${JSON.stringify(options.triggerContext)}`
+      : null,
     `Status: ${options.run.status}`,
     options.run.providerSessionId ? `Provider session: ${options.run.providerSessionId}` : null,
     options.run.error ? `Error: ${options.run.error}` : null,
@@ -551,6 +560,7 @@ function buildRunnerPromptWithNative(options: {
   run: WorkflowRun;
   repos: RepoConfig[];
   nativeResult: string | null;
+  triggerContext?: Record<string, unknown> | null;
 }): string {
   const parts = [
     `Run workflow: ${options.definition.name}`,
@@ -582,6 +592,7 @@ function buildRunnerPromptWithNative(options: {
         id: options.run.id,
         reason: options.run.reason,
         artifactPath: options.run.artifactPath,
+        triggerContext: options.triggerContext ?? null,
       },
       workflow: {
         name: options.definition.name,

--- a/src/workflows/executor.ts
+++ b/src/workflows/executor.ts
@@ -133,7 +133,10 @@ export class WorkflowExecutor {
           buildRunnerPromptWithNative({
             definition: request.definition,
             run,
-            repos: this.reposFor(request.definition),
+            repos: this.reposForRun(
+              request.definition,
+              request.triggerContext ?? null,
+            ),
             nativeResult: null,
             triggerContext: request.triggerContext ?? null,
           }),
@@ -477,6 +480,19 @@ export class WorkflowExecutor {
     return this.config.repos.filter((repo) => permitted.has(repo.name));
   }
 
+  private reposForRun(
+    definition: WorkflowDefinition,
+    triggerContext: Record<string, unknown> | null,
+  ): RepoConfig[] {
+    const repos = this.reposFor(definition);
+    const githubTargets = githubMergeTargets(triggerContext);
+    if (githubTargets === null) return repos;
+    return repos.filter((repo) =>
+      repo.githubRepo != null &&
+      githubTargets.has(repo.githubRepo.toLowerCase())
+    );
+  }
+
   private timeoutFor(provider: ImplementedRunnerProvider): number {
     if (provider === "codex-app-server") return this.config.codex.timeoutMs;
     return provider === "opencode" || provider === "opencode-sdk"
@@ -608,6 +624,7 @@ function buildRunnerPromptWithNative(options: {
         name: repo.name,
         path: repo.path,
         defaultBase: repo.defaultBase,
+        githubRepo: repo.githubRepo ?? null,
       })),
     }, null, 2),
     "",
@@ -618,6 +635,24 @@ function buildRunnerPromptWithNative(options: {
   );
 
   return parts.join("\n");
+}
+
+function githubMergeTargets(
+  triggerContext: Record<string, unknown> | null,
+): Set<string> | null {
+  if (triggerContext?.source !== "github.pr.merged") return null;
+  const pullRequests = triggerContext.pullRequests;
+  if (!Array.isArray(pullRequests)) return new Set();
+
+  const targets = new Set<string>();
+  for (const pullRequest of pullRequests) {
+    if (!pullRequest || typeof pullRequest !== "object") continue;
+    const owner = (pullRequest as { owner?: unknown }).owner;
+    const repo = (pullRequest as { repo?: unknown }).repo;
+    if (typeof owner !== "string" || typeof repo !== "string") continue;
+    targets.add(`${owner}/${repo}`.toLowerCase());
+  }
+  return targets;
 }
 
 function buildIdleContinuePrompt(

--- a/src/workflows/scheduler.test.ts
+++ b/src/workflows/scheduler.test.ts
@@ -41,6 +41,55 @@ describe("timerDelayFor", () => {
 });
 
 describe("WorkflowScheduler", () => {
+  it("forwards structured event context to the executor", async () => {
+    const definition = workflowDefinition();
+    const store = new InMemoryWorkflowStore();
+    const registry = {
+      get: (name: string) => name === definition.name ? definition : undefined,
+      snapshot: () => ({ definitions: new Map([[definition.name, definition]]), errors: [] }),
+      onEvent: () => undefined,
+    } as unknown as WorkflowRegistry;
+    let receivedContext: Record<string, unknown> | null | undefined;
+    const executor = {
+      run: async (request: { triggerContext?: Record<string, unknown> | null }) => {
+        receivedContext = request.triggerContext;
+        return {
+          summary: "ok",
+          run: {
+            id: "run-1",
+            workflowName: definition.name,
+            workflowVersionHash: definition.versionHash,
+            sourcePath: definition.sourcePath,
+            reason: "event",
+            actorSlackUserId: null,
+            status: "success",
+            startedAt: 1,
+            finishedAt: 2,
+            artifactPath: "data/workflow-runs/worklog/run.md",
+            providerSessionId: null,
+            slackChannel: null,
+            slackThreadTs: null,
+            error: null,
+          },
+        };
+      },
+    } as unknown as WorkflowExecutor;
+    const { WorkflowScheduler } = await import("./scheduler.ts");
+    const scheduler = new WorkflowScheduler({ registry, store, executor });
+    const triggerContext = {
+      source: "github.pr.merged",
+      pullRequests: [{ repo: "widgets", branch: "agent/fix" }],
+    };
+
+    await scheduler.runNow({
+      name: definition.name,
+      reason: "event",
+      triggerContext,
+    });
+
+    expect(receivedContext).toEqual(triggerContext);
+  });
+
   it("blocks stopped command triggers but allows manual runs", async () => {
     const definition = workflowDefinition();
     const store = new InMemoryWorkflowStore();

--- a/src/workflows/scheduler.ts
+++ b/src/workflows/scheduler.ts
@@ -60,6 +60,7 @@ export class WorkflowScheduler {
     name: string;
     reason: WorkflowRunReason;
     actorSlackUserId?: string | null;
+    triggerContext?: Record<string, unknown> | null;
   }): Promise<{ summary: string; runId: string }> {
     const definition = this.registry.get(options.name);
     if (!definition) throw new Error(`Unknown workflow: ${options.name}`);
@@ -82,6 +83,7 @@ export class WorkflowScheduler {
         definition,
         reason: options.reason,
         actorSlackUserId: options.actorSlackUserId ?? null,
+        triggerContext: options.triggerContext ?? null,
       });
       await this.schedule(definition);
       return { summary: result.summary, runId: result.run.id };

--- a/workflows/worktree-prune.workflow.md
+++ b/workflows/worktree-prune.workflow.md
@@ -36,7 +36,9 @@ Use the runtime context as the source of truth for repositories and their absolu
 
 When `run.triggerContext.source` is `github.pr.merged`, limit the run to the
 listed `pullRequests`: inspect only the matching repo and worktree branch for
-each entry. Verify the worktree HEAD matches the supplied `headSha` before
+each entry. Match the event's `owner/repo` only against `repo.githubRepo`,
+case-insensitively; never infer a match from the local repo name, path,
+basename, or head SHA. Verify the worktree HEAD matches the supplied `headSha` before
 removal. If the branch has no registered local worktree, report that compactly
 and do not broaden the event-triggered run into a full sweep. Scheduled and
 manually triggered runs without this context continue to inspect every repo.

--- a/workflows/worktree-prune.workflow.md
+++ b/workflows/worktree-prune.workflow.md
@@ -34,6 +34,13 @@ Prune stale local git worktrees across the configured Junior repos.
 
 Use the runtime context as the source of truth for repositories and their absolute paths. For each repo with a usable local git checkout:
 
+When `run.triggerContext.source` is `github.pr.merged`, limit the run to the
+listed `pullRequests`: inspect only the matching repo and worktree branch for
+each entry. Verify the worktree HEAD matches the supplied `headSha` before
+removal. If the branch has no registered local worktree, report that compactly
+and do not broaden the event-triggered run into a full sweep. Scheduled and
+manually triggered runs without this context continue to inspect every repo.
+
 1. Establish the protected primary checkout and default branch.
    - Use the repo path from runtime context as the primary checkout. Never delete or move this directory.
    - Normalize `repo.defaultBase` before fetching or resolving it. If it starts with `origin/`, treat that full value as the preferred base ref and fetch only its branch part from the remote, e.g. `origin/main` means fetch `main`. Otherwise prefer `origin/<base>`, then the local `<base>` branch.


### PR DESCRIPTION
## Summary
- Trigger `worktree-prune` asynchronously when GitHub reconciliation observes a pull request transition to merged, limiting cleanup to the exact repo, branch, and head SHA while retaining existing safety gates.
- Coalesce newly merged targets and retry overlap skips so the workflow's concurrency policy avoids duplicate runs without dropping merge-triggered cleanup.
- Propagate structured trigger context through workflow execution and artifacts, with focused coverage and updated workflow/reconciliation docs.

## Test plan
- [x] Two focused test passes (40/40 each)
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] Full suite: 2027 passed, 4 skipped; 2 Codex app-server timing flakes
- [x] Isolated Codex app-server test rerun: 7/7 passed