### PR TITLE
feat(dashboard): persist usage events and dashboard audit log

### DIFF
--- a/src/http/audit/factory.ts
+++ b/src/http/audit/factory.ts
@@ -1,0 +1,22 @@
+import { Database } from "bun:sqlite";
+import { resolve } from "node:path";
+import type { DashboardAuditStore } from "./interface.ts";
+import { InMemoryDashboardAuditStore } from "./memory.ts";
+import { SqliteDashboardAuditStore } from "./sqlite.ts";
+
+export type DashboardAuditStoreOptions = {
+  kind?: "memory" | "sqlite";
+  sqlitePath?: string;
+  db?: Database;
+};
+
+export function createDashboardAuditStore(
+  options: DashboardAuditStoreOptions = {},
+): DashboardAuditStore {
+  const kind = options.kind ?? (options.db ? "sqlite" : "memory");
+  if (kind === "memory") return new InMemoryDashboardAuditStore();
+  if (options.db) return new SqliteDashboardAuditStore(options.db);
+  return new SqliteDashboardAuditStore(
+    resolve(options.sqlitePath ?? "data/sessions.db"),
+  );
+}

--- a/src/http/audit/interface.ts
+++ b/src/http/audit/interface.ts
@@ -1,0 +1,49 @@
+export type DashboardAuditResult =
+  | "received"
+  | "ok"
+  | "buffered"
+  | "skipped"
+  | "error"
+  | "denied"
+  | "partial";
+
+export type DashboardAuditEntry = {
+  id: string;
+  at: number;
+  actor: string;
+  action: string;
+  targetType: string;
+  targetId: string;
+  request: Record<string, unknown>;
+  result: string;
+  error: string | null;
+  slackTs: string | null;
+  commitSha: string | null;
+};
+
+export type DashboardAuditRecordInput = {
+  id?: string;
+  at?: number;
+  actor: string;
+  action: string;
+  targetType: string;
+  targetId: string;
+  request?: Record<string, unknown>;
+  result: string;
+  error?: string | null;
+  slackTs?: string | null;
+  commitSha?: string | null;
+};
+
+export interface DashboardAuditStore {
+  record(entry: DashboardAuditRecordInput): Promise<DashboardAuditEntry>;
+  list(filter?: {
+    action?: string;
+    targetType?: string;
+    from?: number;
+    to?: number;
+    limit?: number;
+  }): Promise<DashboardAuditEntry[]>;
+  deleteOlderThan(at: number): Promise<number>;
+  close?(): void;
+}

--- a/src/http/audit/memory.ts
+++ b/src/http/audit/memory.ts
@@ -1,0 +1,69 @@
+import type {
+  DashboardAuditEntry,
+  DashboardAuditRecordInput,
+  DashboardAuditStore,
+} from "./interface.ts";
+
+export class InMemoryDashboardAuditStore implements DashboardAuditStore {
+  private entries: DashboardAuditEntry[] = [];
+
+  async record(entry: DashboardAuditRecordInput): Promise<DashboardAuditEntry> {
+    const stored = toEntry(entry);
+    this.entries.push(stored);
+    return stored;
+  }
+
+  async list(filter: {
+    action?: string;
+    targetType?: string;
+    from?: number;
+    to?: number;
+    limit?: number;
+  } = {}): Promise<DashboardAuditEntry[]> {
+    const rows = this.entries
+      .filter((entry) => matchesFilter(entry, filter))
+      .sort((a, b) => b.at - a.at || b.id.localeCompare(a.id));
+    const limit = Math.min(filter.limit ?? 100, 500);
+    return rows.slice(0, limit);
+  }
+
+  async deleteOlderThan(at: number): Promise<number> {
+    const before = this.entries.length;
+    this.entries = this.entries.filter((entry) => entry.at >= at);
+    return before - this.entries.length;
+  }
+}
+
+function toEntry(entry: DashboardAuditRecordInput): DashboardAuditEntry {
+  return {
+    id: entry.id ?? crypto.randomUUID(),
+    at: entry.at ?? Date.now(),
+    actor: entry.actor,
+    action: entry.action,
+    targetType: entry.targetType,
+    targetId: entry.targetId,
+    request: entry.request ?? {},
+    result: entry.result,
+    error: entry.error ?? null,
+    slackTs: entry.slackTs ?? null,
+    commitSha: entry.commitSha ?? null,
+  };
+}
+
+function matchesFilter(
+  entry: DashboardAuditEntry,
+  filter: {
+    action?: string;
+    targetType?: string;
+    from?: number;
+    to?: number;
+  },
+): boolean {
+  if (filter.action != null && entry.action !== filter.action) return false;
+  if (filter.targetType != null && entry.targetType !== filter.targetType) {
+    return false;
+  }
+  if (filter.from != null && entry.at < filter.from) return false;
+  if (filter.to != null && entry.at > filter.to) return false;
+  return true;
+}

--- a/src/http/audit/sqlite.test.ts
+++ b/src/http/audit/sqlite.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { AUDIT_RETENTION_MS } from "../../lifecycle/cleanup.ts";
+import { SqliteDashboardAuditStore } from "./sqlite.ts";
+
+describe("SqliteDashboardAuditStore", () => {
+  let tmpDir: string;
+  let store: SqliteDashboardAuditStore;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "junior-audit-"));
+    store = new SqliteDashboardAuditStore(join(tmpDir, "sessions.db"));
+  });
+
+  afterEach(() => {
+    store.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("records and lists newest first", async () => {
+    await store.record({
+      at: 100,
+      actor: "dashboard-operator",
+      action: "session.continue",
+      targetType: "session",
+      targetId: "thread-1",
+      request: { prompt: "hello" },
+      result: "ok",
+    });
+    await store.record({
+      at: 200,
+      actor: "U123",
+      action: "session.stop",
+      targetType: "session",
+      targetId: "thread-1",
+      result: "ok",
+    });
+
+    const rows = await store.list({ targetType: "session" });
+    expect(rows.map((row) => row.action)).toEqual([
+      "session.stop",
+      "session.continue",
+    ]);
+    expect(rows[1]?.request).toEqual({ prompt: "hello" });
+  });
+
+  it("deletes rows older than the retention cutoff", async () => {
+    const now = 1_800_000_000_000;
+    await store.record({
+      at: now - AUDIT_RETENTION_MS - 5,
+      actor: "dashboard-operator",
+      action: "workflow.run",
+      targetType: "workflow",
+      targetId: "worklog",
+      result: "ok",
+    });
+    await store.record({
+      at: now - 1_000,
+      actor: "dashboard-operator",
+      action: "session.stop",
+      targetType: "session",
+      targetId: "thread-1",
+      result: "ok",
+    });
+
+    expect(await store.deleteOlderThan(now - AUDIT_RETENTION_MS)).toBe(1);
+    const remaining = await store.list();
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]?.action).toBe("session.stop");
+  });
+});

--- a/src/http/audit/sqlite.ts
+++ b/src/http/audit/sqlite.ts
@@ -1,0 +1,174 @@
+import { Database } from "bun:sqlite";
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import type {
+  DashboardAuditEntry,
+  DashboardAuditRecordInput,
+  DashboardAuditStore,
+} from "./interface.ts";
+
+type AuditRow = {
+  id: string;
+  at: number;
+  actor: string;
+  action: string;
+  target_type: string;
+  target_id: string;
+  request_json: string;
+  result: string;
+  error: string | null;
+  slack_ts: string | null;
+  commit_sha: string | null;
+};
+
+export class SqliteDashboardAuditStore implements DashboardAuditStore {
+  private db: Database;
+  private ownsDb: boolean;
+
+  constructor(dbPathOrDb: string | Database) {
+    if (typeof dbPathOrDb === "string") {
+      mkdirSync(dirname(dbPathOrDb), { recursive: true });
+      this.db = new Database(dbPathOrDb);
+      this.ownsDb = true;
+      this.db.run("PRAGMA journal_mode = WAL");
+      this.db.run("PRAGMA synchronous = NORMAL");
+    } else {
+      this.db = dbPathOrDb;
+      this.ownsDb = false;
+    }
+    this.migrate();
+  }
+
+  close(): void {
+    if (this.ownsDb) this.db.close();
+  }
+
+  async record(entry: DashboardAuditRecordInput): Promise<DashboardAuditEntry> {
+    const stored: DashboardAuditEntry = {
+      id: entry.id ?? crypto.randomUUID(),
+      at: entry.at ?? Date.now(),
+      actor: entry.actor,
+      action: entry.action,
+      targetType: entry.targetType,
+      targetId: entry.targetId,
+      request: entry.request ?? {},
+      result: entry.result,
+      error: entry.error ?? null,
+      slackTs: entry.slackTs ?? null,
+      commitSha: entry.commitSha ?? null,
+    };
+    this.db
+      .query(
+        `INSERT INTO dashboard_audit (
+          id, at, actor, action, target_type, target_id,
+          request_json, result, error, slack_ts, commit_sha
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        stored.id,
+        stored.at,
+        stored.actor,
+        stored.action,
+        stored.targetType,
+        stored.targetId,
+        JSON.stringify(stored.request),
+        stored.result,
+        stored.error,
+        stored.slackTs,
+        stored.commitSha,
+      );
+    return stored;
+  }
+
+  async list(filter: {
+    action?: string;
+    targetType?: string;
+    from?: number;
+    to?: number;
+    limit?: number;
+  } = {}): Promise<DashboardAuditEntry[]> {
+    const clauses: string[] = [];
+    const params: Array<string | number> = [];
+    if (filter.action != null) {
+      clauses.push("action = ?");
+      params.push(filter.action);
+    }
+    if (filter.targetType != null) {
+      clauses.push("target_type = ?");
+      params.push(filter.targetType);
+    }
+    if (filter.from != null) {
+      clauses.push("at >= ?");
+      params.push(filter.from);
+    }
+    if (filter.to != null) {
+      clauses.push("at <= ?");
+      params.push(filter.to);
+    }
+    const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
+    const limit = Math.min(filter.limit ?? 100, 500);
+    params.push(limit);
+    const rows = this.db
+      .query<AuditRow, Array<string | number>>(
+        `SELECT * FROM dashboard_audit ${where} ORDER BY at DESC, id DESC LIMIT ?`,
+      )
+      .all(...params);
+    return rows.map(rowToEntry);
+  }
+
+  async deleteOlderThan(at: number): Promise<number> {
+    const result = this.db
+      .query("DELETE FROM dashboard_audit WHERE at < ?")
+      .run(at);
+    return result.changes;
+  }
+
+  private migrate(): void {
+    this.db.run(`
+      CREATE TABLE IF NOT EXISTS dashboard_audit (
+        id TEXT PRIMARY KEY,
+        at INTEGER NOT NULL,
+        actor TEXT NOT NULL,
+        action TEXT NOT NULL,
+        target_type TEXT NOT NULL,
+        target_id TEXT NOT NULL,
+        request_json TEXT NOT NULL,
+        result TEXT NOT NULL,
+        error TEXT,
+        slack_ts TEXT,
+        commit_sha TEXT
+      )
+    `);
+    this.db.run(`
+      CREATE INDEX IF NOT EXISTS dashboard_audit_at_idx
+        ON dashboard_audit (at DESC)
+    `);
+  }
+}
+
+function rowToEntry(row: AuditRow): DashboardAuditEntry {
+  return {
+    id: row.id,
+    at: row.at,
+    actor: row.actor,
+    action: row.action,
+    targetType: row.target_type,
+    targetId: row.target_id,
+    request: parseRequest(row.request_json),
+    result: row.result,
+    error: row.error,
+    slackTs: row.slack_ts,
+    commitSha: row.commit_sha,
+  };
+}
+
+function parseRequest(raw: string): Record<string, unknown> {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,12 @@ import { createSessionStore } from "./session/store/factory.ts";
 import { setupGracefulShutdown } from "./lifecycle/shutdown.ts";
 import { registerHomeTab } from "./slack/home.ts";
 import { checkOrphanedSessions } from "./lifecycle/health.ts";
-import { cleanupStaleSessions } from "./lifecycle/cleanup.ts";
+import {
+  cleanupOperationalTables,
+  cleanupStaleSessions,
+} from "./lifecycle/cleanup.ts";
+import { createUsageStore } from "./usage/store/factory.ts";
+import { createDashboardAuditStore } from "./http/audit/factory.ts";
 import { reconcileTmuxSessions } from "./lifecycle/tmux-reconcile.ts";
 import { evictIdleTmuxSessions } from "./lifecycle/tmux-evict.ts";
 import type { TmuxDriver } from "./claude/tmux-driver.ts";
@@ -97,6 +102,15 @@ const pipelineStore = createPipelineStore({
   kind: config.session.store === "memory" ? "memory" : "sqlite",
   sqlitePath: resolve(config.session.sqlitePath),
 });
+const usageStore = createUsageStore({
+  kind: config.session.store === "memory" ? "memory" : "sqlite",
+  sqlitePath: resolve(config.session.sqlitePath),
+});
+const auditStore = createDashboardAuditStore({
+  kind: config.session.store === "memory" ? "memory" : "sqlite",
+  sqlitePath: resolve(config.session.sqlitePath),
+});
+sessionManager.usageStore = usageStore;
 const pipelineRuntimeMode = config.pipeline?.runtimeMode ?? "off";
 const pipelineToolRuntime: PipelineToolRuntime = {
   store: pipelineStore,
@@ -178,6 +192,7 @@ const workflowExecutor = new WorkflowExecutor({
   store: workflowStore,
   slackClient: app.client,
   memoryStore,
+  usageStore,
 });
 const workflowScheduler = new WorkflowScheduler({
   registry: workflowRegistry,
@@ -379,6 +394,8 @@ setupGracefulShutdown(sessionManager, devServerManager, async () => {
   workflowRegistry.stopWatching();
   workflowStore.close?.();
   pipelineStore.close?.();
+  usageStore.close?.();
+  auditStore.close?.();
   actionStore.close();
   memoryStore.close();
   runbookCatalogStore.close();
@@ -622,6 +639,19 @@ setInterval(() => {
     if (cleaned.length > 0) {
       log.info("cleanup", `Removed ${cleaned.length} stale sessions: ${cleaned.join(", ")}`);
     }
+  });
+  cleanupOperationalTables({ usageStore, auditStore }).then((report) => {
+    if (report.usageDeleted > 0 || report.auditDeleted > 0) {
+      log.info(
+        "cleanup",
+        `Removed ${report.usageDeleted} usage event(s) and ${report.auditDeleted} audit row(s).`,
+      );
+    }
+  }).catch((err) => {
+    log.warn(
+      "cleanup",
+      `operational table cleanup failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
   });
 }, config.session.cleanupIntervalMs);
 

--- a/src/lifecycle/cleanup.test.ts
+++ b/src/lifecycle/cleanup.test.ts
@@ -2,10 +2,21 @@ import { describe, it, expect } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
-import { cleanupStaleSessions, runCleanupFromEnv } from "./cleanup.ts";
+import {
+  AUDIT_RETENTION_MS,
+  USAGE_RETENTION_MS,
+  cleanupOperationalTables,
+  cleanupStaleSessions,
+  runCleanupFromEnv,
+} from "./cleanup.ts";
 import { InMemorySessionStore } from "../session/store/memory.ts";
 import { SqliteSessionStore } from "../session/store/sqlite.ts";
 import { createSession } from "../session/types.ts";
+import { InMemoryUsageStore } from "../usage/store/memory.ts";
+import { InMemoryDashboardAuditStore } from "../http/audit/memory.ts";
+import { SqliteUsageStore } from "../usage/store/sqlite.ts";
+import { SqliteDashboardAuditStore } from "../http/audit/sqlite.ts";
+import type { NormalizedUsage } from "../usage/normalize.ts";
 
 describe("cleanupStaleSessions", () => {
   it("keeps stale idle sessions that still own a pipeline run", async () => {
@@ -247,3 +258,123 @@ describe("cleanupStaleSessions", () => {
     }
   });
 });
+
+describe("cleanupOperationalTables", () => {
+  it("deletes usage older than 90 days and audit older than 180 days", async () => {
+    const now = 2_000_000_000_000;
+    const usageStore = new InMemoryUsageStore();
+    const auditStore = new InMemoryDashboardAuditStore();
+    await usageStore.add(usageEvent({
+      sourceId: "old",
+      occurredAt: now - USAGE_RETENTION_MS - 1,
+    }));
+    await usageStore.add(usageEvent({
+      sourceId: "fresh",
+      occurredAt: now - 1_000,
+    }));
+    await auditStore.record({
+      at: now - AUDIT_RETENTION_MS - 1,
+      actor: "dashboard-operator",
+      action: "workflow.run",
+      targetType: "workflow",
+      targetId: "old",
+      result: "ok",
+    });
+    await auditStore.record({
+      at: now - 1_000,
+      actor: "dashboard-operator",
+      action: "session.stop",
+      targetType: "session",
+      targetId: "fresh",
+      result: "ok",
+    });
+
+    const report = await cleanupOperationalTables({
+      usageStore,
+      auditStore,
+      now,
+    });
+
+    expect(report).toEqual({ usageDeleted: 1, auditDeleted: 1 });
+    expect(await usageStore.get("session-turn", "old")).toBeUndefined();
+    expect(await usageStore.get("session-turn", "fresh")).toBeDefined();
+    expect(await auditStore.list()).toHaveLength(1);
+    expect((await auditStore.list())[0]?.targetId).toBe("fresh");
+  });
+
+  it("CLI cleanup deletes stale usage and audit rows from sqlite", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "junior-cleanup-ops-"));
+    const dbPath = join(dir, "sessions.db");
+    const now = Date.now();
+    const usageStore = new SqliteUsageStore(dbPath);
+    const auditStore = new SqliteDashboardAuditStore(dbPath);
+    try {
+      await usageStore.add(usageEvent({
+        sourceId: "old-cli",
+        occurredAt: now - USAGE_RETENTION_MS - 5_000,
+      }));
+      await auditStore.record({
+        at: now - AUDIT_RETENTION_MS - 5_000,
+        actor: "dashboard-operator",
+        action: "workflow.run",
+        targetType: "workflow",
+        targetId: "old-cli",
+        result: "ok",
+      });
+    } finally {
+      usageStore.close();
+      auditStore.close();
+    }
+
+    const logs: unknown[] = [];
+    await runCleanupFromEnv(
+      {
+        SESSION_STORE: "sqlite",
+        SESSION_DB_PATH: dbPath,
+        SESSION_STALE_TIMEOUT_MS: "50000",
+      },
+      { log: (message?: unknown) => logs.push(message) },
+    );
+
+    const verifyUsage = new SqliteUsageStore(dbPath);
+    const verifyAudit = new SqliteDashboardAuditStore(dbPath);
+    try {
+      expect(await verifyUsage.get("session-turn", "old-cli")).toBeUndefined();
+      expect(await verifyAudit.list()).toEqual([]);
+      expect(logs.some((line) =>
+        typeof line === "string" && line.includes("usage event")
+      )).toBe(true);
+    } finally {
+      verifyUsage.close();
+      verifyAudit.close();
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+function usageEvent(overrides: Partial<NormalizedUsage> = {}): NormalizedUsage {
+  return {
+    sourceKind: "session-turn",
+    sourceId: "thread-1:default:1",
+    threadId: "thread-1",
+    channelId: "C1",
+    agentName: "default",
+    provider: "opencode",
+    providerSessionId: null,
+    pipelineRunId: null,
+    assignmentId: null,
+    workflowName: null,
+    workflowRunId: null,
+    inputTokens: 1,
+    outputTokens: 1,
+    cacheReadTokens: null,
+    cacheWriteTokens: null,
+    totalTokens: 2,
+    costUsd: null,
+    costEstimatedUsd: null,
+    numTurns: null,
+    raw: {},
+    occurredAt: Date.now(),
+    ...overrides,
+  };
+}

--- a/src/lifecycle/cleanup.ts
+++ b/src/lifecycle/cleanup.ts
@@ -2,6 +2,13 @@ import { resolve } from "node:path";
 import type { SessionStore } from "../session/store/interface.ts";
 import { InMemorySessionStore } from "../session/store/memory.ts";
 import { SqliteSessionStore } from "../session/store/sqlite.ts";
+import type { UsageStore } from "../usage/store/interface.ts";
+import { createUsageStore } from "../usage/store/factory.ts";
+import type { DashboardAuditStore } from "../http/audit/interface.ts";
+import { createDashboardAuditStore } from "../http/audit/factory.ts";
+
+export const USAGE_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
+export const AUDIT_RETENTION_MS = 180 * 24 * 60 * 60 * 1000;
 
 export async function cleanupStaleSessions(
   store: SessionStore,
@@ -49,6 +56,21 @@ export async function cleanupStaleSessions(
   return cleaned;
 }
 
+export async function cleanupOperationalTables(options: {
+  usageStore?: Pick<UsageStore, "deleteOlderThan">;
+  auditStore?: Pick<DashboardAuditStore, "deleteOlderThan">;
+  now?: number;
+}): Promise<{ usageDeleted: number; auditDeleted: number }> {
+  const now = options.now ?? Date.now();
+  const usageDeleted = options.usageStore
+    ? await options.usageStore.deleteOlderThan(now - USAGE_RETENTION_MS)
+    : 0;
+  const auditDeleted = options.auditStore
+    ? await options.auditStore.deleteOlderThan(now - AUDIT_RETENTION_MS)
+    : 0;
+  return { usageDeleted, auditDeleted };
+}
+
 interface CleanupEnv extends Record<string, string | undefined> {
   SESSION_STORE?: string;
   SESSION_DB_PATH?: string;
@@ -66,6 +88,16 @@ export async function runCleanupFromEnv(
   logger: CleanupLogger = console,
 ): Promise<string[]> {
   const store = createCleanupStore(env);
+  const storeKind = env.SESSION_STORE ?? "sqlite";
+  const sqlitePath = resolve(env.SESSION_DB_PATH ?? "data/sessions.db");
+  const usageStore = createUsageStore({
+    kind: storeKind === "memory" ? "memory" : "sqlite",
+    sqlitePath,
+  });
+  const auditStore = createDashboardAuditStore({
+    kind: storeKind === "memory" ? "memory" : "sqlite",
+    sqlitePath,
+  });
   try {
     const staleTimeoutMs = parsePositiveIntegerEnv(
       env.SESSION_STALE_TIMEOUT_MS,
@@ -73,13 +105,24 @@ export async function runCleanupFromEnv(
       "SESSION_STALE_TIMEOUT_MS",
     );
     const cleaned = await cleanupStaleSessions(store, staleTimeoutMs);
+    const operational = await cleanupOperationalTables({
+      usageStore,
+      auditStore,
+    });
     logger.log(`Removed ${cleaned.length} stale session(s).`);
     if (cleaned.length > 0) {
       logger.log(cleaned.join("\n"));
     }
+    if (operational.usageDeleted > 0 || operational.auditDeleted > 0) {
+      logger.log(
+        `Removed ${operational.usageDeleted} usage event(s) and ${operational.auditDeleted} audit row(s).`,
+      );
+    }
     return cleaned;
   } finally {
     store.close?.();
+    usageStore.close?.();
+    auditStore.close?.();
   }
 }
 

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -29,6 +29,7 @@ interface MockHandle extends SpawnHandle {
     sessionId?: string | null,
     events?: RunnerEvent[],
     completion?: RunnerCompletion,
+    usage?: Record<string, unknown>,
   ) => void;
   _error: (errorMsg: string) => void;
 }
@@ -54,6 +55,7 @@ function createMockHandle(
       sid?: string | null,
       resultEvents?: RunnerEvent[],
       completion?: RunnerCompletion,
+      usage?: Record<string, unknown>,
     ) => {
       const finalResponse = resp ?? response;
       const finalSessionId = sid === undefined ? sessionId : sid;
@@ -66,7 +68,7 @@ function createMockHandle(
           });
         }
       for (const l of listeners)
-        l({ type: "done", provider: "claude" });
+        l({ type: "done", provider: "claude", ...(usage ? { usage } : {}) });
       resolveResult({
         provider: "claude",
         sessionId: finalSessionId,
@@ -104,6 +106,7 @@ mock.module("../lifecycle/timeout.ts", () => ({
 // Import after mocking
 const { SessionManager } = await import("./manager.ts");
 import { InMemorySessionStore } from "./store/memory.ts";
+import { InMemoryUsageStore } from "../usage/store/memory.ts";
 import type { DriverMap } from "../claude/factory.ts";
 import type { ClaudeDriver } from "../claude/driver.ts";
 
@@ -4011,6 +4014,64 @@ describe("SessionManager", () => {
       expect(calls[3]).toEqual({ action: "remove", ts: TS_B, emoji: EMOJI });
     });
   });
+
+  it("records usage on done for a quiet session", async () => {
+    const usageStore = new InMemoryUsageStore();
+    manager.usageStore = usageStore;
+    const seen: string[] = [];
+    manager.onEvent = (session, event) => {
+      seen.push(event.type);
+      if (session.verbosity === "quiet") return;
+      throw new Error("quiet onEvent must return before Slack status work");
+    };
+
+    await manager.handleMessage(makeEvent({
+      ts: "111.222",
+      pipelineInvocation: {
+        runId: "run-spend",
+        assignmentId: "asg-spend",
+        dispatchKey: "dispatch-spend",
+        outcomeCountAtDispatch: 0,
+        retryCount: 0,
+      },
+    }));
+    currentHandle._complete("quiet ok", "ses-quiet", [], undefined, {
+      total_cost_usd: 0.02,
+      usage: {
+        input_tokens: 11,
+        output_tokens: 7,
+        cache_read_input_tokens: 3,
+        cache_creation_input_tokens: 1,
+      },
+      num_turns: 2,
+    });
+    await waitFor(async () => (await store.get("thread-1"))?.status === "idle");
+    const row = await waitForUsage(
+      usageStore,
+      "session-turn",
+      "thread-1:default:111.222",
+    );
+
+    expect(seen).toContain("done");
+    expect((await store.get("thread-1"))?.verbosity).toBe("quiet");
+    expect(row).toMatchObject({
+      sourceKind: "session-turn",
+      sourceId: "thread-1:default:111.222",
+      threadId: "thread-1",
+      agentName: "default",
+      provider: "claude",
+      pipelineRunId: "run-spend",
+      assignmentId: "asg-spend",
+      inputTokens: 11,
+      outputTokens: 7,
+      cacheReadTokens: 3,
+      cacheWriteTokens: 1,
+      totalTokens: 22,
+      costUsd: 0.02,
+      costEstimatedUsd: null,
+      numTurns: 2,
+    });
+  });
 });
 
 describe("typed pipeline settlement", () => {
@@ -5203,3 +5264,14 @@ describe("typed pipeline settlement", () => {
     expect(outcomes[0]!.reason).toContain("without a recovery continuation");
   });
 });
+
+async function waitForUsage(
+  usageStore: InMemoryUsageStore,
+  sourceKind: "session-turn",
+  sourceId: string,
+) {
+  await waitFor(async () => Boolean(await usageStore.get(sourceKind, sourceId)));
+  const row = await usageStore.get(sourceKind, sourceId);
+  if (!row) throw new Error(`missing usage ${sourceKind} ${sourceId}`);
+  return row;
+}

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -4072,6 +4072,53 @@ describe("SessionManager", () => {
       numTurns: 2,
     });
   });
+
+  it("records distinct usage rows for sequential worker turns", async () => {
+    const usageStore = new InMemoryUsageStore();
+    const leadHandle = createMockHandle();
+    const reviewHandle1 = createMockHandle();
+    const reviewHandle2 = createMockHandle();
+    const handles = [leadHandle, reviewHandle1, reviewHandle2];
+    mockSpawnFn = mock(() => handles.shift() ?? createMockHandle());
+    manager = createTestManager(store);
+    manager.usageStore = usageStore;
+
+    await manager.handleMessage(makeEvent({ text: "lead first", ts: "ts-lead" }));
+    leadHandle._complete("lead ok", "lead-ses", [], undefined, {
+      usage: { input_tokens: 1, output_tokens: 1 },
+    });
+    await waitFor(async () => (await store.get("thread-1"))?.status === "idle");
+    await waitForUsage(usageStore, "session-turn", "thread-1:default:ts-lead");
+
+    await manager.handleAgentMessage(
+      makeEvent({ text: "review one", ts: "ts-review-1" }),
+      "review",
+    );
+    reviewHandle1._complete("first", "review-ses-1", [], undefined, {
+      usage: { input_tokens: 10, output_tokens: 1 },
+    });
+    await waitFor(async () =>
+      (await store.get("thread-1"))?.agentSessions.review?.status === "done"
+    );
+    await waitForUsage(usageStore, "session-turn", "thread-1:review:ts-review-1");
+
+    await manager.handleAgentMessage(
+      makeEvent({ text: "review two", ts: "ts-review-2" }),
+      "review",
+    );
+    reviewHandle2._complete("second", "review-ses-2", [], undefined, {
+      usage: { input_tokens: 20, output_tokens: 2 },
+    });
+    await waitForUsage(usageStore, "session-turn", "thread-1:review:ts-review-2");
+
+    const first = await usageStore.get("session-turn", "thread-1:review:ts-review-1");
+    const second = await usageStore.get("session-turn", "thread-1:review:ts-review-2");
+    const collapsed = await usageStore.get("session-turn", "thread-1:review:ts-lead");
+    expect(first).toMatchObject({ inputTokens: 10, outputTokens: 1 });
+    expect(second).toMatchObject({ inputTokens: 20, outputTokens: 2 });
+    expect(collapsed).toBeUndefined();
+    expect(await usageStore.list({ sourceKind: "session-turn" })).toHaveLength(3);
+  });
 });
 
 describe("typed pipeline settlement", () => {

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -2304,8 +2304,9 @@ export class SessionManager {
           );
         }
         const runSession = this.buildRunSession(session, agentName, agentIdentity);
+        runSession.currentMessageTs = latestTs ?? null;
         this.onEvent?.(runSession, event);
-        this.recordSessionTurnUsage(runSession, event);
+        this.recordSessionTurnUsage(runSession, event, latestTs);
       });
       await this.persistRunProcessDetails(session.threadId, agentName, handle.pid);
 
@@ -2502,8 +2503,9 @@ export class SessionManager {
               );
             }
             const runSession = this.buildRunSession(session, agentName, agentIdentity);
+            runSession.currentMessageTs = latestTs ?? null;
             this.onEvent?.(runSession, event);
-            this.recordSessionTurnUsage(runSession, event);
+            this.recordSessionTurnUsage(runSession, event, latestTs);
           });
           await this.persistRunProcessDetails(session.threadId, agentName, retryHandle.pid);
 
@@ -3851,6 +3853,7 @@ export class SessionManager {
   private recordSessionTurnUsage(
     session: ThreadSession,
     event: RunnerEvent,
+    postedTs?: string,
   ): void {
     if (event.type !== "done" || !this.usageStore) return;
     const agentName = session.activeAgentName ?? session.agentType ?? "default";
@@ -3863,7 +3866,7 @@ export class SessionManager {
     }
     const normalized = normalizeRunnerUsage(event.usage, {
       sourceKind: "session-turn",
-      sourceId: sessionTurnSourceId(session, agentName),
+      sourceId: sessionTurnSourceId(session, agentName, postedTs),
       threadId: session.threadId,
       channelId: session.channel,
       agentName,

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -20,6 +20,9 @@ import { resolveAgentManifest } from "../agents/registry.ts";
 import { requiresManagedWorktree } from "../agents/capabilities.ts";
 import type { WorktreeManager } from "../worktree/manager.ts";
 import type { PipelineStore } from "../pipelines/store/interface.ts";
+import type { UsageStore } from "../usage/store/interface.ts";
+import { normalizeRunnerUsage } from "../usage/normalize.ts";
+import { sessionTurnSourceId } from "../usage/source-id.ts";
 import {
   createProductRun,
   shouldCreateProductRun,
@@ -143,6 +146,7 @@ export class SessionManager {
    * Also used to enrich !status when a run is active.
    */
   pipelineStore?: PipelineStore;
+  usageStore?: UsageStore;
   onResponse?: (session: ThreadSession, response: string) => unknown;
   onAgentSettled?: (
     session: ThreadSession,
@@ -2299,7 +2303,9 @@ export class SessionManager {
             invocationCwd,
           );
         }
-        this.onEvent?.(this.buildRunSession(session, agentName, agentIdentity), event);
+        const runSession = this.buildRunSession(session, agentName, agentIdentity);
+        this.onEvent?.(runSession, event);
+        this.recordSessionTurnUsage(runSession, event);
       });
       await this.persistRunProcessDetails(session.threadId, agentName, handle.pid);
 
@@ -2495,7 +2501,9 @@ export class SessionManager {
                 invocationCwd,
               );
             }
-            this.onEvent?.(this.buildRunSession(session, agentName, agentIdentity), event);
+            const runSession = this.buildRunSession(session, agentName, agentIdentity);
+            this.onEvent?.(runSession, event);
+            this.recordSessionTurnUsage(runSession, event);
           });
           await this.persistRunProcessDetails(session.threadId, agentName, retryHandle.pid);
 
@@ -3838,6 +3846,45 @@ export class SessionManager {
       worktreePath: null,
       worktreePaths: {},
     };
+  }
+
+  private recordSessionTurnUsage(
+    session: ThreadSession,
+    event: RunnerEvent,
+  ): void {
+    if (event.type !== "done" || !this.usageStore) return;
+    const agentName = session.activeAgentName ?? session.agentType ?? "default";
+    const invocation = session.activePipelineInvocation;
+    if (!event.usage) {
+      _log.info(
+        "spend",
+        `spend.missing provider=${event.provider} thread=${session.threadId}`,
+      );
+    }
+    const normalized = normalizeRunnerUsage(event.usage, {
+      sourceKind: "session-turn",
+      sourceId: sessionTurnSourceId(session, agentName),
+      threadId: session.threadId,
+      channelId: session.channel,
+      agentName,
+      provider: event.provider ?? session.provider ?? null,
+      providerSessionId: session.sessionId,
+      pipelineRunId:
+        invocation?.runId ??
+        session.activeRunId ??
+        session.activePipelineRunId ??
+        null,
+      assignmentId: invocation?.assignmentId ?? null,
+      workflowName: null,
+      workflowRunId: null,
+      occurredAt: Date.now(),
+    });
+    void this.usageStore.add(normalized).catch((err) => {
+      _log.warn(
+        "spend",
+        `spend.persist.fail thread=${session.threadId} agent=${agentName}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
   }
 
   private buildRunSession(

--- a/src/usage/merge.ts
+++ b/src/usage/merge.ts
@@ -1,0 +1,97 @@
+import {
+  sumPresent,
+  type NormalizedUsage,
+  type UsageEvent,
+} from "./normalize.ts";
+
+export function mergeUsage(
+  existing: UsageEvent,
+  incoming: NormalizedUsage,
+): UsageEvent {
+  const inputTokens = sumNullable(existing.inputTokens, incoming.inputTokens);
+  const outputTokens = sumNullable(existing.outputTokens, incoming.outputTokens);
+  const cacheReadTokens = sumNullable(
+    existing.cacheReadTokens,
+    incoming.cacheReadTokens,
+  );
+  const cacheWriteTokens = sumNullable(
+    existing.cacheWriteTokens,
+    incoming.cacheWriteTokens,
+  );
+  return {
+    id: existing.id,
+    sourceKind: existing.sourceKind,
+    sourceId: existing.sourceId,
+    threadId: existing.threadId ?? incoming.threadId,
+    channelId: existing.channelId ?? incoming.channelId,
+    agentName: existing.agentName ?? incoming.agentName,
+    provider: existing.provider ?? incoming.provider,
+    providerSessionId: existing.providerSessionId ?? incoming.providerSessionId,
+    pipelineRunId: existing.pipelineRunId ?? incoming.pipelineRunId,
+    assignmentId: existing.assignmentId ?? incoming.assignmentId,
+    workflowName: existing.workflowName ?? incoming.workflowName,
+    workflowRunId: existing.workflowRunId ?? incoming.workflowRunId,
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheWriteTokens,
+    totalTokens: sumPresent([
+      inputTokens,
+      outputTokens,
+      cacheReadTokens,
+      cacheWriteTokens,
+    ]),
+    costUsd: sumNullable(existing.costUsd, incoming.costUsd),
+    costEstimatedUsd: null,
+    numTurns: maxNullable(existing.numTurns, incoming.numTurns),
+    raw: mergeRaw(existing.raw, incoming.raw),
+    occurredAt: Math.min(existing.occurredAt, incoming.occurredAt),
+  };
+}
+
+export function mergeNormalizedUsage(
+  existing: NormalizedUsage,
+  incoming: NormalizedUsage,
+): NormalizedUsage {
+  const { id: _id, ...merged } = mergeUsage(
+    { id: "merge", ...existing },
+    incoming,
+  );
+  return merged;
+}
+
+function sumNullable(a: number | null, b: number | null): number | null {
+  if (a == null && b == null) return null;
+  return (a ?? 0) + (b ?? 0);
+}
+
+function maxNullable(a: number | null, b: number | null): number | null {
+  if (a == null) return b;
+  if (b == null) return a;
+  return Math.max(a, b);
+}
+
+function mergeRaw(
+  existing: Record<string, unknown>,
+  incoming: Record<string, unknown>,
+): Record<string, unknown> {
+  const existingEmpty = Object.keys(existing).length === 0;
+  const incomingEmpty = Object.keys(incoming).length === 0;
+  if (existingEmpty) return incomingEmpty ? {} : incoming;
+  if (incomingEmpty) return existing;
+  const parts = [
+    ...rawParts(existing),
+    ...rawParts(incoming),
+  ];
+  return { parts };
+}
+
+function rawParts(raw: Record<string, unknown>): Record<string, unknown>[] {
+  if (Array.isArray(raw.parts)) {
+    return raw.parts.filter(
+      (part): part is Record<string, unknown> =>
+        part !== null && typeof part === "object" && !Array.isArray(part),
+    );
+  }
+  return [raw];
+}

--- a/src/usage/normalize.test.ts
+++ b/src/usage/normalize.test.ts
@@ -128,7 +128,7 @@ describe("normalizeRunnerUsage", () => {
 });
 
 describe("sessionTurnSourceId", () => {
-  it("prefers activeTopLevelMessageTs over postedTs and generation", () => {
+  it("prefers activeTopLevelMessageTs over postedTs and generation for top-level agents", () => {
     expect(sessionTurnSourceId(
       {
         threadId: "T1",
@@ -140,18 +140,45 @@ describe("sessionTurnSourceId", () => {
     )).toBe("T1:default:111.1");
   });
 
-  it("falls back to postedTs then pending generation then unknown", () => {
+  it("uses invocation ts for workers instead of a stale top-level ts or generation", () => {
+    expect(sessionTurnSourceId(
+      {
+        threadId: "T1",
+        activeTopLevelMessageTs: "lead-ts",
+        activeTurnGeneration: "gen-1",
+      },
+      "review",
+      "review-ts",
+    )).toBe("T1:review:review-ts");
+    expect(sessionTurnSourceId(
+      {
+        threadId: "T1",
+        activeTopLevelMessageTs: "lead-ts",
+        currentMessageTs: "current-ts",
+      },
+      "review",
+    )).toBe("T1:review:current-ts");
     expect(sessionTurnSourceId(
       { threadId: "T1", activeTurnGeneration: "gen-1" },
       "review",
-      "posted-ts",
-    )).toBe("T1:review:posted-ts");
-    expect(sessionTurnSourceId(
-      { threadId: "T1", activeTurnGeneration: "gen-1" },
-      "review",
-    )).toBe("T1:review:pending-gen-1");
+    )).toBe("T1:review:unknown");
     expect(sessionTurnSourceId({ threadId: "T1" }, "review")).toBe(
       "T1:review:unknown",
+    );
+  });
+
+  it("falls back to postedTs then pending generation then unknown for top-level", () => {
+    expect(sessionTurnSourceId(
+      { threadId: "T1", activeTurnGeneration: "gen-1" },
+      "default",
+      "posted-ts",
+    )).toBe("T1:default:posted-ts");
+    expect(sessionTurnSourceId(
+      { threadId: "T1", activeTurnGeneration: "gen-1" },
+      "lead",
+    )).toBe("T1:lead:pending-gen-1");
+    expect(sessionTurnSourceId({ threadId: "T1" }, "default")).toBe(
+      "T1:default:unknown",
     );
   });
 });

--- a/src/usage/normalize.test.ts
+++ b/src/usage/normalize.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "bun:test";
+import { normalizeRunnerUsage, type UsageMeta } from "./normalize.ts";
+import { sessionTurnSourceId } from "./source-id.ts";
+
+const meta: UsageMeta = {
+  sourceKind: "session-turn",
+  sourceId: "thread-1:default:111.222",
+  threadId: "thread-1",
+  channelId: "C123",
+  agentName: "default",
+  provider: "claude",
+  providerSessionId: "ses-1",
+  pipelineRunId: null,
+  assignmentId: null,
+  workflowName: null,
+  workflowRunId: null,
+  occurredAt: 1_700_000_000_000,
+};
+
+describe("normalizeRunnerUsage", () => {
+  it("maps Claude done usage including cache tokens and provider cost", () => {
+    const usage = normalizeRunnerUsage(
+      {
+        total_cost_usd: 0.042,
+        usage: {
+          input_tokens: 100,
+          output_tokens: 50,
+          cache_read_input_tokens: 10,
+          cache_creation_input_tokens: 5,
+        },
+        num_turns: 3,
+      },
+      { ...meta, provider: "claude" },
+    );
+
+    expect(usage).toMatchObject({
+      inputTokens: 100,
+      outputTokens: 50,
+      cacheReadTokens: 10,
+      cacheWriteTokens: 5,
+      totalTokens: 165,
+      costUsd: 0.042,
+      costEstimatedUsd: null,
+      numTurns: 3,
+    });
+    expect(usage.raw.total_cost_usd).toBe(0.042);
+  });
+
+  it("maps Codex app-server input/output tokens without inventing cost", () => {
+    const usage = normalizeRunnerUsage(
+      { input_tokens: 12, output_tokens: 8 },
+      { ...meta, provider: "codex-app-server" },
+    );
+
+    expect(usage).toMatchObject({
+      inputTokens: 12,
+      outputTokens: 8,
+      cacheReadTokens: null,
+      cacheWriteTokens: null,
+      totalTokens: 20,
+      costUsd: null,
+      costEstimatedUsd: null,
+      numTurns: null,
+    });
+  });
+
+  it("maps OpenCode { input, output } tokens", () => {
+    const usage = normalizeRunnerUsage(
+      { input: 2, output: 3 },
+      { ...meta, provider: "opencode" },
+    );
+
+    expect(usage).toMatchObject({
+      inputTokens: 2,
+      outputTokens: 3,
+      totalTokens: 5,
+      costUsd: null,
+      costEstimatedUsd: null,
+    });
+  });
+
+  it("maps OpenCode input_tokens/output_tokens aliases", () => {
+    const usage = normalizeRunnerUsage(
+      { input_tokens: 9, output_tokens: 4 },
+      { ...meta, provider: "opencode" },
+    );
+
+    expect(usage).toMatchObject({
+      inputTokens: 9,
+      outputTokens: 4,
+      totalTokens: 13,
+    });
+  });
+
+  it("maps OpenCode SDK { input, output }", () => {
+    const usage = normalizeRunnerUsage(
+      { input: 40, output: 6 },
+      { ...meta, provider: "opencode-sdk" },
+    );
+
+    expect(usage).toMatchObject({
+      inputTokens: 40,
+      outputTokens: 6,
+      totalTokens: 46,
+      costUsd: null,
+      costEstimatedUsd: null,
+    });
+  });
+
+  it("inserts a missing-usage row with null tokens and empty raw", () => {
+    const usage = normalizeRunnerUsage(undefined, {
+      ...meta,
+      provider: "opencode",
+    });
+
+    expect(usage).toMatchObject({
+      inputTokens: null,
+      outputTokens: null,
+      cacheReadTokens: null,
+      cacheWriteTokens: null,
+      totalTokens: null,
+      costUsd: null,
+      costEstimatedUsd: null,
+      numTurns: null,
+      raw: {},
+    });
+  });
+});
+
+describe("sessionTurnSourceId", () => {
+  it("prefers activeTopLevelMessageTs over postedTs and generation", () => {
+    expect(sessionTurnSourceId(
+      {
+        threadId: "T1",
+        activeTopLevelMessageTs: "111.1",
+        activeTurnGeneration: "gen-1",
+      },
+      "default",
+      "posted-ts",
+    )).toBe("T1:default:111.1");
+  });
+
+  it("falls back to postedTs then pending generation then unknown", () => {
+    expect(sessionTurnSourceId(
+      { threadId: "T1", activeTurnGeneration: "gen-1" },
+      "review",
+      "posted-ts",
+    )).toBe("T1:review:posted-ts");
+    expect(sessionTurnSourceId(
+      { threadId: "T1", activeTurnGeneration: "gen-1" },
+      "review",
+    )).toBe("T1:review:pending-gen-1");
+    expect(sessionTurnSourceId({ threadId: "T1" }, "review")).toBe(
+      "T1:review:unknown",
+    );
+  });
+});

--- a/src/usage/normalize.ts
+++ b/src/usage/normalize.ts
@@ -1,0 +1,135 @@
+export type UsageSourceKind =
+  | "session-turn"
+  | "workflow-run"
+  | "pipeline-assignment";
+
+export type NormalizedUsage = {
+  sourceKind: UsageSourceKind;
+  sourceId: string;
+  threadId: string | null;
+  channelId: string | null;
+  agentName: string | null;
+  provider: string | null;
+  providerSessionId: string | null;
+  pipelineRunId: string | null;
+  assignmentId: string | null;
+  workflowName: string | null;
+  workflowRunId: string | null;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  cacheReadTokens: number | null;
+  cacheWriteTokens: number | null;
+  totalTokens: number | null;
+  costUsd: number | null;
+  costEstimatedUsd: null;
+  numTurns: number | null;
+  raw: Record<string, unknown>;
+  occurredAt: number;
+};
+
+export type UsageEvent = NormalizedUsage & { id: string };
+
+export type UsageMeta = Omit<
+  NormalizedUsage,
+  | "inputTokens"
+  | "outputTokens"
+  | "cacheReadTokens"
+  | "cacheWriteTokens"
+  | "totalTokens"
+  | "costUsd"
+  | "costEstimatedUsd"
+  | "numTurns"
+  | "raw"
+>;
+
+export function normalizeRunnerUsage(
+  usage: Record<string, unknown> | undefined,
+  meta: UsageMeta,
+): NormalizedUsage {
+  if (!usage) {
+    return emptyUsage(meta, {});
+  }
+
+  const raw = { ...usage };
+  const provider = meta.provider;
+  let inputTokens: number | null = null;
+  let outputTokens: number | null = null;
+  let cacheReadTokens: number | null = null;
+  let cacheWriteTokens: number | null = null;
+  let costUsd: number | null = null;
+  let numTurns: number | null = null;
+
+  if (provider === "claude") {
+    const nested = asRecord(usage.usage) ?? usage;
+    inputTokens = readNumber(nested.input_tokens);
+    outputTokens = readNumber(nested.output_tokens);
+    cacheReadTokens = readNumber(nested.cache_read_input_tokens);
+    cacheWriteTokens = readNumber(nested.cache_creation_input_tokens);
+    costUsd = readNumber(usage.total_cost_usd);
+    numTurns = readNumber(usage.num_turns);
+  } else if (provider === "codex-app-server" || provider === "codex") {
+    inputTokens = readNumber(usage.input_tokens);
+    outputTokens = readNumber(usage.output_tokens);
+  } else {
+    const tokens = asRecord(usage.tokens) ?? usage;
+    inputTokens = readNumber(tokens.input) ?? readNumber(tokens.input_tokens);
+    outputTokens = readNumber(tokens.output) ?? readNumber(tokens.output_tokens);
+  }
+
+  return {
+    ...meta,
+    inputTokens,
+    outputTokens,
+    cacheReadTokens,
+    cacheWriteTokens,
+    totalTokens: sumPresent([
+      inputTokens,
+      outputTokens,
+      cacheReadTokens,
+      cacheWriteTokens,
+    ]),
+    costUsd,
+    costEstimatedUsd: null,
+    numTurns,
+    raw,
+  };
+}
+
+function emptyUsage(
+  meta: UsageMeta,
+  raw: Record<string, unknown>,
+): NormalizedUsage {
+  return {
+    ...meta,
+    inputTokens: null,
+    outputTokens: null,
+    cacheReadTokens: null,
+    cacheWriteTokens: null,
+    totalTokens: null,
+    costUsd: null,
+    costEstimatedUsd: null,
+    numTurns: null,
+    raw,
+  };
+}
+
+function readNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+export function sumPresent(values: Array<number | null>): number | null {
+  let total = 0;
+  let seen = false;
+  for (const value of values) {
+    if (value == null) continue;
+    total += value;
+    seen = true;
+  }
+  return seen ? total : null;
+}

--- a/src/usage/source-id.ts
+++ b/src/usage/source-id.ts
@@ -3,14 +3,17 @@ export function sessionTurnSourceId(
     threadId: string;
     activeTopLevelMessageTs?: string | null;
     activeTurnGeneration?: string | null;
+    currentMessageTs?: string | null;
   },
   agentName: string,
   postedTs?: string,
 ): string {
+  const isTopLevel = agentName === "lead" || agentName === "default";
+  const invocationTs = postedTs ?? session.currentMessageTs ?? undefined;
   const turnKey =
-    session.activeTopLevelMessageTs
-    ?? postedTs
-    ?? (session.activeTurnGeneration
+    (isTopLevel ? session.activeTopLevelMessageTs : undefined)
+    ?? invocationTs
+    ?? (isTopLevel && session.activeTurnGeneration
       ? `pending-${session.activeTurnGeneration}`
       : "unknown");
   return `${session.threadId}:${agentName}:${turnKey}`;

--- a/src/usage/source-id.ts
+++ b/src/usage/source-id.ts
@@ -1,0 +1,17 @@
+export function sessionTurnSourceId(
+  session: {
+    threadId: string;
+    activeTopLevelMessageTs?: string | null;
+    activeTurnGeneration?: string | null;
+  },
+  agentName: string,
+  postedTs?: string,
+): string {
+  const turnKey =
+    session.activeTopLevelMessageTs
+    ?? postedTs
+    ?? (session.activeTurnGeneration
+      ? `pending-${session.activeTurnGeneration}`
+      : "unknown");
+  return `${session.threadId}:${agentName}:${turnKey}`;
+}

--- a/src/usage/store/aggregate.ts
+++ b/src/usage/store/aggregate.ts
@@ -1,0 +1,81 @@
+import type { NormalizedUsage, UsageEvent } from "../normalize.ts";
+import type {
+  UsageBucket,
+  UsageGroupBy,
+  UsageGroupResult,
+  UsageTotals,
+} from "./interface.ts";
+
+export function isMissingUsage(usage: NormalizedUsage): boolean {
+  return (
+    usage.inputTokens == null &&
+    usage.outputTokens == null &&
+    usage.cacheReadTokens == null &&
+    usage.cacheWriteTokens == null &&
+    usage.costUsd == null
+  );
+}
+
+export function groupUsageEvents(
+  events: UsageEvent[],
+  groupBy: UsageGroupBy,
+): UsageGroupResult {
+  const buckets = new Map<string, UsageBucket>();
+  const totals: UsageTotals = {
+    turns: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    costUsd: 0,
+    costEstimatedUsd: 0,
+    missingUsageTurns: 0,
+  };
+
+  for (const event of events) {
+    totals.turns += 1;
+    totals.inputTokens += event.inputTokens ?? 0;
+    totals.outputTokens += event.outputTokens ?? 0;
+    totals.costUsd += event.costUsd ?? 0;
+    if (isMissingUsage(event)) totals.missingUsageTurns += 1;
+
+    const key = groupKey(event, groupBy);
+    const existing = buckets.get(key);
+    if (!existing) {
+      buckets.set(key, {
+        key,
+        label: key,
+        turns: 1,
+        inputTokens: event.inputTokens ?? 0,
+        outputTokens: event.outputTokens ?? 0,
+        costUsd: event.costUsd ?? 0,
+        costEstimatedUsd: 0,
+      });
+      continue;
+    }
+    existing.turns += 1;
+    existing.inputTokens += event.inputTokens ?? 0;
+    existing.outputTokens += event.outputTokens ?? 0;
+    existing.costUsd += event.costUsd ?? 0;
+  }
+
+  return {
+    totals,
+    buckets: [...buckets.values()].sort((a, b) => a.key.localeCompare(b.key)),
+  };
+}
+
+function groupKey(event: UsageEvent, groupBy: UsageGroupBy): string {
+  switch (groupBy) {
+    case "day":
+      return new Date(event.occurredAt).toISOString().slice(0, 10);
+    case "session":
+      return event.threadId ?? "unknown";
+    case "agent":
+      return event.agentName ?? "unknown";
+    case "provider":
+      return event.provider ?? "unknown";
+    case "workflow":
+      return event.workflowName ?? event.workflowRunId ?? "unknown";
+    case "pipeline":
+      return event.pipelineRunId ?? "unknown";
+  }
+}

--- a/src/usage/store/aggregate.ts
+++ b/src/usage/store/aggregate.ts
@@ -66,7 +66,7 @@ export function groupUsageEvents(
 function groupKey(event: UsageEvent, groupBy: UsageGroupBy): string {
   switch (groupBy) {
     case "day":
-      return new Date(event.occurredAt).toISOString().slice(0, 10);
+      return localDayKey(event.occurredAt);
     case "session":
       return event.threadId ?? "unknown";
     case "agent":
@@ -78,4 +78,12 @@ function groupKey(event: UsageEvent, groupBy: UsageGroupBy): string {
     case "pipeline":
       return event.pipelineRunId ?? "unknown";
   }
+}
+
+function localDayKey(occurredAt: number): string {
+  const date = new Date(occurredAt);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }

--- a/src/usage/store/factory.ts
+++ b/src/usage/store/factory.ts
@@ -1,0 +1,20 @@
+import { Database } from "bun:sqlite";
+import { resolve } from "node:path";
+import type { UsageStore } from "./interface.ts";
+import { InMemoryUsageStore } from "./memory.ts";
+import { SqliteUsageStore } from "./sqlite.ts";
+
+export type UsageStoreOptions = {
+  kind?: "memory" | "sqlite";
+  sqlitePath?: string;
+  db?: Database;
+};
+
+export function createUsageStore(
+  options: UsageStoreOptions = {},
+): UsageStore {
+  const kind = options.kind ?? (options.db ? "sqlite" : "memory");
+  if (kind === "memory") return new InMemoryUsageStore();
+  if (options.db) return new SqliteUsageStore(options.db);
+  return new SqliteUsageStore(resolve(options.sqlitePath ?? "data/sessions.db"));
+}

--- a/src/usage/store/interface.ts
+++ b/src/usage/store/interface.ts
@@ -1,0 +1,61 @@
+import type {
+  NormalizedUsage,
+  UsageEvent,
+  UsageSourceKind,
+} from "../normalize.ts";
+
+export type { NormalizedUsage, UsageEvent, UsageSourceKind };
+
+export type UsageGroupBy =
+  | "day"
+  | "session"
+  | "agent"
+  | "provider"
+  | "workflow"
+  | "pipeline";
+
+export type UsageTotals = {
+  turns: number;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  costEstimatedUsd: number;
+  missingUsageTurns: number;
+};
+
+export type UsageBucket = {
+  key: string;
+  label: string;
+  turns: number;
+  inputTokens: number;
+  outputTokens: number;
+  costUsd: number;
+  costEstimatedUsd: number;
+};
+
+export type UsageGroupResult = {
+  totals: UsageTotals;
+  buckets: UsageBucket[];
+};
+
+export interface UsageStore {
+  add(usage: NormalizedUsage): Promise<UsageEvent>;
+  get(
+    sourceKind: UsageSourceKind,
+    sourceId: string,
+  ): Promise<UsageEvent | undefined>;
+  list(filter?: {
+    from?: number;
+    to?: number;
+    threadId?: string;
+    sourceKind?: UsageSourceKind;
+    limit?: number;
+  }): Promise<UsageEvent[]>;
+  groupBy(input: {
+    from: number;
+    to: number;
+    groupBy: UsageGroupBy;
+  }): Promise<UsageGroupResult>;
+  deleteOlderThan(occurredAt: number): Promise<number>;
+  close?(): void;
+}

--- a/src/usage/store/memory.ts
+++ b/src/usage/store/memory.ts
@@ -1,0 +1,80 @@
+import { mergeUsage } from "../merge.ts";
+import type { NormalizedUsage, UsageEvent, UsageSourceKind } from "../normalize.ts";
+import { groupUsageEvents } from "./aggregate.ts";
+import type { UsageGroupBy, UsageGroupResult, UsageStore } from "./interface.ts";
+
+export class InMemoryUsageStore implements UsageStore {
+  private events = new Map<string, UsageEvent>();
+
+  async add(usage: NormalizedUsage): Promise<UsageEvent> {
+    const key = sourceKey(usage.sourceKind, usage.sourceId);
+    const existing = this.events.get(key);
+    const stored = existing
+      ? mergeUsage(existing, usage)
+      : { id: crypto.randomUUID(), ...usage };
+    this.events.set(key, stored);
+    return stored;
+  }
+
+  async get(
+    sourceKind: UsageSourceKind,
+    sourceId: string,
+  ): Promise<UsageEvent | undefined> {
+    return this.events.get(sourceKey(sourceKind, sourceId));
+  }
+
+  async list(filter: {
+    from?: number;
+    to?: number;
+    threadId?: string;
+    sourceKind?: UsageSourceKind;
+    limit?: number;
+  } = {}): Promise<UsageEvent[]> {
+    const rows = [...this.events.values()]
+      .filter((event) => matchesFilter(event, filter))
+      .sort((a, b) => b.occurredAt - a.occurredAt || a.id.localeCompare(b.id));
+    return filter.limit == null ? rows : rows.slice(0, filter.limit);
+  }
+
+  async groupBy(input: {
+    from: number;
+    to: number;
+    groupBy: UsageGroupBy;
+  }): Promise<UsageGroupResult> {
+    const events = await this.list({ from: input.from, to: input.to });
+    return groupUsageEvents(events, input.groupBy);
+  }
+
+  async deleteOlderThan(occurredAt: number): Promise<number> {
+    let deleted = 0;
+    for (const [key, event] of this.events) {
+      if (event.occurredAt < occurredAt) {
+        this.events.delete(key);
+        deleted += 1;
+      }
+    }
+    return deleted;
+  }
+}
+
+function sourceKey(sourceKind: UsageSourceKind, sourceId: string): string {
+  return `${sourceKind}\0${sourceId}`;
+}
+
+function matchesFilter(
+  event: UsageEvent,
+  filter: {
+    from?: number;
+    to?: number;
+    threadId?: string;
+    sourceKind?: UsageSourceKind;
+  },
+): boolean {
+  if (filter.from != null && event.occurredAt < filter.from) return false;
+  if (filter.to != null && event.occurredAt > filter.to) return false;
+  if (filter.threadId != null && event.threadId !== filter.threadId) return false;
+  if (filter.sourceKind != null && event.sourceKind !== filter.sourceKind) {
+    return false;
+  }
+  return true;
+}

--- a/src/usage/store/sqlite.test.ts
+++ b/src/usage/store/sqlite.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { normalizeRunnerUsage, type NormalizedUsage } from "../normalize.ts";
+import { SqliteUsageStore } from "./sqlite.ts";
+import { USAGE_RETENTION_MS } from "../../lifecycle/cleanup.ts";
+
+function usage(overrides: Partial<NormalizedUsage> = {}): NormalizedUsage {
+  return {
+    sourceKind: "session-turn",
+    sourceId: "thread-1:default:111.1",
+    threadId: "thread-1",
+    channelId: "C123",
+    agentName: "default",
+    provider: "opencode",
+    providerSessionId: "ses-1",
+    pipelineRunId: null,
+    assignmentId: null,
+    workflowName: null,
+    workflowRunId: null,
+    inputTokens: 10,
+    outputTokens: 2,
+    cacheReadTokens: null,
+    cacheWriteTokens: null,
+    totalTokens: 12,
+    costUsd: null,
+    costEstimatedUsd: null,
+    numTurns: null,
+    raw: { input: 10, output: 2 },
+    occurredAt: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+describe("SqliteUsageStore", () => {
+  let tmpDir: string;
+  let store: SqliteUsageStore;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "junior-usage-"));
+    store = new SqliteUsageStore(join(tmpDir, "sessions.db"));
+  });
+
+  afterEach(() => {
+    store.close();
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it("sums tokens for the same source_kind + source_id", async () => {
+    await store.add(usage({
+      inputTokens: 10,
+      outputTokens: 2,
+      totalTokens: 12,
+      raw: { input: 10 },
+    }));
+    await store.add(usage({
+      inputTokens: 5,
+      outputTokens: 3,
+      cacheReadTokens: 4,
+      totalTokens: 12,
+      costUsd: 0.01,
+      occurredAt: 1_700_000_000_500,
+      raw: { input: 5 },
+    }));
+
+    const row = await store.get("session-turn", "thread-1:default:111.1");
+    expect(row).toMatchObject({
+      inputTokens: 15,
+      outputTokens: 5,
+      cacheReadTokens: 4,
+      totalTokens: 24,
+      costUsd: 0.01,
+      costEstimatedUsd: null,
+      occurredAt: 1_700_000_000_000,
+    });
+    expect(Array.isArray(row?.raw.parts)).toBe(true);
+  });
+
+  it("stores a missing-usage row with null token fields", async () => {
+    const missing = normalizeRunnerUsage(undefined, {
+      sourceKind: "session-turn",
+      sourceId: "thread-1:default:missing",
+      threadId: "thread-1",
+      channelId: "C123",
+      agentName: "default",
+      provider: "opencode",
+      providerSessionId: null,
+      pipelineRunId: null,
+      assignmentId: null,
+      workflowName: null,
+      workflowRunId: null,
+      occurredAt: 1_700_000_000_000,
+    });
+    await store.add(missing);
+    const row = await store.get("session-turn", "thread-1:default:missing");
+    expect(row).toMatchObject({
+      inputTokens: null,
+      outputTokens: null,
+      totalTokens: null,
+      costUsd: null,
+      raw: {},
+    });
+  });
+
+  it("groups rows by agent and session", async () => {
+    await store.add(usage({
+      sourceId: "t1:default:1",
+      threadId: "t1",
+      agentName: "default",
+      inputTokens: 10,
+      outputTokens: 1,
+      occurredAt: 1_700_000_100_000,
+    }));
+    await store.add(usage({
+      sourceId: "t1:review:2",
+      threadId: "t1",
+      agentName: "review",
+      inputTokens: 20,
+      outputTokens: 4,
+      occurredAt: 1_700_000_200_000,
+    }));
+    await store.add(usage({
+      sourceId: "t2:default:3",
+      threadId: "t2",
+      agentName: "default",
+      inputTokens: 5,
+      outputTokens: 1,
+      occurredAt: 1_700_000_300_000,
+    }));
+
+    const byAgent = await store.groupBy({
+      from: 1_700_000_000_000,
+      to: 1_700_000_400_000,
+      groupBy: "agent",
+    });
+    expect(byAgent.totals).toMatchObject({
+      turns: 3,
+      inputTokens: 35,
+      outputTokens: 6,
+      missingUsageTurns: 0,
+    });
+    expect(byAgent.buckets).toEqual([
+      {
+        key: "default",
+        label: "default",
+        turns: 2,
+        inputTokens: 15,
+        outputTokens: 2,
+        costUsd: 0,
+        costEstimatedUsd: 0,
+      },
+      {
+        key: "review",
+        label: "review",
+        turns: 1,
+        inputTokens: 20,
+        outputTokens: 4,
+        costUsd: 0,
+        costEstimatedUsd: 0,
+      },
+    ]);
+
+    const bySession = await store.groupBy({
+      from: 1_700_000_000_000,
+      to: 1_700_000_400_000,
+      groupBy: "session",
+    });
+    expect(bySession.buckets.map((bucket) => bucket.key)).toEqual(["t1", "t2"]);
+  });
+
+  it("deletes rows older than the retention cutoff", async () => {
+    const now = 1_800_000_000_000;
+    await store.add(usage({
+      sourceId: "old",
+      occurredAt: now - USAGE_RETENTION_MS - 1,
+    }));
+    await store.add(usage({
+      sourceId: "fresh",
+      occurredAt: now - 1_000,
+    }));
+
+    expect(await store.deleteOlderThan(now - USAGE_RETENTION_MS)).toBe(1);
+    expect(await store.get("session-turn", "old")).toBeUndefined();
+    expect(await store.get("session-turn", "fresh")).toBeDefined();
+  });
+});

--- a/src/usage/store/sqlite.test.ts
+++ b/src/usage/store/sqlite.test.ts
@@ -169,6 +169,26 @@ describe("SqliteUsageStore", () => {
     expect(bySession.buckets.map((bucket) => bucket.key)).toEqual(["t1", "t2"]);
   });
 
+  it("groups day buckets in the host local timezone", async () => {
+    const occurredAt = new Date(2026, 5, 15, 23, 30, 0).getTime();
+    await store.add(usage({
+      sourceId: "local-day",
+      occurredAt,
+    }));
+    const result = await store.groupBy({
+      from: occurredAt - 1,
+      to: occurredAt + 1,
+      groupBy: "day",
+    });
+    const local = new Date(occurredAt);
+    const expected = [
+      String(local.getFullYear()),
+      String(local.getMonth() + 1).padStart(2, "0"),
+      String(local.getDate()).padStart(2, "0"),
+    ].join("-");
+    expect(result.buckets.map((bucket) => bucket.key)).toEqual([expected]);
+  });
+
   it("deletes rows older than the retention cutoff", async () => {
     const now = 1_800_000_000_000;
     await store.add(usage({

--- a/src/usage/store/sqlite.ts
+++ b/src/usage/store/sqlite.ts
@@ -1,0 +1,279 @@
+import { Database } from "bun:sqlite";
+import { mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { mergeUsage } from "../merge.ts";
+import type { NormalizedUsage, UsageEvent, UsageSourceKind } from "../normalize.ts";
+import { groupUsageEvents } from "./aggregate.ts";
+import type { UsageGroupBy, UsageGroupResult, UsageStore } from "./interface.ts";
+
+type UsageRow = {
+  id: string;
+  source_kind: string;
+  source_id: string;
+  thread_id: string | null;
+  channel_id: string | null;
+  agent_name: string | null;
+  provider: string | null;
+  provider_session_id: string | null;
+  pipeline_run_id: string | null;
+  assignment_id: string | null;
+  workflow_name: string | null;
+  workflow_run_id: string | null;
+  input_tokens: number | null;
+  output_tokens: number | null;
+  cache_read_tokens: number | null;
+  cache_write_tokens: number | null;
+  total_tokens: number | null;
+  cost_usd: number | null;
+  cost_estimated_usd: number | null;
+  num_turns: number | null;
+  raw_json: string;
+  occurred_at: number;
+};
+
+export class SqliteUsageStore implements UsageStore {
+  private db: Database;
+  private ownsDb: boolean;
+
+  constructor(dbPathOrDb: string | Database) {
+    if (typeof dbPathOrDb === "string") {
+      mkdirSync(dirname(dbPathOrDb), { recursive: true });
+      this.db = new Database(dbPathOrDb);
+      this.ownsDb = true;
+      this.db.run("PRAGMA journal_mode = WAL");
+      this.db.run("PRAGMA synchronous = NORMAL");
+    } else {
+      this.db = dbPathOrDb;
+      this.ownsDb = false;
+    }
+    this.migrate();
+  }
+
+  close(): void {
+    if (this.ownsDb) this.db.close();
+  }
+
+  async add(usage: NormalizedUsage): Promise<UsageEvent> {
+    return this.db.transaction(() => {
+      const existing = this.getSync(usage.sourceKind, usage.sourceId);
+      const stored = existing
+        ? mergeUsage(existing, usage)
+        : { id: crypto.randomUUID(), ...usage };
+      this.db
+        .query(
+          `INSERT INTO usage_events (
+            id, source_kind, source_id, thread_id, channel_id, agent_name,
+            provider, provider_session_id, pipeline_run_id, assignment_id,
+            workflow_name, workflow_run_id, input_tokens, output_tokens,
+            cache_read_tokens, cache_write_tokens, total_tokens, cost_usd,
+            cost_estimated_usd, num_turns, raw_json, occurred_at
+          ) VALUES (
+            ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+          )
+          ON CONFLICT(source_kind, source_id) DO UPDATE SET
+            thread_id = excluded.thread_id,
+            channel_id = excluded.channel_id,
+            agent_name = excluded.agent_name,
+            provider = excluded.provider,
+            provider_session_id = excluded.provider_session_id,
+            pipeline_run_id = excluded.pipeline_run_id,
+            assignment_id = excluded.assignment_id,
+            workflow_name = excluded.workflow_name,
+            workflow_run_id = excluded.workflow_run_id,
+            input_tokens = excluded.input_tokens,
+            output_tokens = excluded.output_tokens,
+            cache_read_tokens = excluded.cache_read_tokens,
+            cache_write_tokens = excluded.cache_write_tokens,
+            total_tokens = excluded.total_tokens,
+            cost_usd = excluded.cost_usd,
+            cost_estimated_usd = excluded.cost_estimated_usd,
+            num_turns = excluded.num_turns,
+            raw_json = excluded.raw_json,
+            occurred_at = excluded.occurred_at`,
+        )
+        .run(
+          stored.id,
+          stored.sourceKind,
+          stored.sourceId,
+          stored.threadId,
+          stored.channelId,
+          stored.agentName,
+          stored.provider,
+          stored.providerSessionId,
+          stored.pipelineRunId,
+          stored.assignmentId,
+          stored.workflowName,
+          stored.workflowRunId,
+          stored.inputTokens,
+          stored.outputTokens,
+          stored.cacheReadTokens,
+          stored.cacheWriteTokens,
+          stored.totalTokens,
+          stored.costUsd,
+          stored.costEstimatedUsd,
+          stored.numTurns,
+          JSON.stringify(stored.raw),
+          stored.occurredAt,
+        );
+      return stored;
+    })();
+  }
+
+  async get(
+    sourceKind: UsageSourceKind,
+    sourceId: string,
+  ): Promise<UsageEvent | undefined> {
+    return this.getSync(sourceKind, sourceId);
+  }
+
+  async list(filter: {
+    from?: number;
+    to?: number;
+    threadId?: string;
+    sourceKind?: UsageSourceKind;
+    limit?: number;
+  } = {}): Promise<UsageEvent[]> {
+    const clauses: string[] = [];
+    const params: Array<string | number> = [];
+    if (filter.from != null) {
+      clauses.push("occurred_at >= ?");
+      params.push(filter.from);
+    }
+    if (filter.to != null) {
+      clauses.push("occurred_at <= ?");
+      params.push(filter.to);
+    }
+    if (filter.threadId != null) {
+      clauses.push("thread_id = ?");
+      params.push(filter.threadId);
+    }
+    if (filter.sourceKind != null) {
+      clauses.push("source_kind = ?");
+      params.push(filter.sourceKind);
+    }
+    const where = clauses.length > 0 ? `WHERE ${clauses.join(" AND ")}` : "";
+    const limit = filter.limit != null ? " LIMIT ?" : "";
+    if (filter.limit != null) params.push(filter.limit);
+    const rows = this.db
+      .query<UsageRow, Array<string | number>>(
+        `SELECT * FROM usage_events ${where} ORDER BY occurred_at DESC, id ASC${limit}`,
+      )
+      .all(...params);
+    return rows.map(rowToEvent);
+  }
+
+  async groupBy(input: {
+    from: number;
+    to: number;
+    groupBy: UsageGroupBy;
+  }): Promise<UsageGroupResult> {
+    const events = await this.list({ from: input.from, to: input.to });
+    return groupUsageEvents(events, input.groupBy);
+  }
+
+  async deleteOlderThan(occurredAt: number): Promise<number> {
+    const result = this.db
+      .query("DELETE FROM usage_events WHERE occurred_at < ?")
+      .run(occurredAt);
+    return result.changes;
+  }
+
+  private getSync(
+    sourceKind: UsageSourceKind,
+    sourceId: string,
+  ): UsageEvent | undefined {
+    const row = this.db
+      .query<UsageRow, [string, string]>(
+        "SELECT * FROM usage_events WHERE source_kind = ? AND source_id = ?",
+      )
+      .get(sourceKind, sourceId);
+    return row ? rowToEvent(row) : undefined;
+  }
+
+  private migrate(): void {
+    this.db.run(`
+      CREATE TABLE IF NOT EXISTS usage_events (
+        id                TEXT PRIMARY KEY,
+        source_kind       TEXT NOT NULL,
+        source_id         TEXT NOT NULL,
+        thread_id         TEXT,
+        channel_id        TEXT,
+        agent_name        TEXT,
+        provider          TEXT,
+        provider_session_id TEXT,
+        pipeline_run_id   TEXT,
+        assignment_id     TEXT,
+        workflow_name     TEXT,
+        workflow_run_id   TEXT,
+        input_tokens      INTEGER,
+        output_tokens     INTEGER,
+        cache_read_tokens INTEGER,
+        cache_write_tokens INTEGER,
+        total_tokens      INTEGER,
+        cost_usd          REAL,
+        cost_estimated_usd REAL,
+        num_turns         INTEGER,
+        raw_json          TEXT NOT NULL,
+        occurred_at       INTEGER NOT NULL
+      )
+    `);
+    this.db.run(`
+      CREATE UNIQUE INDEX IF NOT EXISTS usage_events_source_uidx
+        ON usage_events (source_kind, source_id)
+    `);
+    this.db.run(`
+      CREATE INDEX IF NOT EXISTS usage_events_occurred_idx
+        ON usage_events (occurred_at)
+    `);
+    this.db.run(`
+      CREATE INDEX IF NOT EXISTS usage_events_thread_idx
+        ON usage_events (thread_id, occurred_at)
+    `);
+    this.db.run(`
+      CREATE INDEX IF NOT EXISTS usage_events_pipeline_idx
+        ON usage_events (pipeline_run_id)
+    `);
+    this.db.run(`
+      CREATE INDEX IF NOT EXISTS usage_events_workflow_idx
+        ON usage_events (workflow_name, occurred_at)
+    `);
+  }
+}
+
+function rowToEvent(row: UsageRow): UsageEvent {
+  return {
+    id: row.id,
+    sourceKind: row.source_kind as UsageSourceKind,
+    sourceId: row.source_id,
+    threadId: row.thread_id,
+    channelId: row.channel_id,
+    agentName: row.agent_name,
+    provider: row.provider,
+    providerSessionId: row.provider_session_id,
+    pipelineRunId: row.pipeline_run_id,
+    assignmentId: row.assignment_id,
+    workflowName: row.workflow_name,
+    workflowRunId: row.workflow_run_id,
+    inputTokens: row.input_tokens,
+    outputTokens: row.output_tokens,
+    cacheReadTokens: row.cache_read_tokens,
+    cacheWriteTokens: row.cache_write_tokens,
+    totalTokens: row.total_tokens,
+    costUsd: row.cost_usd,
+    costEstimatedUsd: null,
+    numTurns: row.num_turns,
+    raw: parseRaw(row.raw_json),
+    occurredAt: row.occurred_at,
+  };
+}
+
+function parseRaw(rawJson: string): Record<string, unknown> {
+  try {
+    const parsed: unknown = JSON.parse(rawJson);
+    return parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)
+      ? (parsed as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}

--- a/src/workflows/executor.test.ts
+++ b/src/workflows/executor.test.ts
@@ -12,6 +12,8 @@ import {
   WORKFLOW_UTILITY_CWD,
 } from "./executor.ts";
 import { InMemoryWorkflowStore } from "./store.ts";
+import { InMemoryUsageStore } from "../usage/store/memory.ts";
+import type { NormalizedUsage } from "../usage/normalize.ts";
 import type { WorkflowDefinition } from "./types.ts";
 import { SqliteMemoryStore } from "../memory/sqlite.ts";
 import { ProfileStore } from "../memory/profiles/store.ts";
@@ -738,6 +740,104 @@ describe("WorkflowExecutor", () => {
       const runs = await store.listRuns(definition.name, 1);
       expect(runs[0]?.providerSessionId).toBe("ses-shutdown");
       expect(runs[0]?.status).toBe("failed");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("persists workflow usage once from SpawnResult, not per onEvent", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "junior-workflow-usage-"));
+    const added: NormalizedUsage[] = [];
+    const usageStore = new InMemoryUsageStore();
+    const origAdd = usageStore.add.bind(usageStore);
+    usageStore.add = async (usage) => {
+      added.push(usage);
+      return origAdd(usage);
+    };
+    const spawn: SpawnRunnerFn = (): SpawnHandle => ({
+      provider: "opencode",
+      result: Promise.resolve({
+        provider: "opencode",
+        sessionId: "ses-usage",
+        response: "workflow done",
+        events: [
+          { type: "done", provider: "opencode", usage: { input: 10, output: 2 } },
+          { type: "done", provider: "opencode", usage: { input: 5, output: 3 } },
+        ],
+        exitCode: 0,
+        error: null,
+      }),
+      onEvent: (cb) => {
+        cb({ type: "init", provider: "opencode", sessionId: "ses-usage" });
+        cb({ type: "done", provider: "opencode", usage: { input: 10, output: 2 } });
+        cb({ type: "done", provider: "opencode", usage: { input: 5, output: 3 } });
+      },
+      kill: () => undefined,
+      pid: null,
+    });
+    const executor = new WorkflowExecutor({
+      config: testConfig(),
+      store: new InMemoryWorkflowStore(),
+      spawn,
+      usageStore,
+      now: () => new Date("2026-05-21T13:30:00.000Z"),
+    });
+
+    try {
+      const result = await executor.run({
+        definition: workflowDefinition(dir),
+        reason: "manual",
+      });
+      expect(added).toHaveLength(1);
+      expect(added[0]).toMatchObject({
+        sourceKind: "workflow-run",
+        sourceId: result.run.id,
+        workflowName: "worklog",
+        workflowRunId: result.run.id,
+        provider: "opencode",
+        inputTokens: 15,
+        outputTokens: 5,
+        totalTokens: 20,
+        costEstimatedUsd: null,
+      });
+      expect(await usageStore.get("workflow-run", result.run.id)).toMatchObject({
+        inputTokens: 15,
+        outputTokens: 5,
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("persists a zero-token usage row after a native handler returns", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "junior-workflow-native-usage-"));
+    const definition = workflowDefinition(dir);
+    definition.name = "slack-archive-maintenance";
+    definition.nativeHandler = "slack-archive-maintenance";
+    definition.runner = undefined;
+    definition.outputs = [{ type: "docs", path: join(dir, "slack-archive-maintenance") }];
+    const usageStore = new InMemoryUsageStore();
+    const executor = new WorkflowExecutor({
+      config: testConfig(),
+      store: new InMemoryWorkflowStore(),
+      usageStore,
+      slackClient: {} as WebClient,
+      now: () => new Date("2026-08-16T03:17:00+05:30"),
+    });
+
+    try {
+      const result = await executor.run({ definition, reason: "schedule" });
+      const row = await usageStore.get("workflow-run", result.run.id);
+      expect(row).toMatchObject({
+        sourceKind: "workflow-run",
+        sourceId: result.run.id,
+        workflowName: "slack-archive-maintenance",
+        inputTokens: 0,
+        outputTokens: 0,
+        totalTokens: 0,
+        costUsd: null,
+        raw: { nativeHandler: "slack-archive-maintenance" },
+      });
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }

--- a/src/workflows/executor.test.ts
+++ b/src/workflows/executor.test.ts
@@ -775,12 +775,23 @@ describe("WorkflowExecutor", () => {
       kill: () => undefined,
       pid: null,
     });
+    let nowMs = Date.parse("2026-05-21T13:30:00.000Z");
+    const slackClient = {
+      chat: {
+        postMessage: async () => ({ ok: true, ts: "123.456" }),
+      },
+    } as unknown as WebClient;
     const executor = new WorkflowExecutor({
       config: testConfig(),
       store: new InMemoryWorkflowStore(),
+      slackClient,
       spawn,
       usageStore,
-      now: () => new Date("2026-05-21T13:30:00.000Z"),
+      now: () => {
+        const date = new Date(nowMs);
+        nowMs += 1_000;
+        return date;
+      },
     });
 
     try {
@@ -795,14 +806,66 @@ describe("WorkflowExecutor", () => {
         workflowName: "worklog",
         workflowRunId: result.run.id,
         provider: "opencode",
+        channelId: "C123ABC",
         inputTokens: 15,
         outputTokens: 5,
         totalTokens: 20,
         costEstimatedUsd: null,
+        occurredAt: result.run.finishedAt,
       });
+      expect(result.run.finishedAt).not.toBe(result.run.startedAt);
       expect(await usageStore.get("workflow-run", result.run.id)).toMatchObject({
         inputTokens: 15,
         outputTokens: 5,
+        channelId: "C123ABC",
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("persists runner usage after a failed workflow run", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "junior-workflow-usage-fail-"));
+    const usageStore = new InMemoryUsageStore();
+    const spawn: SpawnRunnerFn = (): SpawnHandle => ({
+      provider: "opencode",
+      result: Promise.resolve({
+        provider: "opencode",
+        sessionId: "ses-fail",
+        response: "",
+        events: [
+          { type: "done", provider: "opencode", usage: { input: 8, output: 1 } },
+        ],
+        exitCode: 1,
+        error: "runner failed",
+      }),
+      onEvent: () => undefined,
+      kill: () => undefined,
+      pid: null,
+    });
+    const store = new InMemoryWorkflowStore();
+    const executor = new WorkflowExecutor({
+      config: testConfig(),
+      store,
+      spawn,
+      usageStore,
+      now: () => new Date("2026-05-21T13:31:00.000Z"),
+    });
+
+    try {
+      await expect(executor.run({
+        definition: workflowDefinition(dir),
+        reason: "manual",
+      })).rejects.toThrow("Workflow runner failed");
+      const run = (await store.listRuns("worklog", 1))[0];
+      expect(run?.status).toBe("failed");
+      const rows = await usageStore.list({ sourceKind: "workflow-run" });
+      expect(rows).toHaveLength(1);
+      expect(rows[0]).toMatchObject({
+        inputTokens: 8,
+        outputTokens: 1,
+        occurredAt: run?.finishedAt,
+        channelId: null,
       });
     } finally {
       rmSync(dir, { recursive: true, force: true });

--- a/src/workflows/executor.ts
+++ b/src/workflows/executor.ts
@@ -4,6 +4,13 @@ import type { WebClient } from "@slack/web-api";
 import type { Config, RepoConfig } from "../config.ts";
 import { spawnRunner } from "../runners/index.ts";
 import type { RunnerEvent, SpawnHandle, SpawnRunnerFn } from "../runners/types.ts";
+import {
+  normalizeRunnerUsage,
+  type NormalizedUsage,
+  type UsageMeta,
+} from "../usage/normalize.ts";
+import { mergeNormalizedUsage } from "../usage/merge.ts";
+import type { UsageStore } from "../usage/store/interface.ts";
 import { createSession, type ImplementedRunnerProvider } from "../session/types.ts";
 import { withTimeout } from "../lifecycle/timeout.ts";
 import { log } from "../logger.ts";
@@ -61,6 +68,7 @@ export interface WorkflowExecutorOptions {
     resolvePeople?: PeopleResolver;
   };
   slackArchiveMaintenance?: () => Promise<SlackArchiveMaintenanceReport>;
+  usageStore?: UsageStore;
 }
 
 export interface WorkflowRunRequest {
@@ -91,6 +99,7 @@ export class WorkflowExecutor {
   private memoryStore?: MemoryStore;
   private consolidationDeps?: WorkflowExecutorOptions["consolidationDeps"];
   private slackArchiveMaintenance?: WorkflowExecutorOptions["slackArchiveMaintenance"];
+  private usageStore?: UsageStore;
   private activeHandles = new Set<SpawnHandle>();
 
   constructor(options: WorkflowExecutorOptions) {
@@ -102,6 +111,7 @@ export class WorkflowExecutor {
     this.memoryStore = options.memoryStore;
     this.consolidationDeps = options.consolidationDeps;
     this.slackArchiveMaintenance = options.slackArchiveMaintenance;
+    this.usageStore = options.usageStore;
   }
 
   async run(request: WorkflowRunRequest): Promise<WorkflowRunResult> {
@@ -138,6 +148,11 @@ export class WorkflowExecutor {
         const nativeResult = await this.runNativeHandler(request.definition.nativeHandler);
         summary = nativeResult.summary;
         run.status = nativeResult.status;
+        await this.persistNativeWorkflowUsage(
+          request.definition,
+          run,
+          request.definition.nativeHandler,
+        );
       } else if (request.definition.runner) {
         summary = await this.runWithRunner(
           request.definition,
@@ -237,14 +252,25 @@ export class WorkflowExecutor {
       "Junior will write your final response to configured docs outputs and post it to configured Slack outputs.",
     ].join("\n\n");
 
-    return await this.runWorkflowRunnerAttempts({
-      definition,
-      run,
-      runner,
-      provider,
-      session,
-      initialPrompt: prompt,
-    });
+    const collectedEvents: RunnerEvent[] = [];
+    try {
+      return await this.runWorkflowRunnerAttempts({
+        definition,
+        run,
+        runner,
+        provider,
+        session,
+        initialPrompt: prompt,
+        collectedEvents,
+      });
+    } finally {
+      await this.persistRunnerWorkflowUsage({
+        definition,
+        run,
+        provider,
+        events: collectedEvents,
+      });
+    }
   }
 
   private async runWorkflowRunnerAttempts(options: {
@@ -254,6 +280,7 @@ export class WorkflowExecutor {
     provider: ImplementedRunnerProvider;
     session: ReturnType<typeof createSession>;
     initialPrompt: string;
+    collectedEvents: RunnerEvent[];
   }): Promise<string> {
     const idleResumeEnabled = this.idleResumeEnabled(options.provider);
     const maxIdleInterrupts = options.runner.idleTimeoutMs && idleResumeEnabled
@@ -268,6 +295,7 @@ export class WorkflowExecutor {
         prompt,
         idleResumeEnabled,
       });
+      options.collectedEvents.push(...attempt.result.events);
       if (attempt.result.sessionId) {
         options.session.sessionId = attempt.result.sessionId;
       }
@@ -376,6 +404,84 @@ export class WorkflowExecutor {
       this.activeHandles.delete(handle);
     });
     return { result, idleInterrupted };
+  }
+
+  private workflowUsageMeta(
+    definition: WorkflowDefinition,
+    run: WorkflowRun,
+    provider: string | null,
+  ): UsageMeta {
+    return {
+      sourceKind: "workflow-run",
+      sourceId: run.id,
+      threadId: null,
+      channelId: run.slackChannel,
+      agentName: definition.runner?.agentName ?? null,
+      provider,
+      providerSessionId: run.providerSessionId,
+      pipelineRunId: null,
+      assignmentId: null,
+      workflowName: definition.name,
+      workflowRunId: run.id,
+      occurredAt: run.finishedAt ?? run.startedAt,
+    };
+  }
+
+  private async persistNativeWorkflowUsage(
+    definition: WorkflowDefinition,
+    run: WorkflowRun,
+    nativeHandler: WorkflowNativeHandler,
+  ): Promise<void> {
+    if (!this.usageStore) return;
+    const usage = normalizeRunnerUsage(
+      undefined,
+      this.workflowUsageMeta(definition, run, null),
+    );
+    usage.raw = { nativeHandler };
+    usage.inputTokens = 0;
+    usage.outputTokens = 0;
+    usage.cacheReadTokens = 0;
+    usage.cacheWriteTokens = 0;
+    usage.totalTokens = 0;
+    await this.writeWorkflowUsage(definition, run, usage);
+  }
+
+  private async persistRunnerWorkflowUsage(input: {
+    definition: WorkflowDefinition;
+    run: WorkflowRun;
+    provider: ImplementedRunnerProvider;
+    events: RunnerEvent[];
+  }): Promise<void> {
+    if (!this.usageStore) return;
+    const meta = this.workflowUsageMeta(
+      input.definition,
+      input.run,
+      input.provider,
+    );
+    const usage = usageFromDoneEvents(input.events, meta);
+    if (!usage.raw || Object.keys(usage.raw).length === 0) {
+      log.info(
+        "spend",
+        `spend.missing provider=${input.provider} workflow=${input.definition.name} run=${input.run.id}`,
+      );
+    }
+    await this.writeWorkflowUsage(input.definition, input.run, usage);
+  }
+
+  private async writeWorkflowUsage(
+    definition: WorkflowDefinition,
+    run: WorkflowRun,
+    usage: NormalizedUsage,
+  ): Promise<void> {
+    if (!this.usageStore) return;
+    try {
+      await this.usageStore.add(usage);
+    } catch (err) {
+      log.warn(
+        "spend",
+        `spend.persist.fail workflow=${definition.name} run=${run.id}: ${formatError(err)}`,
+      );
+    }
   }
 
   private idleResumeEnabled(provider: ImplementedRunnerProvider): boolean {
@@ -748,4 +854,26 @@ function logWorkflowRunnerEvent(
 
 function formatError(err: unknown): string {
   return err instanceof Error ? err.message : String(err);
+}
+
+function usageFromDoneEvents(
+  events: RunnerEvent[],
+  meta: UsageMeta,
+): NormalizedUsage {
+  const dones = events.filter((event) => event.type === "done");
+  if (dones.length === 0) return normalizeRunnerUsage(undefined, meta);
+  let acc = normalizeRunnerUsage(dones[0]!.usage, {
+    ...meta,
+    provider: dones[0]!.provider ?? meta.provider,
+  });
+  for (const done of dones.slice(1)) {
+    acc = mergeNormalizedUsage(
+      acc,
+      normalizeRunnerUsage(done.usage, {
+        ...meta,
+        provider: done.provider ?? meta.provider,
+      }),
+    );
+  }
+  return acc;
 }

--- a/src/workflows/executor.ts
+++ b/src/workflows/executor.ts
@@ -143,17 +143,20 @@ export class WorkflowExecutor {
     await this.store.createRun(run);
 
     let summary = "";
+    let nativeHandlerName: WorkflowNativeHandler | null = null;
+    let runnerProvider: ImplementedRunnerProvider | null = null;
+    const runnerEvents: RunnerEvent[] = [];
     try {
       if (request.definition.nativeHandler) {
         const nativeResult = await this.runNativeHandler(request.definition.nativeHandler);
         summary = nativeResult.summary;
         run.status = nativeResult.status;
-        await this.persistNativeWorkflowUsage(
-          request.definition,
-          run,
-          request.definition.nativeHandler,
-        );
+        nativeHandlerName = request.definition.nativeHandler;
       } else if (request.definition.runner) {
+        const runner = request.definition.runner;
+        runnerProvider = runner.provider === "default"
+          ? this.config.runner.provider
+          : runner.provider;
         summary = await this.runWithRunner(
           request.definition,
           run,
@@ -168,6 +171,7 @@ export class WorkflowExecutor {
             triggerContext: request.triggerContext ?? null,
             instructions,
           }),
+          runnerEvents,
         );
       } else {
         summary = request.definition.prompt.trim() ||
@@ -205,6 +209,21 @@ export class WorkflowExecutor {
       await this.store.updateRun(run);
       await this.updateStateAfterRun(request.definition, run);
       throw err;
+    } finally {
+      if (nativeHandlerName) {
+        await this.persistNativeWorkflowUsage(
+          request.definition,
+          run,
+          nativeHandlerName,
+        );
+      } else if (runnerProvider) {
+        await this.persistRunnerWorkflowUsage({
+          definition: request.definition,
+          run,
+          provider: runnerProvider,
+          events: runnerEvents,
+        });
+      }
     }
   }
 
@@ -228,6 +247,7 @@ export class WorkflowExecutor {
     definition: WorkflowDefinition,
     run: WorkflowRun,
     prompt: string,
+    collectedEvents: RunnerEvent[],
   ): Promise<string> {
     const runner = definition.runner;
     if (!runner) throw new Error(`Workflow ${definition.name} has no runner`);
@@ -252,25 +272,15 @@ export class WorkflowExecutor {
       "Junior will write your final response to configured docs outputs and post it to configured Slack outputs.",
     ].join("\n\n");
 
-    const collectedEvents: RunnerEvent[] = [];
-    try {
-      return await this.runWorkflowRunnerAttempts({
-        definition,
-        run,
-        runner,
-        provider,
-        session,
-        initialPrompt: prompt,
-        collectedEvents,
-      });
-    } finally {
-      await this.persistRunnerWorkflowUsage({
-        definition,
-        run,
-        provider,
-        events: collectedEvents,
-      });
-    }
+    return await this.runWorkflowRunnerAttempts({
+      definition,
+      run,
+      runner,
+      provider,
+      session,
+      initialPrompt: prompt,
+      collectedEvents,
+    });
   }
 
   private async runWorkflowRunnerAttempts(options: {


### PR DESCRIPTION
Always-on usage ledger and dashboard audit stores. Capture `done` events inside `SessionManager` (quiet-safe) and once from workflow `SpawnResult`. No HTTP routes yet.

Part of execute-plan `06ec4caa` (PR 1/7).