### PR TITLE
feat(dashboard): continue and stop sessions through SessionManager

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,11 @@ indexes, and the source links in those documents.
 - [MCP server](features/mcp-server.md): loopback Slack, agent, memory,
   pipeline, GitHub, MongoDB, and WhatsApp tool surfaces.
 - [Dynamic workflows](features/dynamic-workflows.md): markdown definitions,
-  registry overlays, scheduler, executor, and dashboard state.
+  registry overlays, scheduler, executor, Slack `!workflow`, and dashboard
+  enqueue/create/edit.
+- [HTTP dashboard](features/http-dashboard.md): loopback operator console —
+  session continue/stop, pipeline swimlane, spend ledger, runbook viewer,
+  Git-backed workflow writes, and `dashboard_audit`.
 - [Pipeline implementation](features/agent-product-debugging-pipeline-implementation-plan.md):
   typed product/bug runs, assignments, outbox delivery, recovery, and GC.
 - [GitHub reconciliation](code_index/github-reconciliation.md): review-state
@@ -65,13 +69,7 @@ The remaining indexes are listed by module in `docs/code_index/`.
 
 ## Historical and proposal documents
 
-Active proposals (designed, not implemented):
-
-- [Operator dashboard redesign](features/operator-dashboard-redesign.md):
-  continue sessions, pipeline swimlane, spend ledger, Git-backed workflow
-  edits, and a runbook viewer on the localhost console.
-
-The claim dedup write guard, pre-recall synthesis, and task
+The operator dashboard redesign, claim dedup write guard, pre-recall synthesis, and task
 routes all graduated out of this list — they are shipped and listed under
 [current runtime surfaces](#current-runtime-surfaces).
 

--- a/docs/code_index/http-dashboard.md
+++ b/docs/code_index/http-dashboard.md
@@ -1,6 +1,8 @@
 # Code Index: HTTP Dashboard
 
-Localhost-only HTTP server for operator inspection (sessions, dev-servers, workflows, pipelines, logs, docs, profiles, and memory projections). Off by default; enabled via `HTTP_DASHBOARD_PORT`. Binds 127.0.0.1 and intentionally has no auth; do not expose it beyond a trusted local operator environment.
+Localhost-only HTTP server for operator inspection and a bounded write surface (session continue/stop, workflow enqueue/start/stop/reload/create/edit). Off by default; enabled via `HTTP_DASHBOARD_PORT`. Binds 127.0.0.1 and intentionally has no auth; do not expose it beyond a trusted local operator environment. Mutating calls write `dashboard_audit`. Session continue/stop also post to the Slack thread. Workflow mutations post to a Slack output channel only when the definition has one — otherwise git + audit is a weaker trail than Slack `!` commands.
+
+Spend capture (`usage_events`) and audit retention deletes are always-on: they are not gated on `HTTP_DASHBOARD_PORT`.
 
 ## Code Index
 
@@ -8,14 +10,21 @@ Localhost-only HTTP server for operator inspection (sessions, dev-servers, workf
 
 | Symbol | File | Purpose |
 |---|---|---|
-| `startHttpServer(deps)` | `server.ts` | Bun.serve on 127.0.0.1:port; routes API + serves `public/index.html`, `public/js/*`, leftover `public/assets/*` |
+| `startHttpServer(deps)` | `server.ts` | Bun.serve on 127.0.0.1:port; `matchApi` + method 405; serves `public/index.html`, `public/js/*`, leftover `public/assets/*` |
 | `resolvePublicStaticPath(pathname)` | `server.ts` | Resolves `/js/*` and leftover `/assets/*` under `public/`; rejects `..`, `.`, empty segments, and null bytes |
-| `HttpServerDeps` | `server.ts` | `{ store, config, devServerManager, devServerQueue, repos, workflowRegistry, workflowScheduler, workflowStore, memoryStore?, profileStore?, pipelineStore, resolveSlackPermalink?, usageStore, auditStore, runbookCatalog? }` |
+| `matchApi(pathname)` / `allowedMethods(kind)` | `match-api.ts` | Nested session/workflow/pipeline paths; 405 on wrong method |
+| `HttpServerDeps` | `server.ts` | `{ store, config, devServerManager, devServerQueue, repos, workflowRegistry, workflowScheduler, workflowStore, memoryStore?, profileStore?, pipelineStore, resolveSlackPermalink?, sessionManager, slackPoster, usageStore, auditStore, runbookCatalog?, projectRoot? }` |
 | `handleHealth(store, config, startedAt, extras?)` | `routes/health.ts` | `GET /api/health` — uptime, session counts, agent counts, repo list, `pipeline.runtimeMode`, spend/audit today counters |
 | `handleSessions(store, usageStore?)` | `routes/sessions.ts` | `GET /api/sessions` — allowlist projection + numeric pending + spend summary |
 | `handleSessionDetail(store, threadId, resolveSlackPermalink?, usageStore?)` | `routes/sessions.ts` | `GET /api/sessions/:threadId` — same allowlist plus `resumeCwd`, spend, and a best-effort Slack permalink |
+| `handleSessionContinue(req, threadId, deps)` | `routes/sessions.ts` | `POST /api/sessions/:threadId/continue` — attribution Slack post, then `injectDashboardContinue` |
+| `handleSessionStop(threadId, deps)` | `routes/sessions.ts` | `POST /api/sessions/:threadId/stop` — `interruptThread` + `formatStopReply` Slack post |
+| `dashboardActor(config)` / `CONTINUE_PROMPT_MAX` | `routes/sessions.ts` | `ADMIN_SLACK_USER_ID` or `dashboard-operator`; 8000-char prompt cap |
 | `handleDevServers(manager, queue, repos)` | `routes/dev-server.ts` | `GET /api/dev-server` — per-repo state, idle TTL remaining, queue depth |
-| `handleWorkflows(registry, store, scheduler)` | `routes/workflows.ts` | `GET /api/workflows` — definitions, persisted state, recent runs, registry errors, and live scheduler-derived display status |
+| `handleWorkflows(registry, store, scheduler, projectRoot?)` | `routes/workflows.ts` | `GET /api/workflows` — definitions, persisted state, recent runs, registry errors, live `displayStatus`, overlay/junior git probes |
+| `handleWorkflowDetail(name, deps)` | `routes/workflows.ts` | `GET /api/workflows/:name` — on-disk markdown + both hashes + git + last 20 runs |
+| `handleWorkflowRun` / `handleWorkflowStart` / `handleWorkflowStop` / `handleWorkflowReload` | `routes/workflows.ts` | Dashboard mutations; run uses `enqueueManualRun`, not blocking `runNow` |
+| `handleWorkflowCreate` / `handleWorkflowPut` | `routes/workflows.ts` | Git-backed create (201) / edit (200); `?validate=1` dry-run |
 | `handlePipelines(store, params, runId?, options?)` | `routes/pipelines.ts` | `GET /api/pipelines` and `GET /api/pipelines/:runId` — summaries hide default-kind unless `includeDefault=1` or `kind=default`; detail expands leases/outbox/gates |
 | `handlePipelineArtifact(store, runId, params, options?)` | `routes/pipelines.ts` | `GET /api/pipelines/:runId/artifacts?ref=` — relative-to-run-root file read, 256 KiB cap |
 | `handleSpend(store, params)` | `routes/spend.ts` | `GET /api/spend` — usage `groupBy` over a host-local window (max 90 days) |
@@ -27,50 +36,126 @@ Localhost-only HTTP server for operator inspection (sessions, dev-servers, workf
 | `handleMemoryRead(filePath)` | `routes/memory.ts` | `GET /api/memory/:path` — read a doc file (path-traversal guarded) |
 | `handleMemoryRecall(store, params)` | `routes/memory.ts` | `GET /api/memory/recall` — semantic claim recall without recording dashboard usage |
 | `handleMemoryProjection(store, params?)` | `routes/memory.ts` | `GET /api/memory/projection` — 3D PCA + spread + KNN projection for the memory galaxy; memoised per claim set, `?refresh=1` rebuilds |
-| `resumeCmd(provider, sessionId, resumeCwd)` | `public/js/threads.js` | Renders provider-correct Claude, OpenCode, or Codex resume commands from detail `resumeCwd`. |
+| `parseLimit` / `parseTimeBound` / `startOfLocalDay` | `query.ts` | Shared query parsing (host-local day bounds) |
+| `resumeCmd(provider, sessionId, resumeCwd)` | `public/js/threads.js` | Renders provider-correct Claude, OpenCode, or Codex resume commands from detail `resumeCwd`. Continue/stop composer lives in the same module. |
 | `projectClaims(claims, k?, spread?)` | `projection.ts` | PCA to 3D (power iteration + deflation) → separation relaxation → cosine KNN edges |
+
+### src/http/audit
+
+| Symbol | File | Purpose |
+|---|---|---|
+| `DashboardAuditStore` | `audit/interface.ts` | `record` / `list` / `count` / `deleteOlderThan` |
+| `SqliteDashboardAuditStore` | `audit/sqlite.ts` | `dashboard_audit` in `SESSION_DB_PATH` |
+| `InMemoryDashboardAuditStore` | `audit/memory.ts` | Tests / `SESSION_STORE=memory` |
+| `createDashboardAuditStore` | `audit/factory.ts` | memory vs sqlite |
+
+### Supporting control plane (not under `src/http`)
+
+| Symbol | File | Purpose |
+|---|---|---|
+| `injectDashboardContinue` / `interruptThread` | `src/session/manager.ts` | Dedicated inject (returns accepted/buffered/muted) and extracted `!stop` body |
+| `toDashboardSlackEvent` | `src/session/inject.ts` | Attribution inject event; `dashboardContinue: true`; dedupe `dashboard:${threadId}:${postedTs}` |
+| `resolveContinueRoute` | `src/session/continue-route.ts` | `junior`/`default` → top-level default; `lead` → lead; else existing `agentSessions` row |
+| `enqueueManualRun` | `src/workflows/scheduler.ts` | Await durable `persistNewRun`, void `executePersistedRun` |
+| `persistNewRun` / `executePersistedRun` | `src/workflows/executor.ts` | Split so HTTP can 202 only after the run row exists |
+| `writeDashboardWorkflow` / `probeWorkflowRepo` / `preflightGitRepo` | `src/workflows/git-commit.ts` | Scoped commit; refuse detached HEAD / merge / rebase; overlay parent pointer |
+| `pauseReloads` / `resumeReloads` | `src/workflows/registry.ts` | Pause watcher reloads across write+commit |
+| `normalizeRunnerUsage` | `src/usage/normalize.ts` | Provider blobs → one ledger row; Claude `costUsd` only |
+| `sessionTurnSourceId` | `src/usage/source-id.ts` | Unique turn key with specified fallbacks |
+| `UsageStore` | `src/usage/store/*` | Idempotent upsert + sum on `(source_kind, source_id)` |
+| `cleanupOperationalTables` | `src/lifecycle/cleanup.ts` | Delete usage older than 90d, audit older than 180d |
 
 ## Routes
 
 ```
-GET /                       → public/index.html
-GET /api/health             → handleHealth
-GET /api/sessions           → handleSessions
-GET /api/sessions/<id>      → handleSessionDetail
-GET /api/dev-server         → handleDevServers
-GET /api/workflows          → handleWorkflows
-GET /api/pipelines          → handlePipelines (runtimeMode + default-kind hide)
-GET /api/pipelines/<runId>  → handlePipelines (detail)
-GET /api/pipelines/<runId>/artifacts?ref= → handlePipelineArtifact
-GET /api/spend              → handleSpend
-GET /api/runbooks           → handleRunbooks
-GET /api/runbooks/<name>    → handleRunbookDetail
-GET /api/audit              → handleAudit
-GET /api/logs?date=...      → handleLogs
-GET /api/profiles[?kind=…]  → handleProfiles
-GET /api/memory             → handleMemoryList
-GET /api/memory/<path>      → handleMemoryRead
-GET /api/memory/recall      → handleMemoryRecall (503 if unavailable)
-GET /api/memory/projection  → handleMemoryProjection (503 if unavailable)
+GET    /                       → public/index.html
+GET    /api/health             → handleHealth
+GET    /api/sessions           → handleSessions
+GET    /api/sessions/<id>      → handleSessionDetail
+POST   /api/sessions/<id>/continue → handleSessionContinue
+POST   /api/sessions/<id>/stop     → handleSessionStop
+GET    /api/dev-server         → handleDevServers
+GET    /api/workflows          → handleWorkflows
+POST   /api/workflows          → handleWorkflowCreate
+GET    /api/workflows/<name>   → handleWorkflowDetail
+PUT    /api/workflows/<name>   → handleWorkflowPut
+POST   /api/workflows/<name>/run   → handleWorkflowRun (enqueueManualRun)
+POST   /api/workflows/<name>/start → handleWorkflowStart
+POST   /api/workflows/<name>/stop  → handleWorkflowStop
+POST   /api/workflows/reload   → handleWorkflowReload
+GET    /api/pipelines          → handlePipelines (runtimeMode + default-kind hide)
+GET    /api/pipelines/<runId>  → handlePipelines (detail)
+GET    /api/pipelines/<runId>/artifacts?ref= → handlePipelineArtifact
+GET    /api/spend              → handleSpend
+GET    /api/runbooks           → handleRunbooks
+GET    /api/runbooks/<name>    → handleRunbookDetail
+GET    /api/audit              → handleAudit
+GET    /api/logs?date=...      → handleLogs
+GET    /api/profiles[?kind=…]  → handleProfiles
+GET    /api/memory             → handleMemoryList
+GET    /api/memory/<path>      → handleMemoryRead
+GET    /api/memory/recall      → handleMemoryRecall (503 if unavailable)
+GET    /api/memory/projection  → handleMemoryProjection (503 if unavailable)
     ?refresh=1                force a rebuild instead of the memoised result
-GET /js/*                  → public/js/* (text/javascript, Cache-Control: no-cache)
-GET /assets/*              → leftover public/assets/* (same headers; three.* and pipeline-worker stay dedicated)
-GET /assets/three.module.js → locally served pinned Three.js module
-GET /assets/three.core.min.js → locally served pinned Three.js core module
-GET /assets/pipeline-worker.js → locally served pipeline worker
+GET    /js/*                   → public/js/* (text/javascript, Cache-Control: no-cache)
+GET    /assets/*               → leftover public/assets/* (same headers; three.* and pipeline-worker stay dedicated)
+GET    /assets/three.module.js → locally served pinned Three.js module
+GET    /assets/three.core.min.js → locally served pinned Three.js core module
+GET    /assets/pipeline-worker.js → locally served pipeline worker
 ```
+
+Wrong method on a known `/api/*` path → 405 `{ error: "method not allowed" }`.
+
+## Frontend modules (`public/js/`)
+
+| File | Role |
+|---|---|
+| `api.js` | `safeFetch`, poll, error toast |
+| `app.js` | hash router, nav, overview |
+| `threads.js` | list, drawer, continue/stop, `resumeCmd` |
+| `pipelines.js` | list + **swimlane default** + Topology toggle |
+| `pipeline-layout.js` | swimlane/tape geometry helpers |
+| `workflows.js` | list, markdown editor, run, git status, create |
+| `runbooks.js` | list + viewer |
+| `spend.js` | KPI + `groupBy` table (no canvas chart) |
+| `audit.js` | audit table |
+| `markdown.js` | shared markdown renderer |
+| `galaxy.js` | Three.js memory scene |
+
+`pipelineViewMode` defaults to `"swimlane"`. 3D topology is opt-in.
 
 ## Key Concepts
 
 ### Loopback-only threat model
 
-Binds `127.0.0.1`. No CORS headers — same-origin from `public/index.html`. Don't expose this port. No auth. The internal MCP server is a separate loopback-only service.
+Binds `127.0.0.1`. No CORS headers — same-origin from `public/index.html`. Don't expose this port. No auth. Writes raise the cost of a compromised localhost tab; compensating controls are `dashboard_audit`, Slack posts for continue/stop, and optional Slack one-liners for workflows that declare an output channel. The internal MCP server is a separate loopback-only service.
+
+### Session allowlist
+
+List and detail share `projectSession`. Explicitly **omit**: `worktreePath`, `worktreePaths`, `cwd`, thread and per-agent `pid`, `systemPrompt`, `slackIdentity`, pending bodies, `activeTurnInput`, `activeTurnAuthor`, `activePipelineInvocation`, assignment capability envelopes. Detail-only: `resumeCwd`, `slackPermalink`. `pendingMessages` is a number.
+
+### Continue / stop
+
+Attribution Slack body is `*Dashboard continue*` plus a `>`-quoted preview so `containsDispatchDirective` cannot match. Event API also drops texts that start with `*Dashboard continue*`. Inject uses `dashboardContinue: true` to skip default-run hijack and short-followup. Stop reuses `interruptThread`; it does not invent a second kill path.
+
+### Workflow enqueue vs `runNow`
+
+`runNow` awaits the whole executor (Slack `!workflow run`). `enqueueManualRun` awaits only `persistNewRun`, then backgrounds `executePersistedRun` with `.then(schedule)` / `.catch` (failed-run status) / `.finally(releaseRun)`. HTTP 202 only after `store.getRun(runId)` would succeed. Skip-concurrency already-running is 200 `{ status: "skipped", runId: "" }`.
+
+### Git detached-HEAD and overlay parent pointer
+
+`writeDashboardWorkflow` / `preflightGitRepo` refuse detached HEAD, merge, rebase, and unresolved conflicts. Overlay writes preflight Junior as well, then after a successful `agents-org` commit do `git add -- agents-org` only on Junior. Parent-pointer failure does not roll back the overlay commit. Registry reloads are paused across the critical section.
+
+### Spend and audit retention
+
+`usage_events` 90 days, `dashboard_audit` 180 days, both swept by `cleanupOperationalTables` from the existing cleanup interval and `bun run cleanup`. Capture is inside `SessionManager` (session turns, including quiet) and once per workflow run from `SpawnResult`.
 
 ### Path traversal guards
 
 - Logs: `date` must match `^\d{4}-\d{2}-\d{2}$` exactly.
 - Memory: rejects `..` and absolute paths; verifies resolved path stays inside `docs/`.
 - Dashboard JS/assets: `resolvePublicStaticPath` rejects empty/`.`/`..` segments and null bytes, then requires the resolved path stay inside `public/`.
+- Pipeline artifacts: `ref` is relative to `data/pipelines/<runId>/`; absolute paths, `..`, and strings that start with `data/pipelines/` are 400. Assignment-registered alternate roots are not readable (`resolvePipelineArtifactPath` is called without an assignment).
 
 ### Memory galaxy projection
 
@@ -99,9 +184,9 @@ overlays on that single graph scene.
 
 ### Boot wiring
 
-`index.ts` dynamic-imports `./http/server.ts` inside a try/catch — a port conflict on dashboard must not crash the bot.
+`index.ts` dynamic-imports `./http/server.ts` inside a try/catch — a port conflict on dashboard must not crash the bot. `UsageStore` and `DashboardAuditStore` are constructed next to the session/workflow sqlite path regardless of whether the dashboard port is set.
 
 ## Dependencies
 
-- **Uses**: `Bun.serve`, `SessionStore`, `DevServerManager`, `DevServerQueue`, `WorkflowRegistry`, `WorkflowScheduler`, `WorkflowStore`, `PipelineStore`, `UsageStore`, `DashboardAuditStore`, optional `MemoryStore`, `ProfileStore`, and runbook `CatalogStore`, optional Slack permalink resolver, `RepoConfig`, `logger`
-- **Used by**: `src/index.ts` (gated on `config.http.enabled`)
+- **Uses**: `Bun.serve`, `SessionStore`, `SessionManager` (`injectDashboardContinue`, `interruptThread`, `isAdmin`, `isExplicitAdmin`, `getSession`), Slack poster, `DevServerManager`, `DevServerQueue`, `WorkflowRegistry`, `WorkflowScheduler`, `WorkflowStore`, `PipelineStore`, `UsageStore`, `DashboardAuditStore`, optional `MemoryStore`, `ProfileStore`, and runbook `CatalogStore`, optional Slack permalink resolver, `RepoConfig`, `logger`
+- **Used by**: `src/index.ts` (gated on `config.http.enabled` for the listener; usage/audit stores are always constructed)

--- a/docs/code_index/pipelines.md
+++ b/docs/code_index/pipelines.md
@@ -14,7 +14,9 @@ disabled by default (`PIPELINE_RUNTIME_MODE=off`) and can run in `shadow` or
 | Persistence | `src/pipelines/store/*` | Memory and SQLite stores, versioned writes, and transactional outcome handling. |
 | Reliability | `src/pipelines/outbox.ts`, `recovery.ts`, `settlement-recovery` paths | At-least-once outbox delivery, lease recovery, and settlement repair. |
 | Outcomes | `src/pipelines/outcomes.ts`, `revision.ts`, `artifacts.ts` | Idempotent agent outcomes, revisions, artifacts, and handoffs. |
-| Projection and cleanup | `src/pipelines/projection.ts`, `src/pipelines/gc.ts` | Dashboard projections and retention cleanup. |
+| Slack/`!status` summary | `src/pipelines/projection.ts` | Human-readable `projectRunSummary` for Slack status. Not the dashboard HTTP projector. |
+| Dashboard operator projection | `src/http/routes/pipelines.ts` | List + detail + artifact read. Hides `kind=default` unless `includeDefault=1` or `kind=default`. Detail expands leases, full-run outbox (payload stripped), attempt-scoped gates, GitHub resources, dev-server jobs, artifact refs. |
+| Retention cleanup | `src/pipelines/gc.ts` | Pipeline retention GC (`PIPELINE_RETENTION_DAYS`). |
 | Legacy bridge | `src/pipelines/legacy-directives.ts`, `src/support/pipeline-guard.ts` | Safely maps selected legacy directives while preserving existing routing. |
 | MCP tools | `src/pipelines/tools.ts` | Runner-facing pipeline read/write tools with scope and idempotency checks. |
 
@@ -32,6 +34,13 @@ consumers and outcome writes must remain idempotent; version/CAS checks prevent
 stale workers from overwriting newer state. Retention is controlled by
 `PIPELINE_RETENTION_DAYS`.
 
-See [the implementation plan](../features/agent-product-debugging-pipeline-implementation-plan.md)
-for design history and [GitHub reconciliation](github-reconciliation.md) for
+The localhost dashboard default is an assignment **swimlane + phase tape**
+(`public/js/pipelines.js`, `pipelineViewMode = "swimlane"`). The older 3D
+topology graph stays behind a Topology toggle and still uses
+`public/pipeline-worker.js`. There are no pipeline writes from the dashboard
+(no force-transition, no outbox replay); those stay in Slack / MCP.
+
+See [the HTTP index](http-dashboard.md) for the operator routes,
+[the implementation plan](../features/agent-product-debugging-pipeline-implementation-plan.md)
+for design history, and [GitHub reconciliation](github-reconciliation.md) for
 the external review boundary.

--- a/docs/code_index/workflows.md
+++ b/docs/code_index/workflows.md
@@ -2,16 +2,21 @@
 
 Dynamic workflows are markdown-defined, typed runs scheduled and executed by
 Junior. Definitions are data; the runtime owns validation, scheduling,
-execution, persistence, and dashboard projection.
+execution, persistence, and dashboard projection. The localhost dashboard can
+also enqueue, start, stop, reload, create, and edit workflows; see
+[the HTTP index](http-dashboard.md).
 
 ## Sources
 
 | Symbol/area | File | Purpose |
 |---|---|---|
-| `WorkflowRegistry` | `src/workflows/registry.ts` | Loads definitions, applies overlay precedence, and watches for changes. |
-| Definition parser | `src/workflows/definition.ts` | Parses and validates frontmatter/body workflow definitions. |
+| `WorkflowRegistry` | `src/workflows/registry.ts` | Loads definitions, applies overlay precedence, and watches for changes. `pauseReloads` / `resumeReloads` wrap dashboard git writes so the 350 ms watcher cannot load uncommitted bytes. |
+| Definition parser | `src/workflows/definition.ts` | Parses and validates frontmatter/body workflow definitions. `WORKFLOW_NAME_RE` is the HTTP name guard. |
 | `WorkflowScheduler` | `src/workflows/scheduler.ts` | Computes due work, persists scheduler state, and tracks live per-workflow run counts for operator projections. |
-| `WorkflowExecutor` | `src/workflows/executor.ts` | Runs a validated workflow step through the configured runner boundary. |
+| `runNow` | `src/workflows/scheduler.ts` | Blocking manual/scheduled entry. Slack `!workflow run` still uses this. |
+| `enqueueManualRun` | `src/workflows/scheduler.ts` | Dashboard fire-and-forget: await `persistNewRun`, void `executePersistedRun` with `.then(schedule)` / `.catch` (failed-run status) / `.finally(releaseRun)`. Returns `{ status: "started", runId }` or `{ status: "skipped", runId: "" }`. |
+| `persistNewRun` / `executePersistedRun` | `src/workflows/executor.ts` | Split so HTTP can 202 only after the `workflow_runs` row is durable. `run()` still does persist then execute. Persists usage once from `SpawnResult` (or a zero-token native-handler row). |
+| `writeDashboardWorkflow` / `preflightGitRepo` / `probeWorkflowRepo` | `src/workflows/git-commit.ts` | Scoped `git add -- <path>` + isolated identity commit. Refuses detached HEAD, merge, rebase, conflicts. Overlay: preflight Junior, then parent-pointer `git add -- agents-org` only; parent failure does not roll back the overlay. No push. |
 | Controller | `src/workflows/controller.ts` | Coordinates registry, scheduler, executor, and store. |
 | Store | `src/workflows/store.ts` | Persists workflow state and run history; definitions remain file-backed in the registry. |
 | Types | `src/workflows/types.ts` | Workflow definition, trigger/output, state, run, and execution contracts. |
@@ -33,8 +38,18 @@ Private overlay definitions may be loaded from `agents-org/workflows/` when
 that directory exists. Overlay precedence and file-watch reload behavior are
 implemented in the registry, not in individual workflow files.
 
-The localhost dashboard exposes workflow state at `/api/workflows`; see
-[the HTTP index](http-dashboard.md). Its `displayStatus` uses the scheduler's
-live run count rather than persisted `running` history, which may be stale after
-a hard restart. Workflow utility runs with an explicit cwd intentionally do not
-inherit Junior's project MCP wiring.
+The localhost dashboard exposes workflow state at `/api/workflows` and mutations
+at `/api/workflows` (POST create), `/api/workflows/:name` (PUT edit, `?validate=1`
+dry-run), `/api/workflows/:name/run|start|stop`, and `/api/workflows/reload`.
+`displayStatus` uses the scheduler's live run count rather than persisted
+`running` history, which may be stale after a hard restart. Dashboard **run**
+calls `enqueueManualRun`, not blocking `runNow`. Create/edit refuse detached
+HEAD and pause registry reloads around the commit.
+
+Workflow mutations write `dashboard_audit`. They post a one-liner to a
+definition Slack output channel when one exists; **without that channel the
+trail is weaker than Slack `!` commands** (git + audit only). Actor is
+`ADMIN_SLACK_USER_ID` or `dashboard-operator`.
+
+Workflow utility runs with an explicit cwd intentionally do not inherit Junior's
+project MCP wiring.

--- a/docs/features/dynamic-workflows.md
+++ b/docs/features/dynamic-workflows.md
@@ -1,13 +1,13 @@
 # Dynamic Workflows
 
-> **Current status (2026-08-15):** Shipped. The registry, SQLite state/run store, hot reload, scheduler, Slack commands, and localhost dashboard endpoint are live. Current definitions include `worklog`, `release-notes`, `memory-consolidation`, `memory-dedup-sweep`, `slack-archive-maintenance`, and `worktree-prune`; private overlays may add or override definitions. `slack-archive-maintenance` is a native deterministic handler, not an agent-run workflow.
+> **Current status (2026-08-15):** Shipped. The registry, SQLite state/run store, hot reload, scheduler, Slack commands, and localhost dashboard (read + enqueue/start/stop/reload + Git-backed create/edit) are live. Current definitions include `worklog`, `release-notes`, `memory-consolidation`, `memory-dedup-sweep`, `slack-archive-maintenance`, and `worktree-prune`; private overlays may add or override definitions. `slack-archive-maintenance` is a native deterministic handler, not an agent-run workflow.
 
 ## Problem
 
 Junior needs recurring and on-demand workflows that can be added without restarting the bot. The first workflow is a daily worklog: collect my PRs and commits, turn them into grouped "things I did", store a markdown artifact, and post a Slack summary.
 
 **Who has this problem:** Junior operators who need repeatable automation.
-**What happens today:** Workflow definitions are discovered from `workflows/` and `agents-org/workflows/`, reloaded on file changes, persisted in SQLite, and controllable through `!workflow` / `!workflows`. The dashboard exposes the same state at `GET /api/workflows`.
+**What happens today:** Workflow definitions are discovered from `workflows/` and `agents-org/workflows/`, reloaded on file changes, persisted in SQLite, and controllable through `!workflow` / `!workflows` and the localhost dashboard. Slack `!workflow run` still awaits blocking `runNow`. The dashboard calls `enqueueManualRun` (durable `persistNewRun`, then background `executePersistedRun`) so a long worklog does not hold the HTTP request. Create/edit write `*.workflow.md` and commit on a named branch (detached HEAD refused); overlay writes also try a Junior submodule-pointer commit.
 **Painful part:** Every new cron-like behavior currently risks becoming a code deploy.
 **"Finally" moment:** Add or edit `workflows/worklog.workflow.md`; Junior reloads it, schedules it, and owners can `!workflow run worklog` or `!workflow stop worklog` from Slack.
 
@@ -203,6 +203,8 @@ Admin-only commands:
 
 Authorization uses existing Junior admins plus `ownerSlackUserIds` from the workflow file. Non-authorized mutating commands are rejected with a reaction and no workflow run.
 
+The dashboard uses the same `canManage` / admin checks with actor `ADMIN_SLACK_USER_ID` or `dashboard-operator`. Create/edit/reload require admin (open-mode still allows them, matching Slack). Dashboard run/start/stop/reload/create/edit write `dashboard_audit`. If the definition has a `slack` or `slack-thread` output, the dashboard also posts a one-liner there. **If it has none, git + `dashboard_audit` is a weaker trail than Slack `!` commands** — accepted for the no-auth loopback console, not Slack-parity. Continue/stop on sessions remain full Slack-thread records; see [http-dashboard.md](http-dashboard.md).
+
 ## Hot Reload
 
 Junior uses `fs.watch` on both fixed workflow roots. Watch events are debounced and followed by a full rescan of each root because file watchers can coalesce, duplicate, or miss exact filenames across platforms.
@@ -278,13 +280,14 @@ This is a CLI fallback, not OpenCode's native server interrupt. The implemented 
 
 ## Cut List
 
-- Interactive workflow creation from Slack.
+- Interactive workflow creation from Slack (the dashboard can already create/edit Git-backed files).
 - Multi-step workflow DAGs.
-- Retrying failed workflow runs.
+- Retrying failed workflow runs from the UI.
 - Per-output templates.
 - Workflow-specific secrets.
-- A UI for workflow states and history.
+- Automatic `git push` / PR after a dashboard create or edit. Commits stay local and unpushed. Detached HEAD, merge, and rebase are refused; overlay writes also commit the Junior `agents-org` pointer (`git add -- agents-org` only) and report — without rolling back the overlay — if that parent commit fails.
+- Slack-parity conversation-of-record for dashboard workflow writes that have no Slack output channel. Today those leave only git + `dashboard_audit`.
 
-The localhost dashboard already exposes workflow definitions, state, recent runs,
-and registry errors through `GET /api/workflows`; a richer interactive UI remains
-out of scope.
+The localhost dashboard lists definitions, state, recent runs, and registry
+errors, and can enqueue (`enqueueManualRun`), start, stop, reload, create, and
+edit workflows. See [http-dashboard.md](http-dashboard.md).

--- a/docs/features/http-dashboard.md
+++ b/docs/features/http-dashboard.md
@@ -2,65 +2,197 @@
 
 ## Problem
 
-Operators running junior on a server have no live view of what's happening: which threads are active, which agents are busy, which dev-servers are running and on what branch, what the recent logs look like. The Slack home tab covers thread-list use cases but doesn't surface dev-server queue state, structured logs, or per-agent run state.
+Operators running junior on a server have no live view of what's happening: which threads are active, which agents are busy, which pipeline holds a lease, what today cost, which workflow is running, and what the recent logs look like. The Slack home tab covers thread-list use cases but does not surface spend, pipeline leases/gates, runbooks, or dashboard-originated mutations.
 
 **Who has this problem:** The operator (Pranav, mostly) tailing logs and `ps`ing for stuck processes.
-**What happens today:** SSH + `tail -f logs/<date>.log` + `sqlite3 data/sessions.db`.
-**"Finally" moment:** Open `http://127.0.0.1:<port>` on the host, see sessions / dev-servers / logs / docs in one page.
+**What happens today:** Open `http://127.0.0.1:<port>` on the host. The console lists sessions, continues or stops a thread, inspects pipelines, queries spend, triggers or edits Git-backed workflows, and browses runbooks and the audit log.
+**"Finally" moment:** Continue a stuck thread, see who holds a pipeline lease, and check today's tokens without SSH + sqlite3.
+
+This page documents the shipped operator console. The design record is [operator-dashboard-redesign.md](operator-dashboard-redesign.md).
 
 ## Shape
 
 ```
 src/http/
-├── server.ts              -- Bun.serve, route table, single fetch handler
+├── server.ts              -- Bun.serve, matchApi route table, /js/* + /assets/*
+├── match-api.ts           -- pathname + method matching; 405 on mismatch
+├── query.ts               -- shared limit / host-local day / time-bound parsers
 ├── projection.ts          -- 3D PCA + spread + KNN for the memory galaxy
+├── audit/                 -- DashboardAuditStore (memory + sqlite + factory)
 └── routes/
-    ├── health.ts          -- uptime + session/agent counters
-    ├── sessions.ts        -- list + per-thread detail
+    ├── health.ts          -- uptime, session/agent counters, spend/audit today
+    ├── sessions.ts        -- allowlist list/detail + continue/stop
     ├── dev-server.ts      -- DevServerManager + DevServerQueue state
     ├── logs.ts            -- tail logs/<date>.log with tag/level filters
     ├── profiles.ts        -- read-only person/repo/project/situation browser
-    ├── pipelines.ts       -- read-only product/bug pipeline run + assignment views
+    ├── pipelines.ts       -- operator projection + relative artifact reads
+    ├── workflows.ts       -- list/detail + enqueue/start/stop/reload + create/edit
+    ├── spend.ts           -- usage groupBy over a host-local window
+    ├── runbooks.ts        -- registry + catalog + metrics (view only)
+    ├── audit.ts           -- newest-first dashboard_audit rows
     └── memory.ts          -- docs browser + claim recall + galaxy projection
+
+src/usage/                 -- always-on spend ledger (not gated on the dashboard port)
+src/workflows/git-commit.ts
+public/
+├── index.html             -- shell, CSS, nav, view mounts
+├── pipeline-worker.js     -- 3D topology layout worker
+└── js/                    -- same-origin modules (no bundler)
 ```
 
-Bun-native: no router framework, no auth, no CORS. Static `public/index.html` is served at `/` from the same origin as the API, so cross-origin access has no reason to exist.
+Bun-native: no router framework, no auth, no CORS. Static `public/index.html` plus `public/js/*` are served from the same origin as the API.
 
 Junior is intentionally insecure as a networked product. The dashboard assumes a trusted local operator and host-level access control; exposing it beyond loopback requires adding authentication, authorization, and a real security review.
 
 ## Security posture
 
-- **Loopback-only.** Binds `127.0.0.1` — never reachable off-host without an explicit SSH tunnel. This is the entire threat model; there is intentionally no auth layer behind it.
+- **Loopback-only.** Binds `127.0.0.1` — never reachable off-host without an explicit SSH tunnel. This is the entire threat model; there is intentionally no auth layer behind it. Do not tunnel the port without adding auth.
+- **Writes are in scope.** Continue, stop, workflow run/start/stop/reload, and Git-backed create/edit are first-class. They do not invent a second control plane: they call `SessionManager` / `WorkflowScheduler` / the git helper the Slack path already uses.
+- **Audit is required, Slack-parity is not.** Every mutating call writes `dashboard_audit`. Session continue/stop also post to the Slack thread (conversation of record). Workflow mutations post a one-liner to a `slack` / `slack-thread` output **when the definition has one**. Workflows without an output channel leave only git + `dashboard_audit` — **weaker than Slack `!` commands**, accepted for a no-auth loopback console, and must not be documented as Slack-parity.
+- **Actor is loopback identity.** `ADMIN_SLACK_USER_ID` when set, else `dashboard-operator`. Fail closed when the `admins` table is non-empty but the env admin is unset. Open-mode (neither tier configured) matches Slack open-mode.
 - **Profiles are private operator data.** `/api/profiles` can include derived context about real people. It is available only inside the same loopback-only console and must not be exposed through a public bind or permissive CORS.
 - **Same-origin.** Dashboard HTML is served by the same Bun process. No CORS headers — adding `Access-Control-Allow-Origin: *` would only let arbitrary websites the operator visits read this server's data.
-- **Path-traversal rejection at the input layer.** `/api/logs?date=` accepts only `YYYY-MM-DD` (strict regex); `/api/memory/<path>` rejects `..` and absolute paths and verifies the resolved path stays inside `docs/`. Reject early, don't sanitize after concatenation.
-- **Projection on `/api/sessions`.** Filesystem paths (`worktreePath`, `cwd`), PIDs (`pid`), prompt-engineering details (`systemPrompt`), and `slackIdentity` are stripped before serialization. `pendingMessages` is reduced to a length count — message bodies never leave the box.
-- **Provider-aware resume commands.** Session and agent cards use the CLI that owns the session: `claude --resume`, `opencode --session`, or `codex resume`. Codex app-server IDs are never presented as OpenCode commands.
+- **Path-traversal rejection at the input layer.** `/api/logs?date=` accepts only `YYYY-MM-DD`; `/api/memory/<path>` rejects `..` and absolute paths and verifies the resolved path stays inside `docs/`. Pipeline artifact `ref` is relative to `data/pipelines/<runId>/` only. Workflow/runbook names must match `^[a-z0-9][a-z0-9-]*$`. Reject early, don't sanitize after concatenation.
+- **Allowlist projection on `/api/sessions`.** Filesystem paths (`worktreePath`, `cwd`) stay off the list. Detail-only `resumeCwd` is the one path the resume CLI needs. PIDs, `systemPrompt`, `slackIdentity`, pending bodies, `activeTurnInput`, and assignment capability envelopes never leave the box. `pendingMessages` is a length.
+
+## Write contract
+
+Dashboard writes keep the loopback threat model. They do **not** stay read-only so Slack can be the only audit trail. Compensation, by action:
+
+| Action | Slack conversation of record | Other trail |
+|---|---|---|
+| `session.continue` | Attribution-only post in the thread (no raw `!` lines) | `dashboard_audit` + `injectDashboardContinue` |
+| `session.stop` | Same “Interrupted (N agents)” / “Nothing running.” line `!stop` posts | `dashboard_audit` + `slack_ts` |
+| `workflow.run` / `start` / `stop` / `reload` | One-liner to the workflow’s Slack output channel **if present** | `dashboard_audit`; weaker than Slack if no output channel |
+| `workflow.create` / `update` | Same optional one-liner | **git commit** is the reviewable record + `dashboard_audit` |
+
+Pipeline, spend, runbook, profile, memory, log, and docs routes stay read-only. Killing a worktree, evicting a dev-server slot, and `!reset` / `!cancel` stay Slack-only.
+
+### Continue / stop
+
+`POST /api/sessions/:threadId/continue` `{ prompt, agentName? }`:
+
+1. Validate prompt (non-empty, ≤ 8000 chars) and resolve the agent **before** Slack. `"junior"` / `"default"` / missing → top-level `handleMessage`. `"lead"` → `handleLeadMessage`. Any other name must already have an `agentSessions` row; otherwise 400. `"junior"` is never passed to `handleAgentMessage`.
+2. Muted → 409, no Slack post.
+3. Raw `chat.postMessage` of an attribution-only record (`*Dashboard continue* · local operator · …` plus a `>`-quoted 240-char preview). Slack body contains no line matching `^!(\S+)`. Slack failure → 502, **do not inject**.
+4. `SessionManager.injectDashboardContinue` returns `{ accepted | buffered | muted }`. HTTP 202 for accepted/buffered. The Event API also drops posts that start with `*Dashboard continue*` so the echo cannot re-enter. `dashboardContinue` skips `routeDirectTaskThroughDefaultRun` and is ineligible for short-followup interrupt.
+5. Dormant sessions proceed: clear `dormant` and set `needsThreadCatchup` (same as `!listen` / @mention). Do not change `targetRepo` / worktrees.
+
+`POST /api/sessions/:threadId/stop` calls the same `interruptThread` body `!stop` uses (driver interrupt + `handle.kill`, keep the session), then posts `formatStopReply`. Slack post failure is `partial` on the audit row; the interrupt still happened. `!cancel` stays Slack-only.
+
+### Workflow enqueue and Git writes
+
+Slack `!workflow run` still awaits blocking `WorkflowScheduler.runNow`. The dashboard must not: Bun.serve’s idle timeout would kill a worklog-length request.
+
+`POST /api/workflows/:name/run` calls `WorkflowScheduler.enqueueManualRun`:
+
+- Same pre-checks as `runNow` (`enabled`, not `invalid`; `reason` is always `"manual"`, so `stopped` still allows a one-shot).
+- Await `persistNewRun` so the `workflow_runs` row is durable **before** HTTP 202 `{ status: "started", runId }`.
+- `void` only `executePersistedRun`. `schedule` / failed-run status / `releaseRun` hang on that promise, not on the HTTP method.
+- `concurrency === "skip"` and already running → 200 `{ status: "skipped", runId: "" }` after `markSkipped`.
+- `concurrency === "parallel"` may start a second overlapping run (202 after the new row is durable). Native handlers reject `instructions` (400). `enabled: false` is 409.
+
+Create/edit write `*.workflow.md` and make a scoped git commit. Git is the source of authority; SQLite `workflow_states` / `workflow_runs` remain runtime.
+
+| Policy | Behavior |
+|---|---|
+| Named branch only | Refuse detached HEAD (`git rev-parse --abbrev-ref HEAD` is `HEAD` or empty). Overlay also refuses unless that name is a real branch. Do not auto-checkout. |
+| Repo safety | Refuse merge / rebase / unresolved conflicts (`UU`/`AA`/`DD`/`AU`/`UA`) on **any** path in the target repo. |
+| Scoped add | `git add -- <relativePath>` only. Never `-A`. Isolated `user.name=Junior Dashboard` / `user.email=junior-dashboard@localhost`. No push, no PR, no force-push, no new branch. |
+| Pause reloads | `registry.pauseReloads()` around write+commit so the 350 ms watcher cannot load uncommitted bytes. `resumeReloads()` reloads whatever is now on disk. Commit failure restores the file to HEAD (or deletes a new file) before resume. |
+| Overlay parent pointer | Preflight **both** `agents-org` and Junior before writing the overlay file. After overlay `ok`, `git add -- agents-org` only on Junior’s named branch. Parent failure after overlay success is **not** rolled back: HTTP 200 with `overlayCommitted: true, parentPointerCommitted: false`. Public-root writes skip this step. |
+| Non-`main`/`master` | Save requires an explicit `commitHereAnyway` checkbox (default off). Detached / merging / rebasing on either repo disable Save. |
+
+Optimistic concurrency on PUT compares `expectedVersionHash` to the **on-disk** `fileVersionHash`, not last-known-good. GET detail always returns on-disk markdown plus both hashes and `runtimeUsesFile`.
+
+## Session allowlist
+
+Shared list + detail projector (`projectSession` in `routes/sessions.ts`):
+
+```
+threadId, channel, provider, sessionId, leadSessionId, status,
+agentType, defaultAgent, activeAgentName, targetRepo, baseRef,
+muted, dormant, verbosity, driverMode, lastActivity, createdAt,
+lastError                      -- type + message only
+pendingMessages                -- length, never bodies
+hasWorktree                    -- Boolean(worktreePath || worktreePaths)
+agents[]                       -- agentName, sessionId, status, lastActivity,
+                                  pendingMessages (length), provider
+spend                          -- { inputTokens, outputTokens, costUsd, turns }
+```
+
+Detail only: `resumeCwd` (`worktreePath || cwd`) and `slackPermalink`. List never emits filesystem paths.
+
+## Pipeline operator view
+
+Default UI is an **assignment swimlane + phase tape**, not the 3D topology graph. Topology stays behind a toggle (`public/js/pipelines.js`, `pipelineViewMode = "swimlane"`).
+
+- Lanes are `assignment.targetAgent` (`lead`, `default`, then A–Z).
+- Bars encode lease / pending / waiting / terminal; unleased pending is hollow.
+- Phase tape is `transitions[]`. Click an assignment to load the rail (objective, lease, dispatch, outcomes, artifacts, attempt-scoped gates).
+- `GET /api/pipelines` hides `kind=default` unless `includeDefault=1` or `kind=default`. `limit` default 50, max 200. Response includes `runtimeMode` from config (never inferred) and `openCount`.
+- `GET /api/pipelines/:runId` expands leases, full-run outbox **without payload**, outcomes, gates, GitHub resources, dev-server jobs, and artifact refs. No pipeline writes (no force-transition, no replay).
+- `GET /api/pipelines/:runId/artifacts?ref=` reads a path relative to `data/pipelines/<runId>/` only, 256 KiB cap. 400 on traversal, 404 if missing.
+
+Empty copy: “No typed pipeline runs. Default-run durability is hidden unless you enable it.”
+
+## Spend ledger
+
+Usage capture is **always-on** — not gated on `HTTP_DASHBOARD_PORT`. Tables live in `SESSION_DB_PATH` (`data/sessions.db`).
+
+- Session turns: `SessionManager` records `done` via `normalizeRunnerUsage` + `sessionTurnSourceId` (unique `(source_kind, source_id)`; later `done` events for the same turn **sum**). Quiet verbosity cannot skip it.
+- Workflow runs: once from `SpawnResult` after `runWithRunner`, keyed by `workflowRunId`. Native handlers insert a zero-token row with `raw: { nativeHandler }`.
+- Pipeline assignment rows are not a third writer; session-turn rows already carry invocation ids.
+- `costUsd` is Claude `total_cost_usd` only. `costEstimatedUsd` is always null. No `rates.ts`. Missing usage still inserts a row so “turns without telemetry” is visible.
+- Retention: **90 days** for `usage_events`, **180 days** for `dashboard_audit`. `cleanupOperationalTables` runs from the same interval as stale-session cleanup and from `runCleanupFromEnv`.
+- `GET /api/spend?from=&to=&groupBy=day|session|agent|provider|workflow|pipeline`. Default window is today 00:00 in the **host local** timezone (shown in the UI). Max range 90 days.
+
+UI is table-first (KPI strip + `groupBy` chips + sortable buckets). No canvas chart.
+
+## Runbook viewer
+
+Runbooks stay a separate registry (`src/runbooks/`). The dashboard does not merge them with workflows and does not author or execute them.
+
+- `GET /api/runbooks` — `searchRunbooks` (default 25 / max 100) joined with `getRunbook` (`filePath`), catalog, and `computeMetrics`. Empty registry is 200 `{ runbooks: [], errors: [] }`, not 503.
+- `GET /api/runbooks/:name` — definition (including prompt body), catalog, metrics, git provenance. 404 if not loaded.
 
 ## Endpoints
 
 | Endpoint | Returns |
 |---|---|
 | `GET /` | `public/index.html` (dashboard UI) |
-| `GET /api/health` | `{ status, uptime, startedAt, sessions: {total,busy,idle,draining,errors}, agents: {total,busy}, repos[], pipeline: {runtimeMode, bugPipelineEnabled, productPipelineEnabled, githubReconcileEnabled, githubEventWakeEnabled, sessionsWithActiveRun} }` |
-| `GET /api/sessions` | Sessions sorted by `lastActivity` desc, with filtered projection and a reshaped `agents[]` array per session |
-| `GET /api/sessions/:threadId` | Full `ThreadSession` plus a best-effort Slack permalink for the detail view |
+| `GET /js/*` | same-origin modules from `public/js/` (`Cache-Control: no-cache`) |
+| `GET /api/health` | `{ status, uptime, startedAt, sessions, agents, repos[], pipeline: { runtimeMode, … }, spend: { eventsToday }, audit: { writesToday } }` |
+| `GET /api/sessions` | Allowlisted sessions sorted by `lastActivity` desc, numeric pending, spend summary |
+| `GET /api/sessions/:threadId` | Same allowlist plus `resumeCwd`, spend, and a best-effort Slack permalink |
+| `POST /api/sessions/:threadId/continue` | `{ status: "accepted" \| "buffered" }` 202; 409 muted; 502 Slack failed |
+| `POST /api/sessions/:threadId/stop` | `{ status: "ok", interrupted, message }` |
 | `GET /api/dev-server` | Per-repo `{ devCommand, devPort, readyUrl, running, pid, branch, startedAt, lastUsedAt, idleMsRemaining, holder, waiters }` plus top-level `idleTtlMs` |
-| `GET /api/workflows` | Definitions, persisted scheduler state, five recent runs, registry errors, and a live `displayStatus` from scheduler activity |
-| `GET /api/pipelines` | Pipeline run summaries, filterable by `status` (`active|waiting|needs-human|terminal`) and `kind` (`default|product|bug`), with assignment/artifact state |
-| `GET /api/pipelines/:runId` | One pipeline run with its assignment and artifact detail |
+| `GET /api/workflows` | Definitions (`nativeHandler`, owners, permissions, concurrency), state, five recent runs, registry errors, live `displayStatus`, overlay/junior git probes |
+| `GET /api/workflows/:name` | LKG/live projection (or null) + on-disk `source` (both hashes) + git + last 20 runs |
+| `POST /api/workflows` | Create + scoped commit. 201. `sourceRoot` required (`public` \| `overlay`) |
+| `PUT /api/workflows/:name` | Edit + scoped commit. `?validate=1` dry-run does not write |
+| `POST /api/workflows/:name/run` | `enqueueManualRun` — 202 started or 200 skipped |
+| `POST /api/workflows/:name/start` | `{ name, status: "active" }` |
+| `POST /api/workflows/:name/stop` | `{ name, status: "stopped" }` |
+| `POST /api/workflows/reload` | Admin `registry.reload()` + `scheduler.reconcile` |
+| `GET /api/pipelines` | Summaries; default-kind hidden unless `includeDefault=1` or `kind=default` |
+| `GET /api/pipelines/:runId` | Operator projection (leases, outbox without payload, gates, artifacts, …) |
+| `GET /api/pipelines/:runId/artifacts?ref=` | `{ ref, content, truncated }` — 256 KiB cap |
+| `GET /api/spend?from=&to=&groupBy=` | `{ from, to, totals, buckets }` |
+| `GET /api/runbooks` | List + catalog + metrics |
+| `GET /api/runbooks/:name` | Definition + catalog + metrics + git |
+| `GET /api/audit?action=&targetType=&from=&to=&limit=` | Newest-first audit rows (default 100, max 500) |
 | `GET /api/logs?date=YYYY-MM-DD&tail=N&tag=&level=` | Parsed entries from `logs/<date>.log` |
-| `GET /api/profiles[?kind=person|repo|project|situation]` | Derived profiles plus per-kind counts; inspection does not bump recall usage |
+| `GET /api/profiles[?kind=person\|repo\|project\|situation]` | Derived profiles plus per-kind counts; inspection does not bump recall usage |
 | `GET /api/memory` | List of `docs/**/*.md` paths |
 | `GET /api/memory/:path` | Contents of one doc file |
 | `GET /api/memory/recall?query=&tags=&kinds=&repo=&limit=` | Cosine-ranked claims; the route embeds the query, recall never records dashboard usage |
 | `GET /api/memory/projection[?refresh=1]` | `{ points[{id,x,y,z,kind,text,tags,repo,weight,createdAt,lastUsedAt}], edges[{a,b,sim}], facets{tags,kinds,repos} }` |
 
-`OPTIONS *` returns 204 (preflight handler kept for browsers that probe; no CORS headers attached). Unknown paths return JSON `{ error: "not found" }` 404. Handler exceptions log to the `http` tag and return JSON 500 — the bot does not die on a route bug.
+`OPTIONS *` returns 204 (preflight handler kept for browsers that probe; no CORS headers attached). Unknown paths return JSON `{ error: "not found" }` 404. Wrong method on a known `/api/*` path returns 405 `{ error: "method not allowed" }`. Handler exceptions log to the `http` tag and return JSON 500 — the bot does not die on a route bug. Mutations also log on the `dashboard` tag.
 
-The server also serves the locally pinned Three.js modules and pipeline worker
-under `/assets/`; these are fixed allowlisted paths, not a general static-file
-server.
+The server also serves the locally pinned Three.js modules and pipeline worker under `/assets/`; these are fixed allowlisted paths, not a general static-file server.
 
 ## Memory galaxy
 
@@ -103,30 +235,41 @@ HTTP_DASHBOARD_PORT=4567  # positive integer 1-65535. Unset = disabled.
 - Unset/empty → `{ enabled: false }`, `startHttpServer` is never called from `index.ts`.
 - Anything other than a positive integer in range throws at config load — better to fail boot than silently bind to a surprise port.
 - `Bun.serve` startup failures (port in use, permissions) are caught and logged; the bot continues without the dashboard.
+- Unsetting the port hides the UI. It does **not** stop `usage_events` / `dashboard_audit` writes; those are wired in `SessionManager`, `WorkflowExecutor`, and cleanup regardless of the port.
 
 ## Integration points
 
-- **`SessionStore` ([session-persistence.md](session-persistence.md), [session-management.md](session-management.md)).** All session reads go through the interface — sqlite in production, in-memory in dev/tests. `/api/health` and `/api/sessions` call `getAll()`; `/api/sessions/:id` calls `get(threadId)`. The detail route resolves the thread's Slack permalink on demand; Slack API failures leave the session readable with a null link. `agentSessions` is flattened into `agents[]` so the UI can render multi-agent threads without knowing the storage shape.
-- **`DevServerManager` ([process-lifecycle.md](process-lifecycle.md)).** `/api/dev-server` calls `manager.status()` for live `DevServerState` and `manager.getIdleTtlMs()` for the configured TTL (no hard-coded 20 min in the route — single source of truth).
-- **`DevServerQueue`.** `queue.readQueueDepth(repo)` supplies `{ holder, waiters }` so the dashboard can show "you're 3rd in line" parity with `!devserver status`.
-- **`WorkflowScheduler`.** `/api/workflows` uses the scheduler's process-local
-  active-run count for `displayStatus`. Persisted run history remains historical
-  evidence and is not treated as a liveness signal after restart.
-- **`PipelineStore`.** `/api/pipelines` reads durable product/bug pipeline
-  state; the route is read-only and does not dispatch or mutate runs.
-- **`logs/<date>.log`.** Written by `src/logger.ts`. The route is read-only and parses the same line format the logger emits (`<iso> [LEVEL] [tag] message`).
+- **`SessionStore` / `SessionManager` ([session-persistence.md](session-persistence.md), [session-management.md](session-management.md)).** Reads go through the store. Writes go through `injectDashboardContinue` and `interruptThread` — not a second spawn path. HTTP never talks to a runner CLI.
+- **`DevServerManager` ([process-lifecycle.md](process-lifecycle.md)).** `/api/dev-server` calls `manager.status()` and `manager.getIdleTtlMs()`.
+- **`DevServerQueue`.** `queue.readQueueDepth(repo)` supplies `{ holder, waiters }`.
+- **`WorkflowScheduler` / `WorkflowRegistry` ([dynamic-workflows.md](dynamic-workflows.md)).** List `displayStatus` uses the process-local active-run count. Dashboard run is `enqueueManualRun`; Slack keeps blocking `runNow`. Create/edit pause the registry, commit, then resume+reload.
+- **`PipelineStore`.** Operator reads only. The HTTP projector is `src/http/routes/pipelines.ts`; `src/pipelines/projection.ts` remains the Slack/`!status` human summary.
+- **`UsageStore`.** Always-on ledger in `data/sessions.db`. Dashboard queries it; capture does not depend on the port.
+- **`DashboardAuditStore`.** Same DB. Required once write routes exist (no 503).
+- **Runbook registry + `CatalogStore`.** View-only HTTP over the existing MCP/registry surface.
+- **`logs/<date>.log`.** Written by `src/logger.ts`. Read-only parse of `<iso> [LEVEL] [tag] message`.
 - **`docs/`.** Read-only doc browser, scoped to the project's `docs/` directory.
 
 ## Dependencies
 
-- [session-management.md](session-management.md) — shape of `ThreadSession` / `AgentSession` consumed by `/api/sessions`.
-- [session-persistence.md](session-persistence.md) — the `SessionStore` interface backing those reads.
-- [process-lifecycle.md](process-lifecycle.md) — `DevServerManager` / `DevServerQueue` invariants surfaced by `/api/dev-server`.
+- [session-management.md](session-management.md) — `ThreadSession` / inject / interrupt.
+- [session-persistence.md](session-persistence.md) — `SessionStore`.
+- [dynamic-workflows.md](dynamic-workflows.md) — registry, scheduler, git-backed definitions.
+- [process-lifecycle.md](process-lifecycle.md) — `DevServerManager` / `DevServerQueue` / operational cleanup.
+- [agent-product-debugging-pipeline-implementation-plan.md](agent-product-debugging-pipeline-implementation-plan.md) — typed run/assignment/outbox shape the swimlane reads.
 - `three` — locally served WebGL runtime for the memory graph.
 
 ## Cut list (true v2)
 
-- Auth (token, OAuth). Loopback binding is enough until junior runs on a multi-tenant host.
-- Server-Sent Events / WebSocket push for live updates. Today the UI polls.
-- Write endpoints (kill a session, evict a dev-server slot). Stays read-only — destructive ops go through Slack `!` commands so they're auditable.
-- Per-thread message-body view. `pendingMessages` lengths only, by design.
+- Auth (token, OAuth). Loopback binding is enough until junior runs on a multi-tenant host. A same-origin token would be theater.
+- Server-Sent Events / WebSocket push. The UI still polls (~2s).
+- Per-thread pending-message body view. Lengths only, by design.
+- Kill a worktree, evict a dev-server slot, or `!reset` / `!cancel` from the dashboard. Those stay Slack `!` commands.
+- Starting a new Slack thread from the dashboard. Continue existing sessions only.
+- Dashboard-authored runbooks, runbook PRs, or merging runbooks into the workflow registry.
+- Push / open a PR after a workflow commit. Commits stay local and unpushed.
+- Binding the dashboard off loopback.
+- Spend bar chart, estimated USD (`rates.ts`), or accurate cost for providers that do not emit `total_cost_usd`.
+- Pipeline writes (force-transition, replay outbox) from the dashboard.
+
+The previous cut-list line “write endpoints stay read-only — destructive ops go through Slack so they're auditable” is **superseded**. The compensating control is loopback + `dashboard_audit` + Slack posts where a destination exists. Workflow writes without a Slack output channel are an accepted weaker trail than Slack `!` commands.

--- a/docs/features/http-dashboard.md
+++ b/docs/features/http-dashboard.md
@@ -47,7 +47,7 @@ Junior is intentionally insecure as a networked product. The dashboard assumes a
 ## Security posture
 
 - **Loopback-only.** Binds `127.0.0.1` — never reachable off-host without an explicit SSH tunnel. This is the entire threat model; there is intentionally no auth layer behind it. Do not tunnel the port without adding auth.
-- **Writes are in scope.** Continue, stop, workflow run/start/stop/reload, and Git-backed create/edit are first-class. They do not invent a second control plane: they call `SessionManager` / `WorkflowScheduler` / the git helper the Slack path already uses.
+- **Writes are in scope.** Continue, stop, workflow run/start/stop/reload, and Git-backed create/edit are first-class. They do not invent a second session/workflow runtime: continue/stop go through `SessionManager` (`injectDashboardContinue` / `interruptThread`); run/start/stop reuse scheduler enablement and `canManage` checks. Dashboard **run** is `enqueueManualRun` — Slack `!workflow run` still blocks on `runNow`. Create/edit use a dashboard-only scoped git helper (`src/workflows/git-commit.ts`); Slack never commits workflow files.
 - **Audit is required, Slack-parity is not.** Every mutating call writes `dashboard_audit`. Session continue/stop also post to the Slack thread (conversation of record). Workflow mutations post a one-liner to a `slack` / `slack-thread` output **when the definition has one**. Workflows without an output channel leave only git + `dashboard_audit` — **weaker than Slack `!` commands**, accepted for a no-auth loopback console, and must not be documented as Slack-parity.
 - **Actor is loopback identity.** `ADMIN_SLACK_USER_ID` when set, else `dashboard-operator`. Fail closed when the `admins` table is non-empty but the env admin is unset. Open-mode (neither tier configured) matches Slack open-mode.
 - **Profiles are private operator data.** `/api/profiles` can include derived context about real people. It is available only inside the same loopback-only console and must not be exposed through a public bind or permissive CORS.
@@ -134,7 +134,7 @@ Default UI is an **assignment swimlane + phase tape**, not the 3D topology graph
 - `GET /api/pipelines/:runId` expands leases, full-run outbox **without payload**, outcomes, gates, GitHub resources, dev-server jobs, and artifact refs. No pipeline writes (no force-transition, no replay).
 - `GET /api/pipelines/:runId/artifacts?ref=` reads a path relative to `data/pipelines/<runId>/` only, 256 KiB cap. 400 on traversal, 404 if missing.
 
-Empty copy: “No typed pipeline runs. Default-run durability is hidden unless you enable it.”
+Empty copy: “No typed pipeline runs. Default-kind durability is hidden unless you enable it.”
 
 ## Spend ledger
 
@@ -235,7 +235,7 @@ HTTP_DASHBOARD_PORT=4567  # positive integer 1-65535. Unset = disabled.
 - Unset/empty → `{ enabled: false }`, `startHttpServer` is never called from `index.ts`.
 - Anything other than a positive integer in range throws at config load — better to fail boot than silently bind to a surprise port.
 - `Bun.serve` startup failures (port in use, permissions) are caught and logged; the bot continues without the dashboard.
-- Unsetting the port hides the UI. It does **not** stop `usage_events` / `dashboard_audit` writes; those are wired in `SessionManager`, `WorkflowExecutor`, and cleanup regardless of the port.
+- Unsetting the port hides the UI. Spend capture (`usage_events` from `SessionManager` / `WorkflowExecutor`) and 90-day/180-day retention deletes stay always-on. `dashboard_audit` **inserts** happen only when a mutating HTTP route runs; they do not fire when the dashboard is off. `cleanupOperationalTables` deletes old usage/audit rows — it does not write them.
 
 ## Integration points
 

--- a/docs/features/operator-dashboard-redesign.md
+++ b/docs/features/operator-dashboard-redesign.md
@@ -5,14 +5,14 @@
 | **Title** | Redesign Junior's HTML dashboard, HTTP API, and supporting codebase |
 | **Author** | Junior dashboard redesign |
 | **Date** | 2026-08-15 |
-| **Status** | Draft |
+| **Status** | Implemented. Current behavior lives in [http-dashboard.md](http-dashboard.md). This file is the design record. |
 | **Supersedes** | `docs/features/http-dashboard.md` cut list item "Write endpoints stay read-only". The localhost dashboard becomes a first-class operator control surface. Session continue/stop post to the Slack thread (parity with `!` commands). Workflow mutations write `dashboard_audit` and a git commit; they post to a workflow Slack output channel when one exists, and are otherwise an accepted weaker trail than Slack (loopback-only identity). |
 
 ---
 
 ## Overview
 
-The localhost dashboard (`HTTP_DASHBOARD_PORT`, binds `127.0.0.1`) is a trusted-operator console. Today it is almost entirely read-only: sessions list + a Slack permalink, a copy-paste resume CLI command, a thin workflow card list, a 3D pipeline dispatch graph that omits leases / artifacts / blockers / gates, no spend ledger, and no runbook browser. Mutations go through Slack so they stay auditable.
+The localhost dashboard (`HTTP_DASHBOARD_PORT`, binds `127.0.0.1`) is a trusted-operator console. **Baseline below (`main` @ `77076fe`, 2026-08-15) was almost entirely read-only:** sessions list + a Slack permalink, a copy-paste resume CLI command, a thin workflow card list, a 3D pipeline dispatch graph that omits leases / artifacts / blockers / gates, no spend ledger, and no runbook browser. Mutations went through Slack so they stayed auditable. That surface is what this redesign replaced; see [http-dashboard.md](http-dashboard.md) for what shipped.
 
 This redesign keeps the loopback threat model and the existing control plane. It adds five operator capabilities — continue a session, inspect a live pipeline, query token/cost spend, trigger/edit/create Git-backed workflows, and view runbooks — by extending the existing Bun HTTP server, session manager, workflow controller, pipeline store, and runbook registry. Dashboard-originated turns go through a new `SessionManager.injectDashboardContinue` that resolves the `junior`/`default`/`lead` alias, skips default-run hijack, and returns `{ accepted | buffered | muted }` — it does not call `handleAgentMessage("junior")` and does not invent a fire-and-forget result from void `handle*` methods. Workflow **trigger** uses a new `WorkflowScheduler.enqueueManualRun` (because `runNow` awaits the whole executor). Creates and edits write `*.workflow.md` files and make a scoped git commit only on a named branch. Every mutating call writes a durable audit row.
 
@@ -22,7 +22,7 @@ The UI stays a no-build vanilla operator console. `public/index.html` is already
 
 ## Background & Motivation
 
-### Current state (verified 2026-08-15, `main` @ `77076fe`)
+### Baseline before this work (verified 2026-08-15, `main` @ `77076fe`)
 
 | Surface | What exists | Gap |
 |---|---|---|
@@ -398,7 +398,7 @@ Justification:
 | Phase tape | One cell per `transitions[]` entry, labeled `toPhase`, width proportional to time until the next transition (last cell stretches to now). |
 | Pins | Blocker kinds on the assignment bar; `needs-human` run status is an amber pin on the tape. |
 | Click | Selects the assignment; the right rail shows objective, lease, dispatch, outcomes, artifact refs, gates for `run.activeAttemptId`. No “agent chat” pane in v1. |
-| Empty | “No typed pipeline runs. Default-run durability is hidden unless you enable it.” |
+| Empty | “No typed pipeline runs. Default-kind durability is hidden unless you enable it.” |
 
 ```mermaid
 flowchart LR
@@ -508,7 +508,7 @@ No pipeline writes from the dashboard in v1 (no force-transition, no replay outb
 
 ### UI states
 
-- Empty: "No typed pipeline runs. Default-run durability is hidden unless you enable it."
+- Empty: "No typed pipeline runs. Default-kind durability is hidden unless you enable it."
 - `runtimeMode=off` and no rows: same empty, plus a hint that controllers are off.
 - Loading detail: keep the current summary skeleton; do not blank the list.
 - Failed detail: "Failed to load run. Retry." (existing `pipelineDetailErrors` set).

--- a/docs/features/session-management.md
+++ b/docs/features/session-management.md
@@ -88,7 +88,7 @@ Admins: bootstrap one in `ADMIN_SLACK_USER_ID`; the rest live in the `admins` SQ
 ## Observability
 
 - Per-agent status pills stream via `onEvent` (see [stream-to-slack.md](stream-to-slack.md)).
-- HTTP dashboard reads `getRecent` and surfaces `defaultAgent` + `agentSessions`.
+- HTTP dashboard lists sessions via `store.getAll()` and `projectSession` (allowlist: numeric `pendingMessages`, `agents[]` without bodies/paths/`pid`; detail-only `resumeCwd`). See [http-dashboard.md](http-dashboard.md).
 - `!status` prints status, muted, agentType, defaultAgent, repo, worktree, last activity, pending count.
 
 ## Cleanup

--- a/docs/features/v2-backlog.md
+++ b/docs/features/v2-backlog.md
@@ -4,7 +4,7 @@ Features explicitly deferred from MVP. To be scoped when MVP is running.
 
 ## Admin Dashboard (DONE)
 
-**Status:** Completed as the [HTTP Dashboard](./http-dashboard.md). Surfaces live sessions, dev-server queue, workflows/pipelines, logs, docs, profiles, and memory projections.
+**Status:** Completed as the [HTTP Dashboard](./http-dashboard.md). Surfaces live sessions (allowlisted), a swimlane pipeline operator view, spend ledger, runbook viewer, audit log, logs, docs, profiles, and memory projections. Session continue/stop go through `SessionManager` and post to the Slack thread. Workflow enqueue/start/stop/reload/create/edit are loopback writes with `dashboard_audit`; they post to a workflow Slack output channel only when one exists — otherwise the trail is weaker than Slack `!` commands. Remaining dashboard items (auth, SSE, pending-body viewer, worktree/dev-server kill, push/PR) stay on that feature doc's cut list.
 
 ## Batch User Resolution in Thread Context
 
@@ -30,7 +30,7 @@ Features explicitly deferred from MVP. To be scoped when MVP is running.
 **Open questions:**
 - Should active sessions pin the identity/prompt version they started with, or adopt new identity data on the next turn?
 - Should invalid org overlays fail closed for private assets, or fall back to public defaults?
-- Which command surface owns this: a general `!org reload`, per-asset commands, or an admin dashboard action?
+- Which command surface owns this: a general `!org reload`, per-asset commands, or an admin dashboard action? (Workflow files already hot-reload via `fs.watch`, and the dashboard exposes `POST /api/workflows/reload` as the same diagnostic as `!workflow reload`. That does not extend to other org assets.)
 
 ## Per-agent mute
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -8,7 +8,7 @@ Do not expose Junior, its dashboard, or its MCP server to untrusted networks wit
 The [HTTP Dashboard](./features/http-dashboard.md) binds only to `127.0.0.1` by default.
 - **No Remote Access**: It is not reachable from the internet without an explicit SSH tunnel.
 - **No Auth by Design**: Because Junior assumes a trusted local operator, the dashboard does not include an authentication layer.
-- **No CORS Opt-in**: The dashboard does not emit CORS headers, so arbitrary websites cannot read API responses from a browser. The current dashboard is read-only; it does not validate `Origin` or `Sec-Fetch-Site` as a CSRF defense.
+- **No CORS Opt-in**: The dashboard does not emit CORS headers, so arbitrary websites cannot read API responses from a browser. It does not validate `Origin` or `Sec-Fetch-Site` as a CSRF defense. Writes (session continue/stop, workflow enqueue/edit) are allowed from any local process that can reach `127.0.0.1`; compensating controls are `dashboard_audit` plus Slack posts where a destination exists. Do not tunnel the port without adding auth.
 
 ## 2. Worktree Isolation
 Target repositories are never edited in their original paths.

--- a/public/index.html
+++ b/public/index.html
@@ -286,6 +286,21 @@
   }
   .copy-btn:hover { color: var(--fg); border-color: var(--accent); background: rgba(0,100,255,0.08); }
   .copy-btn.copied { color: var(--green); border-color: rgba(34,197,94,0.4); }
+  .continue-box { margin-top: 18px; }
+  .continue-box textarea {
+    width: 100%; min-height: 88px; resize: vertical; box-sizing: border-box;
+    background: var(--bg-paper); color: var(--fg);
+    border: 1px solid var(--border-subtle); border-radius: 8px;
+    padding: 8px 10px; font-family: inherit; font-size: 13px; line-height: 1.45;
+    outline: none;
+  }
+  .continue-box textarea:focus { border-color: var(--accent); }
+  .continue-actions { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-top: 8px; }
+  .continue-actions select.ctrl { min-width: 140px; }
+  .continue-status { margin-top: 8px; font-size: 12px; color: var(--fg-dim); }
+  .continue-status.err { color: var(--red); }
+  button.ctrl.danger { color: var(--red); }
+  button.ctrl:disabled { opacity: 0.5; cursor: not-allowed; }
   .agent-card { border: 1px solid var(--border); border-radius: 10px; padding: 12px 14px; margin-bottom: 10px; background: var(--surface); }
   .agent-card .top { display: flex; align-items: center; gap: 10px; margin-bottom: 6px; }
   .agent-card .top b { font-size: 13.5px; }

--- a/public/index.html
+++ b/public/index.html
@@ -368,7 +368,7 @@
   .qrow .pos { color: var(--fg-faint); width: 22px; }
 
   /* ---------- workflows ---------- */
-  .wf-card { padding: 16px 18px; border-bottom: 1px solid var(--border-subtle); display: grid; grid-template-columns: 1.2fr 1fr 1.2fr; gap: 16px; }
+  .wf-card { padding: 16px 18px; border-bottom: 1px solid var(--border-subtle); display: grid; grid-template-columns: 1.1fr 0.9fr 1fr 1.15fr; gap: 16px; }
   .wf-card.on { background: rgba(0,100,255,.1); box-shadow: inset 2px 0 var(--accent); }
   .wf-card:last-child { border-bottom: none; }
   .wf-card .name { font-weight: 700; font-size: 14px; }
@@ -376,6 +376,23 @@
   .wf-card .src { font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-faint); margin-top: 6px; }
   .wf-card .mrow { font-family: var(--font-mono); font-size: 11.5px; color: var(--fg-dim); line-height: 1.9; }
   .wf-card .mrow b { color: var(--fg); font-weight: 500; }
+  .wf-actions { display: flex; flex-direction: column; gap: 8px; min-width: 0; }
+  .wf-actions textarea {
+    width: 100%; min-height: 56px; resize: vertical;
+    background: var(--bg-paper); color: var(--fg);
+    border: 1px solid var(--border-subtle); border-radius: 8px;
+    padding: 8px 10px; font-family: var(--font-sans); font-size: 12px;
+  }
+  .wf-actions textarea:focus { outline: none; border-color: var(--accent); }
+  .wf-actions .row { display: flex; gap: 6px; align-items: center; flex-wrap: wrap; }
+  .wf-count { margin-left: auto; font-family: var(--font-mono); font-size: 10px; color: var(--fg-faint); }
+  .wf-foot { padding: 10px 18px; font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-faint); }
+  #wf-status { font-family: var(--font-mono); font-size: 11.5px; color: var(--fg-dim); }
+  #wf-status.err { color: var(--red); }
+  #wf-status.ok { color: var(--green); }
+  @media (max-width: 900px) {
+    .wf-card { grid-template-columns: 1fr; }
+  }
   .runs { display: flex; gap: 4px; align-items: center; margin-top: 6px; }
   .run-dot { width: 10px; height: 10px; border-radius: 3px; background: var(--surface-strong); cursor: default; }
   .run-dot.done { background: rgba(34,197,94,0.7); }
@@ -1633,8 +1650,13 @@
       <div class="view-head" data-index="05">
         <h2>Workflows</h2>
         <span class="sub">scheduled runs · last outcomes per workflow</span>
+        <span class="right">
+          <span id="wf-status"></span>
+          <button class="ctrl" id="wf-reload" type="button">reload</button>
+        </span>
       </div>
       <div class="panel" id="wf-list"><div class="empty">loading…</div></div>
+      <div class="wf-foot">Workflow mutations write dashboard_audit and post to a Slack output channel when the definition has one. Otherwise the trail is weaker than Slack ! commands.</div>
     </section>
 
     <!-- ================= PIPELINES ================= -->

--- a/public/index.html
+++ b/public/index.html
@@ -390,6 +390,36 @@
   #wf-status { font-family: var(--font-mono); font-size: 11.5px; color: var(--fg-dim); }
   #wf-status.err { color: var(--red); }
   #wf-status.ok { color: var(--green); }
+  .wf-banner {
+    padding: 8px 10px; border-radius: 8px; font-size: 12px; margin-bottom: 8px;
+    background: rgba(245,158,11,0.12); color: var(--amber); border: 1px solid rgba(245,158,11,0.25);
+  }
+  .wf-banner.err { background: rgba(255,59,59,0.1); color: var(--red); border-color: rgba(255,59,59,0.25); }
+  .wf-banner.ok { background: rgba(34,197,94,0.1); color: var(--green); border-color: rgba(34,197,94,0.25); }
+  #wf-editor { margin-top: 12px; padding: 16px 18px; display: none; }
+  #wf-editor.open { display: block; }
+  #wf-editor .wf-editor-head {
+    display: flex; align-items: center; gap: 10px; margin-bottom: 10px;
+  }
+  #wf-editor .wf-editor-head strong { font-size: 14px; }
+  #wf-markdown {
+    width: 100%; min-height: 280px; resize: vertical;
+    background: var(--bg-paper); color: var(--fg);
+    border: 1px solid var(--border-subtle); border-radius: 8px;
+    padding: 10px 12px; font-family: var(--font-mono); font-size: 12px; line-height: 1.45;
+  }
+  #wf-markdown:focus { outline: none; border-color: var(--accent); }
+  .wf-field { display: flex; flex-direction: column; gap: 4px; min-width: 160px; }
+  .wf-field span { font-family: var(--font-mono); font-size: 10.5px; color: var(--fg-faint); }
+  .wf-field input, .wf-field select {
+    background: var(--bg-paper); color: var(--fg);
+    border: 1px solid var(--border-subtle); border-radius: 8px;
+    padding: 6px 8px; font-family: var(--font-mono); font-size: 12px;
+  }
+  #wf-save-result {
+    margin: 10px 0 0; white-space: pre-wrap; font-family: var(--font-mono);
+    font-size: 11px; color: var(--fg-dim);
+  }
   @media (max-width: 900px) {
     .wf-card { grid-template-columns: 1fr; }
   }
@@ -1652,11 +1682,44 @@
         <span class="sub">scheduled runs · last outcomes per workflow</span>
         <span class="right">
           <span id="wf-status"></span>
+          <button class="ctrl" id="wf-new" type="button">New workflow</button>
           <button class="ctrl" id="wf-reload" type="button">reload</button>
         </span>
       </div>
       <div class="panel" id="wf-list"><div class="empty">loading…</div></div>
-      <div class="wf-foot">Workflow mutations write dashboard_audit and post to a Slack output channel when the definition has one. Otherwise the trail is weaker than Slack ! commands.</div>
+      <div class="panel" id="wf-editor">
+        <div class="wf-editor-head">
+          <strong id="wf-editor-title">New workflow</strong>
+          <span class="right">
+            <button class="ctrl" id="wf-editor-close" type="button">close</button>
+          </span>
+        </div>
+        <div id="wf-banners"></div>
+        <div class="row" style="gap:12px; margin-bottom:10px; flex-wrap:wrap">
+          <label class="wf-field">
+            <span>name</span>
+            <input id="wf-name" spellcheck="false" autocomplete="off" />
+          </label>
+          <label class="wf-field">
+            <span>sourceRoot</span>
+            <select id="wf-source-root">
+              <option value="overlay">overlay (agents-org)</option>
+              <option value="public">public (workflows/)</option>
+            </select>
+          </label>
+        </div>
+        <textarea id="wf-markdown" spellcheck="false"></textarea>
+        <label id="wf-anyway-row" class="row" style="display:none; margin-top:8px; gap:8px; align-items:center; font-size:12px">
+          <input id="wf-anyway" type="checkbox" />
+          commit here anyway (<span id="wf-branch"></span> is not main/master)
+        </label>
+        <div class="row" style="margin-top:10px; gap:6px">
+          <button class="ctrl" id="wf-validate" type="button">Validate</button>
+          <button class="ctrl" id="wf-save" type="button">Save &amp; commit</button>
+        </div>
+        <pre id="wf-save-result"></pre>
+      </div>
+      <div class="wf-foot">Workflow mutations write dashboard_audit and a scoped git commit. They post to a Slack output channel when the definition has one. Otherwise the trail is weaker than Slack ! commands. Commits are not pushed.</div>
     </section>
 
     <!-- ================= PIPELINES ================= -->

--- a/public/js/api.js
+++ b/public/js/api.js
@@ -125,6 +125,8 @@ var devServers = [];
 var idleTtlMs = null;
 var workflows = [];
 var workflowErrors = [];
+var workflowWriteGit = { junior: null, overlay: null };
+var overlayRootExists = false;
 var pipelines = [];
 var attentionPipelines = [];
 var openPipelineCount = 0;
@@ -313,6 +315,8 @@ async function refreshMain() {
   if (w.ok) {
     workflows = w.data.workflows || [];
     workflowErrors = w.data.errors || [];
+    workflowWriteGit = w.data.git || workflowWriteGit;
+    overlayRootExists = Boolean(w.data.overlayRootExists);
   }
   if (pipelineGeneration === pipelineFetchGeneration) {
     applyPipelineListResponse(p);

--- a/public/js/threads.js
+++ b/public/js/threads.js
@@ -185,9 +185,116 @@ async function openDrawer(threadId) {
     "</div>" +
     '<h3 class="sect">Resume lead session (' + esc(provider) + ")</h3>" +
     cmdRow(resumeCmd(provider, leadId, cwd)) +
-    '<h3 class="sect">Agent sessions · ' + agents.length + "</h3>" + agentHtml;
+    '<h3 class="sect">Agent sessions · ' + agents.length + "</h3>" + agentHtml +
+    continueComposerHtml(t, agents);
 
   $("drawer-close").addEventListener("click", closeDrawer);
+  bindContinueComposer(t);
+}
+
+function continueComposerHtml(t, agents) {
+  if (!t.channel || !t.threadId) return "";
+  const options = ['<option value="">thread default</option>'];
+  if (t.defaultAgent === "lead") {
+    options[0] = '<option value="lead">lead</option>';
+    options.push('<option value="default">default</option>');
+  } else {
+    options.push('<option value="lead">lead</option>');
+  }
+  for (const a of agents) {
+    if (a.agentName === "lead" || a.agentName === "default" || a.agentName === "junior") continue;
+    options.push('<option value="' + esc(a.agentName) + '">' + esc(a.agentName) + "</option>");
+  }
+  const mutedNote = t.muted
+    ? '<div class="continue-status">Session is muted. Unmute in Slack before continuing.</div>'
+    : "";
+  return (
+    '<div class="continue-box">' +
+    '<h3 class="sect">Continue</h3>' +
+    '<textarea id="continue-prompt" maxlength="8000" placeholder="Send a prompt into this thread" ' +
+    (t.muted ? "disabled " : "") + "></textarea>" +
+    '<div class="continue-actions">' +
+    '<select class="ctrl" id="continue-agent"' + (t.muted ? " disabled" : "") + ">" +
+    options.join("") + "</select>" +
+    '<button class="ctrl" type="button" id="continue-btn"' + (t.muted ? " disabled" : "") +
+    ">Continue</button>" +
+    '<button class="ctrl danger" type="button" id="stop-btn">Stop</button>' +
+    "</div>" +
+    mutedNote +
+    '<div class="continue-status" id="continue-status"></div>' +
+    "</div>"
+  );
+}
+
+function setContinueStatus(text, isError) {
+  const el = $("continue-status");
+  if (!el) return;
+  el.textContent = text;
+  el.classList.toggle("err", !!isError);
+}
+
+async function postSessionWrite(path, body) {
+  const res = await fetch(path, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: body == null ? "{}" : JSON.stringify(body),
+  });
+  let data = null;
+  try { data = await res.json(); } catch {}
+  return { ok: res.ok, status: res.status, data };
+}
+
+function bindContinueComposer(t) {
+  const promptEl = $("continue-prompt");
+  const agentEl = $("continue-agent");
+  const continueBtn = $("continue-btn");
+  const stopBtn = $("stop-btn");
+  if (continueBtn) {
+    continueBtn.addEventListener("click", async () => {
+      const prompt = promptEl ? promptEl.value : "";
+      if (!prompt.trim()) {
+        setContinueStatus("Enter a prompt.", true);
+        return;
+      }
+      continueBtn.disabled = true;
+      if (stopBtn) stopBtn.disabled = true;
+      setContinueStatus("Sending…", false);
+      const agentName = agentEl && agentEl.value ? agentEl.value : undefined;
+      const res = await postSessionWrite(
+        "/api/sessions/" + encodeURIComponent(t.threadId) + "/continue",
+        { prompt, agentName },
+      );
+      if (!res.ok) {
+        setContinueStatus((res.data && res.data.error) || ("Continue failed (" + res.status + ")"), true);
+        continueBtn.disabled = false;
+        if (stopBtn) stopBtn.disabled = false;
+        return;
+      }
+      setContinueStatus(res.data && res.data.status === "buffered" ? "Buffered." : "Accepted.", false);
+      if (promptEl) promptEl.value = "";
+      if (typeof refreshMain === "function") await refreshMain();
+      if (drawerThreadId === t.threadId) await openDrawer(t.threadId);
+    });
+  }
+  if (stopBtn) {
+    stopBtn.addEventListener("click", async () => {
+      stopBtn.disabled = true;
+      if (continueBtn) continueBtn.disabled = true;
+      setContinueStatus("Stopping…", false);
+      const res = await postSessionWrite(
+        "/api/sessions/" + encodeURIComponent(t.threadId) + "/stop",
+      );
+      if (!res.ok) {
+        setContinueStatus((res.data && res.data.error) || ("Stop failed (" + res.status + ")"), true);
+        stopBtn.disabled = false;
+        if (continueBtn && !t.muted) continueBtn.disabled = false;
+        return;
+      }
+      setContinueStatus((res.data && res.data.message) || "Stopped.", false);
+      if (typeof refreshMain === "function") await refreshMain();
+      if (drawerThreadId === t.threadId) await openDrawer(t.threadId);
+    });
+  }
 }
 
 function closeDrawer() {

--- a/public/js/threads.js
+++ b/public/js/threads.js
@@ -114,7 +114,7 @@ $("th-list").addEventListener("click", (e) => {
   if (row) openDrawer(row.dataset.openThread);
 });
 
-async function openDrawer(threadId) {
+async function openDrawer(threadId, settle) {
   drawerThreadId = threadId;
   $("drawer").innerHTML = '<button class="close" type="button" id="drawer-close">esc</button><div class="empty">loading…</div>';
   $("drawer").classList.add("open");
@@ -190,6 +190,7 @@ async function openDrawer(threadId) {
 
   $("drawer-close").addEventListener("click", closeDrawer);
   bindContinueComposer(t);
+  if (settle && settle.text) setContinueStatus(settle.text, !!settle.isError);
 }
 
 function continueComposerHtml(t, agents) {
@@ -259,21 +260,30 @@ function bindContinueComposer(t) {
       continueBtn.disabled = true;
       if (stopBtn) stopBtn.disabled = true;
       setContinueStatus("Sending…", false);
-      const agentName = agentEl && agentEl.value ? agentEl.value : undefined;
-      const res = await postSessionWrite(
-        "/api/sessions/" + encodeURIComponent(t.threadId) + "/continue",
-        { prompt, agentName },
-      );
-      if (!res.ok) {
-        setContinueStatus((res.data && res.data.error) || ("Continue failed (" + res.status + ")"), true);
-        continueBtn.disabled = false;
-        if (stopBtn) stopBtn.disabled = false;
-        return;
+      let settled = false;
+      try {
+        const agentName = agentEl && agentEl.value ? agentEl.value : undefined;
+        const res = await postSessionWrite(
+          "/api/sessions/" + encodeURIComponent(t.threadId) + "/continue",
+          { prompt, agentName },
+        );
+        if (!res.ok) {
+          setContinueStatus((res.data && res.data.error) || ("Continue failed (" + res.status + ")"), true);
+          return;
+        }
+        settled = true;
+        const statusText = res.data && res.data.status === "buffered" ? "Buffered." : "Accepted.";
+        if (promptEl) promptEl.value = "";
+        if (typeof refreshMain === "function") await refreshMain();
+        if (drawerThreadId === t.threadId) await openDrawer(t.threadId, { text: statusText });
+      } catch (err) {
+        setContinueStatus((err && err.message) || "Continue failed.", true);
+      } finally {
+        if (!settled) {
+          continueBtn.disabled = false;
+          if (stopBtn) stopBtn.disabled = false;
+        }
       }
-      setContinueStatus(res.data && res.data.status === "buffered" ? "Buffered." : "Accepted.", false);
-      if (promptEl) promptEl.value = "";
-      if (typeof refreshMain === "function") await refreshMain();
-      if (drawerThreadId === t.threadId) await openDrawer(t.threadId);
     });
   }
   if (stopBtn) {
@@ -281,18 +291,27 @@ function bindContinueComposer(t) {
       stopBtn.disabled = true;
       if (continueBtn) continueBtn.disabled = true;
       setContinueStatus("Stopping…", false);
-      const res = await postSessionWrite(
-        "/api/sessions/" + encodeURIComponent(t.threadId) + "/stop",
-      );
-      if (!res.ok) {
-        setContinueStatus((res.data && res.data.error) || ("Stop failed (" + res.status + ")"), true);
-        stopBtn.disabled = false;
-        if (continueBtn && !t.muted) continueBtn.disabled = false;
-        return;
+      let settled = false;
+      try {
+        const res = await postSessionWrite(
+          "/api/sessions/" + encodeURIComponent(t.threadId) + "/stop",
+        );
+        if (!res.ok) {
+          setContinueStatus((res.data && res.data.error) || ("Stop failed (" + res.status + ")"), true);
+          return;
+        }
+        settled = true;
+        const statusText = (res.data && res.data.message) || "Stopped.";
+        if (typeof refreshMain === "function") await refreshMain();
+        if (drawerThreadId === t.threadId) await openDrawer(t.threadId, { text: statusText });
+      } catch (err) {
+        setContinueStatus((err && err.message) || "Stop failed.", true);
+      } finally {
+        if (!settled) {
+          stopBtn.disabled = false;
+          if (continueBtn && !t.muted) continueBtn.disabled = false;
+        }
       }
-      setContinueStatus((res.data && res.data.message) || "Stopped.", false);
-      if (typeof refreshMain === "function") await refreshMain();
-      if (drawerThreadId === t.threadId) await openDrawer(t.threadId);
     });
   }
 }

--- a/public/js/workflows.js
+++ b/public/js/workflows.js
@@ -1,4 +1,7 @@
 /* =================== workflows =================== */
+var WF_INSTR_MAX = 500;
+var wfActionBusy = false;
+
 function renderWorkflows() {
   const items = workflows;
   const errors = workflowErrors || [];
@@ -10,6 +13,7 @@ function renderWorkflows() {
     const state = w.state || {};
     const schedulerStatus = state.status || (w.enabled ? "active" : "stopped");
     const displayStatus = w.displayStatus ?? schedulerStatus;
+    const concurrency = w.concurrency || "skip";
     // runs are newest-first from API; reverse for oldest → newest dots
     const runs = (w.runs || []).slice().reverse();
     const dots = runs.map((r) =>
@@ -30,12 +34,22 @@ function renderWorkflows() {
     const triggers = (w.triggers || []).map((t) =>
       t.type === "schedule" ? (t.cron + " " + (t.timezone || "")) : t.type
     ).join(", ") || "none";
-    const runner = w.runner
-      ? (w.runner.provider + "/" + w.runner.agentName)
-      : "none";
+    const runner = w.nativeHandler
+      ? ("native/" + w.nativeHandler)
+      : w.runner
+        ? (w.runner.provider + "/" + w.runner.agentName)
+        : "none";
+    const runLabel = "run · " + concurrency;
+    const instructions = w.nativeHandler
+      ? ""
+      : '<textarea class="wf-instr" data-name="' + esc(w.name) +
+        '" maxlength="' + WF_INSTR_MAX + '" placeholder="optional instructions"></textarea>' +
+        '<div class="row"><span class="wf-count" data-count="' + esc(w.name) + '">0 / ' +
+        WF_INSTR_MAX + "</span></div>";
     return (
       '<div class="wf-card' + (selectedWorkflowName === w.name ? " on" : "") +
-      '" id="wf-card-' + esc(w.name) + '" data-workflow="' + esc(w.name) + '">' +
+      '" id="wf-card-' + esc(w.name) + '" data-name="' + esc(w.name) +
+      '" data-workflow="' + esc(w.name) + '">' +
       '<div><div class="name">' + esc(w.name) + "</div>" +
       '<div class="desc">' + esc(w.description || "no description") + "</div>" +
       '<div class="src">' + esc(w.sourcePath || "") + "</div></div>" +
@@ -44,11 +58,22 @@ function renderWorkflows() {
       "<br/>next <b>" + esc(fmtNext(state.nextRunAt)) + "</b>" +
       "<br/>last <b>" + (state.lastRunAt ? ago(state.lastRunAt) + " ago" : "never") + "</b>" +
       "<br/>runner <b>" + esc(runner) + "</b>" +
+      "<br/>concurrency <b>" + esc(concurrency) + "</b>" +
       "<br/>cron <b>" + esc(triggers) + "</b>" +
       (state.lastError ? '<br/><span style="color:var(--red)">' + esc(state.lastError) + "</span>" : "") +
       "</div>" +
       '<div><div class="mrow" style="margin-bottom:2px">recent runs · oldest → newest</div>' +
-      '<div class="runs">' + dots + "</div>" + lastRuns + "</div></div>"
+      '<div class="runs">' + dots + "</div>" + lastRuns + "</div>" +
+      '<div class="wf-actions">' +
+      instructions +
+      '<div class="row">' +
+      '<button class="ctrl wf-run" type="button" data-name="' + esc(w.name) + '"' +
+      (w.enabled ? "" : " disabled") + ">" + esc(runLabel) + "</button>" +
+      (schedulerStatus === "stopped"
+        ? '<button class="ctrl wf-start" type="button" data-name="' + esc(w.name) + '"' +
+          (w.enabled ? "" : " disabled") + ">start</button>"
+        : '<button class="ctrl wf-stop" type="button" data-name="' + esc(w.name) + '">stop</button>') +
+      "</div></div></div>"
     );
   }).join("");
   if (errors.length) {
@@ -62,3 +87,137 @@ function renderWorkflows() {
     if (card) card.scrollIntoView({ block: "center" });
   }
 }
+
+function setWfStatus(text, kind) {
+  const el = $("wf-status");
+  if (!el) return;
+  el.textContent = text || "";
+  el.className = kind || "";
+}
+
+async function postWorkflow(path, body) {
+  const res = await fetch(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: body == null ? "{}" : JSON.stringify(body),
+  });
+  const data = await res.json().catch(() => ({}));
+  return { status: res.status, ok: res.ok, data };
+}
+
+async function refreshWorkflowList() {
+  const w = await safeFetch("/api/workflows");
+  if (w.ok) {
+    workflows = w.data.workflows || [];
+    workflowErrors = w.data.errors || [];
+    renderWorkflows();
+  }
+}
+
+async function runWorkflow(name) {
+  if (wfActionBusy) return;
+  const item = workflows.find((w) => w.name === name);
+  if (!item) return;
+  const running = item.displayStatus === "running";
+  if (item.concurrency === "skip" && running) {
+    if (!confirm("This workflow is already running (concurrency=skip). A second run will be skipped. Continue?")) {
+      return;
+    }
+  }
+  if (item.concurrency === "parallel" && running) {
+    if (!confirm("This workflow allows parallel runs; start another?")) return;
+  }
+  const field = document.querySelector('.wf-instr[data-name="' + name + '"]');
+  const instructions = field ? String(field.value || "").trim() : "";
+  wfActionBusy = true;
+  setWfStatus("starting " + name + "…");
+  try {
+    const result = await postWorkflow("/api/workflows/" + encodeURIComponent(name) + "/run", {
+      instructions: instructions || undefined,
+    });
+    if (!result.ok && result.status !== 202) {
+      setWfStatus(result.data.error || ("run failed " + result.status), "err");
+      return;
+    }
+    const summary = result.data.summary || result.data.status || "started";
+    setWfStatus(summary, result.data.status === "skipped" ? "" : "ok");
+    await refreshWorkflowList();
+  } catch (err) {
+    setWfStatus(String(err && err.message ? err.message : err), "err");
+  } finally {
+    wfActionBusy = false;
+  }
+}
+
+async function toggleWorkflow(name, action) {
+  if (wfActionBusy) return;
+  wfActionBusy = true;
+  setWfStatus(action + " " + name + "…");
+  try {
+    const result = await postWorkflow(
+      "/api/workflows/" + encodeURIComponent(name) + "/" + action,
+    );
+    if (!result.ok) {
+      setWfStatus(result.data.error || (action + " failed " + result.status), "err");
+      return;
+    }
+    setWfStatus(name + " " + (result.data.status || action), "ok");
+    await refreshWorkflowList();
+  } catch (err) {
+    setWfStatus(String(err && err.message ? err.message : err), "err");
+  } finally {
+    wfActionBusy = false;
+  }
+}
+
+async function reloadWorkflows() {
+  if (wfActionBusy) return;
+  wfActionBusy = true;
+  setWfStatus("reloading…");
+  try {
+    const result = await postWorkflow("/api/workflows/reload");
+    if (!result.ok) {
+      setWfStatus(result.data.error || ("reload failed " + result.status), "err");
+      return;
+    }
+    setWfStatus("reloaded " + (result.data.definitions ?? 0) + " workflow(s)", "ok");
+    await refreshWorkflowList();
+  } catch (err) {
+    setWfStatus(String(err && err.message ? err.message : err), "err");
+  } finally {
+    wfActionBusy = false;
+  }
+}
+
+document.addEventListener("click", (event) => {
+  const run = event.target.closest && event.target.closest(".wf-run");
+  if (run) {
+    event.preventDefault();
+    runWorkflow(run.dataset.name);
+    return;
+  }
+  const start = event.target.closest && event.target.closest(".wf-start");
+  if (start) {
+    event.preventDefault();
+    toggleWorkflow(start.dataset.name, "start");
+    return;
+  }
+  const stop = event.target.closest && event.target.closest(".wf-stop");
+  if (stop) {
+    event.preventDefault();
+    toggleWorkflow(stop.dataset.name, "stop");
+    return;
+  }
+  if (event.target.id === "wf-reload") {
+    event.preventDefault();
+    reloadWorkflows();
+  }
+});
+
+document.addEventListener("input", (event) => {
+  const field = event.target.closest && event.target.closest(".wf-instr");
+  if (!field) return;
+  const name = field.dataset.name;
+  const counter = document.querySelector('.wf-count[data-count="' + name + '"]');
+  if (counter) counter.textContent = field.value.length + " / " + WF_INSTR_MAX;
+});

--- a/public/js/workflows.js
+++ b/public/js/workflows.js
@@ -80,11 +80,53 @@ function renderWorkflows() {
     html += '<div class="empty" style="color:var(--red)">Validation errors: ' +
       errors.map((e) => esc(e.path) + " — " + esc(e.message)).join("; ") + "</div>";
   }
+  const draft = snapshotWorkflowInputs();
   $("wf-list").innerHTML = html;
+  restoreWorkflowInputs(draft);
   if (workflowScrollPending && selectedWorkflowName) {
     workflowScrollPending = false;
     const card = document.getElementById("wf-card-" + selectedWorkflowName);
     if (card) card.scrollIntoView({ block: "center" });
+  }
+}
+
+function snapshotWorkflowInputs() {
+  const values = {};
+  let focus = null;
+  const list = $("wf-list");
+  if (!list) return { values, focus };
+  for (const field of list.querySelectorAll(".wf-instr")) {
+    values[field.dataset.name] = field.value;
+  }
+  const active = document.activeElement;
+  if (active && active.classList && active.classList.contains("wf-instr")) {
+    focus = {
+      name: active.dataset.name,
+      start: active.selectionStart,
+      end: active.selectionEnd,
+    };
+  }
+  return { values, focus };
+}
+
+function restoreWorkflowInputs(draft) {
+  const list = $("wf-list");
+  if (!list) return;
+  for (const name of Object.keys(draft.values || {})) {
+    const field = list.querySelector('.wf-instr[data-name="' + name + '"]');
+    if (!field) continue;
+    field.value = draft.values[name];
+    const counter = list.querySelector('.wf-count[data-count="' + name + '"]');
+    if (counter) counter.textContent = field.value.length + " / " + WF_INSTR_MAX;
+  }
+  if (!draft.focus) return;
+  const field = list.querySelector('.wf-instr[data-name="' + draft.focus.name + '"]');
+  if (!field) return;
+  field.focus();
+  try {
+    field.setSelectionRange(draft.focus.start, draft.focus.end);
+  } catch {
+    // some browsers reject setSelectionRange on an unfocused node
   }
 }
 
@@ -118,20 +160,20 @@ async function runWorkflow(name) {
   if (wfActionBusy) return;
   const item = workflows.find((w) => w.name === name);
   if (!item) return;
-  const running = item.displayStatus === "running";
-  if (item.concurrency === "skip" && running) {
-    if (!confirm("This workflow is already running (concurrency=skip). A second run will be skipped. Continue?")) {
-      return;
-    }
-  }
-  if (item.concurrency === "parallel" && running) {
-    if (!confirm("This workflow allows parallel runs; start another?")) return;
-  }
-  const field = document.querySelector('.wf-instr[data-name="' + name + '"]');
-  const instructions = field ? String(field.value || "").trim() : "";
   wfActionBusy = true;
-  setWfStatus("starting " + name + "…");
   try {
+    const running = item.displayStatus === "running";
+    if (item.concurrency === "skip" && running) {
+      if (!confirm("This workflow is already running (concurrency=skip). A second run will be skipped. Continue?")) {
+        return;
+      }
+    }
+    if (item.concurrency === "parallel" && running) {
+      if (!confirm("This workflow allows parallel runs; start another?")) return;
+    }
+    const field = document.querySelector('.wf-instr[data-name="' + name + '"]');
+    const instructions = field ? String(field.value || "").trim() : "";
+    setWfStatus("starting " + name + "…");
     const result = await postWorkflow("/api/workflows/" + encodeURIComponent(name) + "/run", {
       instructions: instructions || undefined,
     });

--- a/public/js/workflows.js
+++ b/public/js/workflows.js
@@ -1,6 +1,14 @@
 /* =================== workflows =================== */
 var WF_INSTR_MAX = 500;
 var wfActionBusy = false;
+var wfEditor = {
+  mode: null,
+  name: null,
+  sourceRoot: null,
+  fileVersionHash: null,
+  git: null,
+  parentGit: null,
+};
 
 function renderWorkflows() {
   const items = workflows;
@@ -73,6 +81,7 @@ function renderWorkflows() {
         ? '<button class="ctrl wf-start" type="button" data-name="' + esc(w.name) + '"' +
           (w.enabled ? "" : " disabled") + ">start</button>"
         : '<button class="ctrl wf-stop" type="button" data-name="' + esc(w.name) + '">stop</button>') +
+      '<button class="ctrl wf-edit" type="button" data-name="' + esc(w.name) + '">edit</button>' +
       "</div></div></div>"
     );
   }).join("");
@@ -152,7 +161,10 @@ async function refreshWorkflowList() {
   if (w.ok) {
     workflows = w.data.workflows || [];
     workflowErrors = w.data.errors || [];
+    workflowWriteGit = w.data.git || workflowWriteGit;
+    overlayRootExists = Boolean(w.data.overlayRootExists);
     renderWorkflows();
+    if (wfEditor.mode === "create") syncCreateGitControls();
   }
 }
 
@@ -253,6 +265,38 @@ document.addEventListener("click", (event) => {
   if (event.target.id === "wf-reload") {
     event.preventDefault();
     reloadWorkflows();
+    return;
+  }
+  const edit = event.target.closest && event.target.closest(".wf-edit");
+  if (edit) {
+    event.preventDefault();
+    openWorkflowEditor(edit.dataset.name);
+    return;
+  }
+  if (event.target.id === "wf-new") {
+    event.preventDefault();
+    openNewWorkflowEditor();
+    return;
+  }
+  if (event.target.id === "wf-editor-close") {
+    event.preventDefault();
+    closeWorkflowEditor();
+    return;
+  }
+  if (event.target.id === "wf-validate") {
+    event.preventDefault();
+    validateWorkflowEditor();
+    return;
+  }
+  if (event.target.id === "wf-save") {
+    event.preventDefault();
+    saveWorkflowEditor();
+  }
+});
+
+document.addEventListener("change", (event) => {
+  if (event.target.id === "wf-source-root" || event.target.id === "wf-anyway") {
+    syncCreateGitControls();
   }
 });
 
@@ -263,3 +307,256 @@ document.addEventListener("input", (event) => {
   const counter = document.querySelector('.wf-count[data-count="' + name + '"]');
   if (counter) counter.textContent = field.value.length + " / " + WF_INSTR_MAX;
 });
+
+function newWorkflowTemplate(name) {
+  const slug = name || "my-workflow";
+  return [
+    "---",
+    "name: " + slug,
+    "enabled: true",
+    "description: ",
+    "ownerSlackUserIds: []",
+    "triggers:",
+    "  - type: command",
+    "    command: " + slug,
+    "outputs:",
+    "  - type: docs",
+    "    path: data/workflow-runs/" + slug,
+    "permissions:",
+    "  tools:",
+    "    - docs.write",
+    "---",
+    "",
+    "Describe the work.",
+    "",
+  ].join("\n");
+}
+
+function gitBlocked(git) {
+  return Boolean(git && (git.detached || git.merging || git.rebasing));
+}
+
+function gitNeedsAnyway(git) {
+  return Boolean(git && git.branch && git.branch !== "main" && git.branch !== "master");
+}
+
+function writeReposForEditor() {
+  const sourceRoot = $("wf-source-root").value;
+  const repos = [];
+  if (wfEditor.mode === "edit") {
+    repos.push({ label: wfEditor.sourceRoot === "overlay" ? "agents-org" : "junior", git: wfEditor.git });
+    if (wfEditor.sourceRoot === "overlay") {
+      repos.push({ label: "junior", git: wfEditor.parentGit || (workflowWriteGit && workflowWriteGit.junior) });
+    }
+    return repos;
+  }
+  if (sourceRoot === "overlay") {
+    repos.push({ label: "agents-org", git: workflowWriteGit && workflowWriteGit.overlay });
+    repos.push({ label: "junior", git: workflowWriteGit && workflowWriteGit.junior });
+  } else {
+    repos.push({ label: "junior", git: workflowWriteGit && workflowWriteGit.junior });
+  }
+  return repos;
+}
+
+function renderEditorBanners(extra) {
+  const el = $("wf-banners");
+  if (!el) return;
+  const banners = extra ? extra.slice() : [];
+  if (wfEditor.mode === "edit" && wfEditor.sourceRoot === "overlay") {
+    banners.push("An overlay is active; editing the public file will not change runtime.");
+  }
+  if (wfEditor.runtimeUsesFile === false) {
+    banners.push(
+      "Runtime is using last-known-good (`" +
+      esc(wfEditor.loadedVersionHash || "") +
+      "`); editor shows on-disk bytes (`" +
+      esc(wfEditor.fileVersionHash || "") +
+      "`).",
+    );
+  }
+  el.innerHTML = banners.map((text) =>
+    '<div class="wf-banner' + (text.indexOf("parent pointer") >= 0 ? " err" : "") + '">' + text + "</div>"
+  ).join("");
+}
+
+function syncCreateGitControls() {
+  const repos = writeReposForEditor();
+  const blocked = repos.some((item) => gitBlocked(item.git));
+  const anywayNeeded = repos.some((item) => gitNeedsAnyway(item.git));
+  const row = $("wf-anyway-row");
+  const branch = $("wf-branch");
+  if (row) row.style.display = anywayNeeded && !blocked ? "flex" : "none";
+  if (branch) {
+    branch.textContent = repos
+      .filter((item) => gitNeedsAnyway(item.git))
+      .map((item) => item.label + ":" + item.git.branch)
+      .join(", ") || "branch";
+  }
+  const save = $("wf-save");
+  if (save) {
+    save.disabled = blocked || (anywayNeeded && !$("wf-anyway").checked);
+  }
+}
+
+function closeWorkflowEditor() {
+  wfEditor = {
+    mode: null,
+    name: null,
+    sourceRoot: null,
+    fileVersionHash: null,
+    git: null,
+    parentGit: null,
+  };
+  const editor = $("wf-editor");
+  if (editor) editor.classList.remove("open");
+  if ($("wf-save-result")) $("wf-save-result").textContent = "";
+}
+
+function openNewWorkflowEditor() {
+  wfEditor = {
+    mode: "create",
+    name: null,
+    sourceRoot: overlayRootExists ? "overlay" : "public",
+    fileVersionHash: null,
+    git: null,
+    parentGit: null,
+    runtimeUsesFile: true,
+  };
+  $("wf-editor-title").textContent = "New workflow";
+  $("wf-name").value = "";
+  $("wf-name").disabled = false;
+  $("wf-source-root").value = overlayRootExists ? "overlay" : "public";
+  $("wf-source-root").disabled = false;
+  $("wf-markdown").value = newWorkflowTemplate("my-workflow");
+  $("wf-anyway").checked = false;
+  $("wf-save-result").textContent = "";
+  $("wf-editor").classList.add("open");
+  renderEditorBanners();
+  syncCreateGitControls();
+}
+
+async function openWorkflowEditor(name) {
+  setWfStatus("loading " + name + "…");
+  const res = await safeFetch("/api/workflows/" + encodeURIComponent(name));
+  if (!res.ok) {
+    setWfStatus((res.data && res.data.error) || "failed to load workflow", "err");
+    return;
+  }
+  const source = res.data.source || {};
+  const git = res.data.git || {};
+  wfEditor = {
+    mode: "edit",
+    name: name,
+    sourceRoot: source.sourceRoot || "public",
+    fileVersionHash: source.fileVersionHash || "",
+    loadedVersionHash: source.loadedVersionHash || null,
+    runtimeUsesFile: res.data.runtimeUsesFile !== false,
+    git: git,
+    parentGit: git.parent || null,
+  };
+  $("wf-editor-title").textContent = "Edit " + name;
+  $("wf-name").value = name;
+  $("wf-name").disabled = true;
+  $("wf-source-root").value = wfEditor.sourceRoot;
+  $("wf-source-root").disabled = true;
+  $("wf-markdown").value = source.markdown || "";
+  $("wf-anyway").checked = false;
+  $("wf-save-result").textContent = "";
+  $("wf-editor").classList.add("open");
+  renderEditorBanners();
+  syncCreateGitControls();
+  setWfStatus("");
+}
+
+async function validateWorkflowEditor() {
+  const name = wfEditor.mode === "create" ? String($("wf-name").value || "").trim() : wfEditor.name;
+  if (!name) {
+    setWfStatus("name is required", "err");
+    return;
+  }
+  const result = await fetch("/api/workflows/" + encodeURIComponent(name) + "?validate=1", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ markdown: $("wf-markdown").value }),
+  });
+  const data = await result.json().catch(() => ({}));
+  if (!result.ok) {
+    const errors = (data.errors || []).map((e) => e.message).join("; ");
+    setWfStatus(errors || data.error || "invalid workflow", "err");
+    return;
+  }
+  setWfStatus("valid", "ok");
+}
+
+async function saveWorkflowEditor() {
+  if (wfActionBusy) return;
+  const name = wfEditor.mode === "create" ? String($("wf-name").value || "").trim() : wfEditor.name;
+  if (!name) {
+    setWfStatus("name is required", "err");
+    return;
+  }
+  wfActionBusy = true;
+  $("wf-save").disabled = true;
+  setWfStatus("saving " + name + "…");
+  try {
+    const payload = {
+      markdown: $("wf-markdown").value,
+      sourceRoot: $("wf-source-root").value,
+      commitHereAnyway: $("wf-anyway").checked,
+    };
+    if (wfEditor.mode === "create") payload.name = name;
+    if (wfEditor.mode === "edit" && wfEditor.fileVersionHash) {
+      payload.expectedVersionHash = wfEditor.fileVersionHash;
+    }
+    const path = wfEditor.mode === "create"
+      ? "/api/workflows"
+      : "/api/workflows/" + encodeURIComponent(name);
+    const result = await fetch(path, {
+      method: wfEditor.mode === "create" ? "POST" : "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    const data = await result.json().catch(() => ({}));
+    if (!result.ok) {
+      const errors = (data.errors || []).map((e) => e.message).join("; ");
+      setWfStatus(errors || data.error || ("save failed " + result.status), "err");
+      return;
+    }
+    const lines = [];
+    if (data.commit) {
+      lines.push(
+        data.commit.repo + " " + (data.commit.sha || "").slice(0, 12) +
+        " on " + (data.commit.branch || "?") + " · not pushed",
+      );
+      if (data.commit.stat) lines.push(data.commit.stat);
+    }
+    if (data.parentPointer && data.parentPointer.sha) {
+      lines.push(
+        "junior pointer " + data.parentPointer.sha.slice(0, 12) +
+        " on " + (data.parentPointer.branch || "?") + " · not pushed",
+      );
+      if (data.parentPointer.stat) lines.push(data.parentPointer.stat);
+    }
+    $("wf-save-result").textContent = lines.join("\n");
+    const extra = [];
+    if (data.parentPointerCommitted === false) {
+      extra.push(
+        "parent pointer failed after overlay commit " +
+        ((data.commit && data.commit.sha) || "") +
+        ". Bump agents-org manually. " +
+        ((data.parentPointer && data.parentPointer.detail) || data.parentPointer && data.parentPointer.code || ""),
+      );
+    }
+    renderEditorBanners(extra);
+    setWfStatus("saved " + name, data.parentPointerCommitted === false ? "err" : "ok");
+    if (wfEditor.mode === "edit") wfEditor.fileVersionHash = data.versionHash;
+    await refreshWorkflowList();
+    if (wfEditor.mode === "edit") await openWorkflowEditor(name);
+  } catch (err) {
+    setWfStatus(String(err && err.message ? err.message : err), "err");
+  } finally {
+    wfActionBusy = false;
+    syncCreateGitControls();
+  }
+}

--- a/public/js/workflows.js
+++ b/public/js/workflows.js
@@ -363,8 +363,10 @@ function renderEditorBanners(extra) {
   const el = $("wf-banners");
   if (!el) return;
   const banners = extra ? extra.slice() : [];
-  if (wfEditor.mode === "edit" && wfEditor.sourceRoot === "overlay") {
+  if (wfEditor.mode === "edit" && wfEditor.sourceRoot === "public" && wfEditor.overlayExists) {
     banners.push("An overlay is active; editing the public file will not change runtime.");
+  } else if (wfEditor.mode === "edit" && wfEditor.sourceRoot === "overlay") {
+    banners.push("An overlay is active; runtime loads this overlay file.");
   }
   if (wfEditor.runtimeUsesFile === false) {
     banners.push(
@@ -451,6 +453,7 @@ async function openWorkflowEditor(name) {
     sourceRoot: source.sourceRoot || "public",
     fileVersionHash: source.fileVersionHash || "",
     loadedVersionHash: source.loadedVersionHash || null,
+    overlayExists: Boolean(source.overlayExists || source.sourceRoot === "overlay"),
     runtimeUsesFile: res.data.runtimeUsesFile !== false,
     git: git,
     parentGit: git.parent || null,
@@ -506,7 +509,7 @@ async function saveWorkflowEditor() {
       commitHereAnyway: $("wf-anyway").checked,
     };
     if (wfEditor.mode === "create") payload.name = name;
-    if (wfEditor.mode === "edit" && wfEditor.fileVersionHash) {
+    if (wfEditor.mode === "edit") {
       payload.expectedVersionHash = wfEditor.fileVersionHash;
     }
     const path = wfEditor.mode === "create"

--- a/src/http/match-api.ts
+++ b/src/http/match-api.ts
@@ -1,0 +1,110 @@
+import { WORKFLOW_NAME_RE } from "../workflows/definition.ts";
+
+export type MatchedApi =
+  | { kind: "health" }
+  | { kind: "sessions" }
+  | { kind: "session"; threadId: string }
+  | { kind: "session-continue"; threadId: string }
+  | { kind: "session-stop"; threadId: string }
+  | { kind: "dev-server" }
+  | { kind: "workflows" }
+  | { kind: "workflow-reload" }
+  | { kind: "workflow"; name: string }
+  | { kind: "workflow-run"; name: string }
+  | { kind: "workflow-start"; name: string }
+  | { kind: "workflow-stop"; name: string }
+  | { kind: "pipelines" }
+  | { kind: "pipeline"; id: string }
+  | { kind: "pipeline-artifacts"; id: string }
+  | { kind: "spend" }
+  | { kind: "runbooks" }
+  | { kind: "runbook"; name: string }
+  | { kind: "audit" }
+  | { kind: "logs" }
+  | { kind: "profiles" }
+  | { kind: "memory" }
+  | { kind: "memory-recall" }
+  | { kind: "memory-projection" }
+  | { kind: "memory-read"; filePath: string }
+  | { kind: "not-found" };
+
+const GET = ["GET"] as const;
+const POST = ["POST"] as const;
+
+export function allowedMethods(kind: MatchedApi["kind"]): readonly string[] {
+  switch (kind) {
+    case "session-continue":
+    case "session-stop":
+    case "workflow-reload":
+    case "workflow-run":
+    case "workflow-start":
+    case "workflow-stop":
+      return POST;
+    case "not-found":
+      return [];
+    default:
+      return GET;
+  }
+}
+
+export function matchApi(pathname: string): MatchedApi {
+  if (pathname === "/api/health") return { kind: "health" };
+  if (pathname === "/api/sessions") return { kind: "sessions" };
+  if (pathname.startsWith("/api/sessions/")) {
+    const rest = decodeURIComponent(pathname.slice("/api/sessions/".length));
+    const parts = rest.split("/").filter(Boolean);
+    if (parts.length === 1) return { kind: "session", threadId: parts[0]! };
+    if (parts.length === 2 && parts[1] === "continue") {
+      return { kind: "session-continue", threadId: parts[0]! };
+    }
+    if (parts.length === 2 && parts[1] === "stop") {
+      return { kind: "session-stop", threadId: parts[0]! };
+    }
+    return { kind: "not-found" };
+  }
+  if (pathname === "/api/dev-server") return { kind: "dev-server" };
+  if (pathname === "/api/workflows") return { kind: "workflows" };
+  if (pathname === "/api/workflows/reload") return { kind: "workflow-reload" };
+  if (pathname.startsWith("/api/workflows/")) {
+    const rest = decodeURIComponent(pathname.slice("/api/workflows/".length));
+    const parts = rest.split("/").filter(Boolean);
+    if (parts.length === 1 && WORKFLOW_NAME_RE.test(parts[0]!)) {
+      return { kind: "workflow", name: parts[0]! };
+    }
+    if (parts.length === 2 && WORKFLOW_NAME_RE.test(parts[0]!)) {
+      if (parts[1] === "run") return { kind: "workflow-run", name: parts[0]! };
+      if (parts[1] === "start") return { kind: "workflow-start", name: parts[0]! };
+      if (parts[1] === "stop") return { kind: "workflow-stop", name: parts[0]! };
+    }
+    return { kind: "not-found" };
+  }
+  if (pathname === "/api/pipelines") return { kind: "pipelines" };
+  if (pathname.startsWith("/api/pipelines/")) {
+    const rest = decodeURIComponent(pathname.slice("/api/pipelines/".length));
+    const artifactsMatch = rest.match(/^([^/]+)\/artifacts$/);
+    if (artifactsMatch?.[1]) {
+      return { kind: "pipeline-artifacts", id: artifactsMatch[1] };
+    }
+    if (!rest || rest.includes("/")) return { kind: "not-found" };
+    return { kind: "pipeline", id: rest };
+  }
+  if (pathname === "/api/spend") return { kind: "spend" };
+  if (pathname === "/api/runbooks") return { kind: "runbooks" };
+  if (pathname.startsWith("/api/runbooks/")) {
+    const name = decodeURIComponent(pathname.slice("/api/runbooks/".length));
+    if (!name || name.includes("/")) return { kind: "not-found" };
+    return { kind: "runbook", name };
+  }
+  if (pathname === "/api/audit") return { kind: "audit" };
+  if (pathname === "/api/logs") return { kind: "logs" };
+  if (pathname === "/api/profiles") return { kind: "profiles" };
+  if (pathname === "/api/memory") return { kind: "memory" };
+  if (pathname === "/api/memory/recall") return { kind: "memory-recall" };
+  if (pathname === "/api/memory/projection") return { kind: "memory-projection" };
+  if (pathname.startsWith("/api/memory/")) {
+    const filePath = decodeURIComponent(pathname.slice("/api/memory/".length));
+    if (!filePath) return { kind: "not-found" };
+    return { kind: "memory-read", filePath };
+  }
+  return { kind: "not-found" };
+}

--- a/src/http/match-api.ts
+++ b/src/http/match-api.ts
@@ -30,6 +30,8 @@ export type MatchedApi =
 
 const GET = ["GET"] as const;
 const POST = ["POST"] as const;
+const GET_POST = ["GET", "POST"] as const;
+const GET_PUT = ["GET", "PUT"] as const;
 
 export function allowedMethods(kind: MatchedApi["kind"]): readonly string[] {
   switch (kind) {
@@ -40,6 +42,10 @@ export function allowedMethods(kind: MatchedApi["kind"]): readonly string[] {
     case "workflow-start":
     case "workflow-stop":
       return POST;
+    case "workflows":
+      return GET_POST;
+    case "workflow":
+      return GET_PUT;
     case "not-found":
       return [];
     default:

--- a/src/http/routes/sessions-write.test.ts
+++ b/src/http/routes/sessions-write.test.ts
@@ -1,0 +1,416 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import type { Config } from "../../config.ts";
+import type {
+  SpawnHandle,
+  SpawnResult,
+  SpawnRunnerFn,
+} from "../../runners/types.ts";
+import { SessionManager } from "../../session/manager.ts";
+import { InMemorySessionStore } from "../../session/store/memory.ts";
+import { createSession } from "../../session/types.ts";
+import { InMemoryPipelineStore } from "../../pipelines/store/memory.ts";
+import { InMemoryDashboardAuditStore } from "../audit/memory.ts";
+import { InMemoryUsageStore } from "../../usage/store/memory.ts";
+import { startHttpServer, type HttpServerDeps } from "../server.ts";
+import {
+  formatDashboardContinueSlackBody,
+} from "./sessions.ts";
+
+const THREAD_ID = "1712345678.123456";
+const CHANNEL = "C123";
+
+describe("session continue/stop writes", () => {
+  let store: InMemorySessionStore;
+  let manager: SessionManager;
+  let auditStore: InMemoryDashboardAuditStore;
+  let slackPosts: Array<{ channel: string; threadTs: string; text: string }>;
+  let slackPostResult: { ts: string } | null;
+  let spawn: ReturnType<typeof mock<SpawnRunnerFn>>;
+  let lastHandle: SpawnHandle;
+  let server: ReturnType<typeof startHttpServer> | undefined;
+  let config: Config;
+
+  beforeEach(async () => {
+    store = new InMemorySessionStore();
+    auditStore = new InMemoryDashboardAuditStore();
+    slackPosts = [];
+    slackPostResult = { ts: "1712345678.999001" };
+    lastHandle = createHandle();
+    spawn = mock<SpawnRunnerFn>((() => lastHandle) as SpawnRunnerFn);
+    config = testConfig();
+    manager = new SessionManager(store, config, spawn);
+    await store.set(THREAD_ID, createSession(THREAD_ID, CHANNEL));
+  });
+
+  afterEach(() => {
+    server?.stop(true);
+    server = undefined;
+  });
+
+  it("continues an idle session with 202 accepted", async () => {
+    const res = await continueRequest({ prompt: "please continue" });
+    expect(res.status).toBe(202);
+    expect(await res.json()).toEqual({ status: "accepted" });
+    expect(slackPosts).toHaveLength(1);
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect((spawn.mock.calls[0] as unknown[])[1]).toBe("please continue");
+    const audit = await auditStore.list({ action: "session.continue" });
+    expect(audit[0]).toMatchObject({
+      result: "ok",
+      slackTs: "1712345678.999001",
+    });
+  });
+
+  it("returns 202 buffered from injectDashboardContinue when the agent is busy", async () => {
+    await manager.handleMessage({
+      threadId: THREAD_ID,
+      channel: CHANNEL,
+      user: "UADMIN01",
+      text: "start the task",
+      ts: "1.1",
+      command: null,
+    });
+    expect(spawn).toHaveBeenCalledTimes(1);
+
+    const res = await continueRequest({ prompt: "follow up" });
+    expect(res.status).toBe(202);
+    expect(await res.json()).toEqual({ status: "buffered" });
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect(slackPosts).toHaveLength(1);
+    const session = await store.get(THREAD_ID);
+    expect(session?.pendingMessages.map((m) => m.text)).toEqual(["follow up"]);
+    const audit = await auditStore.list({ action: "session.continue" });
+    expect(audit[0]?.result).toBe("buffered");
+  });
+
+  it("returns 409 for a muted session and does not post to Slack", async () => {
+    await store.mutateThread(THREAD_ID, (s) => {
+      s.muted = true;
+    });
+    const res = await continueRequest({ prompt: "hello" });
+    expect(res.status).toBe(409);
+    expect(await res.json()).toEqual({ error: "session muted" });
+    expect(slackPosts).toHaveLength(0);
+    expect(spawn).not.toHaveBeenCalled();
+    const audit = await auditStore.list({ action: "session.continue" });
+    expect(audit[0]).toMatchObject({ result: "denied", error: "session muted" });
+  });
+
+  it("returns 502 when Slack post fails and does not inject", async () => {
+    slackPostResult = null;
+    const res = await continueRequest({ prompt: "hello" });
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({ error: "slack post failed" });
+    expect(spawn).not.toHaveBeenCalled();
+    expect((await store.get(THREAD_ID))?.status).toBe("idle");
+    const audit = await auditStore.list({ action: "session.continue" });
+    expect(audit[0]).toMatchObject({ result: "error", error: "slack post failed" });
+  });
+
+  it("returns 400 for an unknown or not-on-thread agent before Slack post", async () => {
+    const unknown = await continueRequest({ prompt: "hello", agentName: "review" });
+    expect(unknown.status).toBe(400);
+    expect(await unknown.json()).toEqual({ error: "unknown-agent" });
+    expect(slackPosts).toHaveLength(0);
+    expect(spawn).not.toHaveBeenCalled();
+
+    const missing = await continueRequest({ prompt: "hello" }, "missing-thread");
+    expect(missing.status).toBe(404);
+    expect(slackPosts).toHaveLength(0);
+  });
+
+  it('routes defaultAgent "junior" to handleMessage and never handleAgentMessage', async () => {
+    await store.mutateThread(THREAD_ID, (s) => {
+      s.defaultAgent = "junior";
+    });
+    const agentCalls: string[] = [];
+    const origAgent = manager.handleAgentMessage.bind(manager);
+    manager.handleAgentMessage = async (event, agentName) => {
+      agentCalls.push(agentName);
+      return origAgent(event, agentName);
+    };
+
+    const res = await continueRequest({ prompt: "keep going" });
+    expect(res.status).toBe(202);
+    expect(await res.json()).toEqual({ status: "accepted" });
+    expect(agentCalls).toEqual([]);
+    expect((await store.get(THREAD_ID))?.agentSessions?.junior).toBeUndefined();
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it("quotes a !review prompt on Slack and injects exactly once", async () => {
+    const injectCalls: unknown[] = [];
+    const origInject = manager.injectDashboardContinue.bind(manager);
+    manager.injectDashboardContinue = async (input) => {
+      injectCalls.push(input);
+      return origInject(input);
+    };
+    const agentCalls: string[] = [];
+    const origAgent = manager.handleAgentMessage.bind(manager);
+    manager.handleAgentMessage = async (event, agentName) => {
+      agentCalls.push(agentName);
+      return origAgent(event, agentName);
+    };
+
+    const prompt = "!review please inspect this\nand another line";
+    const res = await continueRequest({ prompt });
+    expect(res.status).toBe(202);
+    expect(slackPosts).toHaveLength(1);
+    const body = slackPosts[0]!.text;
+    expect(body.startsWith("*Dashboard continue*")).toBe(true);
+    expect(body).toBe(formatDashboardContinueSlackBody("UADMIN01", prompt));
+    for (const line of body.split("\n")) {
+      expect(line.match(/^!(\S+)/)).toBeNull();
+    }
+    expect(body).toContain("> ");
+    expect(injectCalls).toHaveLength(1);
+    expect(agentCalls).toEqual([]);
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not hijack an active pipeline run via routeDirectTaskThroughDefaultRun", async () => {
+    const pipelineStore = new InMemoryPipelineStore();
+    config = testConfig({
+      pipeline: {
+        runtimeMode: "active",
+        legacyDirectivesEnabled: true,
+        bugPipelineEnabled: true,
+        productPipelineEnabled: true,
+        retentionDays: 90,
+      },
+    });
+    manager = new SessionManager(store, config, spawn);
+    manager.pipelineStore = pipelineStore;
+
+    await manager.handleMessage({
+      threadId: THREAD_ID,
+      channel: CHANNEL,
+      user: "UADMIN01",
+      text: "start the task",
+      ts: "1.1",
+      command: null,
+    });
+    const beforeAssignments = (await pipelineStore.getRunByThread(THREAD_ID))
+      ? await pipelineStore.listAssignments(
+        (await pipelineStore.getRunByThread(THREAD_ID))!.id,
+      )
+      : [];
+
+    const res = await continueRequest({ prompt: "dashboard follow-up" });
+    expect(res.status).toBe(202);
+    expect(await res.json()).toEqual({ status: "buffered" });
+    const session = await store.get(THREAD_ID);
+    expect(session?.pendingMessages.map((m) => m.text)).toEqual(["dashboard follow-up"]);
+    expect(session?.pendingMessages[0]?.text).not.toContain("[task-follow-up]");
+    const run = await pipelineStore.getRunByThread(THREAD_ID);
+    const afterAssignments = run ? await pipelineStore.listAssignments(run.id) : [];
+    expect(afterAssignments).toHaveLength(beforeAssignments.length);
+    expect(
+      afterAssignments.some((a) => a.contextRefs.includes("control-branch:human-input")),
+    ).toBe(false);
+  });
+
+  it("buffers a dashboard continue when short-followup interrupt is enabled", async () => {
+    config = testConfig({
+      session: {
+        ...testConfig().session,
+        shortFollowupInterruptEnabled: true,
+        shortFollowupMaxLength: 240,
+      },
+    });
+    lastHandle = createHandle();
+    const kill = lastHandle.kill as ReturnType<typeof mock>;
+    manager = new SessionManager(store, config, spawn);
+
+    await manager.handleMessage({
+      threadId: THREAD_ID,
+      channel: CHANNEL,
+      user: "UADMIN01",
+      text: "start the task",
+      ts: "1.1",
+      command: null,
+    });
+
+    const res = await continueRequest({ prompt: "small correction" });
+    expect(res.status).toBe(202);
+    expect(await res.json()).toEqual({ status: "buffered" });
+    expect(kill).not.toHaveBeenCalled();
+    expect(spawn).toHaveBeenCalledTimes(1);
+    expect((await store.get(THREAD_ID))?.pendingMessages[0]?.text).toBe("small correction");
+  });
+
+  it("stop calls interruptThread and posts the !stop Slack line", async () => {
+    await manager.handleMessage({
+      threadId: THREAD_ID,
+      channel: CHANNEL,
+      user: "UADMIN01",
+      text: "go",
+      ts: "1.1",
+      command: null,
+    });
+    expect((await store.get(THREAD_ID))?.status).toBe("busy");
+
+    const res = await stopRequest();
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      status: "ok",
+      interrupted: 1,
+      message: "Interrupted (1 agent). Send a new message to continue.",
+    });
+    expect(lastHandle.kill).toHaveBeenCalled();
+    expect(slackPosts).toEqual([{
+      channel: CHANNEL,
+      threadTs: THREAD_ID,
+      text: "Interrupted (1 agent). Send a new message to continue.",
+    }]);
+    expect((await store.get(THREAD_ID))?.status).toBe("idle");
+    const audit = await auditStore.list({ action: "session.stop" });
+    expect(audit[0]).toMatchObject({
+      result: "ok",
+      slackTs: "1712345678.999001",
+    });
+  });
+
+  it("returns 405 on POST /api/sessions/:id", async () => {
+    const res = await request("POST", `/api/sessions/${THREAD_ID}`);
+    expect(res.status).toBe(405);
+    expect(await res.json()).toEqual({ error: "method not allowed" });
+    expect(slackPosts).toHaveLength(0);
+    expect(spawn).not.toHaveBeenCalled();
+  });
+
+  async function continueRequest(
+    body: { prompt: string; agentName?: string },
+    threadId = THREAD_ID,
+  ) {
+    return request("POST", `/api/sessions/${threadId}/continue`, body);
+  }
+
+  async function stopRequest(threadId = THREAD_ID) {
+    return request("POST", `/api/sessions/${threadId}/stop`);
+  }
+
+  async function request(method: string, path: string, body?: unknown) {
+    ensureServer();
+    return fetch(`http://127.0.0.1:${server!.port}${path}`, {
+      method,
+      headers: body ? { "content-type": "application/json" } : undefined,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+  }
+
+  function ensureServer() {
+    if (server) return;
+    server = startHttpServer(deps());
+  }
+
+  function deps(): HttpServerDeps {
+    return {
+      store,
+      config,
+      devServerManager: {} as HttpServerDeps["devServerManager"],
+      devServerQueue: {} as HttpServerDeps["devServerQueue"],
+      repos: [],
+      workflowRegistry: {} as HttpServerDeps["workflowRegistry"],
+      workflowScheduler: {} as HttpServerDeps["workflowScheduler"],
+      workflowStore: {} as HttpServerDeps["workflowStore"],
+      pipelineStore: {} as HttpServerDeps["pipelineStore"],
+      usageStore: new InMemoryUsageStore(),
+      auditStore,
+      sessionManager: manager,
+      slackPoster: {
+        post: async (channel, threadTs, text) => {
+          if (!slackPostResult) return null;
+          slackPosts.push({ channel, threadTs, text });
+          return slackPostResult;
+        },
+        react: async () => {},
+      },
+    };
+  }
+});
+
+function createHandle(): SpawnHandle {
+  let resolveResult!: (result: SpawnResult) => void;
+  const result = new Promise<SpawnResult>((res) => {
+    resolveResult = res;
+  });
+  return {
+    provider: "claude",
+    result,
+    onEvent: () => undefined,
+    kill: mock(() => {
+      resolveResult({
+        provider: "claude",
+        sessionId: "ses-1",
+        response: "",
+        events: [],
+        exitCode: 130,
+        error: "interrupted",
+      });
+    }),
+    pid: 1,
+  };
+}
+
+function testConfig(overrides: Partial<Config> = {}): Config {
+  return {
+    slack: { botToken: "xoxb-test", appToken: "xapp-test", signingSecret: "s" },
+    claude: {
+      maxTurns: 25,
+      timeoutMs: 300000,
+      permissionMode: "bypassPermissions",
+      defaultModel: null,
+      defaultDriver: "headless",
+      tmuxIdleTtlMs: 14_400_000,
+      tmuxSweepIntervalMs: 900_000,
+    },
+    runner: { provider: "claude" },
+    opencode: {
+      model: null,
+      timeoutMs: 300000,
+      continuityEnabled: false,
+      permission: "allow",
+      mcpEnabled: true,
+      slackMcpEnabled: true,
+      playwrightMcpEnabled: true,
+      mixpanelMcpEnabled: true,
+      mongodbMcpEnabled: true,
+    },
+    codex: {
+      mode: "app-server",
+      model: null,
+      timeoutMs: 300000,
+      sandbox: "workspace-write",
+      askForApproval: "never",
+      searchEnabled: false,
+      appServerContinuityEnabled: false,
+      mcpEnabled: true,
+      slackMcpEnabled: true,
+      playwrightMcpEnabled: true,
+      mixpanelMcpEnabled: true,
+      mongodbMcpEnabled: true,
+      memoryMcpEnabled: true,
+      isolatedHomePath: "data/codex-home",
+    },
+    repos: [],
+    session: {
+      staleTimeoutMs: 86400000,
+      cleanupIntervalMs: 900000,
+      store: "memory",
+      sqlitePath: "data/sessions.db",
+      homeWindowMs: 172800000,
+      defaultVerbosity: "quiet",
+      idleTimeoutMs: 300000,
+      maxIdleInterrupts: 3,
+      shortFollowupInterruptEnabled: false,
+      shortFollowupMaxLength: 280,
+    },
+    memory: { sqlitePath: "data/memory.db" },
+    threadArchives: { dir: "data/thread-archives" },
+    channelDefaults: {},
+    adminSlackUserId: "UADMIN01",
+    http: { enabled: true, port: 0 },
+    ...overrides,
+  } as Config;
+}

--- a/src/http/routes/sessions-write.test.ts
+++ b/src/http/routes/sessions-write.test.ts
@@ -324,7 +324,6 @@ describe("session continue/stop writes", () => {
           slackPosts.push({ channel, threadTs, text });
           return slackPostResult;
         },
-        react: async () => {},
       },
     };
   }

--- a/src/http/routes/sessions.ts
+++ b/src/http/routes/sessions.ts
@@ -16,7 +16,6 @@ const SLACK_ID_RE = /^[UWB][A-Z0-9]+$/;
 
 export type SlackPoster = {
   post: (channel: string, threadTs: string, text: string) => Promise<{ ts: string } | null>;
-  react: (channel: string, ts: string, emoji: string) => Promise<void>;
 };
 
 export function dashboardActor(config: Config): string {

--- a/src/http/routes/sessions.ts
+++ b/src/http/routes/sessions.ts
@@ -1,6 +1,36 @@
+import type { Config } from "../../config.ts";
+import type { DashboardAuditStore } from "../audit/interface.ts";
+import { log } from "../../logger.ts";
+import { resolveContinueRoute } from "../../session/continue-route.ts";
+import {
+  formatStopReply,
+  type SessionManager,
+} from "../../session/manager.ts";
 import type { SessionStore } from "../../session/store/interface.ts";
 import type { AgentSession, ThreadSession } from "../../session/types.ts";
 import type { UsageStore } from "../../usage/store/interface.ts";
+
+export const CONTINUE_PROMPT_MAX = 8000;
+
+const SLACK_ID_RE = /^[UWB][A-Z0-9]+$/;
+
+export type SlackPoster = {
+  post: (channel: string, threadTs: string, text: string) => Promise<{ ts: string } | null>;
+  react: (channel: string, ts: string, emoji: string) => Promise<void>;
+};
+
+export function dashboardActor(config: Config): string {
+  return config.adminSlackUserId ?? "dashboard-operator";
+}
+
+export function formatDashboardContinueSlackBody(
+  actor: string,
+  prompt: string,
+): string {
+  const who = SLACK_ID_RE.test(actor) ? `<@${actor}>` : "`dashboard-operator`";
+  const preview = prompt.replace(/\r\n/g, " · ").replace(/[\r\n]/g, " · ").slice(0, 240);
+  return `*Dashboard continue* · local operator · ${who}\n> ${preview}`;
+}
 
 export type SlackPermalinkResolver = (
   channel: string,
@@ -153,4 +183,273 @@ async function spendByThreadId(
     });
   }
   return result;
+}
+
+export async function handleSessionContinue(
+  req: Request,
+  threadId: string,
+  deps: {
+    sessionManager: Pick<
+      SessionManager,
+      "injectDashboardContinue" | "getSession"
+    >;
+    slackPoster: SlackPoster;
+    auditStore: DashboardAuditStore;
+    config: Config;
+  },
+): Promise<Response> {
+  const actor = dashboardActor(deps.config);
+  const parsed = await readJsonBody(req);
+  if (!parsed.ok) {
+    await recordSessionAudit(deps.auditStore, {
+      actor,
+      action: "session.continue",
+      targetId: threadId,
+      request: {},
+      result: "error",
+      error: parsed.error,
+    });
+    return Response.json({ error: parsed.error }, { status: 400 });
+  }
+
+  const prompt = parsed.value.prompt;
+  const agentName = parsed.value.agentName;
+  const request = {
+    prompt: typeof prompt === "string" ? prompt : prompt ?? null,
+    agentName: agentName ?? null,
+  };
+
+  if (typeof prompt !== "string" || prompt.trim() === "") {
+    await recordSessionAudit(deps.auditStore, {
+      actor,
+      action: "session.continue",
+      targetId: threadId,
+      request,
+      result: "error",
+      error: "invalid prompt",
+    });
+    return Response.json({ error: "invalid prompt" }, { status: 400 });
+  }
+  if (prompt.length > CONTINUE_PROMPT_MAX) {
+    await recordSessionAudit(deps.auditStore, {
+      actor,
+      action: "session.continue",
+      targetId: threadId,
+      request,
+      result: "error",
+      error: "prompt too long",
+    });
+    return Response.json({ error: "prompt too long" }, { status: 400 });
+  }
+  if (agentName !== undefined && typeof agentName !== "string") {
+    await recordSessionAudit(deps.auditStore, {
+      actor,
+      action: "session.continue",
+      targetId: threadId,
+      request,
+      result: "error",
+      error: "unknown-agent",
+    });
+    return Response.json({ error: "unknown-agent" }, { status: 400 });
+  }
+
+  const session = await deps.sessionManager.getSession(threadId);
+  if (!session) {
+    await recordSessionAudit(deps.auditStore, {
+      actor,
+      action: "session.continue",
+      targetId: threadId,
+      request,
+      result: "error",
+      error: "session not found",
+    });
+    return Response.json({ error: "session not found" }, { status: 404 });
+  }
+  if (!session.channel || !session.threadId) {
+    await recordSessionAudit(deps.auditStore, {
+      actor,
+      action: "session.continue",
+      targetId: threadId,
+      request,
+      result: "error",
+      error: "session has no channel",
+    });
+    return Response.json({ error: "session has no channel" }, { status: 400 });
+  }
+
+  const route = resolveContinueRoute(agentName, session);
+  if ("error" in route) {
+    await recordSessionAudit(deps.auditStore, {
+      actor,
+      action: "session.continue",
+      targetId: threadId,
+      request,
+      result: "error",
+      error: "unknown-agent",
+    });
+    return Response.json({ error: "unknown-agent" }, { status: 400 });
+  }
+
+  if (session.muted) {
+    await recordSessionAudit(deps.auditStore, {
+      actor,
+      action: "session.continue",
+      targetId: threadId,
+      request,
+      result: "denied",
+      error: "session muted",
+    });
+    return Response.json({ error: "session muted" }, { status: 409 });
+  }
+
+  const posted = await deps.slackPoster.post(
+    session.channel,
+    session.threadId,
+    formatDashboardContinueSlackBody(actor, prompt),
+  );
+  if (!posted?.ts) {
+    await recordSessionAudit(deps.auditStore, {
+      actor,
+      action: "session.continue",
+      targetId: threadId,
+      request,
+      result: "error",
+      error: "slack post failed",
+    });
+    return Response.json({ error: "slack post failed" }, { status: 502 });
+  }
+
+  const injected = await deps.sessionManager.injectDashboardContinue({
+    threadId: session.threadId,
+    channel: session.channel,
+    prompt,
+    agentName,
+    actorSlackUserId: actor,
+    postedTs: posted.ts,
+  });
+
+  if (injected.status === "muted") {
+    await recordSessionAudit(deps.auditStore, {
+      actor,
+      action: "session.continue",
+      targetId: threadId,
+      request,
+      result: "denied",
+      error: "session muted",
+      slackTs: posted.ts,
+    });
+    return Response.json({ error: "session muted" }, { status: 409 });
+  }
+
+  log.info(
+    "dashboard",
+    `action=session.continue thread=${threadId} result=${injected.status}`,
+  );
+  await recordSessionAudit(deps.auditStore, {
+    actor,
+    action: "session.continue",
+    targetId: threadId,
+    request,
+    result: injected.status === "buffered" ? "buffered" : "ok",
+    slackTs: posted.ts,
+  });
+  return Response.json({ status: injected.status }, { status: 202 });
+}
+
+export async function handleSessionStop(
+  threadId: string,
+  deps: {
+    sessionManager: Pick<SessionManager, "interruptThread" | "getSession">;
+    slackPoster: SlackPoster;
+    auditStore: DashboardAuditStore;
+    config: Config;
+  },
+): Promise<Response> {
+  const actor = dashboardActor(deps.config);
+  const session = await deps.sessionManager.getSession(threadId);
+  if (!session) {
+    await recordSessionAudit(deps.auditStore, {
+      actor,
+      action: "session.stop",
+      targetId: threadId,
+      result: "error",
+      error: "session not found",
+    });
+    return Response.json({ error: "session not found" }, { status: 404 });
+  }
+  if (!session.channel || !session.threadId) {
+    await recordSessionAudit(deps.auditStore, {
+      actor,
+      action: "session.stop",
+      targetId: threadId,
+      result: "error",
+      error: "session has no channel",
+    });
+    return Response.json({ error: "session has no channel" }, { status: 400 });
+  }
+
+  const interrupted = await deps.sessionManager.interruptThread(session.threadId);
+  const message = formatStopReply(interrupted);
+  const posted = await deps.slackPoster.post(
+    session.channel,
+    session.threadId,
+    message,
+  );
+
+  log.info(
+    "dashboard",
+    `action=session.stop thread=${threadId} result=ok interrupted=${interrupted}`,
+  );
+  await recordSessionAudit(deps.auditStore, {
+    actor,
+    action: "session.stop",
+    targetId: threadId,
+    result: posted?.ts ? "ok" : "partial",
+    error: posted?.ts ? null : "slack post failed",
+    slackTs: posted?.ts ?? null,
+  });
+  return Response.json({ status: "ok", interrupted, message });
+}
+
+async function readJsonBody(
+  req: Request,
+): Promise<
+  | { ok: true; value: { prompt?: unknown; agentName?: unknown } }
+  | { ok: false; error: string }
+> {
+  const text = await req.text();
+  if (!text.trim()) return { ok: true, value: {} };
+  try {
+    const value = JSON.parse(text) as { prompt?: unknown; agentName?: unknown };
+    if (value == null || typeof value !== "object" || Array.isArray(value)) {
+      return { ok: false, error: "invalid json" };
+    }
+    return { ok: true, value };
+  } catch {
+    return { ok: false, error: "invalid json" };
+  }
+}
+
+async function recordSessionAudit(
+  store: DashboardAuditStore,
+  entry: {
+    actor: string;
+    action: string;
+    targetId: string;
+    request?: Record<string, unknown>;
+    result: string;
+    error?: string | null;
+    slackTs?: string | null;
+  },
+): Promise<void> {
+  await store.record({
+    actor: entry.actor,
+    action: entry.action,
+    targetType: "session",
+    targetId: entry.targetId,
+    request: entry.request ?? {},
+    result: entry.result,
+    error: entry.error ?? null,
+    slackTs: entry.slackTs ?? null,
+  });
 }

--- a/src/http/routes/workflows-write.test.ts
+++ b/src/http/routes/workflows-write.test.ts
@@ -339,6 +339,60 @@ describe("workflow write routes", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it("probes git from the overlay file's toplevel, not Junior", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "junior-wf-git-"));
+    try {
+      const overlayRoot = join(dir, "agents-org");
+      const fileRel = join("workflows", "worklog.workflow.md");
+      mkdirSync(join(overlayRoot, "workflows"), { recursive: true });
+      writeFileSync(join(overlayRoot, fileRel), "# overlay\n");
+      await git(overlayRoot, ["init", "-b", "overlay-branch"]);
+      await git(overlayRoot, ["add", fileRel]);
+      await git(overlayRoot, [
+        "-c", "user.name=t",
+        "-c", "user.email=t@t.test",
+        "-c", "commit.gpgsign=false",
+        "commit", "-m", "overlay",
+      ]);
+      const overlaySha = (await git(overlayRoot, ["rev-parse", "HEAD"])).trim();
+
+      await git(dir, ["init", "-b", "junior-main"]);
+      writeFileSync(join(dir, "README.md"), "parent\n");
+      await git(dir, ["add", "README.md"]);
+      await git(dir, [
+        "-c", "user.name=t",
+        "-c", "user.email=t@t.test",
+        "-c", "commit.gpgsign=false",
+        "commit", "-m", "parent",
+      ]);
+      const parentSha = (await git(dir, ["rev-parse", "HEAD"])).trim();
+      expect(parentSha).not.toBe(overlaySha);
+
+      writeFileSync(join(overlayRoot, fileRel), "# overlay dirty\n");
+      const definition = workflowDefinition({
+        sourcePath: "agents-org/workflows/worklog.workflow.md",
+        sourceRoot: "overlay",
+      });
+      const response = await handleWorkflowDetail("worklog", {
+        registry: registryOf(definition),
+        store: new InMemoryWorkflowStore(),
+        scheduler: { isRunning: () => false },
+        projectRoot: dir,
+      });
+      const body = await response.json() as {
+        git: { sha: string | null; branch: string | null; detached: boolean; dirty: boolean };
+      };
+      expect(body.git).toEqual({
+        sha: overlaySha,
+        branch: "overlay-branch",
+        detached: false,
+        dirty: true,
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("workflow nested routing", () => {
@@ -453,6 +507,21 @@ function stubServerDeps(): HttpServerDeps {
       isExplicitAdmin: async () => false,
     },
   };
+}
+
+async function git(cwd: string, args: string[]): Promise<string> {
+  const proc = Bun.spawn(["git", ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, exited] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exited !== 0) throw new Error(`git ${args.join(" ")} failed: ${stderr}`);
+  return stdout;
 }
 
 async function waitFor(

--- a/src/http/routes/workflows-write.test.ts
+++ b/src/http/routes/workflows-write.test.ts
@@ -11,7 +11,9 @@ import { InMemoryWorkflowStore } from "../../workflows/store.ts";
 import type { WorkflowDefinition } from "../../workflows/types.ts";
 import { startHttpServer, type HttpServerDeps } from "../server.ts";
 import {
+  handleWorkflowCreate,
   handleWorkflowDetail,
+  handleWorkflowPut,
   handleWorkflowReload,
   handleWorkflowRun,
   handleWorkflowStart,
@@ -381,14 +383,337 @@ describe("workflow write routes", () => {
         projectRoot: dir,
       });
       const body = await response.json() as {
-        git: { sha: string | null; branch: string | null; detached: boolean; dirty: boolean };
+        git: {
+          sha: string | null;
+          branch: string | null;
+          detached: boolean;
+          dirty: boolean;
+          parent?: { branch: string | null; detached: boolean };
+        };
       };
-      expect(body.git).toEqual({
+      expect(body.git).toMatchObject({
         sha: overlaySha,
         branch: "overlay-branch",
         detached: false,
         dirty: true,
+        merging: false,
+        rebasing: false,
       });
+      expect(body.git.parent).toMatchObject({
+        detached: false,
+        branch: "junior-main",
+      });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("workflow create/edit routes", () => {
+  it("validates PUT without writing when validate=1", async () => {
+    const dir = tempDir();
+    try {
+      const original = validMarkdown();
+      writeFileSync(join(dir, "workflows", "worklog.workflow.md"), original);
+      const deps = baseDeps({ projectRoot: dir });
+      const response = await handleWorkflowPut(
+        "worklog",
+        jsonWriteReq("PUT", "http://127.0.0.1/api/workflows/worklog?validate=1", {
+          markdown: validMarkdown("worklog", "validated only"),
+        }),
+        deps,
+      );
+      expect(response.status).toBe(200);
+      const body = await response.json() as { valid: boolean; versionHash: string };
+      expect(body.valid).toBe(true);
+      expect(body.versionHash).toBe(hashWorkflowContent(validMarkdown("worklog", "validated only")));
+      expect(await Bun.file(join(dir, "workflows", "worklog.workflow.md")).text()).toBe(original);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns 400 with errors for invalid markdown and does not write", async () => {
+    const dir = tempDir();
+    try {
+      const original = validMarkdown();
+      writeFileSync(join(dir, "workflows", "worklog.workflow.md"), original);
+      const response = await handleWorkflowPut(
+        "worklog",
+        jsonWriteReq("PUT", "http://127.0.0.1/api/workflows/worklog", {
+          markdown: "---\nname: worklog\nenabled: true\nownerSlackUserIds: []\n---\nno schema",
+        }),
+        baseDeps({ projectRoot: dir }),
+      );
+      expect(response.status).toBe(400);
+      const body = await response.json() as { error: string; errors: Array<{ message: string }> };
+      expect(body.error).toBe("invalid workflow");
+      expect(body.errors[0]?.message).toContain("triggers");
+      expect(await Bun.file(join(dir, "workflows", "worklog.workflow.md")).text()).toBe(original);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("returns 409 when expectedVersionHash does not match the on-disk file", async () => {
+    const dir = tempDir();
+    try {
+      const original = validMarkdown();
+      writeFileSync(join(dir, "workflows", "worklog.workflow.md"), original);
+      const response = await handleWorkflowPut(
+        "worklog",
+        jsonWriteReq("PUT", "http://127.0.0.1/api/workflows/worklog", {
+          markdown: validMarkdown("worklog", "new"),
+          expectedVersionHash: "deadbeefdeadbeef",
+        }),
+        baseDeps({ projectRoot: dir }),
+      );
+      expect(response.status).toBe(409);
+      expect(await response.json()).toEqual({
+        error: "version hash mismatch",
+        fileVersionHash: hashWorkflowContent(original),
+      });
+      expect(await Bun.file(join(dir, "workflows", "worklog.workflow.md")).text()).toBe(original);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("allows PUT when the registry name is missing but the overlay file exists", async () => {
+    const pair = await initOverlayPairForHttp();
+    try {
+      const original = await Bun.file(
+        join(pair.overlay, "workflows", "worklog.workflow.md"),
+      ).text();
+      const registry = {
+        ...registryOf(workflowDefinition({
+          sourcePath: "agents-org/workflows/worklog.workflow.md",
+          sourceRoot: "overlay",
+        })),
+        get: () => undefined,
+        all: () => [],
+      } as unknown as WorkflowRegistry;
+      const next = validMarkdown("worklog", "from overlay file");
+      const response = await handleWorkflowPut(
+        "worklog",
+        jsonWriteReq("PUT", "http://127.0.0.1/api/workflows/worklog", {
+          markdown: next,
+          expectedVersionHash: hashWorkflowContent(original),
+        }),
+        baseDeps({ registry, projectRoot: pair.junior }),
+      );
+      expect(response.status).toBe(200);
+      const body = await response.json() as {
+        versionHash: string;
+        sourceRoot: string;
+        overlayCommitted: boolean;
+      };
+      expect(body.sourceRoot).toBe("overlay");
+      expect(body.overlayCommitted).toBe(true);
+      expect(body.versionHash).toBe(hashWorkflowContent(next));
+      expect(await Bun.file(join(pair.overlay, "workflows", "worklog.workflow.md")).text())
+        .toBe(next);
+    } finally {
+      rmSync(pair.root, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  it("commits a public edit and returns the new file hash", async () => {
+    const dir = await initJuniorRepo();
+    try {
+      mkdirSync(join(dir, "workflows"), { recursive: true });
+      const original = validMarkdown();
+      writeFileSync(join(dir, "workflows", "worklog.workflow.md"), original);
+      await git(dir, ["add", "--", "workflows/worklog.workflow.md"]);
+      await git(dir, ["commit", "-m", "public workflow"]);
+      const next = validMarkdown("worklog", "edited from dashboard");
+      const response = await handleWorkflowPut(
+        "worklog",
+        jsonWriteReq("PUT", "http://127.0.0.1/api/workflows/worklog", {
+          markdown: next,
+          expectedVersionHash: hashWorkflowContent(original),
+        }),
+        baseDeps({ projectRoot: dir }),
+      );
+      expect(response.status).toBe(200);
+      const body = await response.json() as {
+        versionHash: string;
+        sourceRoot: string;
+        overlayCommitted: boolean;
+        commit: { sha: string; branch: string; repo: string };
+      };
+      expect(body.sourceRoot).toBe("public");
+      expect(body.overlayCommitted).toBe(false);
+      expect(body.versionHash).toBe(hashWorkflowContent(next));
+      expect(body.commit.branch).toBe("main");
+      expect(body.commit.repo).toBe("junior");
+      expect(await Bun.file(join(dir, "workflows", "worklog.workflow.md")).text()).toBe(next);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("creates a public workflow with 201", async () => {
+    const dir = await initJuniorRepo();
+    try {
+      const markdown = validMarkdown("newlog");
+      const response = await handleWorkflowCreate(
+        jsonWriteReq("POST", "http://127.0.0.1/api/workflows", {
+          name: "newlog",
+          markdown,
+          sourceRoot: "public",
+        }),
+        baseDeps({ projectRoot: dir }),
+      );
+      expect(response.status).toBe(201);
+      const body = await response.json() as {
+        name: string;
+        versionHash: string;
+        sourcePath: string;
+      };
+      expect(body.name).toBe("newlog");
+      expect(body.sourcePath).toBe("workflows/newlog.workflow.md");
+      expect(body.versionHash).toBe(hashWorkflowContent(markdown));
+      expect(await Bun.file(join(dir, "workflows", "newlog.workflow.md")).text()).toBe(markdown);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("refuses a name collision in the chosen root", async () => {
+    const dir = tempDir();
+    try {
+      writeFileSync(join(dir, "workflows", "worklog.workflow.md"), validMarkdown());
+      const response = await handleWorkflowCreate(
+        jsonWriteReq("POST", "http://127.0.0.1/api/workflows", {
+          name: "worklog",
+          markdown: validMarkdown(),
+          sourceRoot: "public",
+        }),
+        baseDeps({ projectRoot: dir }),
+      );
+      expect(response.status).toBe(409);
+      expect(await response.json()).toEqual({ error: "workflow already exists" });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("allows overlay create when a public file already exists", async () => {
+    const pair = await initOverlayPairForHttp();
+    try {
+      writeFileSync(join(pair.junior, "workflows", "worklog.workflow.md"), validMarkdown());
+      await git(pair.junior, ["add", "--", "workflows/worklog.workflow.md"]);
+      await git(pair.junior, ["commit", "-m", "public"]);
+      rmSync(join(pair.overlay, "workflows", "worklog.workflow.md"));
+      await git(pair.overlay, ["add", "--", "workflows/worklog.workflow.md"]);
+      await git(pair.overlay, ["commit", "-m", "remove overlay"]);
+
+      const markdown = validMarkdown("worklog", "overlay override");
+      const response = await handleWorkflowCreate(
+        jsonWriteReq("POST", "http://127.0.0.1/api/workflows", {
+          name: "worklog",
+          markdown,
+          sourceRoot: "overlay",
+        }),
+        baseDeps({ projectRoot: pair.junior }),
+      );
+      expect(response.status).toBe(201);
+      const body = await response.json() as { sourceRoot: string; overlayCommitted: boolean };
+      expect(body.sourceRoot).toBe("overlay");
+      expect(body.overlayCommitted).toBe(true);
+    } finally {
+      rmSync(pair.root, { recursive: true, force: true });
+    }
+  }, 15_000);
+
+  it("refuses public create when an overlay already exists", async () => {
+    const dir = tempDir();
+    try {
+      mkdirSync(join(dir, "agents-org", "workflows"), { recursive: true });
+      writeFileSync(join(dir, "agents-org", "workflows", "worklog.workflow.md"), validMarkdown());
+      const response = await handleWorkflowCreate(
+        jsonWriteReq("POST", "http://127.0.0.1/api/workflows", {
+          name: "worklog",
+          markdown: validMarkdown(),
+          sourceRoot: "public",
+        }),
+        baseDeps({ projectRoot: dir }),
+      );
+      expect(response.status).toBe(409);
+      expect(await response.json()).toEqual({ error: "overlay shadows this name" });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("rejects an invalid create name and a missing sourceRoot", async () => {
+    const missingRoot = await handleWorkflowCreate(
+      jsonWriteReq("POST", "http://127.0.0.1/api/workflows", {
+        name: "worklog",
+        markdown: validMarkdown(),
+      }),
+      baseDeps(),
+    );
+    expect(missingRoot.status).toBe(400);
+    expect(await missingRoot.json()).toEqual({ error: "sourceRoot is required" });
+
+    const badName = await handleWorkflowCreate(
+      jsonWriteReq("POST", "http://127.0.0.1/api/workflows", {
+        name: "Nope",
+        markdown: validMarkdown(),
+        sourceRoot: "public",
+      }),
+      baseDeps(),
+    );
+    expect(badName.status).toBe(400);
+    expect(await badName.json()).toEqual({ error: "invalid workflow name" });
+  });
+
+  it("returns 403 for create/edit when the dashboard actor is not an admin", async () => {
+    const deps = baseDeps({
+      sessionManager: {
+        isAdmin: async () => false,
+        isExplicitAdmin: async () => false,
+      },
+    });
+    const created = await handleWorkflowCreate(
+      jsonWriteReq("POST", "http://127.0.0.1/api/workflows", {
+        name: "worklog",
+        markdown: validMarkdown(),
+        sourceRoot: "public",
+      }),
+      deps,
+    );
+    expect(created.status).toBe(403);
+    const updated = await handleWorkflowPut(
+      "worklog",
+      jsonWriteReq("PUT", "http://127.0.0.1/api/workflows/worklog", {
+        markdown: validMarkdown(),
+      }),
+      deps,
+    );
+    expect(updated.status).toBe(403);
+  });
+
+  it("returns 409 when the target repo is detached", async () => {
+    const dir = await initJuniorRepo();
+    try {
+      mkdirSync(join(dir, "workflows"), { recursive: true });
+      writeFileSync(join(dir, "workflows", "worklog.workflow.md"), validMarkdown());
+      await git(dir, ["add", "--", "workflows/worklog.workflow.md"]);
+      await git(dir, ["commit", "-m", "workflow"]);
+      await git(dir, ["checkout", "--detach"]);
+      const response = await handleWorkflowPut(
+        "worklog",
+        jsonWriteReq("PUT", "http://127.0.0.1/api/workflows/worklog", {
+          markdown: validMarkdown("worklog", "nope"),
+          commitHereAnyway: true,
+        }),
+        baseDeps({ projectRoot: dir }),
+      );
+      expect(response.status).toBe(409);
+      expect(((await response.json()) as { error: string }).error).toBe("detached-head");
     } finally {
       rmSync(dir, { recursive: true, force: true });
     }
@@ -407,9 +732,9 @@ describe("workflow nested routing", () => {
     server = startHttpServer(stubServerDeps());
     const base = `http://127.0.0.1:${server.port}`;
 
-    const postList = await fetch(`${base}/api/workflows`, { method: "POST" });
-    expect(postList.status).toBe(405);
-    expect(await postList.json()).toEqual({ error: "method not allowed" });
+    const postName = await fetch(`${base}/api/workflows/worklog`, { method: "POST" });
+    expect(postName.status).toBe(405);
+    expect(await postName.json()).toEqual({ error: "method not allowed" });
 
     const getReload = await fetch(`${base}/api/workflows/reload`);
     expect(getReload.status).toBe(405);
@@ -428,6 +753,82 @@ function jsonReq(body: Record<string, unknown>): Request {
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   });
+}
+
+function jsonWriteReq(
+  method: string,
+  url: string,
+  body: Record<string, unknown>,
+): Request {
+  return new Request(url, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function validMarkdown(name = "worklog", body = "Do the thing."): string {
+  return [
+    "---",
+    `name: ${name}`,
+    "enabled: true",
+    "ownerSlackUserIds: []",
+    "triggers:",
+    "  - type: command",
+    `    command: ${name}`,
+    "outputs:",
+    "  - type: docs",
+    `    path: data/workflow-runs/${name}`,
+    "permissions:",
+    "  tools:",
+    "    - docs.write",
+    "---",
+    body,
+  ].join("\n");
+}
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "junior-wf-http-"));
+  mkdirSync(join(dir, "workflows"), { recursive: true });
+  return dir;
+}
+
+async function initJuniorRepo(): Promise<string> {
+  const dir = mkdtempSync(join(tmpdir(), "junior-wf-http-repo-"));
+  await git(dir, ["init", "-b", "main"]);
+  await git(dir, ["config", "user.name", "t"]);
+  await git(dir, ["config", "user.email", "t@t.test"]);
+  await git(dir, ["config", "commit.gpgsign", "false"]);
+  writeFileSync(join(dir, "README.md"), "junior\n");
+  await git(dir, ["add", "--", "README.md"]);
+  await git(dir, ["commit", "-m", "init"]);
+  return dir;
+}
+
+async function initOverlayPairForHttp(): Promise<{
+  root: string;
+  junior: string;
+  overlay: string;
+}> {
+  const junior = await initJuniorRepo();
+  const overlay = join(junior, "agents-org");
+  mkdirSync(join(overlay, "workflows"), { recursive: true });
+  await git(overlay, ["init", "-b", "main"]);
+  await git(overlay, ["config", "user.name", "t"]);
+  await git(overlay, ["config", "user.email", "t@t.test"]);
+  await git(overlay, ["config", "commit.gpgsign", "false"]);
+  writeFileSync(join(overlay, "workflows", "worklog.workflow.md"), validMarkdown());
+  await git(overlay, ["add", "--", "workflows/worklog.workflow.md"]);
+  await git(overlay, ["commit", "-m", "overlay"]);
+  writeFileSync(
+    join(junior, ".gitmodules"),
+    '[submodule "agents-org"]\n\tpath = agents-org\n\turl = ./agents-org\n',
+  );
+  mkdirSync(join(junior, "workflows"), { recursive: true });
+  await git(junior, ["add", "--", ".gitmodules", "agents-org"]);
+  await git(junior, ["commit", "-m", "add overlay"]);
+  await git(overlay, ["checkout", "-B", "main"]);
+  return { root: junior, junior, overlay };
 }
 
 function workflowDefinition(
@@ -460,6 +861,9 @@ function registryOf(definition: WorkflowDefinition): WorkflowRegistry {
       definitions: new Map([[definition.name, definition]]),
       errors: [],
     }),
+    pauseReloads: () => undefined,
+    resumeReloads: async () => undefined,
+    validationContext: () => ({ repos: [], builtInCommands: new Set<string>() }),
   } as unknown as WorkflowRegistry;
 }
 

--- a/src/http/routes/workflows-write.test.ts
+++ b/src/http/routes/workflows-write.test.ts
@@ -455,6 +455,24 @@ describe("workflow create/edit routes", () => {
     }
   });
 
+  it("returns 400 when PUT omits expectedVersionHash", async () => {
+    const dir = tempDir();
+    try {
+      writeFileSync(join(dir, "workflows", "worklog.workflow.md"), validMarkdown());
+      const response = await handleWorkflowPut(
+        "worklog",
+        jsonWriteReq("PUT", "http://127.0.0.1/api/workflows/worklog", {
+          markdown: validMarkdown("worklog", "new"),
+        }),
+        baseDeps({ projectRoot: dir }),
+      );
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({ error: "expectedVersionHash is required" });
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   it("returns 409 when expectedVersionHash does not match the on-disk file", async () => {
     const dir = tempDir();
     try {
@@ -552,6 +570,39 @@ describe("workflow create/edit routes", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it("pauses and resumes registry reloads around a successful PUT", async () => {
+    const dir = await initJuniorRepo();
+    try {
+      mkdirSync(join(dir, "workflows"), { recursive: true });
+      const original = validMarkdown();
+      writeFileSync(join(dir, "workflows", "worklog.workflow.md"), original);
+      await git(dir, ["add", "--", "workflows/worklog.workflow.md"]);
+      await git(dir, ["commit", "-m", "public workflow"]);
+      const calls: string[] = [];
+      const registry = {
+        ...registryOf(workflowDefinition()),
+        pauseReloads: () => {
+          calls.push("pause");
+        },
+        resumeReloads: async () => {
+          calls.push("resume");
+        },
+      } as unknown as WorkflowRegistry;
+      const response = await handleWorkflowPut(
+        "worklog",
+        jsonWriteReq("PUT", "http://127.0.0.1/api/workflows/worklog", {
+          markdown: validMarkdown("worklog", "wrapped"),
+          expectedVersionHash: hashWorkflowContent(original),
+        }),
+        baseDeps({ registry, projectRoot: dir }),
+      );
+      expect(response.status).toBe(200);
+      expect(calls).toEqual(["pause", "resume"]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 15_000);
 
   it("creates a public workflow with 201", async () => {
     const dir = await initJuniorRepo();
@@ -708,6 +759,7 @@ describe("workflow create/edit routes", () => {
         "worklog",
         jsonWriteReq("PUT", "http://127.0.0.1/api/workflows/worklog", {
           markdown: validMarkdown("worklog", "nope"),
+          expectedVersionHash: hashWorkflowContent(validMarkdown()),
           commitHereAnyway: true,
         }),
         baseDeps({ projectRoot: dir }),

--- a/src/http/routes/workflows-write.test.ts
+++ b/src/http/routes/workflows-write.test.ts
@@ -1,0 +1,468 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { Config } from "../../config.ts";
+import { InMemoryDashboardAuditStore } from "../audit/memory.ts";
+import { hashWorkflowContent } from "../../workflows/definition.ts";
+import type { WorkflowRegistry } from "../../workflows/registry.ts";
+import { WorkflowScheduler } from "../../workflows/scheduler.ts";
+import { InMemoryWorkflowStore } from "../../workflows/store.ts";
+import type { WorkflowDefinition } from "../../workflows/types.ts";
+import { startHttpServer, type HttpServerDeps } from "../server.ts";
+import {
+  handleWorkflowDetail,
+  handleWorkflowReload,
+  handleWorkflowRun,
+  handleWorkflowStart,
+  handleWorkflowStop,
+  type WorkflowRouteDeps,
+} from "./workflows.ts";
+
+describe("workflow write routes", () => {
+  it("runs through enqueueManualRun and returns 202 started", async () => {
+    const received: Array<unknown> = [];
+    const enqueueManualRun = mock(async (options: {
+      name: string;
+      actorSlackUserId?: string | null;
+      instructions?: string | null;
+    }) => {
+      received.push(options);
+      return {
+        status: "started" as const,
+        runId: "worklog-run-1",
+        summary: "Started *worklog*.",
+      };
+    });
+    const deps = baseDeps({
+      scheduler: {
+        enqueueManualRun,
+        isRunning: () => false,
+        startWorkflow: async () => undefined,
+        stopWorkflow: async () => undefined,
+        reconcile: async () => undefined,
+      },
+    });
+
+    const response = await handleWorkflowRun(
+      "worklog",
+      jsonReq({ instructions: "only widgets" }),
+      deps,
+    );
+    expect(response.status).toBe(202);
+    expect(await response.json()).toEqual({
+      status: "started",
+      runId: "worklog-run-1",
+      summary: "Started *worklog*.",
+    });
+    expect(enqueueManualRun).toHaveBeenCalledTimes(1);
+    expect(received).toEqual([{
+      name: "worklog",
+      actorSlackUserId: "dashboard-operator",
+      instructions: "only widgets",
+    }]);
+    expect("runNow" in deps.scheduler).toBe(false);
+    const audit = await deps.auditStore.list({ action: "workflow.run" });
+    expect(audit[0]).toMatchObject({
+      result: "ok",
+      actor: "dashboard-operator",
+      request: { instructions: "only widgets" },
+    });
+  });
+
+  it("returns 200 skipped with an empty runId", async () => {
+    const deps = baseDeps({
+      scheduler: {
+        enqueueManualRun: async () => ({
+          status: "skipped" as const,
+          runId: "" as const,
+          summary: "Skipped *worklog*: already running.",
+        }),
+        isRunning: () => true,
+        startWorkflow: async () => undefined,
+        stopWorkflow: async () => undefined,
+        reconcile: async () => undefined,
+      },
+    });
+
+    const response = await handleWorkflowRun("worklog", jsonReq({}), deps);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      status: "skipped",
+      runId: "",
+      summary: "Skipped *worklog*: already running.",
+    });
+    const audit = await deps.auditStore.list({ action: "workflow.run" });
+    expect(audit[0]?.result).toBe("skipped");
+  });
+
+  it("starts a second overlapping run when concurrency is parallel", async () => {
+    const store = new InMemoryWorkflowStore();
+    const definition = workflowDefinition({ concurrency: "parallel" });
+    const releases: Array<() => void> = [];
+    let seq = 0;
+    const scheduler = new WorkflowScheduler({
+      registry: registryOf(definition),
+      store,
+      executor: {
+        persistNewRun: async () => {
+          seq += 1;
+          const run = {
+            id: `run-${seq}`,
+            workflowName: definition.name,
+            workflowVersionHash: definition.versionHash,
+            sourcePath: definition.sourcePath,
+            reason: "manual" as const,
+            actorSlackUserId: null,
+            status: "running" as const,
+            startedAt: Date.now(),
+            finishedAt: null,
+            artifactPath: "data/workflow-runs/worklog/run.md",
+            providerSessionId: null,
+            slackChannel: null,
+            slackThreadTs: null,
+            error: null,
+          };
+          await store.createRun(run);
+          return run;
+        },
+        executePersistedRun: async (run: { id: string }) => {
+          await new Promise<void>((resolve) => releases.push(resolve));
+          return { summary: "ok", run };
+        },
+      } as never,
+    });
+    const deps = baseDeps({
+      registry: registryOf(definition),
+      store,
+      scheduler,
+    });
+
+    const first = await handleWorkflowRun("worklog", jsonReq({}), deps);
+    const second = await handleWorkflowRun("worklog", jsonReq({}), deps);
+    expect(first.status).toBe(202);
+    expect(second.status).toBe(202);
+    expect(((await first.json()) as { runId: string }).runId).toBe("run-1");
+    expect(((await second.json()) as { runId: string }).runId).toBe("run-2");
+    expect(scheduler.activeRunCount("worklog")).toBe(2);
+    for (const release of releases) release();
+    await waitFor(() => scheduler.activeRunCount("worklog") === 0);
+  });
+
+  it("rejects native-handler instructions with 400", async () => {
+    const enqueueManualRun = mock(async () => {
+      throw new Error("enqueue should not run");
+    });
+    const definition = workflowDefinition({
+      nativeHandler: "memory-dedup-sweep",
+    });
+    definition.runner = undefined;
+    const deps = baseDeps({
+      registry: registryOf(definition),
+      scheduler: {
+        enqueueManualRun,
+        isRunning: () => false,
+        startWorkflow: async () => undefined,
+        stopWorkflow: async () => undefined,
+        reconcile: async () => undefined,
+      },
+    });
+
+    const response = await handleWorkflowRun(
+      "worklog",
+      jsonReq({ instructions: "only recent claims" }),
+      deps,
+    );
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: "Workflow worklog uses a native handler and does not accept operator instructions.",
+    });
+    expect(enqueueManualRun).not.toHaveBeenCalled();
+  });
+
+  it("returns 409 when the workflow file is disabled", async () => {
+    const definition = workflowDefinition({ enabled: false });
+    const deps = baseDeps({
+      registry: registryOf(definition),
+      scheduler: {
+        enqueueManualRun: async () => {
+          throw new Error("Workflow worklog is disabled in its workflow file.");
+        },
+        startWorkflow: async () => {
+          throw new Error("Workflow worklog is disabled in its workflow file. Change enabled to true before starting it.");
+        },
+        isRunning: () => false,
+        stopWorkflow: async () => undefined,
+        reconcile: async () => undefined,
+      },
+    });
+
+    const run = await handleWorkflowRun("worklog", jsonReq({}), deps);
+    expect(run.status).toBe(409);
+    const start = await handleWorkflowStart("worklog", deps);
+    expect(start.status).toBe(409);
+  });
+
+  it("returns 403 when the dashboard actor is not an admin", async () => {
+    const enqueueManualRun = mock(async () => {
+      throw new Error("must not enqueue");
+    });
+    const deps = baseDeps({
+      sessionManager: {
+        isAdmin: async () => false,
+        isExplicitAdmin: async () => false,
+      },
+      scheduler: {
+        enqueueManualRun,
+        isRunning: () => false,
+        startWorkflow: async () => undefined,
+        stopWorkflow: async () => undefined,
+        reconcile: async () => undefined,
+      },
+    });
+
+    const response = await handleWorkflowRun("worklog", jsonReq({}), deps);
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: "dashboard actor is not an admin",
+    });
+    expect(enqueueManualRun).not.toHaveBeenCalled();
+    const audit = await deps.auditStore.list();
+    expect(audit[0]?.result).toBe("denied");
+  });
+
+  it("starts and stops with the same owner/admin gate as Slack", async () => {
+    const startWorkflow = mock(async () => undefined);
+    const stopWorkflow = mock(async () => undefined);
+    const deps = baseDeps({
+      scheduler: {
+        enqueueManualRun: async () => ({
+          status: "started" as const,
+          runId: "x",
+          summary: "Started *worklog*.",
+        }),
+        startWorkflow,
+        stopWorkflow,
+        isRunning: () => false,
+        reconcile: async () => undefined,
+      },
+    });
+
+    const started = await handleWorkflowStart("worklog", deps);
+    expect(started.status).toBe(200);
+    expect(await started.json()).toEqual({ name: "worklog", status: "active" });
+    const stopped = await handleWorkflowStop("worklog", deps);
+    expect(stopped.status).toBe(200);
+    expect(await stopped.json()).toEqual({ name: "worklog", status: "stopped" });
+    expect(startWorkflow).toHaveBeenCalledTimes(1);
+    expect(stopWorkflow).toHaveBeenCalledTimes(1);
+  });
+
+  it("reloads definitions for an admin actor", async () => {
+    const reload = mock(async () => ({
+      definitions: new Map([["worklog", workflowDefinition()]]),
+      errors: [],
+    }));
+    const reconcile = mock(async () => undefined);
+    const deps = baseDeps({
+      registry: {
+        ...registryOf(workflowDefinition()),
+        reload,
+      } as unknown as WorkflowRegistry,
+      scheduler: {
+        enqueueManualRun: async () => ({
+          status: "started" as const,
+          runId: "x",
+          summary: "ok",
+        }),
+        isRunning: () => false,
+        startWorkflow: async () => undefined,
+        stopWorkflow: async () => undefined,
+        reconcile,
+      },
+    });
+
+    const response = await handleWorkflowReload(deps);
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ definitions: 1, errors: [] });
+    expect(reload).toHaveBeenCalledTimes(1);
+    expect(reconcile).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns on-disk markdown and both hashes when the loaded definition is stale", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "junior-wf-detail-"));
+    try {
+      mkdirSync(join(dir, "agents-org", "workflows"), { recursive: true });
+      const markdown = [
+        "---",
+        "name: worklog",
+        "enabled: true",
+        "ownerSlackUserIds: []",
+        "this is not valid yaml::::",
+        "---",
+        "broken overlay",
+      ].join("\n");
+      writeFileSync(join(dir, "agents-org", "workflows", "worklog.workflow.md"), markdown);
+      const definition = workflowDefinition({
+        versionHash: "loaded-lkg-hash",
+        sourcePath: "agents-org/workflows/worklog.workflow.md",
+        sourceRoot: "overlay",
+      });
+      const registry = {
+        get: () => definition,
+        getErrors: () => [{
+          path: "agents-org/workflows/worklog.workflow.md",
+          message: "invalid yaml",
+        }],
+        all: () => [definition],
+      } as unknown as WorkflowRegistry;
+      const response = await handleWorkflowDetail("worklog", {
+        registry,
+        store: new InMemoryWorkflowStore(),
+        scheduler: { isRunning: () => false },
+        projectRoot: dir,
+      });
+      expect(response.status).toBe(200);
+      const body = await response.json() as {
+        runtimeUsesFile: boolean;
+        source: {
+          markdown: string;
+          fileVersionHash: string;
+          loadedVersionHash: string | null;
+        };
+      };
+      expect(body.source.markdown).toBe(markdown);
+      expect(body.source.fileVersionHash).toBe(hashWorkflowContent(markdown));
+      expect(body.source.loadedVersionHash).toBe("loaded-lkg-hash");
+      expect(body.runtimeUsesFile).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("workflow nested routing", () => {
+  let server: ReturnType<typeof startHttpServer> | undefined;
+
+  afterEach(() => {
+    server?.stop(true);
+    server = undefined;
+  });
+
+  it("returns 405 on the wrong method and keeps /reload off the :name route", async () => {
+    server = startHttpServer(stubServerDeps());
+    const base = `http://127.0.0.1:${server.port}`;
+
+    const postList = await fetch(`${base}/api/workflows`, { method: "POST" });
+    expect(postList.status).toBe(405);
+    expect(await postList.json()).toEqual({ error: "method not allowed" });
+
+    const getReload = await fetch(`${base}/api/workflows/reload`);
+    expect(getReload.status).toBe(405);
+
+    const getRun = await fetch(`${base}/api/workflows/worklog/run`);
+    expect(getRun.status).toBe(405);
+
+    const postHealth = await fetch(`${base}/api/health`, { method: "POST" });
+    expect(postHealth.status).toBe(405);
+  });
+});
+
+function jsonReq(body: Record<string, unknown>): Request {
+  return new Request("http://127.0.0.1/api/workflows/worklog/run", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+function workflowDefinition(
+  overrides: Partial<WorkflowDefinition> = {},
+): WorkflowDefinition {
+  return {
+    name: "worklog",
+    enabled: true,
+    ownerSlackUserIds: [],
+    triggers: [{ type: "command", command: "worklog" }],
+    outputs: [{ type: "docs", path: "data/workflow-runs/worklog" }],
+    permissions: { tools: ["docs.write"] },
+    concurrency: "skip",
+    prompt: "Summarize work.",
+    versionHash: "1234567890abcdef",
+    sourcePath: "workflows/worklog.workflow.md",
+    sourceRoot: "public",
+    ...overrides,
+  };
+}
+
+function registryOf(definition: WorkflowDefinition): WorkflowRegistry {
+  return {
+    get: (name: string) => name === definition.name ? definition : undefined,
+    all: () => [definition],
+    getErrors: () => [],
+    snapshot: () => ({ definitions: new Map([[definition.name, definition]]), errors: [] }),
+    onEvent: () => undefined,
+    reload: async () => ({
+      definitions: new Map([[definition.name, definition]]),
+      errors: [],
+    }),
+  } as unknown as WorkflowRegistry;
+}
+
+function baseDeps(overrides: Partial<WorkflowRouteDeps> = {}): WorkflowRouteDeps {
+  const definition = workflowDefinition();
+  return {
+    registry: registryOf(definition),
+    store: new InMemoryWorkflowStore(),
+    scheduler: {
+      enqueueManualRun: async () => ({
+        status: "started",
+        runId: "run-1",
+        summary: "Started *worklog*.",
+      }),
+      isRunning: () => false,
+      startWorkflow: async () => undefined,
+      stopWorkflow: async () => undefined,
+      reconcile: async () => undefined,
+    },
+    config: { adminSlackUserId: null },
+    sessionManager: {
+      isAdmin: async () => true,
+      isExplicitAdmin: async () => false,
+    },
+    auditStore: new InMemoryDashboardAuditStore(),
+    ...overrides,
+  };
+}
+
+function stubServerDeps(): HttpServerDeps {
+  return {
+    store: {} as HttpServerDeps["store"],
+    config: { http: { enabled: true, port: 0 }, adminSlackUserId: null } as Config,
+    devServerManager: {} as HttpServerDeps["devServerManager"],
+    devServerQueue: {} as HttpServerDeps["devServerQueue"],
+    repos: [],
+    workflowRegistry: {} as HttpServerDeps["workflowRegistry"],
+    workflowScheduler: {} as HttpServerDeps["workflowScheduler"],
+    workflowStore: {} as HttpServerDeps["workflowStore"],
+    pipelineStore: {} as HttpServerDeps["pipelineStore"],
+    usageStore: {} as HttpServerDeps["usageStore"],
+    auditStore: {} as HttpServerDeps["auditStore"],
+    sessionManager: {
+      isAdmin: async () => true,
+      isExplicitAdmin: async () => false,
+    },
+  };
+}
+
+async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs = 500,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error("timed out waiting for condition");
+}

--- a/src/http/routes/workflows-write.test.ts
+++ b/src/http/routes/workflows-write.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import type { Config } from "../../config.ts";
 import { InMemoryDashboardAuditStore } from "../audit/memory.ts";
 import { hashWorkflowContent } from "../../workflows/definition.ts";
-import type { WorkflowRegistry } from "../../workflows/registry.ts";
+import { WorkflowRegistry } from "../../workflows/registry.ts";
 import { WorkflowScheduler } from "../../workflows/scheduler.ts";
 import { InMemoryWorkflowStore } from "../../workflows/store.ts";
 import type { WorkflowDefinition } from "../../workflows/types.ts";
@@ -630,6 +630,37 @@ describe("workflow create/edit routes", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   });
+
+  it("serializes overlapping creates of the same name", async () => {
+    const dir = await initJuniorRepo();
+    try {
+      mkdirSync(join(dir, "workflows"), { recursive: true });
+      const registry = new WorkflowRegistry({
+        repos: [],
+        roots: [{ path: join(dir, "workflows"), sourceRoot: "public" }],
+      });
+      await registry.reload();
+      const deps = baseDeps({ registry, projectRoot: dir });
+      const req = () =>
+        jsonWriteReq("POST", "http://127.0.0.1/api/workflows", {
+          name: "newlog",
+          markdown: validMarkdown("newlog"),
+          sourceRoot: "public",
+        });
+      const [first, second] = await Promise.all([
+        handleWorkflowCreate(req(), deps),
+        handleWorkflowCreate(req(), deps),
+      ]);
+      const statuses = [first.status, second.status].sort((a, b) => a - b);
+      expect(statuses).toEqual([201, 409]);
+      const bodies = await Promise.all([first.json(), second.json()]) as Array<{
+        error?: string;
+      }>;
+      expect(bodies.some((body) => body.error === "workflow already exists")).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 15_000);
 
   it("refuses a name collision in the chosen root", async () => {
     const dir = tempDir();

--- a/src/http/routes/workflows.test.ts
+++ b/src/http/routes/workflows.test.ts
@@ -43,11 +43,37 @@ describe("workflowDisplayStatus", () => {
 
     const response = await handleWorkflows(registry, store, { isRunning: () => false });
     const body = await response.json() as {
-      workflows: Array<{ displayStatus: string; runs: Array<{ status: string }> }>;
+      workflows: Array<{
+        displayStatus: string;
+        nativeHandler: string | null;
+        sourceMarkdown: boolean;
+        runs: Array<{ status: string }>;
+      }>;
     };
 
     expect(body.workflows[0]?.runs[0]?.status).toBe("running");
     expect(body.workflows[0]?.displayStatus).toBe("active");
+    expect(body.workflows[0]?.nativeHandler).toBeNull();
+    expect(body.workflows[0]?.sourceMarkdown).toBe(false);
+  });
+
+  test("includes nativeHandler on the list projection", async () => {
+    const definition = workflowDefinition();
+    definition.nativeHandler = "memory-dedup-sweep";
+    const registry = {
+      all: () => [definition],
+      getErrors: () => [],
+    } as unknown as WorkflowRegistry;
+    const store = {
+      listStates: async () => [],
+      listRuns: async () => [],
+    } as unknown as WorkflowStore;
+
+    const response = await handleWorkflows(registry, store, { isRunning: () => false });
+    const body = await response.json() as {
+      workflows: Array<{ nativeHandler: string | null }>;
+    };
+    expect(body.workflows[0]?.nativeHandler).toBe("memory-dedup-sweep");
   });
 });
 

--- a/src/http/routes/workflows.ts
+++ b/src/http/routes/workflows.ts
@@ -1,7 +1,54 @@
+import { join, relative, resolve } from "node:path";
+import type { Config } from "../../config.ts";
+import { log } from "../../logger.ts";
+import { hashWorkflowContent } from "../../workflows/definition.ts";
 import type { WorkflowRegistry } from "../../workflows/registry.ts";
 import type { WorkflowScheduler } from "../../workflows/scheduler.ts";
 import type { WorkflowStore } from "../../workflows/store.ts";
-import type { WorkflowDefinition, WorkflowRun, WorkflowRuntimeStatus } from "../../workflows/types.ts";
+import type {
+  WorkflowDefinition,
+  WorkflowOutput,
+  WorkflowRun,
+  WorkflowRuntimeStatus,
+  WorkflowSourceRoot,
+} from "../../workflows/types.ts";
+import { OVERLAY_WORKFLOW_ROOT, PUBLIC_WORKFLOW_ROOT } from "../../workflows/types.ts";
+import type { DashboardAuditStore } from "../audit/interface.ts";
+
+export type WorkflowAuth = {
+  isAdmin(userId: string): Promise<boolean>;
+  isExplicitAdmin(userId: string): Promise<boolean>;
+};
+
+export type WorkflowSlackPoster = {
+  post(
+    channel: string,
+    threadTs: string | null,
+    text: string,
+  ): Promise<{ ts: string } | null>;
+};
+
+export type WorkflowRouteDeps = {
+  registry: WorkflowRegistry;
+  store: WorkflowStore;
+  scheduler: Pick<
+    WorkflowScheduler,
+    | "isRunning"
+    | "enqueueManualRun"
+    | "startWorkflow"
+    | "stopWorkflow"
+    | "reconcile"
+  >;
+  config: Pick<Config, "adminSlackUserId">;
+  sessionManager: WorkflowAuth;
+  auditStore: DashboardAuditStore;
+  slackPoster?: WorkflowSlackPoster;
+  projectRoot?: string;
+};
+
+export function dashboardActor(config: Pick<Config, "adminSlackUserId">): string {
+  return config.adminSlackUserId ?? "dashboard-operator";
+}
 
 export async function handleWorkflows(
   registry: WorkflowRegistry,
@@ -34,6 +81,235 @@ export async function handleWorkflows(
   });
 }
 
+export async function handleWorkflowDetail(
+  name: string,
+  deps: {
+    registry: WorkflowRegistry;
+    store: WorkflowStore;
+    scheduler: Pick<WorkflowScheduler, "isRunning">;
+    projectRoot?: string;
+  },
+): Promise<Response> {
+  const projectRoot = deps.projectRoot ?? process.cwd();
+  const definition = deps.registry.get(name);
+  const disk = await readWorkflowDisk(name, definition, projectRoot);
+  if (!definition && !disk) {
+    return Response.json({ error: "not found" }, { status: 404 });
+  }
+
+  const sourcePath = disk?.sourcePath ?? definition?.sourcePath ?? "";
+  const sourceRoot = disk?.sourceRoot ?? definition?.sourceRoot ?? "public";
+  const markdown = disk?.markdown ?? "";
+  const fileVersionHash = disk ? hashWorkflowContent(disk.markdown) : "";
+  const loadedVersionHash = definition?.versionHash ?? null;
+  const state = definition
+    ? await deps.store.getState(definition.name) ?? null
+    : await deps.store.getState(name) ?? null;
+  const runs = (await deps.store.listRuns(name, 20)).map(projectRun);
+  const errors = deps.registry.getErrors().filter((error) =>
+    error.path === sourcePath || error.path.endsWith(`/${name}.workflow.md`)
+  );
+
+  return Response.json({
+    workflow: definition
+      ? {
+        ...projectDefinition(definition),
+        state,
+        runs,
+        displayStatus: workflowDisplayStatus(
+          definition.enabled,
+          state?.status,
+          deps.scheduler.isRunning(definition.name),
+        ),
+      }
+      : null,
+    source: {
+      markdown,
+      sourceRoot,
+      sourcePath,
+      fileVersionHash,
+      loadedVersionHash,
+    },
+    git: await probeWorkflowGit(disk?.absolutePath ?? sourcePath, projectRoot),
+    runtimeUsesFile: Boolean(
+      loadedVersionHash && fileVersionHash && fileVersionHash === loadedVersionHash,
+    ),
+    state,
+    runs,
+    errors,
+  });
+}
+
+export async function handleWorkflowRun(
+  name: string,
+  req: Request,
+  deps: WorkflowRouteDeps,
+): Promise<Response> {
+  const actorGate = await requireDashboardActor(deps, {
+    action: "workflow.run",
+    targetId: name,
+  });
+  if (actorGate instanceof Response) return actorGate;
+  const { actor } = actorGate;
+
+  const body = await readJsonObject(req);
+  if (body instanceof Response) {
+    await recordAudit(deps, {
+      actor,
+      action: "workflow.run",
+      targetId: name,
+      result: "error",
+      error: "invalid json",
+    });
+    return body;
+  }
+  const instructions = readInstructions(body);
+  if (instructions instanceof Response) {
+    await recordAudit(deps, {
+      actor,
+      action: "workflow.run",
+      targetId: name,
+      request: body,
+      result: "error",
+      error: "invalid instructions",
+    });
+    return instructions;
+  }
+
+  const definition = deps.registry.get(name);
+  if (!definition) {
+    await recordAudit(deps, {
+      actor,
+      action: "workflow.run",
+      targetId: name,
+      request: { instructions },
+      result: "error",
+      error: "not found",
+    });
+    return Response.json({ error: "not found" }, { status: 404 });
+  }
+  if (!(await canManage(deps, actor, definition))) {
+    return deny(deps, {
+      actor,
+      action: "workflow.run",
+      targetId: name,
+      request: { instructions },
+    });
+  }
+  if (definition.nativeHandler && instructions) {
+    await recordAudit(deps, {
+      actor,
+      action: "workflow.run",
+      targetId: name,
+      request: { instructions },
+      result: "error",
+      error: "native handler rejects instructions",
+    });
+    return Response.json(
+      { error: `Workflow ${definition.name} uses a native handler and does not accept operator instructions.` },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await deps.scheduler.enqueueManualRun({
+      name: definition.name,
+      actorSlackUserId: actor,
+      instructions,
+    });
+    const slackTs = await postWorkflowNotice(
+      deps,
+      definition,
+      result.status === "skipped" ? "skipped" : "ran",
+      actor,
+    );
+    await recordAudit(deps, {
+      actor,
+      action: "workflow.run",
+      targetId: name,
+      request: { instructions },
+      result: result.status === "skipped" ? "skipped" : "ok",
+      slackTs,
+    });
+    log.info(
+      "dashboard",
+      `dashboard action=workflow.run name=${name} result=${result.status}`,
+    );
+    return Response.json(result, {
+      status: result.status === "started" ? 202 : 200,
+    });
+  } catch (err) {
+    return workflowMutationError(deps, {
+      actor,
+      action: "workflow.run",
+      targetId: name,
+      request: { instructions },
+      err,
+    });
+  }
+}
+
+export async function handleWorkflowStart(
+  name: string,
+  deps: WorkflowRouteDeps,
+): Promise<Response> {
+  return handleStartStop(name, "start", deps);
+}
+
+export async function handleWorkflowStop(
+  name: string,
+  deps: WorkflowRouteDeps,
+): Promise<Response> {
+  return handleStartStop(name, "stop", deps);
+}
+
+export async function handleWorkflowReload(
+  deps: WorkflowRouteDeps,
+): Promise<Response> {
+  const actorGate = await requireDashboardActor(deps, {
+    action: "workflow.reload",
+    targetId: "registry",
+  });
+  if (actorGate instanceof Response) return actorGate;
+  const { actor } = actorGate;
+  if (!(await deps.sessionManager.isAdmin(actor))) {
+    return deny(deps, {
+      actor,
+      action: "workflow.reload",
+      targetId: "registry",
+    });
+  }
+
+  try {
+    const snapshot = await deps.registry.reload();
+    await deps.scheduler.reconcile(snapshot);
+    const slackTs = await postReloadNotice(deps, actor, snapshot.definitions.size);
+    await recordAudit(deps, {
+      actor,
+      action: "workflow.reload",
+      targetId: "registry",
+      request: { definitions: snapshot.definitions.size },
+      result: "ok",
+      slackTs,
+    });
+    log.info(
+      "dashboard",
+      `dashboard action=workflow.reload definitions=${snapshot.definitions.size} result=ok`,
+    );
+    return Response.json({
+      definitions: snapshot.definitions.size,
+      errors: snapshot.errors,
+    });
+  } catch (err) {
+    return workflowMutationError(deps, {
+      actor,
+      action: "workflow.reload",
+      targetId: "registry",
+      err,
+    });
+  }
+}
+
 export function workflowDisplayStatus(
   enabled: boolean,
   schedulerStatus: WorkflowRuntimeStatus | undefined,
@@ -54,6 +330,10 @@ function projectDefinition(definition: WorkflowDefinition) {
     triggers: definition.triggers,
     outputs: definition.outputs,
     runner: definition.runner ?? null,
+    nativeHandler: definition.nativeHandler ?? null,
+    ownerSlackUserIds: definition.ownerSlackUserIds,
+    permissions: definition.permissions,
+    sourceMarkdown: false,
     concurrency: definition.concurrency,
   };
 }
@@ -71,4 +351,355 @@ function projectRun(run: WorkflowRun) {
     slackThreadTs: run.slackThreadTs,
     error: run.error,
   };
+}
+
+async function handleStartStop(
+  name: string,
+  action: "start" | "stop",
+  deps: WorkflowRouteDeps,
+): Promise<Response> {
+  const auditAction = action === "start" ? "workflow.start" : "workflow.stop";
+  const actorGate = await requireDashboardActor(deps, {
+    action: auditAction,
+    targetId: name,
+  });
+  if (actorGate instanceof Response) return actorGate;
+  const { actor } = actorGate;
+
+  const definition = deps.registry.get(name);
+  if (!definition) {
+    await recordAudit(deps, {
+      actor,
+      action: auditAction,
+      targetId: name,
+      result: "error",
+      error: "not found",
+    });
+    return Response.json({ error: "not found" }, { status: 404 });
+  }
+  if (!(await canManage(deps, actor, definition))) {
+    return deny(deps, { actor, action: auditAction, targetId: name });
+  }
+
+  try {
+    if (action === "start") await deps.scheduler.startWorkflow(name);
+    else await deps.scheduler.stopWorkflow(name);
+    const status = action === "start" ? "active" : "stopped";
+    const slackTs = await postWorkflowNotice(deps, definition, action === "start" ? "started" : "stopped", actor);
+    await recordAudit(deps, {
+      actor,
+      action: auditAction,
+      targetId: name,
+      result: "ok",
+      slackTs,
+    });
+    log.info("dashboard", `dashboard action=${auditAction} name=${name} result=ok`);
+    return Response.json({ name, status });
+  } catch (err) {
+    return workflowMutationError(deps, {
+      actor,
+      action: auditAction,
+      targetId: name,
+      err,
+    });
+  }
+}
+
+async function requireDashboardActor(
+  deps: WorkflowRouteDeps,
+  input: { action: string; targetId: string },
+): Promise<{ actor: string } | Response> {
+  const actor = dashboardActor(deps.config);
+  if (
+    !deps.config.adminSlackUserId &&
+    !(await deps.sessionManager.isAdmin("dashboard-operator"))
+  ) {
+    return deny(deps, {
+      actor,
+      action: input.action,
+      targetId: input.targetId,
+      error: "dashboard actor is not an admin",
+    });
+  }
+  return { actor };
+}
+
+async function canManage(
+  deps: WorkflowRouteDeps,
+  actor: string,
+  definition: WorkflowDefinition,
+): Promise<boolean> {
+  return definition.ownerSlackUserIds.includes(actor) ||
+    await deps.sessionManager.isAdmin(actor);
+}
+
+async function deny(
+  deps: WorkflowRouteDeps,
+  input: {
+    actor: string;
+    action: string;
+    targetId: string;
+    request?: Record<string, unknown>;
+    error?: string;
+  },
+): Promise<Response> {
+  const error = input.error ?? "dashboard actor is not an admin";
+  await recordAudit(deps, {
+    actor: input.actor,
+    action: input.action,
+    targetId: input.targetId,
+    request: input.request,
+    result: "denied",
+    error,
+  });
+  log.info(
+    "dashboard",
+    `dashboard action=${input.action} name=${input.targetId} result=denied`,
+  );
+  return Response.json({ error }, { status: 403 });
+}
+
+async function workflowMutationError(
+  deps: WorkflowRouteDeps,
+  input: {
+    actor: string;
+    action: string;
+    targetId: string;
+    request?: Record<string, unknown>;
+    err: unknown;
+  },
+): Promise<Response> {
+  const message = formatError(input.err);
+  const status = statusForWorkflowError(message);
+  await recordAudit(deps, {
+    actor: input.actor,
+    action: input.action,
+    targetId: input.targetId,
+    request: input.request,
+    result: "error",
+    error: message,
+  });
+  log.info(
+    "dashboard",
+    `dashboard action=${input.action} name=${input.targetId} result=error`,
+  );
+  return Response.json({ error: message }, { status });
+}
+
+function statusForWorkflowError(message: string): number {
+  if (message.startsWith("Unknown workflow:")) return 404;
+  if (message.includes("is disabled") || message.includes("is invalid")) return 409;
+  if (message.includes("does not accept operator instructions")) return 400;
+  return 500;
+}
+
+async function recordAudit(
+  deps: Pick<WorkflowRouteDeps, "auditStore">,
+  input: {
+    actor: string;
+    action: string;
+    targetId: string;
+    request?: Record<string, unknown>;
+    result: string;
+    error?: string | null;
+    slackTs?: string | null;
+  },
+): Promise<void> {
+  await deps.auditStore.record({
+    actor: input.actor,
+    action: input.action,
+    targetType: "workflow",
+    targetId: input.targetId,
+    request: input.request ?? {},
+    result: input.result,
+    error: input.error ?? null,
+    slackTs: input.slackTs ?? null,
+  });
+}
+
+async function postWorkflowNotice(
+  deps: WorkflowRouteDeps,
+  definition: WorkflowDefinition,
+  verb: string,
+  actor: string,
+): Promise<string | null> {
+  const dest = slackOutput(definition);
+  if (!dest || !deps.slackPoster) return null;
+  try {
+    const posted = await deps.slackPoster.post(
+      dest.channel,
+      dest.threadTs,
+      `*Dashboard* ${verb} *${definition.name}* · actor=${actor}`,
+    );
+    return posted?.ts ?? null;
+  } catch (err) {
+    log.warn(
+      "dashboard",
+      `workflow slack notice failed name=${definition.name}: ${formatError(err)}`,
+    );
+    return null;
+  }
+}
+
+async function postReloadNotice(
+  deps: WorkflowRouteDeps,
+  actor: string,
+  count: number,
+): Promise<string | null> {
+  if (!deps.slackPoster) return null;
+  for (const definition of deps.registry.all()) {
+    const dest = slackOutput(definition);
+    if (!dest) continue;
+    try {
+      const posted = await deps.slackPoster.post(
+        dest.channel,
+        dest.threadTs,
+        `*Dashboard* reloaded workflows (${count}) · actor=${actor}`,
+      );
+      return posted?.ts ?? null;
+    } catch (err) {
+      log.warn("dashboard", `workflow reload slack notice failed: ${formatError(err)}`);
+      return null;
+    }
+  }
+  return null;
+}
+
+function slackOutput(
+  definition: WorkflowDefinition,
+): { channel: string; threadTs: string | null } | null {
+  const output = definition.outputs.find(
+    (item): item is Exclude<WorkflowOutput, { type: "docs" }> =>
+      item.type === "slack" || item.type === "slack-thread",
+  );
+  if (!output) return null;
+  return {
+    channel: output.channel,
+    threadTs: output.type === "slack" ? output.threadTs ?? null : null,
+  };
+}
+
+async function readJsonObject(
+  req: Request,
+): Promise<Record<string, unknown> | Response> {
+  const text = await req.text();
+  if (!text.trim()) return {};
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return Response.json({ error: "invalid json" }, { status: 400 });
+    }
+    return parsed as Record<string, unknown>;
+  } catch {
+    return Response.json({ error: "invalid json" }, { status: 400 });
+  }
+}
+
+function readInstructions(
+  body: Record<string, unknown>,
+): string | null | Response {
+  if (body.instructions == null) return null;
+  if (typeof body.instructions !== "string") {
+    return Response.json({ error: "instructions must be a string" }, { status: 400 });
+  }
+  const trimmed = body.instructions.trim();
+  return trimmed ? body.instructions : null;
+}
+
+async function readWorkflowDisk(
+  name: string,
+  definition: WorkflowDefinition | undefined,
+  projectRoot: string,
+): Promise<{
+  markdown: string;
+  sourcePath: string;
+  sourceRoot: WorkflowSourceRoot;
+  absolutePath: string;
+} | null> {
+  const overlayRel = join(OVERLAY_WORKFLOW_ROOT, `${name}.workflow.md`);
+  const publicRel = join(PUBLIC_WORKFLOW_ROOT, `${name}.workflow.md`);
+  const overlayAbs = resolve(projectRoot, overlayRel);
+  const publicAbs = resolve(projectRoot, publicRel);
+  const overlay = Bun.file(overlayAbs);
+  if (await overlay.exists()) {
+    return {
+      markdown: await overlay.text(),
+      sourcePath: overlayRel,
+      sourceRoot: "overlay",
+      absolutePath: overlayAbs,
+    };
+  }
+  const pub = Bun.file(publicAbs);
+  if (await pub.exists()) {
+    return {
+      markdown: await pub.text(),
+      sourcePath: publicRel,
+      sourceRoot: "public",
+      absolutePath: publicAbs,
+    };
+  }
+  if (definition?.sourcePath) {
+    const abs = resolve(projectRoot, definition.sourcePath);
+    const file = Bun.file(abs);
+    if (await file.exists()) {
+      return {
+        markdown: await file.text(),
+        sourcePath: definition.sourcePath,
+        sourceRoot: definition.sourceRoot,
+        absolutePath: abs,
+      };
+    }
+  }
+  return null;
+}
+
+async function probeWorkflowGit(
+  sourcePath: string,
+  projectRoot: string,
+): Promise<{
+  sha: string | null;
+  branch: string | null;
+  detached: boolean;
+  dirty: boolean;
+}> {
+  const empty = { sha: null, branch: null, detached: false, dirty: false };
+  if (!sourcePath) return empty;
+  const abs = resolve(projectRoot, sourcePath);
+  try {
+    const sha = (await git(projectRoot, ["rev-parse", "HEAD"])).trim();
+    const branch = (await git(projectRoot, ["rev-parse", "--abbrev-ref", "HEAD"])).trim();
+    const rel = relative(projectRoot, abs);
+    const porcelain = (await git(projectRoot, [
+      "status",
+      "--porcelain",
+      "--",
+      rel,
+    ])).trim();
+    return {
+      sha: sha || null,
+      branch: branch === "HEAD" ? null : branch || null,
+      detached: branch === "HEAD",
+      dirty: porcelain.length > 0,
+    };
+  } catch {
+    return empty;
+  }
+}
+
+async function git(cwd: string, args: string[]): Promise<string> {
+  const proc = Bun.spawn(["git", ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, exited] = await Promise.all([
+    new Response(proc.stdout).text(),
+    proc.exited,
+  ]);
+  if (exited !== 0) throw new Error(`git ${args.join(" ")} failed`);
+  return stdout;
+}
+
+function formatError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }

--- a/src/http/routes/workflows.ts
+++ b/src/http/routes/workflows.ts
@@ -1,8 +1,20 @@
-import { realpathSync } from "node:fs";
+import { existsSync, realpathSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
-import type { Config } from "../../config.ts";
+import type { Config, RepoConfig } from "../../config.ts";
 import { log } from "../../logger.ts";
-import { hashWorkflowContent } from "../../workflows/definition.ts";
+import {
+  hashWorkflowContent,
+  validateWorkflowMarkdown,
+  WORKFLOW_NAME_RE,
+} from "../../workflows/definition.ts";
+import {
+  defaultWorkflowCommitMessage,
+  isProtectedBranch,
+  overlayWorkflowsRootExists,
+  probeWorkflowRepo,
+  writeDashboardWorkflow,
+  type WorkflowGitStatus,
+} from "../../workflows/git-commit.ts";
 import type { WorkflowRegistry } from "../../workflows/registry.ts";
 import type { WorkflowScheduler } from "../../workflows/scheduler.ts";
 import type { WorkflowStore } from "../../workflows/store.ts";
@@ -45,6 +57,7 @@ export type WorkflowRouteDeps = {
   auditStore: DashboardAuditStore;
   slackPoster?: WorkflowSlackPoster;
   projectRoot?: string;
+  repos?: RepoConfig[];
 };
 
 export function dashboardActor(config: Pick<Config, "adminSlackUserId">): string {
@@ -55,6 +68,7 @@ export async function handleWorkflows(
   registry: WorkflowRegistry,
   store: WorkflowStore,
   scheduler: Pick<WorkflowScheduler, "isRunning">,
+  projectRoot?: string,
 ): Promise<Response> {
   const definitions = registry.all();
   const states = await store.listStates();
@@ -76,9 +90,17 @@ export async function handleWorkflows(
     }),
   );
 
+  const root = projectRoot ?? process.cwd();
   return Response.json({
     workflows,
     errors: registry.getErrors(),
+    overlayRootExists: overlayWorkflowsRootExists(root),
+    git: {
+      junior: await probeWorkflowRepo(root),
+      overlay: overlayWorkflowsRootExists(root) || existsSync(join(root, "agents-org"))
+        ? await probeWorkflowRepo(join(root, "agents-org"))
+        : null,
+    },
   });
 }
 
@@ -131,7 +153,7 @@ export async function handleWorkflowDetail(
       fileVersionHash,
       loadedVersionHash,
     },
-    git: await probeWorkflowGit(disk?.absolutePath ?? sourcePath, projectRoot),
+    git: await probeWorkflowGitDetail(disk, sourceRoot, projectRoot),
     runtimeUsesFile: Boolean(
       loadedVersionHash && fileVersionHash && fileVersionHash === loadedVersionHash,
     ),
@@ -311,6 +333,308 @@ export async function handleWorkflowReload(
   }
 }
 
+export async function handleWorkflowPut(
+  name: string,
+  req: Request,
+  deps: WorkflowRouteDeps,
+): Promise<Response> {
+  const actorGate = await requireWriteActor(deps, {
+    action: "workflow.update",
+    targetId: name,
+  });
+  if (actorGate instanceof Response) return actorGate;
+  const { actor } = actorGate;
+
+  const body = await readJsonObject(req);
+  if (body instanceof Response) {
+    await recordAudit(deps, {
+      actor,
+      action: "workflow.update",
+      targetId: name,
+      result: "error",
+      error: "invalid json",
+    });
+    return body;
+  }
+
+  const markdown = readMarkdown(body);
+  if (markdown instanceof Response) {
+    await recordAudit(deps, {
+      actor,
+      action: "workflow.update",
+      targetId: name,
+      result: "error",
+      error: "invalid markdown",
+    });
+    return markdown;
+  }
+  if (!WORKFLOW_NAME_RE.test(name)) {
+    return Response.json({ error: "invalid workflow name" }, { status: 400 });
+  }
+
+  const projectRoot = deps.projectRoot ?? process.cwd();
+  const definition = deps.registry.get(name);
+  const disk = await readWorkflowDisk(name, definition, projectRoot);
+  const validateOnly = new URL(req.url).searchParams.get("validate") === "1";
+  if (!definition && !disk && !validateOnly) {
+    await recordAudit(deps, {
+      actor,
+      action: "workflow.update",
+      targetId: name,
+      result: "error",
+      error: "not found",
+    });
+    return Response.json({ error: "not found" }, { status: 404 });
+  }
+
+  const requestedRoot = body.sourceRoot === "overlay" || body.sourceRoot === "public"
+    ? body.sourceRoot
+    : null;
+  const sourceRoot = disk?.sourceRoot ?? definition?.sourceRoot ?? requestedRoot ?? "public";
+  const sourcePath = disk?.sourcePath ??
+    (sourceRoot === "overlay"
+      ? join(OVERLAY_WORKFLOW_ROOT, `${name}.workflow.md`)
+      : join(PUBLIC_WORKFLOW_ROOT, `${name}.workflow.md`));
+  const fileVersionHash = disk ? hashWorkflowContent(disk.markdown) : "";
+  const ctx = validationContext(deps);
+
+  const validated = tryValidateMarkdown({
+    markdown,
+    path: sourcePath,
+    sourceRoot,
+    repos: ctx.repos,
+    builtInCommands: ctx.builtInCommands,
+  });
+  if (validated instanceof Response) {
+    await recordAudit(deps, {
+      actor,
+      action: "workflow.update",
+      targetId: name,
+      result: "error",
+      error: "invalid workflow",
+    });
+    return validated;
+  }
+  if (validated.name !== name) {
+    return invalidWorkflowResponse(
+      new Error(`Workflow name "${validated.name}" must match filename "${name}"`),
+      sourcePath,
+    );
+  }
+
+  if (validateOnly) {
+    return Response.json({
+      valid: true,
+      name,
+      versionHash: hashWorkflowContent(markdown),
+      sourceRoot,
+      sourcePath,
+    });
+  }
+
+  const expected = body.expectedVersionHash;
+  if (typeof expected === "string" && expected !== fileVersionHash) {
+    await recordAudit(deps, {
+      actor,
+      action: "workflow.update",
+      targetId: name,
+      result: "error",
+      error: "version hash mismatch",
+    });
+    return Response.json(
+      { error: "version hash mismatch", fileVersionHash },
+      { status: 409 },
+    );
+  }
+
+  const commitHereAnyway = body.commitHereAnyway === true;
+  const blocked = await gitWriteBlocked({
+    projectRoot,
+    sourceRoot,
+    commitHereAnyway,
+  });
+  if (blocked) {
+    await recordAudit(deps, {
+      actor,
+      action: "workflow.update",
+      targetId: name,
+      result: "error",
+      error: blocked.error,
+    });
+    return Response.json(blocked, { status: 409 });
+  }
+
+  return commitWorkflowMutation({
+    deps,
+    actor,
+    action: "workflow.update",
+    kind: "update",
+    name,
+    markdown,
+    sourceRoot,
+    sourcePath,
+    commitMessage: readOptionalString(body.commitMessage),
+    status: 200,
+    definition: validated,
+  });
+}
+
+export async function handleWorkflowCreate(
+  req: Request,
+  deps: WorkflowRouteDeps,
+): Promise<Response> {
+  const actorGate = await requireWriteActor(deps, {
+    action: "workflow.create",
+    targetId: "new",
+  });
+  if (actorGate instanceof Response) return actorGate;
+  const { actor } = actorGate;
+
+  const body = await readJsonObject(req);
+  if (body instanceof Response) {
+    await recordAudit(deps, {
+      actor,
+      action: "workflow.create",
+      targetId: "new",
+      result: "error",
+      error: "invalid json",
+    });
+    return body;
+  }
+
+  const name = typeof body.name === "string" ? body.name.trim() : "";
+  if (!WORKFLOW_NAME_RE.test(name)) {
+    await recordAudit(deps, {
+      actor,
+      action: "workflow.create",
+      targetId: name || "new",
+      result: "error",
+      error: "invalid workflow name",
+    });
+    return Response.json({ error: "invalid workflow name" }, { status: 400 });
+  }
+  const sourceRoot = body.sourceRoot;
+  if (sourceRoot !== "public" && sourceRoot !== "overlay") {
+    await recordAudit(deps, {
+      actor,
+      action: "workflow.create",
+      targetId: name,
+      result: "error",
+      error: "sourceRoot is required",
+    });
+    return Response.json({ error: "sourceRoot is required" }, { status: 400 });
+  }
+
+  const markdown = readMarkdown(body);
+  if (markdown instanceof Response) {
+    await recordAudit(deps, {
+      actor,
+      action: "workflow.create",
+      targetId: name,
+      result: "error",
+      error: "invalid markdown",
+    });
+    return markdown;
+  }
+
+  const projectRoot = deps.projectRoot ?? process.cwd();
+  if (sourceRoot === "overlay" && !existsSync(join(projectRoot, "agents-org"))) {
+    await recordAudit(deps, {
+      actor,
+      action: "workflow.create",
+      targetId: name,
+      result: "error",
+      error: "overlay root missing",
+    });
+    return Response.json({ error: "overlay root missing" }, { status: 400 });
+  }
+
+  const overlayRel = join(OVERLAY_WORKFLOW_ROOT, `${name}.workflow.md`);
+  const publicRel = join(PUBLIC_WORKFLOW_ROOT, `${name}.workflow.md`);
+  const overlayExists = existsSync(join(projectRoot, overlayRel));
+  const publicExists = existsSync(join(projectRoot, publicRel));
+  if (sourceRoot === "public" && overlayExists) {
+    await recordAudit(deps, {
+      actor,
+      action: "workflow.create",
+      targetId: name,
+      result: "error",
+      error: "overlay shadows this name",
+    });
+    return Response.json({ error: "overlay shadows this name" }, { status: 409 });
+  }
+  if (
+    (sourceRoot === "public" && publicExists) ||
+    (sourceRoot === "overlay" && overlayExists)
+  ) {
+    await recordAudit(deps, {
+      actor,
+      action: "workflow.create",
+      targetId: name,
+      result: "error",
+      error: "workflow already exists",
+    });
+    return Response.json({ error: "workflow already exists" }, { status: 409 });
+  }
+
+  const sourcePath = sourceRoot === "overlay" ? overlayRel : publicRel;
+  const ctx = validationContext(deps);
+  const validated = tryValidateMarkdown({
+    markdown,
+    path: sourcePath,
+    sourceRoot,
+    repos: ctx.repos,
+    builtInCommands: ctx.builtInCommands,
+  });
+  if (validated instanceof Response) {
+    await recordAudit(deps, {
+      actor,
+      action: "workflow.create",
+      targetId: name,
+      result: "error",
+      error: "invalid workflow",
+    });
+    return validated;
+  }
+  if (validated.name !== name) {
+    return invalidWorkflowResponse(
+      new Error(`Workflow name "${validated.name}" must match filename "${name}"`),
+      sourcePath,
+    );
+  }
+
+  const commitHereAnyway = body.commitHereAnyway === true;
+  const blocked = await gitWriteBlocked({
+    projectRoot,
+    sourceRoot,
+    commitHereAnyway,
+  });
+  if (blocked) {
+    await recordAudit(deps, {
+      actor,
+      action: "workflow.create",
+      targetId: name,
+      result: "error",
+      error: blocked.error,
+    });
+    return Response.json(blocked, { status: 409 });
+  }
+
+  return commitWorkflowMutation({
+    deps,
+    actor,
+    action: "workflow.create",
+    kind: "create",
+    name,
+    markdown,
+    sourceRoot,
+    sourcePath,
+    commitMessage: readOptionalString(body.commitMessage),
+    status: 201,
+    definition: validated,
+  });
+}
+
 export function workflowDisplayStatus(
   enabled: boolean,
   schedulerStatus: WorkflowRuntimeStatus | undefined,
@@ -425,6 +749,18 @@ async function requireDashboardActor(
   return { actor };
 }
 
+async function requireWriteActor(
+  deps: WorkflowRouteDeps,
+  input: { action: string; targetId: string },
+): Promise<{ actor: string } | Response> {
+  const actorGate = await requireDashboardActor(deps, input);
+  if (actorGate instanceof Response) return actorGate;
+  const { actor } = actorGate;
+  if (await deps.sessionManager.isExplicitAdmin(actor)) return { actor };
+  if (await deps.sessionManager.isAdmin(actor)) return { actor };
+  return deny(deps, { actor, action: input.action, targetId: input.targetId });
+}
+
 async function canManage(
   deps: WorkflowRouteDeps,
   actor: string,
@@ -504,6 +840,7 @@ async function recordAudit(
     result: string;
     error?: string | null;
     slackTs?: string | null;
+    commitSha?: string | null;
   },
 ): Promise<void> {
   await deps.auditStore.record({
@@ -515,6 +852,7 @@ async function recordAudit(
     result: input.result,
     error: input.error ?? null,
     slackTs: input.slackTs ?? null,
+    commitSha: input.commitSha ?? null,
   });
 }
 
@@ -654,40 +992,245 @@ async function readWorkflowDisk(
   return null;
 }
 
-async function probeWorkflowGit(
-  sourcePath: string,
+async function probeWorkflowGitDetail(
+  disk: {
+    sourcePath: string;
+    sourceRoot: WorkflowSourceRoot;
+    absolutePath: string;
+  } | null,
+  sourceRoot: WorkflowSourceRoot,
   projectRoot: string,
-): Promise<{
-  sha: string | null;
-  branch: string | null;
-  detached: boolean;
-  dirty: boolean;
-}> {
-  const empty = { sha: null, branch: null, detached: false, dirty: false };
-  if (!sourcePath) return empty;
-  const abs = existingRealpath(resolve(projectRoot, sourcePath));
+): Promise<WorkflowGitStatus & { parent?: WorkflowGitStatus }> {
+  const empty: WorkflowGitStatus = {
+    sha: null,
+    branch: null,
+    detached: false,
+    dirty: false,
+    merging: false,
+    rebasing: false,
+  };
+  const repoRoot = disk
+    ? existingRealpath(dirname(disk.absolutePath) === disk.absolutePath
+      ? disk.absolutePath
+      : resolve(disk.absolutePath, ".."))
+    : sourceRoot === "overlay"
+    ? join(projectRoot, "agents-org")
+    : projectRoot;
+  const fileRepo = disk
+    ? await probeFileRepo(disk.absolutePath, projectRoot)
+    : await probeWorkflowRepo(repoRoot);
+  if (sourceRoot === "overlay") {
+    return {
+      ...fileRepo,
+      parent: await probeWorkflowRepo(projectRoot),
+    };
+  }
+  return fileRepo.sha || fileRepo.branch || fileRepo.detached || fileRepo.merging
+    ? fileRepo
+    : empty;
+}
+
+async function probeFileRepo(
+  absolutePath: string,
+  projectRoot: string,
+): Promise<WorkflowGitStatus> {
+  const empty: WorkflowGitStatus = {
+    sha: null,
+    branch: null,
+    detached: false,
+    dirty: false,
+    merging: false,
+    rebasing: false,
+  };
+  if (!absolutePath) return empty;
   try {
+    const abs = existingRealpath(absolutePath);
     const toplevel = existingRealpath(
       (await git(dirname(abs), ["rev-parse", "--show-toplevel"])).trim(),
     );
-    const sha = (await git(toplevel, ["rev-parse", "HEAD"])).trim();
-    const branch = (await git(toplevel, ["rev-parse", "--abbrev-ref", "HEAD"])).trim();
-    const rel = relative(toplevel, abs);
-    const porcelain = (await git(toplevel, [
-      "status",
-      "--porcelain",
-      "--",
-      rel,
-    ])).trim();
-    return {
-      sha: sha || null,
-      branch: branch === "HEAD" ? null : branch || null,
-      detached: branch === "HEAD",
-      dirty: porcelain.length > 0,
-    };
+    const rel = relative(toplevel, abs).replaceAll("\\", "/");
+    return await probeWorkflowRepo(toplevel, rel);
   } catch {
-    return empty;
+    return probeWorkflowRepo(projectRoot);
   }
+}
+
+async function gitWriteBlocked(input: {
+  projectRoot: string;
+  sourceRoot: WorkflowSourceRoot;
+  commitHereAnyway: boolean;
+}): Promise<{ error: string; repo: string; git?: WorkflowGitStatus; branch?: string | null } | null> {
+  const junior = await probeWorkflowRepo(input.projectRoot);
+  const overlay = input.sourceRoot === "overlay"
+    ? await probeWorkflowRepo(join(input.projectRoot, "agents-org"))
+    : null;
+  const repos: Array<{ git: WorkflowGitStatus; repo: string }> = [
+    {
+      git: overlay ?? junior,
+      repo: overlay ? "agents-org" : "junior",
+    },
+  ];
+  if (overlay) repos.push({ git: junior, repo: "junior" });
+  for (const item of repos) {
+    if (item.git.detached) {
+      return { error: "detached-head", repo: item.repo, git: item.git };
+    }
+    if (item.git.merging) {
+      return { error: "merging", repo: item.repo, git: item.git };
+    }
+    if (item.git.rebasing) {
+      return { error: "rebasing", repo: item.repo, git: item.git };
+    }
+    if (!isProtectedBranch(item.git.branch) && !input.commitHereAnyway) {
+      return {
+        error: "commit here anyway required",
+        branch: item.git.branch,
+        repo: item.repo,
+      };
+    }
+  }
+  return null;
+}
+
+async function commitWorkflowMutation(input: {
+  deps: WorkflowRouteDeps;
+  actor: string;
+  action: "workflow.create" | "workflow.update";
+  kind: "create" | "update";
+  name: string;
+  markdown: string;
+  sourceRoot: WorkflowSourceRoot;
+  sourcePath: string;
+  commitMessage: string | undefined;
+  status: number;
+  definition: WorkflowDefinition;
+}): Promise<Response> {
+  const projectRoot = input.deps.projectRoot ?? process.cwd();
+  const ctx = validationContext(input.deps);
+  input.deps.registry.pauseReloads();
+  try {
+    const result = await writeDashboardWorkflow({
+      projectRoot,
+      sourceRoot: input.sourceRoot,
+      name: input.name,
+      markdown: input.markdown,
+      message: defaultWorkflowCommitMessage({
+        kind: input.kind,
+        name: input.name,
+        sourceRoot: input.sourceRoot,
+        sourcePath: input.sourcePath,
+        actor: input.actor,
+        commitMessage: input.commitMessage,
+      }),
+      actor: input.actor,
+      repos: ctx.repos,
+      builtInCommands: ctx.builtInCommands,
+    });
+    if (!result.ok) {
+      const status = result.code === "overlay-root-missing" ||
+          result.code === "not-a-repo" ||
+          result.code === "path-outside-repo"
+        ? 400
+        : 409;
+      await recordAudit(input.deps, {
+        actor: input.actor,
+        action: input.action,
+        targetId: input.name,
+        request: { sourceRoot: input.sourceRoot },
+        result: "error",
+        error: result.code,
+      });
+      return Response.json(
+        { error: result.code, detail: result.detail },
+        { status },
+      );
+    }
+
+    const slackTs = await postWorkflowNotice(
+      input.deps,
+      input.definition,
+      input.kind === "create" ? "created" : "updated",
+      input.actor,
+    );
+    const parentFailed = result.overlayCommitted &&
+      result.parentPointerCommitted === false;
+    await recordAudit(input.deps, {
+      actor: input.actor,
+      action: input.action,
+      targetId: input.name,
+      request: {
+        sourceRoot: input.sourceRoot,
+        sourcePath: result.sourcePath,
+      },
+      result: parentFailed ? "partial" : "ok",
+      slackTs,
+      commitSha: result.commit.sha,
+      error: parentFailed && result.parentPointer && "code" in result.parentPointer
+        ? result.parentPointer.detail
+        : null,
+    });
+    log.info(
+      "dashboard",
+      `dashboard action=${input.action} name=${input.name} result=${parentFailed ? "partial" : "ok"}`,
+    );
+    return Response.json({
+      name: result.name,
+      sourcePath: result.sourcePath,
+      sourceRoot: result.sourceRoot,
+      versionHash: result.versionHash,
+      overlayCommitted: result.overlayCommitted,
+      commit: result.commit,
+      parentPointerCommitted: result.parentPointerCommitted,
+      parentPointer: result.parentPointer,
+    }, { status: input.status });
+  } finally {
+    await input.deps.registry.resumeReloads();
+  }
+}
+
+function tryValidateMarkdown(input: {
+  markdown: string;
+  path: string;
+  sourceRoot: WorkflowSourceRoot;
+  repos: RepoConfig[];
+  builtInCommands: Set<string>;
+}): WorkflowDefinition | Response {
+  try {
+    return validateWorkflowMarkdown(input);
+  } catch (err) {
+    return invalidWorkflowResponse(err, input.path);
+  }
+}
+
+function invalidWorkflowResponse(err: unknown, path: string): Response {
+  return Response.json(
+    {
+      error: "invalid workflow",
+      errors: [{ path, message: formatError(err) }],
+    },
+    { status: 400 },
+  );
+}
+
+function validationContext(deps: WorkflowRouteDeps): {
+  repos: RepoConfig[];
+  builtInCommands: Set<string>;
+} {
+  if (typeof deps.registry.validationContext === "function") {
+    return deps.registry.validationContext();
+  }
+  return { repos: deps.repos ?? [], builtInCommands: new Set() };
+}
+
+function readMarkdown(body: Record<string, unknown>): string | Response {
+  if (typeof body.markdown !== "string") {
+    return Response.json({ error: "markdown must be a string" }, { status: 400 });
+  }
+  return body.markdown;
+}
+
+function readOptionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
 }
 
 function existingRealpath(path: string): string {

--- a/src/http/routes/workflows.ts
+++ b/src/http/routes/workflows.ts
@@ -1,4 +1,5 @@
-import { join, relative, resolve } from "node:path";
+import { realpathSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
 import type { Config } from "../../config.ts";
 import { log } from "../../logger.ts";
 import { hashWorkflowContent } from "../../workflows/definition.ts";
@@ -664,12 +665,15 @@ async function probeWorkflowGit(
 }> {
   const empty = { sha: null, branch: null, detached: false, dirty: false };
   if (!sourcePath) return empty;
-  const abs = resolve(projectRoot, sourcePath);
+  const abs = existingRealpath(resolve(projectRoot, sourcePath));
   try {
-    const sha = (await git(projectRoot, ["rev-parse", "HEAD"])).trim();
-    const branch = (await git(projectRoot, ["rev-parse", "--abbrev-ref", "HEAD"])).trim();
-    const rel = relative(projectRoot, abs);
-    const porcelain = (await git(projectRoot, [
+    const toplevel = existingRealpath(
+      (await git(dirname(abs), ["rev-parse", "--show-toplevel"])).trim(),
+    );
+    const sha = (await git(toplevel, ["rev-parse", "HEAD"])).trim();
+    const branch = (await git(toplevel, ["rev-parse", "--abbrev-ref", "HEAD"])).trim();
+    const rel = relative(toplevel, abs);
+    const porcelain = (await git(toplevel, [
       "status",
       "--porcelain",
       "--",
@@ -686,17 +690,30 @@ async function probeWorkflowGit(
   }
 }
 
+function existingRealpath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
 async function git(cwd: string, args: string[]): Promise<string> {
+  const env = { ...process.env };
+  delete env.GIT_DIR;
+  delete env.GIT_WORK_TREE;
   const proc = Bun.spawn(["git", ...args], {
     cwd,
+    env,
     stdout: "pipe",
     stderr: "pipe",
   });
-  const [stdout, exited] = await Promise.all([
+  const [stdout, stderr, exited] = await Promise.all([
     new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
     proc.exited,
   ]);
-  if (exited !== 0) throw new Error(`git ${args.join(" ")} failed`);
+  if (exited !== 0) throw new Error(`git ${args.join(" ")} failed: ${stderr.trim()}`);
   return stdout;
 }
 

--- a/src/http/routes/workflows.ts
+++ b/src/http/routes/workflows.ts
@@ -563,32 +563,17 @@ export async function handleWorkflowCreate(
 
   const overlayRel = join(OVERLAY_WORKFLOW_ROOT, `${name}.workflow.md`);
   const publicRel = join(PUBLIC_WORKFLOW_ROOT, `${name}.workflow.md`);
-  const overlayExists = existsSync(join(projectRoot, overlayRel));
-  const publicExists = existsSync(join(projectRoot, publicRel));
-  if (sourceRoot === "public" && overlayExists) {
+  const earlyCollision = createCollision(projectRoot, name, sourceRoot);
+  if (earlyCollision) {
     await recordAudit(deps, {
       actor,
       action: "workflow.create",
       targetId: name,
       result: "error",
-      error: "overlay shadows this name",
+      error: earlyCollision.error,
     });
-    return Response.json({ error: "overlay shadows this name" }, { status: 409 });
+    return Response.json({ error: earlyCollision.error }, { status: 409 });
   }
-  if (
-    (sourceRoot === "public" && publicExists) ||
-    (sourceRoot === "overlay" && overlayExists)
-  ) {
-    await recordAudit(deps, {
-      actor,
-      action: "workflow.create",
-      targetId: name,
-      result: "error",
-      error: "workflow already exists",
-    });
-    return Response.json({ error: "workflow already exists" }, { status: 409 });
-  }
-
   const sourcePath = sourceRoot === "overlay" ? overlayRel : publicRel;
   const ctx = validationContext(deps);
   const validated = tryValidateMarkdown({
@@ -644,6 +629,7 @@ export async function handleWorkflowCreate(
     commitMessage: readOptionalString(body.commitMessage),
     status: 201,
     definition: validated,
+    expectedVersionHash: "",
   });
 }
 
@@ -1124,6 +1110,24 @@ async function commitWorkflowMutation(input: {
     input.deps.registry.pauseReloads();
     let restoreFailed = false;
     try {
+      if (input.kind === "create") {
+        const collision = createCollision(
+          projectRoot,
+          input.name,
+          input.sourceRoot,
+        );
+        if (collision) {
+          await recordAudit(input.deps, {
+            actor: input.actor,
+            action: input.action,
+            targetId: input.name,
+            request: { sourceRoot: input.sourceRoot },
+            result: "error",
+            error: collision.error,
+          });
+          return Response.json({ error: collision.error }, { status: 409 });
+        }
+      }
       const result = await writeDashboardWorkflow({
         projectRoot,
         sourceRoot: input.sourceRoot,
@@ -1144,6 +1148,17 @@ async function commitWorkflowMutation(input: {
       });
       if (!result.ok) {
         restoreFailed = result.code === "restore-failed";
+        if (result.code === "version-hash-mismatch" && input.kind === "create") {
+          await recordAudit(input.deps, {
+            actor: input.actor,
+            action: input.action,
+            targetId: input.name,
+            request: { sourceRoot: input.sourceRoot },
+            result: "error",
+            error: "workflow already exists",
+          });
+          return Response.json({ error: "workflow already exists" }, { status: 409 });
+        }
         if (result.code === "invalid-workflow") {
           await recordAudit(input.deps, {
             actor: input.actor,
@@ -1264,6 +1279,29 @@ function readMarkdown(body: Record<string, unknown>): string | Response {
 
 function readOptionalString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function createCollision(
+  projectRoot: string,
+  name: string,
+  sourceRoot: WorkflowSourceRoot,
+): { error: string } | null {
+  const overlayExists = existsSync(
+    join(projectRoot, OVERLAY_WORKFLOW_ROOT, `${name}.workflow.md`),
+  );
+  const publicExists = existsSync(
+    join(projectRoot, PUBLIC_WORKFLOW_ROOT, `${name}.workflow.md`),
+  );
+  if (sourceRoot === "public" && overlayExists) {
+    return { error: "overlay shadows this name" };
+  }
+  if (
+    (sourceRoot === "public" && publicExists) ||
+    (sourceRoot === "overlay" && overlayExists)
+  ) {
+    return { error: "workflow already exists" };
+  }
+  return null;
 }
 
 function existingRealpath(path: string): string {

--- a/src/http/routes/workflows.ts
+++ b/src/http/routes/workflows.ts
@@ -152,6 +152,7 @@ export async function handleWorkflowDetail(
       sourcePath,
       fileVersionHash,
       loadedVersionHash,
+      overlayExists: existsSync(join(projectRoot, OVERLAY_WORKFLOW_ROOT, `${name}.workflow.md`)),
     },
     git: await probeWorkflowGitDetail(disk, sourceRoot, projectRoot),
     runtimeUsesFile: Boolean(
@@ -433,7 +434,17 @@ export async function handleWorkflowPut(
   }
 
   const expected = body.expectedVersionHash;
-  if (typeof expected === "string" && expected !== fileVersionHash) {
+  if (typeof expected !== "string" || !expected) {
+    await recordAudit(deps, {
+      actor,
+      action: "workflow.update",
+      targetId: name,
+      result: "error",
+      error: "expectedVersionHash is required",
+    });
+    return Response.json({ error: "expectedVersionHash is required" }, { status: 400 });
+  }
+  if (expected !== fileVersionHash) {
     await recordAudit(deps, {
       actor,
       action: "workflow.update",
@@ -476,6 +487,7 @@ export async function handleWorkflowPut(
     commitMessage: readOptionalString(body.commitMessage),
     status: 200,
     definition: validated,
+    expectedVersionHash: expected,
   });
 }
 
@@ -1104,47 +1116,63 @@ async function commitWorkflowMutation(input: {
   commitMessage: string | undefined;
   status: number;
   definition: WorkflowDefinition;
+  expectedVersionHash?: string;
 }): Promise<Response> {
   const projectRoot = input.deps.projectRoot ?? process.cwd();
   const ctx = validationContext(input.deps);
-  input.deps.registry.pauseReloads();
-  try {
-    const result = await writeDashboardWorkflow({
-      projectRoot,
-      sourceRoot: input.sourceRoot,
-      name: input.name,
-      markdown: input.markdown,
-      message: defaultWorkflowCommitMessage({
-        kind: input.kind,
-        name: input.name,
+  const run = async () => {
+    input.deps.registry.pauseReloads();
+    let restoreFailed = false;
+    try {
+      const result = await writeDashboardWorkflow({
+        projectRoot,
         sourceRoot: input.sourceRoot,
-        sourcePath: input.sourcePath,
+        name: input.name,
+        markdown: input.markdown,
+        message: defaultWorkflowCommitMessage({
+          kind: input.kind,
+          name: input.name,
+          sourceRoot: input.sourceRoot,
+          sourcePath: input.sourcePath,
+          actor: input.actor,
+          commitMessage: input.commitMessage,
+        }),
         actor: input.actor,
-        commitMessage: input.commitMessage,
-      }),
-      actor: input.actor,
-      repos: ctx.repos,
-      builtInCommands: ctx.builtInCommands,
-    });
-    if (!result.ok) {
-      const status = result.code === "overlay-root-missing" ||
-          result.code === "not-a-repo" ||
-          result.code === "path-outside-repo"
-        ? 400
-        : 409;
-      await recordAudit(input.deps, {
-        actor: input.actor,
-        action: input.action,
-        targetId: input.name,
-        request: { sourceRoot: input.sourceRoot },
-        result: "error",
-        error: result.code,
+        repos: ctx.repos,
+        builtInCommands: ctx.builtInCommands,
+        expectedVersionHash: input.expectedVersionHash,
       });
-      return Response.json(
-        { error: result.code, detail: result.detail },
-        { status },
-      );
-    }
+      if (!result.ok) {
+        restoreFailed = result.code === "restore-failed";
+        if (result.code === "invalid-workflow") {
+          await recordAudit(input.deps, {
+            actor: input.actor,
+            action: input.action,
+            targetId: input.name,
+            request: { sourceRoot: input.sourceRoot },
+            result: "error",
+            error: "invalid workflow",
+          });
+          return invalidWorkflowResponse(new Error(result.detail), input.sourcePath);
+        }
+        const status = result.code === "overlay-root-missing" ||
+            result.code === "not-a-repo" ||
+            result.code === "path-outside-repo"
+          ? 400
+          : 409;
+        await recordAudit(input.deps, {
+          actor: input.actor,
+          action: input.action,
+          targetId: input.name,
+          request: { sourceRoot: input.sourceRoot },
+          result: "error",
+          error: result.code,
+        });
+        return Response.json(
+          { error: result.code, detail: result.detail },
+          { status },
+        );
+      }
 
     const slackTs = await postWorkflowNotice(
       input.deps,
@@ -1173,19 +1201,24 @@ async function commitWorkflowMutation(input: {
       "dashboard",
       `dashboard action=${input.action} name=${input.name} result=${parentFailed ? "partial" : "ok"}`,
     );
-    return Response.json({
-      name: result.name,
-      sourcePath: result.sourcePath,
-      sourceRoot: result.sourceRoot,
-      versionHash: result.versionHash,
-      overlayCommitted: result.overlayCommitted,
-      commit: result.commit,
-      parentPointerCommitted: result.parentPointerCommitted,
-      parentPointer: result.parentPointer,
-    }, { status: input.status });
-  } finally {
-    await input.deps.registry.resumeReloads();
+      return Response.json({
+        name: result.name,
+        sourcePath: result.sourcePath,
+        sourceRoot: result.sourceRoot,
+        versionHash: result.versionHash,
+        overlayCommitted: result.overlayCommitted,
+        commit: result.commit,
+        parentPointerCommitted: result.parentPointerCommitted,
+        parentPointer: result.parentPointer,
+      }, { status: input.status });
+    } finally {
+      await input.deps.registry.resumeReloads({ reload: !restoreFailed });
+    }
+  };
+  if (typeof input.deps.registry.withWriteLock === "function") {
+    return input.deps.registry.withWriteLock(run);
   }
+  return run();
 }
 
 function tryValidateMarkdown(input: {

--- a/src/http/server.test.ts
+++ b/src/http/server.test.ts
@@ -27,7 +27,6 @@ function stubDeps(): HttpServerDeps {
     },
     slackPoster: {
       post: async () => ({ ts: "1.1" }),
-      react: async () => {},
     },
   };
 }

--- a/src/http/server.test.ts
+++ b/src/http/server.test.ts
@@ -18,6 +18,17 @@ function stubDeps(): HttpServerDeps {
     pipelineStore: {} as HttpServerDeps["pipelineStore"],
     usageStore: {} as HttpServerDeps["usageStore"],
     auditStore: {} as HttpServerDeps["auditStore"],
+    sessionManager: {
+      injectDashboardContinue: async () => ({ status: "accepted" }),
+      interruptThread: async () => 0,
+      isAdmin: async () => true,
+      isExplicitAdmin: async () => false,
+      getSession: async () => undefined,
+    },
+    slackPoster: {
+      post: async () => ({ ts: "1.1" }),
+      react: async () => {},
+    },
   };
 }
 

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -22,10 +22,14 @@ import type { CatalogStore } from "../runbooks/catalog-store.ts";
 import type { UsageStore } from "../usage/store/interface.ts";
 import type { DashboardAuditStore } from "./audit/interface.ts";
 import { handleHealth } from "./routes/health.ts";
+import type { SessionManager } from "../session/manager.ts";
 import {
   handleSessions,
   handleSessionDetail,
+  handleSessionContinue,
+  handleSessionStop,
   type SlackPermalinkResolver,
+  type SlackPoster,
 } from "./routes/sessions.ts";
 import { handleLogs } from "./routes/logs.ts";
 import { handleMemoryList, handleMemoryProjection, handleMemoryRead, handleMemoryRecall } from "./routes/memory.ts";
@@ -70,9 +74,117 @@ export interface HttpServerDeps {
   profileStore?: ProfileStore;
   pipelineStore: PipelineStore;
   resolveSlackPermalink?: SlackPermalinkResolver;
+  sessionManager: Pick<
+    SessionManager,
+    "injectDashboardContinue" | "interruptThread" | "isAdmin" | "isExplicitAdmin" | "getSession"
+  >;
+  slackPoster: SlackPoster;
   usageStore: UsageStore;
   auditStore: DashboardAuditStore;
   runbookCatalog?: CatalogStore;
+}
+
+export type MatchedApi =
+  | { route: "health" }
+  | { route: "sessions" }
+  | { route: "session"; threadId: string }
+  | { route: "session-continue"; threadId: string }
+  | { route: "session-stop"; threadId: string }
+  | { route: "dev-server" }
+  | { route: "workflows" }
+  | { route: "pipelines" }
+  | { route: "pipeline"; runId: string }
+  | { route: "pipeline-artifacts"; runId: string }
+  | { route: "spend" }
+  | { route: "runbooks" }
+  | { route: "runbook"; name: string }
+  | { route: "audit" }
+  | { route: "logs" }
+  | { route: "profiles" }
+  | { route: "memory" }
+  | { route: "memory-recall" }
+  | { route: "memory-projection" }
+  | { route: "memory-read"; filePath: string }
+  | { route: "not-found" };
+
+const API_METHODS: Record<Exclude<MatchedApi["route"], "not-found">, readonly string[]> = {
+  health: ["GET"],
+  sessions: ["GET"],
+  session: ["GET"],
+  "session-continue": ["POST"],
+  "session-stop": ["POST"],
+  "dev-server": ["GET"],
+  workflows: ["GET"],
+  pipelines: ["GET"],
+  pipeline: ["GET"],
+  "pipeline-artifacts": ["GET"],
+  spend: ["GET"],
+  runbooks: ["GET"],
+  runbook: ["GET"],
+  audit: ["GET"],
+  logs: ["GET"],
+  profiles: ["GET"],
+  memory: ["GET"],
+  "memory-recall": ["GET"],
+  "memory-projection": ["GET"],
+  "memory-read": ["GET"],
+};
+
+export function matchApi(pathname: string): MatchedApi {
+  if (!pathname.startsWith("/api/")) return { route: "not-found" };
+  const raw = pathname.slice("/api/".length);
+  if (!raw) return { route: "not-found" };
+  const parts = raw.split("/").filter((part) => part !== "").map((part) => {
+    try {
+      return decodeURIComponent(part);
+    } catch {
+      return part;
+    }
+  });
+  const [head, ...rest] = parts;
+  if (head === "health" && rest.length === 0) return { route: "health" };
+  if (head === "sessions" && rest.length === 0) return { route: "sessions" };
+  if (head === "sessions" && rest.length === 1) {
+    return { route: "session", threadId: rest[0]! };
+  }
+  if (head === "sessions" && rest.length === 2 && rest[1] === "continue") {
+    return { route: "session-continue", threadId: rest[0]! };
+  }
+  if (head === "sessions" && rest.length === 2 && rest[1] === "stop") {
+    return { route: "session-stop", threadId: rest[0]! };
+  }
+  if (head === "dev-server" && rest.length === 0) return { route: "dev-server" };
+  if (head === "workflows" && rest.length === 0) return { route: "workflows" };
+  if (head === "pipelines" && rest.length === 0) return { route: "pipelines" };
+  if (head === "pipelines" && rest.length === 1) {
+    return { route: "pipeline", runId: rest[0]! };
+  }
+  if (head === "pipelines" && rest.length === 2 && rest[1] === "artifacts") {
+    return { route: "pipeline-artifacts", runId: rest[0]! };
+  }
+  if (head === "spend" && rest.length === 0) return { route: "spend" };
+  if (head === "runbooks" && rest.length === 0) return { route: "runbooks" };
+  if (head === "runbooks" && rest.length === 1) {
+    return { route: "runbook", name: rest[0]! };
+  }
+  if (head === "audit" && rest.length === 0) return { route: "audit" };
+  if (head === "logs" && rest.length === 0) return { route: "logs" };
+  if (head === "profiles" && rest.length === 0) return { route: "profiles" };
+  if (head === "memory" && rest.length === 0) return { route: "memory" };
+  if (head === "memory" && rest.length === 1 && rest[0] === "recall") {
+    return { route: "memory-recall" };
+  }
+  if (head === "memory" && rest.length === 1 && rest[0] === "projection") {
+    return { route: "memory-projection" };
+  }
+  if (head === "memory") {
+    return { route: "memory-read", filePath: rest.join("/") };
+  }
+  return { route: "not-found" };
+}
+
+function methodNotAllowed(): Response {
+  return Response.json({ error: "method not allowed" }, { status: 405 });
 }
 
 export function startHttpServer(deps: HttpServerDeps): ReturnType<typeof Bun.serve> {
@@ -89,6 +201,8 @@ export function startHttpServer(deps: HttpServerDeps): ReturnType<typeof Bun.ser
     profileStore,
     pipelineStore,
     resolveSlackPermalink,
+    sessionManager,
+    slackPoster,
     usageStore,
     auditStore,
     runbookCatalog,
@@ -170,87 +284,102 @@ export function startHttpServer(deps: HttpServerDeps): ReturnType<typeof Bun.ser
           return new Response("not found", { status: 404 });
         }
 
-        if (url.pathname === "/api/health") {
-          return await handleHealth(store, config, startedAt, {
-            usageStore,
-            auditStore,
-          });
-        } else if (url.pathname === "/api/sessions") {
-          return await handleSessions(store, usageStore);
-        } else if (url.pathname.startsWith("/api/sessions/")) {
-          const threadId = decodeURIComponent(
-            url.pathname.slice("/api/sessions/".length),
-          );
-          return await handleSessionDetail(
-            store,
-            threadId,
-            resolveSlackPermalink,
-            usageStore,
-          );
-        } else if (url.pathname === "/api/dev-server") {
-          return await handleDevServers(devServerManager, devServerQueue, repos);
-        } else if (url.pathname === "/api/workflows") {
-          return await handleWorkflows(
-            workflowRegistry,
-            workflowStore,
-            workflowScheduler,
-          );
-        } else if (url.pathname === "/api/pipelines") {
-          return await handlePipelines(pipelineStore, url.searchParams, undefined, {
-            runtimeMode: config.pipeline?.runtimeMode ?? "off",
-            resolveSlackPermalink,
-          });
-        } else if (url.pathname.startsWith("/api/pipelines/")) {
-          const rest = decodeURIComponent(
-            url.pathname.slice("/api/pipelines/".length),
-          );
-          const artifactsMatch = rest.match(/^([^/]+)\/artifacts$/);
-          if (artifactsMatch) {
-            return await handlePipelineArtifact(
-              pipelineStore,
-              artifactsMatch[1],
-              url.searchParams,
-            );
-          }
-          if (rest.includes("/")) {
+        if (url.pathname.startsWith("/api/")) {
+          const matched = matchApi(url.pathname);
+          if (matched.route === "not-found") {
             return Response.json({ error: "not found" }, { status: 404 });
           }
-          return await handlePipelines(pipelineStore, url.searchParams, rest, {
-            runtimeMode: config.pipeline?.runtimeMode ?? "off",
-            resolveSlackPermalink,
-          });
-        } else if (url.pathname === "/api/spend") {
-          return await handleSpend(usageStore, url.searchParams);
-        } else if (url.pathname === "/api/runbooks") {
-          return await handleRunbooks(url.searchParams, runbookCatalog);
-        } else if (url.pathname.startsWith("/api/runbooks/")) {
-          const name = decodeURIComponent(
-            url.pathname.slice("/api/runbooks/".length),
-          );
-          if (!name || name.includes("/")) {
-            return Response.json({ error: "not found" }, { status: 404 });
+          if (!API_METHODS[matched.route].includes(req.method)) {
+            return methodNotAllowed();
           }
-          return await handleRunbookDetail(name, runbookCatalog);
-        } else if (url.pathname === "/api/audit") {
-          return await handleAudit(auditStore, url.searchParams);
-        } else if (url.pathname === "/api/logs") {
-          return await handleLogs(url.searchParams);
-        } else if (url.pathname === "/api/profiles") {
-          if (!profileStore) return Response.json({ error: "profile store not available" }, { status: 503 });
-          return await handleProfiles(profileStore, url.searchParams);
-        } else if (url.pathname === "/api/memory/recall") {
-          if (!memoryStore) return Response.json({ error: "memory store not available" }, { status: 503 });
-          return await handleMemoryRecall(memoryStore, url.searchParams);
-        } else if (url.pathname === "/api/memory/projection") {
-          if (!memoryStore) return Response.json({ error: "memory store not available" }, { status: 503 });
-          return await handleMemoryProjection(memoryStore, url.searchParams);
-        } else if (url.pathname === "/api/memory") {
-          return await handleMemoryList();
-        } else if (url.pathname.startsWith("/api/memory/")) {
-          const filePath = decodeURIComponent(
-            url.pathname.slice("/api/memory/".length),
-          );
-          return await handleMemoryRead(filePath);
+          switch (matched.route) {
+            case "health":
+              return await handleHealth(store, config, startedAt, {
+                usageStore,
+                auditStore,
+              });
+            case "sessions":
+              return await handleSessions(store, usageStore);
+            case "session":
+              return await handleSessionDetail(
+                store,
+                matched.threadId,
+                resolveSlackPermalink,
+                usageStore,
+              );
+            case "session-continue":
+              return await handleSessionContinue(req, matched.threadId, {
+                sessionManager,
+                slackPoster,
+                auditStore,
+                config,
+              });
+            case "session-stop":
+              return await handleSessionStop(matched.threadId, {
+                sessionManager,
+                slackPoster,
+                auditStore,
+                config,
+              });
+            case "dev-server":
+              return await handleDevServers(devServerManager, devServerQueue, repos);
+            case "workflows":
+              return await handleWorkflows(
+                workflowRegistry,
+                workflowStore,
+                workflowScheduler,
+              );
+            case "pipelines":
+              return await handlePipelines(pipelineStore, url.searchParams, undefined, {
+                runtimeMode: config.pipeline?.runtimeMode ?? "off",
+                resolveSlackPermalink,
+              });
+            case "pipeline":
+              return await handlePipelines(
+                pipelineStore,
+                url.searchParams,
+                matched.runId,
+                {
+                  runtimeMode: config.pipeline?.runtimeMode ?? "off",
+                  resolveSlackPermalink,
+                },
+              );
+            case "pipeline-artifacts":
+              return await handlePipelineArtifact(
+                pipelineStore,
+                matched.runId,
+                url.searchParams,
+              );
+            case "spend":
+              return await handleSpend(usageStore, url.searchParams);
+            case "runbooks":
+              return await handleRunbooks(url.searchParams, runbookCatalog);
+            case "runbook":
+              return await handleRunbookDetail(matched.name, runbookCatalog);
+            case "audit":
+              return await handleAudit(auditStore, url.searchParams);
+            case "logs":
+              return await handleLogs(url.searchParams);
+            case "profiles":
+              if (!profileStore) {
+                return Response.json({ error: "profile store not available" }, { status: 503 });
+              }
+              return await handleProfiles(profileStore, url.searchParams);
+            case "memory-recall":
+              if (!memoryStore) {
+                return Response.json({ error: "memory store not available" }, { status: 503 });
+              }
+              return await handleMemoryRecall(memoryStore, url.searchParams);
+            case "memory-projection":
+              if (!memoryStore) {
+                return Response.json({ error: "memory store not available" }, { status: 503 });
+              }
+              return await handleMemoryProjection(memoryStore, url.searchParams);
+            case "memory":
+              return await handleMemoryList();
+            case "memory-read":
+              return await handleMemoryRead(matched.filePath);
+          }
         }
         return Response.json({ error: "not found" }, { status: 404 });
       } catch (err) {

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -35,7 +35,9 @@ import { handleLogs } from "./routes/logs.ts";
 import { handleMemoryList, handleMemoryProjection, handleMemoryRead, handleMemoryRecall } from "./routes/memory.ts";
 import { handleDevServers } from "./routes/dev-server.ts";
 import {
+  handleWorkflowCreate,
   handleWorkflowDetail,
+  handleWorkflowPut,
   handleWorkflowReload,
   handleWorkflowRun,
   handleWorkflowStart,
@@ -124,6 +126,7 @@ export function startHttpServer(deps: HttpServerDeps): ReturnType<typeof Bun.ser
     auditStore,
     slackPoster,
     projectRoot,
+    repos,
   };
 
   const server = Bun.serve({
@@ -243,6 +246,9 @@ export function startHttpServer(deps: HttpServerDeps): ReturnType<typeof Bun.ser
             case "dev-server":
               return await handleDevServers(devServerManager, devServerQueue, repos);
             case "workflows":
+              if (req.method === "POST") {
+                return await handleWorkflowCreate(req, workflowDeps);
+              }
               return await handleWorkflows(
                 workflowRegistry,
                 workflowStore,
@@ -250,6 +256,9 @@ export function startHttpServer(deps: HttpServerDeps): ReturnType<typeof Bun.ser
                 projectRoot,
               );
             case "workflow":
+              if (req.method === "PUT") {
+                return await handleWorkflowPut(route.name, req, workflowDeps);
+              }
               return await handleWorkflowDetail(route.name, workflowDeps);
             case "workflow-run":
               return await handleWorkflowRun(route.name, req, workflowDeps);

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -34,12 +34,20 @@ import {
 import { handleLogs } from "./routes/logs.ts";
 import { handleMemoryList, handleMemoryProjection, handleMemoryRead, handleMemoryRecall } from "./routes/memory.ts";
 import { handleDevServers } from "./routes/dev-server.ts";
-import { handleWorkflows } from "./routes/workflows.ts";
+import {
+  handleWorkflowDetail,
+  handleWorkflowReload,
+  handleWorkflowRun,
+  handleWorkflowStart,
+  handleWorkflowStop,
+  handleWorkflows,
+} from "./routes/workflows.ts";
 import { handlePipelineArtifact, handlePipelines } from "./routes/pipelines.ts";
 import { handleProfiles } from "./routes/profiles.ts";
 import { handleSpend } from "./routes/spend.ts";
 import { handleRunbookDetail, handleRunbooks } from "./routes/runbooks.ts";
 import { handleAudit } from "./routes/audit.ts";
+import { allowedMethods, matchApi } from "./match-api.ts";
 import { log } from "../logger.ts";
 
 const PUBLIC_DIR = path.resolve(import.meta.dir, "../../public");
@@ -82,109 +90,7 @@ export interface HttpServerDeps {
   usageStore: UsageStore;
   auditStore: DashboardAuditStore;
   runbookCatalog?: CatalogStore;
-}
-
-export type MatchedApi =
-  | { route: "health" }
-  | { route: "sessions" }
-  | { route: "session"; threadId: string }
-  | { route: "session-continue"; threadId: string }
-  | { route: "session-stop"; threadId: string }
-  | { route: "dev-server" }
-  | { route: "workflows" }
-  | { route: "pipelines" }
-  | { route: "pipeline"; runId: string }
-  | { route: "pipeline-artifacts"; runId: string }
-  | { route: "spend" }
-  | { route: "runbooks" }
-  | { route: "runbook"; name: string }
-  | { route: "audit" }
-  | { route: "logs" }
-  | { route: "profiles" }
-  | { route: "memory" }
-  | { route: "memory-recall" }
-  | { route: "memory-projection" }
-  | { route: "memory-read"; filePath: string }
-  | { route: "not-found" };
-
-const API_METHODS: Record<Exclude<MatchedApi["route"], "not-found">, readonly string[]> = {
-  health: ["GET"],
-  sessions: ["GET"],
-  session: ["GET"],
-  "session-continue": ["POST"],
-  "session-stop": ["POST"],
-  "dev-server": ["GET"],
-  workflows: ["GET"],
-  pipelines: ["GET"],
-  pipeline: ["GET"],
-  "pipeline-artifacts": ["GET"],
-  spend: ["GET"],
-  runbooks: ["GET"],
-  runbook: ["GET"],
-  audit: ["GET"],
-  logs: ["GET"],
-  profiles: ["GET"],
-  memory: ["GET"],
-  "memory-recall": ["GET"],
-  "memory-projection": ["GET"],
-  "memory-read": ["GET"],
-};
-
-export function matchApi(pathname: string): MatchedApi {
-  if (!pathname.startsWith("/api/")) return { route: "not-found" };
-  const raw = pathname.slice("/api/".length);
-  if (!raw) return { route: "not-found" };
-  const parts = raw.split("/").filter((part) => part !== "").map((part) => {
-    try {
-      return decodeURIComponent(part);
-    } catch {
-      return part;
-    }
-  });
-  const [head, ...rest] = parts;
-  if (head === "health" && rest.length === 0) return { route: "health" };
-  if (head === "sessions" && rest.length === 0) return { route: "sessions" };
-  if (head === "sessions" && rest.length === 1) {
-    return { route: "session", threadId: rest[0]! };
-  }
-  if (head === "sessions" && rest.length === 2 && rest[1] === "continue") {
-    return { route: "session-continue", threadId: rest[0]! };
-  }
-  if (head === "sessions" && rest.length === 2 && rest[1] === "stop") {
-    return { route: "session-stop", threadId: rest[0]! };
-  }
-  if (head === "dev-server" && rest.length === 0) return { route: "dev-server" };
-  if (head === "workflows" && rest.length === 0) return { route: "workflows" };
-  if (head === "pipelines" && rest.length === 0) return { route: "pipelines" };
-  if (head === "pipelines" && rest.length === 1) {
-    return { route: "pipeline", runId: rest[0]! };
-  }
-  if (head === "pipelines" && rest.length === 2 && rest[1] === "artifacts") {
-    return { route: "pipeline-artifacts", runId: rest[0]! };
-  }
-  if (head === "spend" && rest.length === 0) return { route: "spend" };
-  if (head === "runbooks" && rest.length === 0) return { route: "runbooks" };
-  if (head === "runbooks" && rest.length === 1) {
-    return { route: "runbook", name: rest[0]! };
-  }
-  if (head === "audit" && rest.length === 0) return { route: "audit" };
-  if (head === "logs" && rest.length === 0) return { route: "logs" };
-  if (head === "profiles" && rest.length === 0) return { route: "profiles" };
-  if (head === "memory" && rest.length === 0) return { route: "memory" };
-  if (head === "memory" && rest.length === 1 && rest[0] === "recall") {
-    return { route: "memory-recall" };
-  }
-  if (head === "memory" && rest.length === 1 && rest[0] === "projection") {
-    return { route: "memory-projection" };
-  }
-  if (head === "memory") {
-    return { route: "memory-read", filePath: rest.join("/") };
-  }
-  return { route: "not-found" };
-}
-
-function methodNotAllowed(): Response {
-  return Response.json({ error: "method not allowed" }, { status: 405 });
+  projectRoot?: string;
 }
 
 export function startHttpServer(deps: HttpServerDeps): ReturnType<typeof Bun.serve> {
@@ -206,7 +112,19 @@ export function startHttpServer(deps: HttpServerDeps): ReturnType<typeof Bun.ser
     usageStore,
     auditStore,
     runbookCatalog,
+    projectRoot,
   } = deps;
+
+  const workflowDeps = {
+    registry: workflowRegistry,
+    store: workflowStore,
+    scheduler: workflowScheduler,
+    config,
+    sessionManager,
+    auditStore,
+    slackPoster,
+    projectRoot,
+  };
 
   const server = Bun.serve({
     port: config.http.port,
@@ -285,14 +203,15 @@ export function startHttpServer(deps: HttpServerDeps): ReturnType<typeof Bun.ser
         }
 
         if (url.pathname.startsWith("/api/")) {
-          const matched = matchApi(url.pathname);
-          if (matched.route === "not-found") {
+          const route = matchApi(url.pathname);
+          if (route.kind === "not-found") {
             return Response.json({ error: "not found" }, { status: 404 });
           }
-          if (!API_METHODS[matched.route].includes(req.method)) {
-            return methodNotAllowed();
+          const allowed = allowedMethods(route.kind);
+          if (!allowed.includes(req.method)) {
+            return Response.json({ error: "method not allowed" }, { status: 405 });
           }
-          switch (matched.route) {
+          switch (route.kind) {
             case "health":
               return await handleHealth(store, config, startedAt, {
                 usageStore,
@@ -303,19 +222,19 @@ export function startHttpServer(deps: HttpServerDeps): ReturnType<typeof Bun.ser
             case "session":
               return await handleSessionDetail(
                 store,
-                matched.threadId,
+                route.threadId,
                 resolveSlackPermalink,
                 usageStore,
               );
             case "session-continue":
-              return await handleSessionContinue(req, matched.threadId, {
+              return await handleSessionContinue(req, route.threadId, {
                 sessionManager,
                 slackPoster,
                 auditStore,
                 config,
               });
             case "session-stop":
-              return await handleSessionStop(matched.threadId, {
+              return await handleSessionStop(route.threadId, {
                 sessionManager,
                 slackPoster,
                 auditStore,
@@ -328,26 +247,32 @@ export function startHttpServer(deps: HttpServerDeps): ReturnType<typeof Bun.ser
                 workflowRegistry,
                 workflowStore,
                 workflowScheduler,
+                projectRoot,
               );
+            case "workflow":
+              return await handleWorkflowDetail(route.name, workflowDeps);
+            case "workflow-run":
+              return await handleWorkflowRun(route.name, req, workflowDeps);
+            case "workflow-start":
+              return await handleWorkflowStart(route.name, workflowDeps);
+            case "workflow-stop":
+              return await handleWorkflowStop(route.name, workflowDeps);
+            case "workflow-reload":
+              return await handleWorkflowReload(workflowDeps);
             case "pipelines":
               return await handlePipelines(pipelineStore, url.searchParams, undefined, {
                 runtimeMode: config.pipeline?.runtimeMode ?? "off",
                 resolveSlackPermalink,
               });
             case "pipeline":
-              return await handlePipelines(
-                pipelineStore,
-                url.searchParams,
-                matched.runId,
-                {
-                  runtimeMode: config.pipeline?.runtimeMode ?? "off",
-                  resolveSlackPermalink,
-                },
-              );
+              return await handlePipelines(pipelineStore, url.searchParams, route.id, {
+                runtimeMode: config.pipeline?.runtimeMode ?? "off",
+                resolveSlackPermalink,
+              });
             case "pipeline-artifacts":
               return await handlePipelineArtifact(
                 pipelineStore,
-                matched.runId,
+                route.id,
                 url.searchParams,
               );
             case "spend":
@@ -355,7 +280,7 @@ export function startHttpServer(deps: HttpServerDeps): ReturnType<typeof Bun.ser
             case "runbooks":
               return await handleRunbooks(url.searchParams, runbookCatalog);
             case "runbook":
-              return await handleRunbookDetail(matched.name, runbookCatalog);
+              return await handleRunbookDetail(route.name, runbookCatalog);
             case "audit":
               return await handleAudit(auditStore, url.searchParams);
             case "logs":
@@ -365,6 +290,8 @@ export function startHttpServer(deps: HttpServerDeps): ReturnType<typeof Bun.ser
                 return Response.json({ error: "profile store not available" }, { status: 503 });
               }
               return await handleProfiles(profileStore, url.searchParams);
+            case "memory":
+              return await handleMemoryList();
             case "memory-recall":
               if (!memoryStore) {
                 return Response.json({ error: "memory store not available" }, { status: 503 });
@@ -375,10 +302,8 @@ export function startHttpServer(deps: HttpServerDeps): ReturnType<typeof Bun.ser
                 return Response.json({ error: "memory store not available" }, { status: 503 });
               }
               return await handleMemoryProjection(memoryStore, url.searchParams);
-            case "memory":
-              return await handleMemoryList();
             case "memory-read":
-              return await handleMemoryRead(matched.filePath);
+              return await handleMemoryRead(route.filePath);
           }
         }
         return Response.json({ error: "not found" }, { status: 404 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -833,14 +833,14 @@ setInterval(() => {
             try {
               const result = await app.client.chat.postMessage({
                 channel,
-                thread_ts: threadTs,
                 text,
+                ...(threadTs ? { thread_ts: threadTs } : {}),
                 unfurl_links: false,
                 unfurl_media: false,
               });
               return typeof result.ts === "string" ? { ts: result.ts } : null;
             } catch (err) {
-              log.error(
+              log.warn(
                 "dashboard",
                 `slack post failed: ${err instanceof Error ? err.message : String(err)}`,
               );
@@ -848,6 +848,7 @@ setInterval(() => {
             }
           },
         },
+        projectRoot: process.cwd(),
         resolveSlackPermalink: async (channel, messageTs) => {
           const result = await app.client.chat.getPermalink({
             channel,

--- a/src/index.ts
+++ b/src/index.ts
@@ -847,20 +847,6 @@ setInterval(() => {
               return null;
             }
           },
-          react: async (channel, ts, emoji) => {
-            try {
-              await app.client.reactions.add({
-                channel,
-                timestamp: ts,
-                name: emoji,
-              });
-            } catch (err) {
-              log.warn(
-                "dashboard",
-                `slack react failed: ${err instanceof Error ? err.message : String(err)}`,
-              );
-            }
-          },
         },
         resolveSlackPermalink: async (channel, messageTs) => {
           const result = await app.client.chat.getPermalink({

--- a/src/index.ts
+++ b/src/index.ts
@@ -827,6 +827,41 @@ setInterval(() => {
         usageStore,
         auditStore,
         runbookCatalog: runbookCatalogStore,
+        sessionManager,
+        slackPoster: {
+          post: async (channel, threadTs, text) => {
+            try {
+              const result = await app.client.chat.postMessage({
+                channel,
+                thread_ts: threadTs,
+                text,
+                unfurl_links: false,
+                unfurl_media: false,
+              });
+              return typeof result.ts === "string" ? { ts: result.ts } : null;
+            } catch (err) {
+              log.error(
+                "dashboard",
+                `slack post failed: ${err instanceof Error ? err.message : String(err)}`,
+              );
+              return null;
+            }
+          },
+          react: async (channel, ts, emoji) => {
+            try {
+              await app.client.reactions.add({
+                channel,
+                timestamp: ts,
+                name: emoji,
+              });
+            } catch (err) {
+              log.warn(
+                "dashboard",
+                `slack react failed: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            }
+          },
+        },
         resolveSlackPermalink: async (channel, messageTs) => {
           const result = await app.client.chat.getPermalink({
             channel,

--- a/src/session/continue-route.test.ts
+++ b/src/session/continue-route.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from "bun:test";
+import { resolveContinueRoute } from "./continue-route.ts";
+import { createSession } from "./types.ts";
+
+function sessionWith(overrides: Parameters<typeof Object.assign>[1] = {}) {
+  return Object.assign(createSession("thread-1", "C123"), overrides);
+}
+
+describe("resolveContinueRoute", () => {
+  it("routes lead to the top-level lead handle", () => {
+    expect(resolveContinueRoute("lead", sessionWith())).toEqual({
+      kind: "top-level",
+      handle: "lead",
+    });
+  });
+
+  it("routes default to the top-level default handle", () => {
+    expect(resolveContinueRoute("default", sessionWith())).toEqual({
+      kind: "top-level",
+      handle: "default",
+    });
+  });
+
+  it("aliases junior to the top-level default handle", () => {
+    expect(resolveContinueRoute("junior", sessionWith({ defaultAgent: "lead" }))).toEqual({
+      kind: "top-level",
+      handle: "default",
+    });
+  });
+
+  it("uses defaultAgent then activeAgentName then default when the request is missing", () => {
+    expect(resolveContinueRoute(undefined, sessionWith({ defaultAgent: "lead" }))).toEqual({
+      kind: "top-level",
+      handle: "lead",
+    });
+    expect(resolveContinueRoute(undefined, sessionWith({
+      defaultAgent: "junior",
+      activeAgentName: "review",
+    }))).toEqual({
+      kind: "top-level",
+      handle: "default",
+    });
+    expect(resolveContinueRoute(undefined, sessionWith({ activeAgentName: "lead" }))).toEqual({
+      kind: "top-level",
+      handle: "lead",
+    });
+    expect(resolveContinueRoute(undefined, sessionWith())).toEqual({
+      kind: "top-level",
+      handle: "default",
+    });
+  });
+
+  it("allows an existing worker agentSessions row", () => {
+    expect(resolveContinueRoute("review", sessionWith({
+      agentSessions: {
+        review: {
+          agentName: "review",
+          sessionId: "ses-review",
+          status: "idle",
+          lastActivity: Date.now(),
+          pendingMessages: [],
+        },
+      },
+    }))).toEqual({
+      kind: "worker",
+      agentName: "review",
+    });
+  });
+
+  it("rejects unknown or not-on-thread workers", () => {
+    expect(resolveContinueRoute("review", sessionWith())).toEqual({
+      error: "unknown-agent",
+    });
+    expect(resolveContinueRoute("pm", sessionWith({
+      agentSessions: {
+        review: {
+          agentName: "review",
+          sessionId: "ses-review",
+          status: "idle",
+          lastActivity: Date.now(),
+          pendingMessages: [],
+        },
+      },
+    }))).toEqual({
+      error: "unknown-agent",
+    });
+  });
+});

--- a/src/session/continue-route.ts
+++ b/src/session/continue-route.ts
@@ -1,0 +1,16 @@
+import type { ThreadSession } from "./types.ts";
+
+export type ContinueRoute =
+  | { kind: "top-level"; handle: "default" | "lead" }
+  | { kind: "worker"; agentName: string };
+
+export function resolveContinueRoute(
+  requested: string | undefined,
+  session: ThreadSession,
+): ContinueRoute | { error: "unknown-agent" } {
+  const raw = requested ?? session.defaultAgent ?? session.activeAgentName ?? "default";
+  if (raw === "lead") return { kind: "top-level", handle: "lead" };
+  if (raw === "default" || raw === "junior") return { kind: "top-level", handle: "default" };
+  if (session.agentSessions?.[raw]) return { kind: "worker", agentName: raw };
+  return { error: "unknown-agent" };
+}

--- a/src/session/followup-policy.test.ts
+++ b/src/session/followup-policy.test.ts
@@ -67,6 +67,7 @@ describe("evaluateBusyFollowup", () => {
     [{ hasCommand: true }, "incoming-has-command"],
     [{ hasPipelineMetadata: true }, "incoming-has-pipeline-metadata"],
     [{ isInternal: true }, "incoming-is-internal"],
+    [{ isDashboardContinue: true }, "incoming-is-dashboard-continue"],
     [{ text: "x".repeat(241) }, "incoming-too-long"],
     [{ text: Array.from({ length: 41 }, () => "word").join(" ") }, "incoming-too-many-words"],
     [{ text: "first line\nsecond line" }, "incoming-multiline-or-code"],

--- a/src/session/followup-policy.ts
+++ b/src/session/followup-policy.ts
@@ -14,6 +14,7 @@ export type FollowupMessageContext = {
   hasCommand: boolean;
   hasPipelineMetadata: boolean;
   isInternal: boolean;
+  isDashboardContinue?: boolean;
 };
 
 export type BusyFollowupContext = {
@@ -57,6 +58,7 @@ function messageIneligibleReason(
   if (message.hasCommand) return `${label}-has-command`;
   if (message.hasPipelineMetadata) return `${label}-has-pipeline-metadata`;
   if (message.isInternal) return `${label}-is-internal`;
+  if (message.isDashboardContinue) return `${label}-is-dashboard-continue`;
   if (message.text.length > maxMessageLength) return `${label}-too-long`;
   if (wordCount(message.text) > maxWordCount) return `${label}-too-many-words`;
   if (isMultilineOrCodeHeavy(message.text)) return `${label}-multiline-or-code`;

--- a/src/session/inject.test.ts
+++ b/src/session/inject.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it, mock } from "bun:test";
+import type { SpawnHandle, SpawnResult, SpawnRunnerFn } from "../runners/types.ts";
+import type { Config } from "../config.ts";
+import { toDashboardSlackEvent } from "./inject.ts";
+import { createSession } from "./types.ts";
+import { InMemorySessionStore } from "./store/memory.ts";
+import { SessionManager } from "./manager.ts";
+
+describe("toDashboardSlackEvent", () => {
+  it("builds an attribution-only inject event with dashboardContinue", () => {
+    const event = toDashboardSlackEvent({
+      threadId: "1712345678.123456",
+      channel: "C123",
+      prompt: "!review please inspect this",
+      actorSlackUserId: "UADMIN01",
+      postedTs: "1712345678.999999",
+    });
+
+    expect(event).toEqual({
+      threadId: "1712345678.123456",
+      channel: "C123",
+      user: "UADMIN01",
+      attributionUserId: "UADMIN01",
+      text: "!review please inspect this",
+      conversationalText: "!review please inspect this",
+      ts: "1712345678.999999",
+      command: null,
+      isSelfBot: true,
+      botUsername: "dashboard",
+      dedupeKey: "dashboard:1712345678.123456:1712345678.999999",
+      dashboardContinue: true,
+    });
+    expect(event.dedupeKey).not.toBe(event.ts);
+    expect(event.dedupeKey).not.toBe(`${event.ts}:review`);
+  });
+});
+
+describe("injectDashboardContinue dormant wake", () => {
+  it("clears dormant and sets needsThreadCatchup before dispatch", async () => {
+    const store = new InMemorySessionStore();
+    const session = createSession("thread-1", "C123");
+    session.dormant = true;
+    session.needsThreadCatchup = false;
+    await store.set(session.threadId, session);
+
+    const spawn = mock<SpawnRunnerFn>((() => createHandle()) as SpawnRunnerFn);
+    const manager = new SessionManager(store, testConfig(), spawn);
+
+    const result = await manager.injectDashboardContinue({
+      threadId: "thread-1",
+      channel: "C123",
+      prompt: "catch me up",
+      actorSlackUserId: "UADMIN01",
+      postedTs: "9.9",
+    });
+
+    expect(result).toEqual({ status: "accepted" });
+    const after = await store.get("thread-1");
+    expect(after?.dormant).toBe(false);
+    expect(after?.needsThreadCatchup).toBe(true);
+    expect(spawn).toHaveBeenCalledTimes(1);
+  });
+});
+
+function createHandle(): SpawnHandle {
+  const result = new Promise<SpawnResult>(() => {});
+  return {
+    provider: "claude",
+    result,
+    onEvent: () => undefined,
+    kill: mock(() => {}),
+    pid: 1,
+  };
+}
+
+function testConfig(): Config {
+  return {
+    slack: { botToken: "xoxb-test", appToken: "xapp-test", signingSecret: "s" },
+    claude: {
+      maxTurns: 25,
+      timeoutMs: 300000,
+      permissionMode: "bypassPermissions",
+      defaultModel: null,
+      defaultDriver: "headless",
+      tmuxIdleTtlMs: 14_400_000,
+      tmuxSweepIntervalMs: 900_000,
+    },
+    runner: { provider: "claude" },
+    opencode: {
+      model: null,
+      timeoutMs: 300000,
+      continuityEnabled: false,
+      permission: "allow",
+      mcpEnabled: true,
+      slackMcpEnabled: true,
+      playwrightMcpEnabled: true,
+      mixpanelMcpEnabled: true,
+      mongodbMcpEnabled: true,
+    },
+    codex: {
+      mode: "app-server",
+      model: null,
+      timeoutMs: 300000,
+      sandbox: "workspace-write",
+      askForApproval: "never",
+      searchEnabled: false,
+      appServerContinuityEnabled: false,
+      mcpEnabled: true,
+      slackMcpEnabled: true,
+      playwrightMcpEnabled: true,
+      mixpanelMcpEnabled: true,
+      mongodbMcpEnabled: true,
+      memoryMcpEnabled: true,
+      isolatedHomePath: "data/codex-home",
+    },
+    repos: [],
+    session: {
+      staleTimeoutMs: 86400000,
+      cleanupIntervalMs: 900000,
+      store: "memory",
+      sqlitePath: "data/sessions.db",
+      homeWindowMs: 172800000,
+      defaultVerbosity: "quiet",
+      idleTimeoutMs: 300000,
+      maxIdleInterrupts: 3,
+      shortFollowupInterruptEnabled: false,
+      shortFollowupMaxLength: 280,
+    },
+    memory: { sqlitePath: "data/memory.db" },
+    threadArchives: { dir: "data/thread-archives" },
+    channelDefaults: {},
+    adminSlackUserId: "UADMIN01",
+    http: { enabled: true, port: 0 },
+  } as Config;
+}

--- a/src/session/inject.ts
+++ b/src/session/inject.ts
@@ -1,0 +1,24 @@
+import type { SlackMessageEvent } from "../slack/events.ts";
+
+export function toDashboardSlackEvent(input: {
+  threadId: string;
+  channel: string;
+  prompt: string;
+  actorSlackUserId: string;
+  postedTs: string;
+}): SlackMessageEvent {
+  return {
+    threadId: input.threadId,
+    channel: input.channel,
+    user: input.actorSlackUserId,
+    attributionUserId: input.actorSlackUserId,
+    text: input.prompt,
+    conversationalText: input.prompt,
+    ts: input.postedTs,
+    command: null,
+    isSelfBot: true,
+    botUsername: "dashboard",
+    dedupeKey: `dashboard:${input.threadId}:${input.postedTs}`,
+    dashboardContinue: true,
+  };
+}

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -2348,6 +2348,33 @@ describe("SessionManager", () => {
 
   // --- Commands ---
 
+  describe("interruptThread / !stop", () => {
+    it("interruptThread matches !stop: kills handles and idles the thread", async () => {
+      await manager.handleMessage(makeEvent({ text: "go" }));
+      expect((await store.get("thread-1"))!.status).toBe("busy");
+
+      const touched = await manager.interruptThread("thread-1");
+      expect(touched).toBe(1);
+      expect(currentHandle.kill).toHaveBeenCalled();
+      expect((await store.get("thread-1"))!.status).toBe("idle");
+    });
+
+    it("!stop calls interruptThread and posts the Slack line", async () => {
+      const onCmd = mock((_e: SlackMessageEvent, _r: string) => {});
+      manager.onCommandResponse = onCmd;
+      await manager.handleMessage(makeEvent({ text: "go" }));
+
+      await manager.handleMessage(makeEvent({ command: "stop", text: "", ts: "ts-stop" }));
+
+      expect(currentHandle.kill).toHaveBeenCalled();
+      expect(onCmd).toHaveBeenCalledWith(
+        expect.objectContaining({ command: "stop" }),
+        "Interrupted (1 agent). Send a new message to continue.",
+      );
+      expect((await store.get("thread-1"))!.status).toBe("idle");
+    });
+  });
+
   describe("!reset", () => {
     it("rejects bare !reset with usage help", async () => {
       const onCmd = mock((_e: SlackMessageEvent, _r: string) => {});

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -33,6 +33,8 @@ import {
   isRunnerProvider,
 } from "./types.ts";
 import { evaluateBusyFollowup } from "./followup-policy.ts";
+import { resolveContinueRoute } from "./continue-route.ts";
+import { toDashboardSlackEvent } from "./inject.ts";
 import {
   runnerTimeoutMs,
   sessionProvider,
@@ -119,6 +121,17 @@ const TURN_PROGRESS_EMOJI = "hourglass_flowing_sand";
  * — and reacting to those is an API call that can only fail.
  */
 const SLACK_MESSAGE_TS = /^\d+\.\d+$/;
+
+export type DashboardInjectResult =
+  | { status: "accepted" }
+  | { status: "buffered" }
+  | { status: "muted" };
+
+export function formatStopReply(interrupted: number): string {
+  return interrupted === 0
+    ? "Nothing running."
+    : `Interrupted (${interrupted} agent${interrupted === 1 ? "" : "s"}). Send a new message to continue.`;
+}
 
 export class SessionManager {
   private store: SessionStore;
@@ -509,17 +522,22 @@ export class SessionManager {
     event: SlackMessageEvent,
     agentName: string,
   ): Promise<void> {
+    await this.dispatchAgentMessage(event, agentName);
+  }
+
+  private async dispatchAgentMessage(
+    event: SlackMessageEvent,
+    agentName: string,
+  ): Promise<DashboardInjectResult> {
     if (agentName === "lead") {
-      await this.runSingleSession(event, "lead");
-      return;
+      return this.runSingleSession(event, "lead");
     }
     if (agentName === "default") {
-      await this.runSingleSession(event, "default");
-      return;
+      return this.runSingleSession(event, "default");
     }
 
     const dedupeKey = event.dedupeKey ?? `${event.ts}:${agentName}`;
-    if (this.seenMessages.has(dedupeKey)) return;
+    if (this.seenMessages.has(dedupeKey)) return { status: "accepted" };
 
     // Ensure the parent row exists before the concurrent-safe mutation.
     await this.getOrCreateSession(event);
@@ -531,7 +549,7 @@ export class SessionManager {
       await this.routeDirectTaskThroughDefaultRun(event, agentName, directSession)
     ) {
       this.rememberSeenMessage(dedupeKey);
-      return;
+      return { status: "accepted" };
     }
 
     // Object wrapper so TS doesn't narrow the flag past the mutator closure.
@@ -555,11 +573,11 @@ export class SessionManager {
     });
     this.rememberSeenMessage(dedupeKey);
 
-    if (outcome.action === "muted") return;
+    if (outcome.action === "muted") return { status: "muted" };
 
     if (outcome.action === "buffer") {
       this.onMessageBuffered?.(event);
-      return;
+      return { status: "buffered" };
     }
 
     const reservation = createRunSetupReservation(
@@ -576,6 +594,7 @@ export class SessionManager {
       event.user,
       reservation,
     );
+    return { status: "accepted" };
   }
 
   // Generic single-session path for "default" (any-channel @mentions) and the
@@ -587,10 +606,10 @@ export class SessionManager {
   private async runSingleSession(
     event: SlackMessageEvent,
     agentName: "lead" | "default",
-  ): Promise<void> {
+  ): Promise<DashboardInjectResult> {
     // Deduplicate: Slack fires both `message` and `app_mention` for @mentions
     const dedupeKey = event.dedupeKey ?? event.ts;
-    if (this.seenMessages.has(dedupeKey)) return;
+    if (this.seenMessages.has(dedupeKey)) return { status: "accepted" };
 
     let session = await this.getOrCreateSession(event);
     await this.captureSlackMemory(event, agentName, "single-session");
@@ -599,7 +618,7 @@ export class SessionManager {
       const handled = await this.handleCommand(session, event);
       if (handled) {
         this.rememberSeenMessage(dedupeKey);
-        return;
+        return { status: "accepted" };
       }
       // Commands may have rewritten the row; re-read before the busy gate.
       session = (await this.store.get(event.threadId)) ?? session;
@@ -607,12 +626,12 @@ export class SessionManager {
 
     if (session.muted) {
       this.rememberSeenMessage(dedupeKey);
-      return;
+      return { status: "muted" };
     }
 
     if (await this.routeDirectTaskThroughDefaultRun(event, agentName, session)) {
       this.rememberSeenMessage(dedupeKey);
-      return;
+      return { status: "accepted" };
     }
 
     await this.onAgentDispatched?.(session, agentName);
@@ -651,6 +670,7 @@ export class SessionManager {
             hasPipelineMetadata:
               pipelineControlled && Boolean(event.pipelineInvocation),
             isInternal: Boolean(event.isSelfBot && !event.attributionUserId),
+            isDashboardContinue: event.dashboardContinue === true,
           },
           maxMessageLength: this.config.session.shortFollowupMaxLength,
           maxWordCount: 40,
@@ -708,6 +728,7 @@ export class SessionManager {
                 hasPipelineMetadata:
                   pipelineControlled && Boolean(event.pipelineInvocation),
                 isInternal: Boolean(event.isSelfBot && !event.attributionUserId),
+                isDashboardContinue: event.dashboardContinue === true,
               },
               maxMessageLength: this.config.session.shortFollowupMaxLength,
               maxWordCount: 40,
@@ -766,7 +787,7 @@ export class SessionManager {
 
     if (outcome.action === "buffer") {
       this.onMessageBuffered?.(event);
-      return;
+      return { status: "buffered" };
     }
 
     if (outcome.action === "interrupt") {
@@ -774,7 +795,7 @@ export class SessionManager {
       // exact handle installed and let its normal settlement path start the
       // consolidated replacement after the process has actually exited.
       outcome.handle!.kill("SIGINT");
-      return;
+      return { status: "accepted" };
     }
 
     const handleKey = this.handleKey(session.threadId, agentName);
@@ -792,6 +813,61 @@ export class SessionManager {
       incomingAuthor ?? undefined,
       reservation,
     );
+    return { status: "accepted" };
+  }
+
+  async injectDashboardContinue(input: {
+    threadId: string;
+    channel: string;
+    prompt: string;
+    agentName?: string;
+    actorSlackUserId: string;
+    postedTs: string;
+  }): Promise<DashboardInjectResult> {
+    const session = await this.getSession(input.threadId);
+    if (!session) return { status: "muted" };
+    if (session.muted) return { status: "muted" };
+
+    const route = resolveContinueRoute(input.agentName, session);
+    if ("error" in route) return { status: "muted" };
+
+    if (session.dormant) {
+      await this.mutateSession(input.threadId, (s) => {
+        if (s.dormant) {
+          s.dormant = false;
+          s.needsThreadCatchup = true;
+        }
+      });
+    }
+
+    const event = toDashboardSlackEvent(input);
+    if (route.kind === "top-level") {
+      return this.runSingleSession(event, route.handle);
+    }
+    return this.dispatchAgentMessage(event, route.agentName);
+  }
+
+  async interruptThread(threadId: string): Promise<number> {
+    const session = await this.store.get(threadId);
+    if (!session) return 0;
+
+    const driver = this.driverFor(session.driverMode);
+    let touched = 0;
+    for (const [key, handle] of this.handles) {
+      if (!key.startsWith(`${threadId}:`)) continue;
+      const agentName = key.slice(threadId.length + 1);
+      await driver.interrupt(threadId, agentName).catch(() => undefined);
+      handle.kill();
+      this.handles.delete(key);
+      touched++;
+    }
+    await this.mutateSession(threadId, (s) => {
+      s.status = "idle";
+      for (const agentSession of Object.values(s.agentSessions ?? {})) {
+        if (agentSession.status === "busy") agentSession.status = "idle";
+      }
+    });
+    return touched;
   }
 
   async getSession(threadId: string): Promise<ThreadSession | undefined> {
@@ -1362,30 +1438,8 @@ export class SessionManager {
       }
 
       case "stop": {
-        // Halt the in-flight turn WITHOUT killing the driver session.
-        // Headless: kill the process (same as !cancel for one slot).
-        // Tmux: send Escape to the TUI — the persistent claude stays alive,
-        // input box clears, next message starts fresh.
-        const driver = this.driverFor(session.driverMode);
-        let touched = 0;
-        for (const [key, handle] of this.handles) {
-          if (!key.startsWith(`${session.threadId}:`)) continue;
-          const agentName = key.slice(session.threadId.length + 1);
-          await driver.interrupt(session.threadId, agentName).catch(() => undefined);
-          handle.kill();
-          this.handles.delete(key);
-          touched++;
-        }
-        await this.mutateSession(session.threadId, (s) => {
-          s.status = "idle";
-          for (const agentSession of Object.values(s.agentSessions ?? {})) {
-            if (agentSession.status === "busy") agentSession.status = "idle";
-          }
-        });
-        this.onCommandResponse?.(
-          event,
-          touched === 0 ? "Nothing running." : `Interrupted (${touched} agent${touched === 1 ? "" : "s"}). Send a new message to continue.`,
-        );
+        const touched = await this.interruptThread(session.threadId);
+        this.onCommandResponse?.(event, formatStopReply(touched));
         return true;
       }
 
@@ -3632,6 +3686,7 @@ export class SessionManager {
     agentName: string,
     session: ThreadSession,
   ): Promise<boolean> {
+    if (event.dashboardContinue) return false;
     if (event.pipelineInvocation || !this.pipelineStore) return false;
     if ((this.config.pipeline?.runtimeMode ?? "off") !== "active") return false;
 

--- a/src/slack/events.test.ts
+++ b/src/slack/events.test.ts
@@ -228,6 +228,32 @@ describe("registerEventHandlers — ✽ filter", () => {
     expect(onMessage).not.toHaveBeenCalled();
   });
 
+  it("drops Event API posts whose text starts with *Dashboard continue*", async () => {
+    const { app, handlers } = makeMockApp();
+    const onMessage = mock((_e: SlackMessageEvent) => {});
+    registerEventHandlers(
+      app,
+      onMessage,
+      undefined,
+      "B_SELF",
+      "U_BOT",
+      new Set(["C_AUTO"]),
+    );
+
+    await handlers.get("message")!({
+      event: {
+        type: "message",
+        text: "*Dashboard continue* · local operator · `dashboard-operator`\n> !review please inspect this",
+        channel: "C_AUTO",
+        channel_type: "channel",
+        ts: "1700000000.000099",
+        bot_id: "B_SELF",
+      },
+    });
+
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+
   it("self-bot message is dropped in a non-auto-trigger channel without a directive", async () => {
     const { app, handlers } = makeMockApp();
     const onMessage = mock((_e: SlackMessageEvent) => {});

--- a/src/slack/events.ts
+++ b/src/slack/events.ts
@@ -79,6 +79,8 @@ export interface SlackMessageEvent {
   attributionUserId?: string;
   /** Raw human text used only for conversational interruption policy. */
   conversationalText?: string;
+  /** Dashboard-originated inject. Skip default-run hijack and short-followup. */
+  dashboardContinue?: boolean;
 }
 
 export type OnMessageCallback = (event: SlackMessageEvent) => void | Promise<void>;
@@ -182,6 +184,11 @@ export function registerEventHandlers(
     const eventText = "text" in event ? event.text : undefined;
     const commandText = eventText ? stripOwnMention(eventText, selfUserId) : undefined;
     const hasDirective = containsDispatchDirective(commandText ?? eventText);
+
+    if (typeof eventText === "string" && eventText.startsWith("*Dashboard continue*")) {
+      logDrop("dashboard-continue", evMeta);
+      return;
+    }
 
     // Only support auto-trigger channels route our own bot messages; other
     // channels keep the legacy self-filter to avoid ordinary response loops.

--- a/src/workflows/definition.ts
+++ b/src/workflows/definition.ts
@@ -23,7 +23,7 @@ export interface LoadWorkflowDefinitionOptions {
   builtInCommands?: Set<string>;
 }
 
-const WORKFLOW_NAME_RE = /^[a-z0-9][a-z0-9-]*$/;
+export const WORKFLOW_NAME_RE = /^[a-z0-9][a-z0-9-]*$/;
 const COMMAND_RE = /^[a-z0-9][a-z0-9-]*$/;
 const SLACK_CHANNEL_RE = /^[CDG][A-Z0-9]+$/;
 const SLACK_USER_RE = /^U[A-Z0-9]+$/;
@@ -138,7 +138,7 @@ export function validateWorkflowDefinition(options: {
     fallback,
     concurrency,
     prompt: options.body.trim(),
-    versionHash: hashContent(options.content),
+    versionHash: hashWorkflowContent(options.content),
     sourcePath: options.path,
     sourceRoot: options.sourceRoot,
   };
@@ -388,6 +388,6 @@ function positiveNumber(value: unknown, label: string): number {
   return value;
 }
 
-function hashContent(content: string): string {
+export function hashWorkflowContent(content: string): string {
   return createHash("sha256").update(content).digest("hex").slice(0, 16);
 }

--- a/src/workflows/definition.ts
+++ b/src/workflows/definition.ts
@@ -55,11 +55,27 @@ export async function loadWorkflowDefinition(
   const file = Bun.file(options.path);
   if (!(await file.exists())) return null;
   const content = await file.text();
-  const { frontmatter, body } = parseFrontmatter(content, options.path);
+  return validateWorkflowMarkdown({
+    markdown: content,
+    path: options.path,
+    sourceRoot: options.sourceRoot,
+    repos: options.repos,
+    builtInCommands: options.builtInCommands,
+  });
+}
+
+export function validateWorkflowMarkdown(options: {
+  markdown: string;
+  path: string;
+  sourceRoot: WorkflowSourceRoot;
+  repos: RepoConfig[];
+  builtInCommands?: Set<string>;
+}): WorkflowDefinition {
+  const { frontmatter, body } = parseFrontmatter(options.markdown, options.path);
   return validateWorkflowDefinition({
     frontmatter,
     body,
-    content,
+    content: options.markdown,
     path: options.path,
     sourceRoot: options.sourceRoot,
     repos: options.repos,

--- a/src/workflows/enqueue.test.ts
+++ b/src/workflows/enqueue.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, it } from "bun:test";
+import type { WorkflowExecutor } from "./executor.ts";
+import type { WorkflowRegistry } from "./registry.ts";
+import { WorkflowScheduler } from "./scheduler.ts";
+import { InMemoryWorkflowStore } from "./store.ts";
+import type { WorkflowDefinition, WorkflowRun } from "./types.ts";
+
+describe("WorkflowScheduler.enqueueManualRun", () => {
+  it("returns started only after the run row is durable and before execute finishes", async () => {
+    const definition = workflowDefinition();
+    const store = new InMemoryWorkflowStore();
+    let executeStarted = false;
+    let releaseExecute: () => void = () => undefined;
+    const executeGate = new Promise<void>((resolve) => {
+      releaseExecute = resolve;
+    });
+    const executor = mockExecutor(store, {
+      execute: async (run) => {
+        executeStarted = true;
+        await executeGate;
+        return successResult(run);
+      },
+    });
+    const scheduler = new WorkflowScheduler({
+      registry: registryOf(definition),
+      store,
+      executor,
+    });
+
+    const pending = scheduler.enqueueManualRun({ name: definition.name });
+    const result = await pending;
+    expect(result).toEqual({
+      status: "started",
+      runId: expect.stringContaining("worklog-") as unknown as string,
+      summary: "Started *worklog*.",
+    });
+    expect(await store.getRun(result.runId)).toMatchObject({
+      id: result.runId,
+      status: "running",
+    });
+    expect(executeStarted).toBe(true);
+    expect(scheduler.isRunning(definition.name)).toBe(true);
+
+    releaseExecute();
+    await waitFor(() => !scheduler.isRunning(definition.name));
+  });
+
+  it("skips a second enqueue while a skip-concurrency run is in flight", async () => {
+    const definition = workflowDefinition();
+    const store = new InMemoryWorkflowStore();
+    let releaseExecute: () => void = () => undefined;
+    const executeGate = new Promise<void>((resolve) => {
+      releaseExecute = resolve;
+    });
+    const executor = mockExecutor(store, {
+      execute: async (run) => {
+        await executeGate;
+        return successResult(run);
+      },
+    });
+    const scheduler = new WorkflowScheduler({
+      registry: registryOf(definition),
+      store,
+      executor,
+    });
+
+    const first = await scheduler.enqueueManualRun({ name: definition.name });
+    expect(first.status).toBe("started");
+
+    const second = await scheduler.enqueueManualRun({ name: definition.name });
+    expect(second).toEqual({
+      status: "skipped",
+      runId: "",
+      summary: "Skipped *worklog*: already running.",
+    });
+    expect((await store.getState(definition.name))?.lastRunStatus).toBe("skipped");
+
+    const third = await scheduler.enqueueManualRun({ name: definition.name });
+    expect(third.status).toBe("skipped");
+    expect(scheduler.isRunning(definition.name)).toBe(true);
+
+    releaseExecute();
+    await waitFor(() => !scheduler.isRunning(definition.name));
+  });
+
+  it("releases the claim when persistNewRun throws and does not start", async () => {
+    const definition = workflowDefinition();
+    const store = new InMemoryWorkflowStore();
+    const executor = mockExecutor(store, {
+      persist: async () => {
+        throw new Error("disk full");
+      },
+    });
+    const scheduler = new WorkflowScheduler({
+      registry: registryOf(definition),
+      store,
+      executor,
+    });
+
+    await expect(scheduler.enqueueManualRun({ name: definition.name }))
+      .rejects.toThrow("disk full");
+    expect(scheduler.isRunning(definition.name)).toBe(false);
+    expect(scheduler.activeRunCount(definition.name)).toBe(0);
+    expect(await store.listRuns(definition.name, 5)).toEqual([]);
+  });
+
+  it("writes lastRunStatus=failed when executePersistedRun throws", async () => {
+    const definition = workflowDefinition();
+    const store = new InMemoryWorkflowStore();
+    const executor = mockExecutor(store, {
+      execute: async () => {
+        throw new Error("runner exploded");
+      },
+    });
+    const scheduler = new WorkflowScheduler({
+      registry: registryOf(definition),
+      store,
+      executor,
+    });
+
+    const result = await scheduler.enqueueManualRun({ name: definition.name });
+    expect(result.status).toBe("started");
+    await waitFor(async () =>
+      (await store.getState(definition.name))?.lastRunStatus === "failed"
+    );
+    expect((await store.getState(definition.name))?.lastError).toBe("runner exploded");
+    expect(scheduler.isRunning(definition.name)).toBe(false);
+  });
+
+  it("increments activeRunCounts for overlapping parallel runs", async () => {
+    const definition = { ...workflowDefinition(), concurrency: "parallel" as const };
+    const store = new InMemoryWorkflowStore();
+    const releases: Array<() => void> = [];
+    const executor = mockExecutor(store, {
+      execute: async (run) => {
+        await new Promise<void>((resolve) => releases.push(resolve));
+        return successResult(run);
+      },
+    });
+    const scheduler = new WorkflowScheduler({
+      registry: registryOf(definition),
+      store,
+      executor,
+    });
+
+    const first = await scheduler.enqueueManualRun({ name: definition.name });
+    const second = await scheduler.enqueueManualRun({ name: definition.name });
+    expect(first.status).toBe("started");
+    expect(second.status).toBe("started");
+    expect(first.runId).not.toBe(second.runId);
+    expect(scheduler.activeRunCount(definition.name)).toBe(2);
+    expect(await store.getRun(first.runId)).toBeDefined();
+    expect(await store.getRun(second.runId)).toBeDefined();
+
+    releases[0]?.();
+    await waitFor(() => scheduler.activeRunCount(definition.name) === 1);
+    releases[1]?.();
+    await waitFor(() => scheduler.activeRunCount(definition.name) === 0);
+  });
+});
+
+function workflowDefinition(): WorkflowDefinition {
+  return {
+    name: "worklog",
+    enabled: true,
+    ownerSlackUserIds: ["U123ABC"],
+    triggers: [{ type: "command", command: "worklog" }],
+    outputs: [{ type: "docs", path: "data/workflow-runs/worklog" }],
+    permissions: { tools: ["docs.write"] },
+    concurrency: "skip",
+    prompt: "Summarize work.",
+    versionHash: "1234567890abcdef",
+    sourcePath: "workflows/worklog.workflow.md",
+    sourceRoot: "public",
+  };
+}
+
+function registryOf(definition: WorkflowDefinition): WorkflowRegistry {
+  return {
+    get: (name: string) => name === definition.name ? definition : undefined,
+    snapshot: () => ({ definitions: new Map([[definition.name, definition]]), errors: [] }),
+    onEvent: () => undefined,
+  } as unknown as WorkflowRegistry;
+}
+
+function mockExecutor(
+  store: InMemoryWorkflowStore,
+  hooks: {
+    persist?: (definition: WorkflowDefinition) => Promise<WorkflowRun>;
+    execute?: (run: WorkflowRun) => Promise<{ summary: string; run: WorkflowRun }>;
+  },
+): WorkflowExecutor {
+  let seq = 0;
+  return {
+    persistNewRun: async (request: { definition: WorkflowDefinition }) => {
+      if (hooks.persist) return hooks.persist(request.definition);
+      seq += 1;
+      const run = runningRow(request.definition, `worklog-run-${seq}`);
+      await store.createRun(run);
+      return run;
+    },
+    executePersistedRun: async (run: WorkflowRun) => {
+      if (hooks.execute) return hooks.execute(run);
+      return successResult(run);
+    },
+  } as unknown as WorkflowExecutor;
+}
+
+function runningRow(definition: WorkflowDefinition, id: string): WorkflowRun {
+  return {
+    id,
+    workflowName: definition.name,
+    workflowVersionHash: definition.versionHash,
+    sourcePath: definition.sourcePath,
+    reason: "manual",
+    actorSlackUserId: null,
+    status: "running",
+    startedAt: Date.now(),
+    finishedAt: null,
+    artifactPath: `data/workflow-runs/${definition.name}/${id}.md`,
+    providerSessionId: null,
+    slackChannel: null,
+    slackThreadTs: null,
+    error: null,
+  };
+}
+
+function successResult(run: WorkflowRun) {
+  return {
+    summary: "ok",
+    run: { ...run, status: "success" as const, finishedAt: Date.now() },
+  };
+}
+
+async function waitFor(
+  predicate: () => boolean | Promise<boolean>,
+  timeoutMs = 500,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await predicate()) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error("timed out waiting for condition");
+}

--- a/src/workflows/enqueue.test.ts
+++ b/src/workflows/enqueue.test.ts
@@ -157,6 +157,112 @@ describe("WorkflowScheduler.enqueueManualRun", () => {
     releases[1]?.();
     await waitFor(() => scheduler.activeRunCount(definition.name) === 0);
   });
+
+  it("throws for unknown, disabled, and invalid workflows before claiming a run", async () => {
+    const store = new InMemoryWorkflowStore();
+    let persistCalls = 0;
+    const definition = workflowDefinition();
+    const executor = mockExecutor(store, {
+      persist: async () => {
+        persistCalls += 1;
+        throw new Error("persist should not run");
+      },
+    });
+    const scheduler = new WorkflowScheduler({
+      registry: registryOf(definition),
+      store,
+      executor,
+    });
+
+    await expect(scheduler.enqueueManualRun({ name: "missing" }))
+      .rejects.toThrow("Unknown workflow: missing");
+
+    const disabled = { ...definition, enabled: false };
+    const disabledScheduler = new WorkflowScheduler({
+      registry: registryOf(disabled),
+      store,
+      executor,
+    });
+    await expect(disabledScheduler.enqueueManualRun({ name: definition.name }))
+      .rejects.toThrow("is disabled in its workflow file");
+
+    await store.setState({
+      name: definition.name,
+      status: "invalid",
+      activeVersionHash: definition.versionHash,
+      sourcePath: definition.sourcePath,
+      lastLoadedAt: 1,
+      nextRunAt: null,
+      lastRunAt: null,
+      lastRunStatus: null,
+      lastError: "broken yaml",
+    });
+    await expect(scheduler.enqueueManualRun({ name: definition.name }))
+      .rejects.toThrow("is invalid and cannot run");
+
+    expect(persistCalls).toBe(0);
+    expect(scheduler.activeRunCount(definition.name)).toBe(0);
+    expect(disabledScheduler.activeRunCount(definition.name)).toBe(0);
+  });
+
+  it("one-shots a stopped workflow because reason is always manual", async () => {
+    const definition = workflowDefinition();
+    const store = new InMemoryWorkflowStore();
+    await store.setState({
+      name: definition.name,
+      status: "stopped",
+      activeVersionHash: definition.versionHash,
+      sourcePath: definition.sourcePath,
+      lastLoadedAt: 1,
+      nextRunAt: null,
+      lastRunAt: null,
+      lastRunStatus: null,
+      lastError: null,
+    });
+    const executor = mockExecutor(store);
+    const scheduler = new WorkflowScheduler({
+      registry: registryOf(definition),
+      store,
+      executor,
+    });
+
+    const result = await scheduler.enqueueManualRun({ name: definition.name });
+    expect(result.status).toBe("started");
+    expect(result.runId).toBeTruthy();
+    await waitFor(() => !scheduler.isRunning(definition.name));
+  });
+
+  it("does not overwrite lastRunStatus when schedule fails after a successful execute", async () => {
+    const definition = {
+      ...workflowDefinition(),
+      triggers: [{ type: "schedule" as const, cron: "not-a-cron", timezone: "UTC" }],
+    };
+    const store = new InMemoryWorkflowStore();
+    const executor = mockExecutor(store, {
+      execute: async (run) => {
+        const state = await store.getState(definition.name);
+        if (state) {
+          await store.setState({
+            ...state,
+            lastRunStatus: "success",
+            lastError: null,
+            lastRunAt: Date.now(),
+          });
+        }
+        return successResult(run);
+      },
+    });
+    const scheduler = new WorkflowScheduler({
+      registry: registryOf(definition),
+      store,
+      executor,
+    });
+
+    const result = await scheduler.enqueueManualRun({ name: definition.name });
+    expect(result.status).toBe("started");
+    await waitFor(() => !scheduler.isRunning(definition.name));
+    expect((await store.getState(definition.name))?.lastRunStatus).toBe("success");
+  });
 });
 
 function workflowDefinition(): WorkflowDefinition {
@@ -188,7 +294,7 @@ function mockExecutor(
   hooks: {
     persist?: (definition: WorkflowDefinition) => Promise<WorkflowRun>;
     execute?: (run: WorkflowRun) => Promise<{ summary: string; run: WorkflowRun }>;
-  },
+  } = {},
 ): WorkflowExecutor {
   let seq = 0;
   return {

--- a/src/workflows/executor.ts
+++ b/src/workflows/executor.ts
@@ -83,6 +83,8 @@ export interface WorkflowRunRequest {
    * never relax the workflow's own safety rules. Scheduled runs have none.
    */
   instructions?: string | null;
+  /** Durable id when the caller already allocated one. */
+  runId?: string;
 }
 
 export interface WorkflowRunResult {
@@ -114,7 +116,7 @@ export class WorkflowExecutor {
     this.usageStore = options.usageStore;
   }
 
-  async run(request: WorkflowRunRequest): Promise<WorkflowRunResult> {
+  async persistNewRun(request: WorkflowRunRequest): Promise<WorkflowRun> {
     const instructions = normalizeInstructions(request.instructions);
     if (request.definition.nativeHandler && instructions) {
       throw new Error(
@@ -122,7 +124,8 @@ export class WorkflowExecutor {
       );
     }
     const started = this.now();
-    const runId = `${request.definition.name}-${started.toISOString().replace(/[:.]/g, "-")}`;
+    const runId = request.runId ??
+      `${request.definition.name}-${started.toISOString().replace(/[:.]/g, "-")}`;
     const artifactPath = artifactPathFor(request.definition, started, runId);
     const run: WorkflowRun = {
       id: runId,
@@ -141,6 +144,15 @@ export class WorkflowExecutor {
       error: null,
     };
     await this.store.createRun(run);
+    return run;
+  }
+
+  async executePersistedRun(
+    run: WorkflowRun,
+    request: WorkflowRunRequest,
+  ): Promise<WorkflowRunResult> {
+    const instructions = normalizeInstructions(request.instructions);
+    const artifactPath = run.artifactPath;
 
     let summary = "";
     let nativeHandlerName: WorkflowNativeHandler | null = null;
@@ -225,6 +237,11 @@ export class WorkflowExecutor {
         });
       }
     }
+  }
+
+  async run(request: WorkflowRunRequest): Promise<WorkflowRunResult> {
+    const run = await this.persistNewRun(request);
+    return this.executePersistedRun(run, request);
   }
 
   async terminateActiveRuns(): Promise<void> {

--- a/src/workflows/git-commit.test.ts
+++ b/src/workflows/git-commit.test.ts
@@ -156,9 +156,58 @@ describe("commitWorkflowFile", () => {
     expect(result).toMatchObject({ ok: false, code: "git-failed" });
     expect(await fileText(repo, "workflows/worklog.workflow.md")).toBe(original);
   });
+
+  it("re-reads expectedVersionHash immediately before write", async () => {
+    const repo = await initRepo();
+    mkdirSync(join(repo, "workflows"), { recursive: true });
+    const original = validMarkdown();
+    writeFileSync(join(repo, "workflows", "worklog.workflow.md"), original);
+    await git(repo, ["add", "--", "workflows/worklog.workflow.md"]);
+    await git(repo, ["commit", "-m", "workflow"]);
+    const concurrent = validMarkdown("worklog", "someone else wrote this");
+    writeFileSync(join(repo, "workflows", "worklog.workflow.md"), concurrent);
+    const result = await commitWorkflowFile({
+      repoRoot: repo,
+      allowedRoots: [repo],
+      relativePath: "workflows/worklog.workflow.md",
+      markdown: validMarkdown("worklog", "clobber"),
+      message: "nope",
+      expectedVersionHash: hashWorkflowContent(original),
+    });
+    expect(result).toMatchObject({ ok: false, code: "version-hash-mismatch" });
+    expect(await fileText(repo, "workflows/worklog.workflow.md")).toBe(concurrent);
+  });
+
+  it("returns invalid-workflow instead of git-failed for schema errors", async () => {
+    const repo = await initRepo();
+    const result = await commitWorkflowFile({
+      repoRoot: repo,
+      allowedRoots: [repo],
+      relativePath: "workflows/worklog.workflow.md",
+      markdown: "---\nname: worklog\nenabled: true\nownerSlackUserIds: []\n---\nno schema",
+      message: "nope",
+    });
+    expect(result).toMatchObject({ ok: false, code: "invalid-workflow" });
+    expect(existsSync(join(repo, "workflows", "worklog.workflow.md"))).toBe(false);
+  });
 });
 
 describe("writeDashboardWorkflow overlay parent pointer", () => {
+  it("refuses overlay writes when agents-org is detached", async () => {
+    const { junior, overlay, overlayFile, original } = await initOverlayPair();
+    await git(overlay, ["checkout", "--detach"]);
+    const result = await writeDashboardWorkflow({
+      projectRoot: junior,
+      sourceRoot: "overlay",
+      name: "worklog",
+      markdown: validMarkdown("worklog", "overlay update"),
+      message: "workflow(worklog): update from dashboard",
+      repos: [],
+    });
+    expect(result).toMatchObject({ ok: false, code: "detached-head" });
+    expect(await Bun.file(overlayFile).text()).toBe(original);
+  }, 15_000);
+
   it("does not write the overlay when parent preflight fails", async () => {
     const { junior, overlayFile, original } = await initOverlayPair();
     await git(junior, ["checkout", "--detach"]);

--- a/src/workflows/git-commit.test.ts
+++ b/src/workflows/git-commit.test.ts
@@ -1,0 +1,334 @@
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "bun:test";
+import { hashWorkflowContent } from "./definition.ts";
+import {
+  DASHBOARD_GIT_EMAIL,
+  DASHBOARD_GIT_NAME,
+  commitWorkflowFile,
+  writeDashboardWorkflow,
+} from "./git-commit.ts";
+
+const dirs: string[] = [];
+
+afterEach(() => {
+  while (dirs.length) {
+    const dir = dirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("commitWorkflowFile", () => {
+  it("scoped-adds only the target path and leaves a dirty sibling uncommitted", async () => {
+    const repo = await initRepo();
+    writeFileSync(join(repo, "sibling.md"), "clean\n");
+    await git(repo, ["add", "--", "sibling.md"]);
+    await git(repo, ["commit", "-m", "sibling"]);
+    writeFileSync(join(repo, "sibling.md"), "dirty\n");
+    mkdirSync(join(repo, "workflows"), { recursive: true });
+    writeFileSync(join(repo, "workflows", "worklog.workflow.md"), validMarkdown());
+    await git(repo, ["add", "--", "workflows/worklog.workflow.md"]);
+    await git(repo, ["commit", "-m", "workflow"]);
+
+    const next = validMarkdown("worklog", "updated body");
+    const result = await commitWorkflowFile({
+      repoRoot: repo,
+      allowedRoots: [repo],
+      relativePath: "workflows/worklog.workflow.md",
+      markdown: next,
+      message: "workflow(worklog): update from dashboard",
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.stagedOnly).toEqual(["workflows/worklog.workflow.md"]);
+    expect(await fileText(repo, "workflows/worklog.workflow.md")).toBe(next);
+    expect(await fileText(repo, "sibling.md")).toBe("dirty\n");
+    const author = (await git(repo, ["log", "-1", "--format=%an <%ae>"])).trim();
+    expect(author).toBe(`${DASHBOARD_GIT_NAME} <${DASHBOARD_GIT_EMAIL}>`);
+    const siblingStatus = (await git(repo, ["status", "--porcelain", "--", "sibling.md"]))
+      .trim();
+    expect(siblingStatus.startsWith(" M") || siblingStatus.startsWith("M ")).toBe(true);
+  });
+
+  it("rejects a path that escapes the repo", async () => {
+    const repo = await initRepo();
+    const result = await commitWorkflowFile({
+      repoRoot: repo,
+      allowedRoots: [repo],
+      relativePath: "../secret.workflow.md",
+      markdown: validMarkdown(),
+      message: "nope",
+    });
+    expect(result).toMatchObject({ ok: false, code: "path-outside-repo" });
+  });
+
+  it("refuses unresolved conflicts", async () => {
+    const repo = await initRepo();
+    writeFileSync(join(repo, "conflict.txt"), "base\n");
+    await git(repo, ["add", "--", "conflict.txt"]);
+    await git(repo, ["commit", "-m", "base"]);
+    await git(repo, ["checkout", "-b", "topic"]);
+    writeFileSync(join(repo, "conflict.txt"), "topic\n");
+    await git(repo, ["add", "--", "conflict.txt"]);
+    await git(repo, ["commit", "-m", "topic"]);
+    await git(repo, ["checkout", "main"]);
+    writeFileSync(join(repo, "conflict.txt"), "main\n");
+    await git(repo, ["add", "--", "conflict.txt"]);
+    await git(repo, ["commit", "-m", "main"]);
+    await git(repo, ["merge", "topic"], { allowFail: true });
+
+    const result = await commitWorkflowFile({
+      repoRoot: repo,
+      allowedRoots: [repo],
+      relativePath: "workflows/worklog.workflow.md",
+      markdown: validMarkdown(),
+      message: "nope",
+    });
+    expect(result).toMatchObject({ ok: false, code: "unresolved-conflicts" });
+    expect(existsSync(join(repo, "workflows", "worklog.workflow.md"))).toBe(false);
+  });
+
+  it("refuses detached HEAD", async () => {
+    const repo = await initRepo();
+    await git(repo, ["checkout", "--detach"]);
+    const result = await commitWorkflowFile({
+      repoRoot: repo,
+      allowedRoots: [repo],
+      relativePath: "workflows/worklog.workflow.md",
+      markdown: validMarkdown(),
+      message: "nope",
+    });
+    expect(result).toMatchObject({ ok: false, code: "detached-head" });
+    expect(existsSync(join(repo, "workflows", "worklog.workflow.md"))).toBe(false);
+  });
+
+  it("refuses merge and rebase in progress", async () => {
+    const mergeRepo = await initRepo();
+    writeFileSync(join(mergeRepo, "extra.txt"), "a\n");
+    await git(mergeRepo, ["add", "--", "extra.txt"]);
+    await git(mergeRepo, ["commit", "-m", "extra"]);
+    await git(mergeRepo, ["checkout", "-b", "topic"]);
+    writeFileSync(join(mergeRepo, "topic.txt"), "t\n");
+    await git(mergeRepo, ["add", "--", "topic.txt"]);
+    await git(mergeRepo, ["commit", "-m", "topic"]);
+    await git(mergeRepo, ["checkout", "main"]);
+    await git(mergeRepo, ["merge", "--no-commit", "--no-ff", "topic"]);
+    const merging = await commitWorkflowFile({
+      repoRoot: mergeRepo,
+      allowedRoots: [mergeRepo],
+      relativePath: "workflows/worklog.workflow.md",
+      markdown: validMarkdown(),
+      message: "nope",
+    });
+    expect(merging).toMatchObject({ ok: false, code: "merging" });
+
+    const rebaseRepo = await initRepo();
+    mkdirSync(join(rebaseRepo, ".git", "rebase-merge"));
+    const rebasing = await commitWorkflowFile({
+      repoRoot: rebaseRepo,
+      allowedRoots: [rebaseRepo],
+      relativePath: "workflows/worklog.workflow.md",
+      markdown: validMarkdown(),
+      message: "nope",
+    });
+    expect(rebasing).toMatchObject({ ok: false, code: "rebasing" });
+  });
+
+  it("restores the file to HEAD when a commit hook fails", async () => {
+    const repo = await initRepo();
+    mkdirSync(join(repo, "workflows"), { recursive: true });
+    const original = validMarkdown();
+    writeFileSync(join(repo, "workflows", "worklog.workflow.md"), original);
+    await git(repo, ["add", "--", "workflows/worklog.workflow.md"]);
+    await git(repo, ["commit", "-m", "workflow"]);
+
+    writeFileSync(join(repo, ".git", "hooks", "pre-commit"), "#!/bin/sh\nexit 1\n");
+    chmodSync(join(repo, ".git", "hooks", "pre-commit"), 0o755);
+
+    const result = await commitWorkflowFile({
+      repoRoot: repo,
+      allowedRoots: [repo],
+      relativePath: "workflows/worklog.workflow.md",
+      markdown: validMarkdown("worklog", "should not stick"),
+      message: "nope",
+    });
+    expect(result).toMatchObject({ ok: false, code: "git-failed" });
+    expect(await fileText(repo, "workflows/worklog.workflow.md")).toBe(original);
+  });
+});
+
+describe("writeDashboardWorkflow overlay parent pointer", () => {
+  it("does not write the overlay when parent preflight fails", async () => {
+    const { junior, overlayFile, original } = await initOverlayPair();
+    await git(junior, ["checkout", "--detach"]);
+    const result = await writeDashboardWorkflow({
+      projectRoot: junior,
+      sourceRoot: "overlay",
+      name: "worklog",
+      markdown: validMarkdown("worklog", "overlay update"),
+      message: "workflow(worklog): update from dashboard",
+      repos: [],
+    });
+    expect(result).toMatchObject({ ok: false, code: "detached-head" });
+    expect(await Bun.file(overlayFile).text()).toBe(original);
+  }, 15_000);
+
+  it("parent-adds only agents-org and leaves a dirty junior sibling unstaged", async () => {
+    const { junior, overlay } = await initOverlayPair();
+    writeFileSync(join(junior, "sibling.md"), "dirty junior\n");
+    const markdown = validMarkdown("worklog", "overlay update");
+    const result = await writeDashboardWorkflow({
+      projectRoot: junior,
+      sourceRoot: "overlay",
+      name: "worklog",
+      markdown,
+      message: "workflow(worklog): update from dashboard",
+      repos: [],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.overlayCommitted).toBe(true);
+    expect(result.parentPointerCommitted).toBe(true);
+    expect(result.commit.repo).toBe("agents-org");
+    expect(result.versionHash).toBe(hashWorkflowContent(markdown));
+    const parentFiles = result.parentPointer && "sha" in result.parentPointer
+      ? (await git(junior, [
+        "diff-tree",
+        "--no-commit-id",
+        "--name-only",
+        "-r",
+        result.parentPointer.sha,
+      ])).trim()
+      : "";
+    expect(parentFiles).toBe("agents-org");
+    expect(await fileText(junior, "sibling.md")).toBe("dirty junior\n");
+    const siblingStatus = (await git(junior, ["status", "--porcelain", "--", "sibling.md"]))
+      .trim();
+    expect(siblingStatus.startsWith("??")).toBe(true);
+    const overlayFiles = (await git(overlay, [
+      "diff-tree",
+      "--no-commit-id",
+      "--name-only",
+      "-r",
+      result.commit.sha,
+    ])).trim();
+    expect(overlayFiles).toBe("workflows/worklog.workflow.md");
+  }, 15_000);
+
+  it("leaves the overlay commit when the parent hook fails", async () => {
+    const { junior, overlay, overlayFile } = await initOverlayPair();
+    writeFileSync(join(junior, ".git", "hooks", "pre-commit"), "#!/bin/sh\nexit 1\n");
+    chmodSync(join(junior, ".git", "hooks", "pre-commit"), 0o755);
+    const beforeOverlay = (await git(overlay, ["rev-parse", "HEAD"])).trim();
+    const markdown = validMarkdown("worklog", "overlay stays");
+    const result = await writeDashboardWorkflow({
+      projectRoot: junior,
+      sourceRoot: "overlay",
+      name: "worklog",
+      markdown,
+      message: "workflow(worklog): update from dashboard",
+      repos: [],
+    });
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.overlayCommitted).toBe(true);
+    expect(result.parentPointerCommitted).toBe(false);
+    expect(result.parentPointer).toMatchObject({ code: "git-failed" });
+    expect(result.commit.sha).not.toBe(beforeOverlay);
+    expect(await Bun.file(overlayFile).text()).toBe(markdown);
+    expect((await git(overlay, ["rev-parse", "HEAD"])).trim()).toBe(result.commit.sha);
+  }, 15_000);
+});
+
+function validMarkdown(name = "worklog", body = "Do the thing."): string {
+  return [
+    "---",
+    `name: ${name}`,
+    "enabled: true",
+    "ownerSlackUserIds: []",
+    "triggers:",
+    "  - type: command",
+    `    command: ${name}`,
+    "outputs:",
+    "  - type: docs",
+    `    path: data/workflow-runs/${name}`,
+    "permissions:",
+    "  tools:",
+    "    - docs.write",
+    "---",
+    body,
+  ].join("\n");
+}
+
+async function initRepo(): Promise<string> {
+  const dir = mkdtempSync(join(tmpdir(), "junior-wf-git-"));
+  dirs.push(dir);
+  await git(dir, ["init", "-b", "main"]);
+  await git(dir, ["config", "user.name", "t"]);
+  await git(dir, ["config", "user.email", "t@t.test"]);
+  await git(dir, ["config", "commit.gpgsign", "false"]);
+  await git(dir, ["config", "core.hooksPath", ".git/hooks"]);
+  writeFileSync(join(dir, "README.md"), "repo\n");
+  await git(dir, ["add", "--", "README.md"]);
+  await git(dir, ["commit", "-m", "init"]);
+  return dir;
+}
+
+async function initOverlayPair(): Promise<{
+  junior: string;
+  overlay: string;
+  overlayFile: string;
+  original: string;
+}> {
+  const junior = await initRepo();
+  const overlay = join(junior, "agents-org");
+  mkdirSync(overlay, { recursive: true });
+  await git(overlay, ["init", "-b", "main"]);
+  await git(overlay, ["config", "user.name", "t"]);
+  await git(overlay, ["config", "user.email", "t@t.test"]);
+  await git(overlay, ["config", "commit.gpgsign", "false"]);
+  mkdirSync(join(overlay, "workflows"), { recursive: true });
+  const original = validMarkdown();
+  writeFileSync(join(overlay, "workflows", "worklog.workflow.md"), original);
+  await git(overlay, ["add", "--", "workflows/worklog.workflow.md"]);
+  await git(overlay, ["commit", "-m", "overlay"]);
+  writeFileSync(
+    join(junior, ".gitmodules"),
+    '[submodule "agents-org"]\n\tpath = agents-org\n\turl = ./agents-org\n',
+  );
+  await git(junior, ["add", "--", ".gitmodules", "agents-org"]);
+  await git(junior, ["commit", "-m", "add overlay"]);
+  await git(overlay, ["checkout", "-B", "main"]);
+  return {
+    junior,
+    overlay,
+    overlayFile: join(overlay, "workflows", "worklog.workflow.md"),
+    original,
+  };
+}
+
+async function fileText(repo: string, rel: string): Promise<string> {
+  return Bun.file(join(repo, rel)).text();
+}
+
+async function git(
+  cwd: string,
+  args: string[],
+  options: { allowFail?: boolean } = {},
+): Promise<string> {
+  const proc = Bun.spawn(["git", ...args], {
+    cwd,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (code !== 0 && !options.allowFail) {
+    throw new Error(`git ${args.join(" ")} failed: ${stderr || stdout}`);
+  }
+  return stdout;
+}

--- a/src/workflows/git-commit.ts
+++ b/src/workflows/git-commit.ts
@@ -1,0 +1,684 @@
+import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
+import { realpathSync } from "node:fs";
+import type { RepoConfig } from "../config.ts";
+import {
+  hashWorkflowContent,
+  validateWorkflowMarkdown,
+} from "./definition.ts";
+import {
+  OVERLAY_WORKFLOW_ROOT,
+  PUBLIC_WORKFLOW_ROOT,
+  type WorkflowSourceRoot,
+} from "./types.ts";
+
+export const DASHBOARD_GIT_NAME = "Junior Dashboard";
+export const DASHBOARD_GIT_EMAIL = "junior-dashboard@localhost";
+
+const CONFLICT_CODES = new Set(["UU", "AA", "DD", "AU", "UA"]);
+
+export type WorkflowGitCommitCode =
+  | "not-a-repo"
+  | "path-outside-repo"
+  | "detached-head"
+  | "merging"
+  | "rebasing"
+  | "unresolved-conflicts"
+  | "nothing-to-commit"
+  | "git-failed";
+
+export type WorkflowGitCommitResult =
+  | { ok: true; sha: string; branch: string; stagedOnly: string[] }
+  | { ok: false; code: WorkflowGitCommitCode; detail: string };
+
+export type WorkflowGitStatus = {
+  sha: string | null;
+  branch: string | null;
+  detached: boolean;
+  dirty: boolean;
+  merging: boolean;
+  rebasing: boolean;
+};
+
+export type WorkflowGitCommitInput = {
+  repoRoot: string;
+  allowedRoots: string[];
+  relativePath: string;
+  markdown: string;
+  message: string;
+  requireNamedBranch?: boolean;
+  repos?: RepoConfig[];
+  builtInCommands?: Set<string>;
+  sourceRoot?: WorkflowSourceRoot;
+};
+
+export type DashboardWorkflowWriteInput = {
+  projectRoot: string;
+  sourceRoot: WorkflowSourceRoot;
+  name: string;
+  markdown: string;
+  message: string;
+  parentMessage?: string;
+  actor?: string;
+  repos: RepoConfig[];
+  builtInCommands?: Set<string>;
+};
+
+export type DashboardWorkflowWriteResult =
+  | {
+      ok: true;
+      name: string;
+      sourcePath: string;
+      sourceRoot: WorkflowSourceRoot;
+      versionHash: string;
+      overlayCommitted: boolean;
+      commit: {
+        sha: string;
+        branch: string;
+        repo: "junior" | "agents-org";
+        stat: string;
+      };
+      parentPointerCommitted?: boolean;
+      parentPointer?:
+        | { sha: string; branch: string; stat: string }
+        | { code: string; detail: string };
+    }
+  | { ok: false; code: WorkflowGitCommitCode | "overlay-root-missing"; detail: string };
+
+export function workflowSourcePath(
+  sourceRoot: WorkflowSourceRoot,
+  name: string,
+): string {
+  const file = `${name}.workflow.md`;
+  return sourceRoot === "overlay"
+    ? `${OVERLAY_WORKFLOW_ROOT}/${file}`
+    : `${PUBLIC_WORKFLOW_ROOT}/${file}`;
+}
+
+export function overlayWorkflowsRootExists(projectRoot: string): boolean {
+  try {
+    return existsSync(join(projectRoot, OVERLAY_WORKFLOW_ROOT));
+  } catch {
+    return false;
+  }
+}
+
+export function allowedGitRoots(projectRoot: string): string[] {
+  const roots = [existingRealpath(projectRoot)];
+  const overlay = join(projectRoot, "agents-org");
+  if (existsSync(overlay)) roots.push(existingRealpath(overlay));
+  return roots;
+}
+
+export async function probeWorkflowRepo(
+  repoRoot: string,
+  relativePath?: string,
+): Promise<WorkflowGitStatus> {
+  const empty: WorkflowGitStatus = {
+    sha: null,
+    branch: null,
+    detached: false,
+    dirty: false,
+    merging: false,
+    rebasing: false,
+  };
+  if (!repoRoot || !existsSync(repoRoot)) return empty;
+  try {
+    const toplevel = existingRealpath(
+      (await git(repoRoot, ["rev-parse", "--show-toplevel"])).stdout.trim(),
+    );
+    const sha = (await git(toplevel, ["rev-parse", "HEAD"])).stdout.trim();
+    const branch = (await git(toplevel, ["rev-parse", "--abbrev-ref", "HEAD"]))
+      .stdout
+      .trim();
+    const merging = await repoIsMerging(toplevel);
+    const rebasing = await repoIsRebasing(toplevel);
+    const statusPath = relativePath
+      ? relative(
+        toplevel,
+        existingRealpath(resolve(toplevel, relativePath)),
+      ).replaceAll("\\", "/")
+      : "";
+    if (statusPath.startsWith("..")) {
+      return {
+        sha: sha || null,
+        branch: branch === "HEAD" ? null : branch || null,
+        detached: branch === "HEAD" || !branch,
+        dirty: false,
+        merging,
+        rebasing,
+      };
+    }
+    const porcelainArgs = statusPath
+      ? ["status", "--porcelain", "--", statusPath]
+      : ["status", "--porcelain"];
+    const porcelain = (await git(toplevel, porcelainArgs)).stdout.trim();
+    return {
+      sha: sha || null,
+      branch: branch === "HEAD" ? null : branch || null,
+      detached: branch === "HEAD" || !branch,
+      dirty: porcelain.length > 0,
+      merging,
+      rebasing,
+    };
+  } catch {
+    return empty;
+  }
+}
+
+export async function preflightGitRepo(input: {
+  repoRoot: string;
+  allowedRoots: string[];
+  requireNamedBranch?: boolean;
+}): Promise<
+  | { ok: true; toplevel: string; branch: string; sha: string }
+  | { ok: false; code: WorkflowGitCommitCode; detail: string }
+> {
+  let toplevel: string;
+  try {
+    const parsed = (await git(input.repoRoot, ["rev-parse", "--show-toplevel"]))
+      .stdout
+      .trim();
+    if (!parsed) {
+      return { ok: false, code: "not-a-repo", detail: "not a git repository" };
+    }
+    toplevel = existingRealpath(parsed);
+  } catch (err) {
+    return { ok: false, code: "not-a-repo", detail: formatError(err) };
+  }
+
+  if (!isPathInsideAllowed(toplevel, input.allowedRoots)) {
+    return {
+      ok: false,
+      code: "path-outside-repo",
+      detail: `repo ${toplevel} is outside allowed roots`,
+    };
+  }
+
+  const branch = (await git(toplevel, ["rev-parse", "--abbrev-ref", "HEAD"]))
+    .stdout
+    .trim();
+  if (!branch || branch === "HEAD") {
+    return { ok: false, code: "detached-head", detail: "HEAD is detached" };
+  }
+  if (input.requireNamedBranch) {
+    const verify = await git(
+      toplevel,
+      ["show-ref", "--verify", `refs/heads/${branch}`],
+      { allowFail: true },
+    );
+    if (verify.code !== 0) {
+      return {
+        ok: false,
+        code: "detached-head",
+        detail: `branch ${branch} is not a named refs/heads ref`,
+      };
+    }
+  }
+
+  const porcelain = (await git(toplevel, ["status", "--porcelain"])).stdout;
+  const conflict = porcelain.split("\n").find((line) =>
+    line.length >= 2 && CONFLICT_CODES.has(line.slice(0, 2))
+  );
+  if (conflict) {
+    return {
+      ok: false,
+      code: "unresolved-conflicts",
+      detail: `unresolved conflict: ${conflict.slice(3).trim() || conflict}`,
+    };
+  }
+
+  if (await repoIsMerging(toplevel)) {
+    return { ok: false, code: "merging", detail: "repository is merging" };
+  }
+  if (await repoIsRebasing(toplevel)) {
+    return { ok: false, code: "rebasing", detail: "repository is rebasing" };
+  }
+
+  const sha = (await git(toplevel, ["rev-parse", "HEAD"])).stdout.trim();
+  return { ok: true, toplevel, branch, sha };
+}
+
+export async function commitWorkflowFile(
+  input: WorkflowGitCommitInput,
+): Promise<WorkflowGitCommitResult> {
+  const relativePath = normalizeRepoRelativePath(input.relativePath);
+  if (!relativePath) {
+    return {
+      ok: false,
+      code: "path-outside-repo",
+      detail: `path escapes repo: ${input.relativePath}`,
+    };
+  }
+
+  const preflight = await preflightGitRepo({
+    repoRoot: input.repoRoot,
+    allowedRoots: input.allowedRoots,
+    requireNamedBranch: input.requireNamedBranch,
+  });
+  if (!preflight.ok) return preflight;
+
+  const abs = resolve(preflight.toplevel, relativePath);
+  if (!isPathInsideAllowed(abs, [preflight.toplevel])) {
+    return {
+      ok: false,
+      code: "path-outside-repo",
+      detail: `path escapes repo: ${input.relativePath}`,
+    };
+  }
+
+  try {
+    validateWorkflowMarkdown({
+      markdown: input.markdown,
+      path: input.sourceRoot
+        ? workflowSourcePath(
+          input.sourceRoot,
+          filenameStem(relativePath),
+        )
+        : relativePath,
+      sourceRoot: input.sourceRoot ?? "public",
+      repos: input.repos ?? [],
+      builtInCommands: input.builtInCommands,
+    });
+  } catch (err) {
+    return { ok: false, code: "git-failed", detail: formatError(err) };
+  }
+
+  const existedAtHead = await pathExistsAtHead(preflight.toplevel, relativePath);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(abs, input.markdown);
+
+  const add = await git(preflight.toplevel, ["add", "--", relativePath], {
+    allowFail: true,
+  });
+  if (add.code !== 0) {
+    await restoreWorkflowPath(preflight.toplevel, relativePath, existedAtHead);
+    return {
+      ok: false,
+      code: "git-failed",
+      detail: add.stderr.trim() || "git add failed",
+    };
+  }
+
+  const commit = await git(preflight.toplevel, [
+    "-c",
+    `user.name=${DASHBOARD_GIT_NAME}`,
+    "-c",
+    `user.email=${DASHBOARD_GIT_EMAIL}`,
+    "commit",
+    "-m",
+    input.message,
+    "--",
+    relativePath,
+  ], { allowFail: true });
+  if (commit.code !== 0) {
+    await restoreWorkflowPath(preflight.toplevel, relativePath, existedAtHead);
+    const detail = (commit.stderr || commit.stdout).trim() || "git commit failed";
+    if (/nothing to commit/i.test(detail)) {
+      return { ok: false, code: "nothing-to-commit", detail };
+    }
+    return { ok: false, code: "git-failed", detail };
+  }
+
+  const sha = (await git(preflight.toplevel, ["rev-parse", "HEAD"])).stdout.trim();
+  const stagedOnly = await commitPaths(preflight.toplevel, sha);
+  return { ok: true, sha, branch: preflight.branch, stagedOnly };
+}
+
+export async function commitParentPointer(input: {
+  parentRoot: string;
+  allowedRoots: string[];
+  submodulePath?: string;
+  message: string;
+}): Promise<WorkflowGitCommitResult> {
+  const submodulePath = input.submodulePath ?? "agents-org";
+  const preflight = await preflightGitRepo({
+    repoRoot: input.parentRoot,
+    allowedRoots: input.allowedRoots,
+  });
+  if (!preflight.ok) return preflight;
+
+  const add = await git(preflight.toplevel, ["add", "--", submodulePath], {
+    allowFail: true,
+  });
+  if (add.code !== 0) {
+    await git(preflight.toplevel, ["reset", "--", submodulePath], { allowFail: true });
+    return {
+      ok: false,
+      code: "git-failed",
+      detail: add.stderr.trim() || "git add agents-org failed",
+    };
+  }
+
+  const commit = await git(preflight.toplevel, [
+    "-c",
+    `user.name=${DASHBOARD_GIT_NAME}`,
+    "-c",
+    `user.email=${DASHBOARD_GIT_EMAIL}`,
+    "commit",
+    "-m",
+    input.message,
+    "--",
+    submodulePath,
+  ], { allowFail: true });
+  if (commit.code !== 0) {
+    await git(preflight.toplevel, ["reset", "--", submodulePath], { allowFail: true });
+    const detail = (commit.stderr || commit.stdout).trim() || "parent pointer commit failed";
+    if (/nothing to commit/i.test(detail)) {
+      return { ok: false, code: "nothing-to-commit", detail };
+    }
+    return { ok: false, code: "git-failed", detail };
+  }
+
+  const sha = (await git(preflight.toplevel, ["rev-parse", "HEAD"])).stdout.trim();
+  const stagedOnly = await commitPaths(preflight.toplevel, sha);
+  return { ok: true, sha, branch: preflight.branch, stagedOnly };
+}
+
+export async function writeDashboardWorkflow(
+  input: DashboardWorkflowWriteInput,
+): Promise<DashboardWorkflowWriteResult> {
+  const sourcePath = workflowSourcePath(input.sourceRoot, input.name);
+  try {
+    validateWorkflowMarkdown({
+      markdown: input.markdown,
+      path: sourcePath,
+      sourceRoot: input.sourceRoot,
+      repos: input.repos,
+      builtInCommands: input.builtInCommands,
+    });
+  } catch (err) {
+    return { ok: false, code: "git-failed", detail: formatError(err) };
+  }
+
+  const allowedRoots = allowedGitRoots(input.projectRoot);
+  const juniorRoot = existingRealpath(input.projectRoot);
+
+  if (input.sourceRoot === "overlay") {
+    const overlayDir = join(input.projectRoot, "agents-org");
+    if (!overlayWorkflowsRootExists(input.projectRoot) && !existsSync(overlayDir)) {
+      return {
+        ok: false,
+        code: "overlay-root-missing",
+        detail: "overlay root missing",
+      };
+    }
+    if (!existsSync(overlayDir)) {
+      return { ok: false, code: "overlay-root-missing", detail: "overlay root missing" };
+    }
+
+    const overlayRoot = existingRealpath(overlayDir);
+    const overlayPreflight = await preflightGitRepo({
+      repoRoot: overlayRoot,
+      allowedRoots,
+      requireNamedBranch: true,
+    });
+    if (!overlayPreflight.ok) return overlayPreflight;
+    if (existingRealpath(overlayPreflight.toplevel) !== overlayRoot) {
+      return {
+        ok: false,
+        code: "not-a-repo",
+        detail: "overlay is not its own git repository",
+      };
+    }
+
+    const parentPreflight = await preflightGitRepo({
+      repoRoot: juniorRoot,
+      allowedRoots,
+    });
+    if (!parentPreflight.ok) return parentPreflight;
+
+    const committed = await commitWorkflowFile({
+      repoRoot: overlayRoot,
+      allowedRoots,
+      relativePath: `${PUBLIC_WORKFLOW_ROOT}/${input.name}.workflow.md`,
+      markdown: input.markdown,
+      message: input.message,
+      requireNamedBranch: true,
+      repos: input.repos,
+      builtInCommands: input.builtInCommands,
+      sourceRoot: "overlay",
+    });
+    if (!committed.ok) return committed;
+
+    const parentMessage = input.parentMessage ??
+      parentPointerCommitMessage(
+        input.name,
+        committed.sha,
+        input.actor ?? "dashboard-operator",
+      );
+    const pointer = await commitParentPointer({
+      parentRoot: juniorRoot,
+      allowedRoots,
+      message: parentMessage,
+    });
+    const stat = await showStat(overlayRoot, committed.sha);
+    if (!pointer.ok) {
+      return {
+        ok: true,
+        name: input.name,
+        sourcePath,
+        sourceRoot: "overlay",
+        versionHash: hashWorkflowContent(input.markdown),
+        overlayCommitted: true,
+        commit: {
+          sha: committed.sha,
+          branch: committed.branch,
+          repo: "agents-org",
+          stat,
+        },
+        parentPointerCommitted: false,
+        parentPointer: { code: pointer.code, detail: pointer.detail },
+      };
+    }
+    return {
+      ok: true,
+      name: input.name,
+      sourcePath,
+      sourceRoot: "overlay",
+      versionHash: hashWorkflowContent(input.markdown),
+      overlayCommitted: true,
+      commit: {
+        sha: committed.sha,
+        branch: committed.branch,
+        repo: "agents-org",
+        stat,
+      },
+      parentPointerCommitted: true,
+      parentPointer: {
+        sha: pointer.sha,
+        branch: pointer.branch,
+        stat: await showStat(juniorRoot, pointer.sha),
+      },
+    };
+  }
+
+  const committed = await commitWorkflowFile({
+    repoRoot: juniorRoot,
+    allowedRoots,
+    relativePath: `${PUBLIC_WORKFLOW_ROOT}/${input.name}.workflow.md`,
+    markdown: input.markdown,
+    message: input.message,
+    repos: input.repos,
+    builtInCommands: input.builtInCommands,
+    sourceRoot: "public",
+  });
+  if (!committed.ok) return committed;
+  return {
+    ok: true,
+    name: input.name,
+    sourcePath,
+    sourceRoot: "public",
+    versionHash: hashWorkflowContent(input.markdown),
+    overlayCommitted: false,
+    commit: {
+      sha: committed.sha,
+      branch: committed.branch,
+      repo: "junior",
+      stat: await showStat(juniorRoot, committed.sha),
+    },
+  };
+}
+
+export function defaultWorkflowCommitMessage(input: {
+  kind: "create" | "update";
+  name: string;
+  sourceRoot: WorkflowSourceRoot;
+  sourcePath: string;
+  actor: string;
+  commitMessage?: string;
+}): string {
+  const subject = input.commitMessage?.trim() ||
+    `workflow(${input.name}): ${input.kind} from dashboard`;
+  return [
+    subject,
+    "",
+    `Source: ${input.sourceRoot} ${input.sourcePath}`,
+    `Actor: ${input.actor}`,
+  ].join("\n");
+}
+
+export function parentPointerCommitMessage(
+  name: string,
+  overlaySha: string,
+  actor: string,
+): string {
+  return [
+    `chore(agents-org): bump submodule after dashboard workflow(${name})`,
+    "",
+    `Overlay: ${overlaySha}`,
+    `Actor: ${actor}`,
+  ].join("\n");
+}
+
+export function isProtectedBranch(branch: string | null | undefined): boolean {
+  return branch === "main" || branch === "master";
+}
+
+function normalizeRepoRelativePath(relativePath: string): string | null {
+  const normalized = relativePath.replace(/\\/g, "/").replace(/^\/+/, "");
+  if (!normalized) return null;
+  const parts = normalized.split("/");
+  if (parts.some((part) => part === ".." || part === "." || part === "")) return null;
+  return parts.join("/");
+}
+
+function isPathInsideAllowed(absPath: string, allowedRoots: string[]): boolean {
+  const resolved = existingRealpath(absPath);
+  return allowedRoots.some((root) => {
+    const allowed = existingRealpath(root);
+    return resolved === allowed || resolved.startsWith(allowed + sep);
+  });
+}
+
+function resolveGitPath(cwd: string, gitPath: string): string {
+  return isAbsolute(gitPath) ? gitPath : resolve(cwd, gitPath);
+}
+
+async function repoIsMerging(cwd: string): Promise<boolean> {
+  const mergeHead = (await git(cwd, ["rev-parse", "--git-path", "MERGE_HEAD"]))
+    .stdout
+    .trim();
+  return Boolean(mergeHead) && existsSync(resolveGitPath(cwd, mergeHead));
+}
+
+async function repoIsRebasing(cwd: string): Promise<boolean> {
+  const rebaseMerge = (await git(cwd, ["rev-parse", "--git-path", "rebase-merge"]))
+    .stdout
+    .trim();
+  const rebaseApply = (await git(cwd, ["rev-parse", "--git-path", "rebase-apply"]))
+    .stdout
+    .trim();
+  return (Boolean(rebaseMerge) && existsSync(resolveGitPath(cwd, rebaseMerge))) ||
+    (Boolean(rebaseApply) && existsSync(resolveGitPath(cwd, rebaseApply)));
+}
+
+async function pathExistsAtHead(cwd: string, relativePath: string): Promise<boolean> {
+  const result = await git(cwd, ["cat-file", "-e", `HEAD:${relativePath}`], {
+    allowFail: true,
+  });
+  return result.code === 0;
+}
+
+// Restore from HEAD, not the index: a failed commit leaves the new bytes staged.
+async function restoreWorkflowPath(
+  cwd: string,
+  relativePath: string,
+  existedAtHead: boolean,
+): Promise<void> {
+  if (existedAtHead) {
+    await git(cwd, [
+      "restore",
+      "--source=HEAD",
+      "--staged",
+      "--worktree",
+      "--",
+      relativePath,
+    ], { allowFail: true });
+    return;
+  }
+  await git(cwd, ["reset", "--", relativePath], { allowFail: true });
+  const abs = join(cwd, relativePath);
+  if (existsSync(abs)) unlinkSync(abs);
+}
+
+async function commitPaths(cwd: string, sha: string): Promise<string[]> {
+  const show = await git(cwd, ["diff-tree", "--no-commit-id", "--name-only", "-r", sha], {
+    allowFail: true,
+  });
+  return show.stdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+async function showStat(cwd: string, sha: string): Promise<string> {
+  const show = await git(cwd, ["show", "--stat", "--format=", sha], { allowFail: true });
+  return show.stdout.trim();
+}
+
+function filenameStem(relativePath: string): string {
+  const base = relativePath.split("/").pop() ?? relativePath;
+  return base.endsWith(".workflow.md")
+    ? base.slice(0, -".workflow.md".length)
+    : base;
+}
+
+function existingRealpath(path: string): string {
+  try {
+    return realpathSync(path);
+  } catch {
+    return resolve(path);
+  }
+}
+
+function formatError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+async function git(
+  cwd: string,
+  args: string[],
+  options: { allowFail?: boolean } = {},
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  const env = { ...process.env };
+  delete env.GIT_DIR;
+  delete env.GIT_WORK_TREE;
+  const proc = Bun.spawn(["git", ...args], {
+    cwd,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (code !== 0 && !options.allowFail) {
+    throw new Error(`git ${args.join(" ")} failed: ${stderr.trim() || stdout.trim()}`);
+  }
+  return { stdout, stderr, code };
+}
+
+

--- a/src/workflows/git-commit.ts
+++ b/src/workflows/git-commit.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, unlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
 import { dirname, isAbsolute, join, relative, resolve, sep } from "node:path";
 import { realpathSync } from "node:fs";
 import type { RepoConfig } from "../config.ts";
@@ -25,6 +25,9 @@ export type WorkflowGitCommitCode =
   | "rebasing"
   | "unresolved-conflicts"
   | "nothing-to-commit"
+  | "invalid-workflow"
+  | "version-hash-mismatch"
+  | "restore-failed"
   | "git-failed";
 
 export type WorkflowGitCommitResult =
@@ -50,6 +53,7 @@ export type WorkflowGitCommitInput = {
   repos?: RepoConfig[];
   builtInCommands?: Set<string>;
   sourceRoot?: WorkflowSourceRoot;
+  expectedVersionHash?: string;
 };
 
 export type DashboardWorkflowWriteInput = {
@@ -62,6 +66,7 @@ export type DashboardWorkflowWriteInput = {
   actor?: string;
   repos: RepoConfig[];
   builtInCommands?: Set<string>;
+  expectedVersionHash?: string;
 };
 
 export type DashboardWorkflowWriteResult =
@@ -281,10 +286,21 @@ export async function commitWorkflowFile(
       builtInCommands: input.builtInCommands,
     });
   } catch (err) {
-    return { ok: false, code: "git-failed", detail: formatError(err) };
+    return { ok: false, code: "invalid-workflow", detail: formatError(err) };
   }
 
   const existedAtHead = await pathExistsAtHead(preflight.toplevel, relativePath);
+  if (input.expectedVersionHash != null) {
+    const onDisk = existsSync(abs) ? readFileSync(abs, "utf8") : "";
+    const currentHash = onDisk ? hashWorkflowContent(onDisk) : "";
+    if (currentHash !== input.expectedVersionHash) {
+      return {
+        ok: false,
+        code: "version-hash-mismatch",
+        detail: "on-disk file changed since the editor loaded",
+      };
+    }
+  }
   mkdirSync(dirname(abs), { recursive: true });
   writeFileSync(abs, input.markdown);
 
@@ -292,12 +308,12 @@ export async function commitWorkflowFile(
     allowFail: true,
   });
   if (add.code !== 0) {
-    await restoreWorkflowPath(preflight.toplevel, relativePath, existedAtHead);
-    return {
-      ok: false,
-      code: "git-failed",
-      detail: add.stderr.trim() || "git add failed",
-    };
+    return failAfterWrite(
+      preflight.toplevel,
+      relativePath,
+      existedAtHead,
+      add.stderr.trim() || "git add failed",
+    );
   }
 
   const commit = await git(preflight.toplevel, [
@@ -312,12 +328,9 @@ export async function commitWorkflowFile(
     relativePath,
   ], { allowFail: true });
   if (commit.code !== 0) {
-    await restoreWorkflowPath(preflight.toplevel, relativePath, existedAtHead);
     const detail = (commit.stderr || commit.stdout).trim() || "git commit failed";
-    if (/nothing to commit/i.test(detail)) {
-      return { ok: false, code: "nothing-to-commit", detail };
-    }
-    return { ok: false, code: "git-failed", detail };
+    const code = /nothing to commit/i.test(detail) ? "nothing-to-commit" as const : "git-failed" as const;
+    return failAfterWrite(preflight.toplevel, relativePath, existedAtHead, detail, code);
   }
 
   const sha = (await git(preflight.toplevel, ["rev-parse", "HEAD"])).stdout.trim();
@@ -388,7 +401,7 @@ export async function writeDashboardWorkflow(
       builtInCommands: input.builtInCommands,
     });
   } catch (err) {
-    return { ok: false, code: "git-failed", detail: formatError(err) };
+    return { ok: false, code: "invalid-workflow", detail: formatError(err) };
   }
 
   const allowedRoots = allowedGitRoots(input.projectRoot);
@@ -438,6 +451,7 @@ export async function writeDashboardWorkflow(
       repos: input.repos,
       builtInCommands: input.builtInCommands,
       sourceRoot: "overlay",
+      expectedVersionHash: input.expectedVersionHash,
     });
     if (!committed.ok) return committed;
 
@@ -502,6 +516,7 @@ export async function writeDashboardWorkflow(
     repos: input.repos,
     builtInCommands: input.builtInCommands,
     sourceRoot: "public",
+    expectedVersionHash: input.expectedVersionHash,
   });
   if (!committed.ok) return committed;
   return {
@@ -600,14 +615,29 @@ async function pathExistsAtHead(cwd: string, relativePath: string): Promise<bool
   return result.code === 0;
 }
 
+async function failAfterWrite(
+  cwd: string,
+  relativePath: string,
+  existedAtHead: boolean,
+  detail: string,
+  code: "git-failed" | "nothing-to-commit" = "git-failed",
+): Promise<WorkflowGitCommitResult> {
+  const restored = await restoreWorkflowPath(cwd, relativePath, existedAtHead);
+  if (!restored.ok) {
+    return { ok: false, code: "restore-failed", detail: restored.detail };
+  }
+  return { ok: false, code, detail };
+}
+
 // Restore from HEAD, not the index: a failed commit leaves the new bytes staged.
 async function restoreWorkflowPath(
   cwd: string,
   relativePath: string,
   existedAtHead: boolean,
-): Promise<void> {
+): Promise<{ ok: true } | { ok: false; detail: string }> {
+  const abs = join(cwd, relativePath);
   if (existedAtHead) {
-    await git(cwd, [
+    const restore = await git(cwd, [
       "restore",
       "--source=HEAD",
       "--staged",
@@ -615,11 +645,34 @@ async function restoreWorkflowPath(
       "--",
       relativePath,
     ], { allowFail: true });
-    return;
+    if (restore.code !== 0) {
+      return {
+        ok: false,
+        detail: restore.stderr.trim() || "git restore failed",
+      };
+    }
+    const head = await git(cwd, ["show", `HEAD:${relativePath}`], { allowFail: true });
+    if (head.code !== 0) {
+      return { ok: false, detail: head.stderr.trim() || "could not read HEAD copy" };
+    }
+    const current = existsSync(abs) ? readFileSync(abs, "utf8") : "";
+    if (current !== head.stdout) {
+      return { ok: false, detail: "restore left dirty bytes on disk" };
+    }
+    return { ok: true };
   }
   await git(cwd, ["reset", "--", relativePath], { allowFail: true });
-  const abs = join(cwd, relativePath);
-  if (existsSync(abs)) unlinkSync(abs);
+  if (existsSync(abs)) {
+    try {
+      unlinkSync(abs);
+    } catch (err) {
+      return { ok: false, detail: formatError(err) };
+    }
+  }
+  if (existsSync(abs)) {
+    return { ok: false, detail: "failed to delete uncommitted new file" };
+  }
+  return { ok: true };
 }
 
 async function commitPaths(cwd: string, sha: string): Promise<string[]> {

--- a/src/workflows/registry.test.ts
+++ b/src/workflows/registry.test.ts
@@ -97,18 +97,56 @@ describe("WorkflowRegistry", () => {
         ],
         debounceMs: 20,
       });
-      await registry.reload();
+      let reloads = 0;
+      registry.onEvent((event) => {
+        if (event.type === "reloaded") reloads += 1;
+      });
+      await registry.startWatching();
       expect(registry.get("worklog")?.description).toBe("overlay");
+      const afterStart = reloads;
 
       registry.pauseReloads();
+      registry.pauseReloads();
       await Bun.write(overlayPath, "---\nname: mismatch\nenabled: true\n---\nbroken");
-      await new Promise((resolve) => setTimeout(resolve, 60));
+      await new Promise((resolve) => setTimeout(resolve, 80));
+      expect(reloads).toBe(afterStart);
       expect(registry.get("worklog")?.description).toBe("overlay");
       expect(registry.getErrors()).toHaveLength(0);
 
       await registry.resumeReloads();
+      expect(reloads).toBe(afterStart);
+      expect(registry.getErrors()).toHaveLength(0);
+
+      await registry.resumeReloads();
+      expect(reloads).toBe(afterStart + 1);
       expect(registry.get("worklog")?.description).toBe("overlay");
       expect(registry.getErrors()).toHaveLength(1);
+      registry.stopWatching();
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("skips reload when resumeReloads({ reload: false })", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "junior-workflows-"));
+    try {
+      const overlayRoot = join(dir, "agents-org", "workflows");
+      const overlayPath = join(overlayRoot, "worklog.workflow.md");
+      await mkdir(overlayRoot, { recursive: true });
+      await Bun.write(overlayPath, workflowFile({
+        description: "overlay",
+        command: "private-worklog",
+      }));
+      const registry = new WorkflowRegistry({
+        repos,
+        roots: [{ path: overlayRoot, sourceRoot: "overlay" }],
+      });
+      await registry.reload();
+      registry.pauseReloads();
+      await Bun.write(overlayPath, "---\nname: mismatch\nenabled: true\n---\nbroken");
+      await registry.resumeReloads({ reload: false });
+      expect(registry.get("worklog")?.description).toBe("overlay");
+      expect(registry.getErrors()).toHaveLength(0);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/src/workflows/registry.test.ts
+++ b/src/workflows/registry.test.ts
@@ -76,6 +76,44 @@ describe("WorkflowRegistry", () => {
     }
   });
 
+  it("pauses watch reloads and reloads once on resume", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "junior-workflows-"));
+    try {
+      const publicRoot = join(dir, "workflows");
+      const overlayRoot = join(dir, "agents-org", "workflows");
+      const overlayPath = join(overlayRoot, "worklog.workflow.md");
+      await mkdir(publicRoot, { recursive: true });
+      await mkdir(overlayRoot, { recursive: true });
+      await Bun.write(overlayPath, workflowFile({
+        description: "overlay",
+        command: "private-worklog",
+      }));
+
+      const registry = new WorkflowRegistry({
+        repos,
+        roots: [
+          { path: publicRoot, sourceRoot: "public" },
+          { path: overlayRoot, sourceRoot: "overlay" },
+        ],
+        debounceMs: 20,
+      });
+      await registry.reload();
+      expect(registry.get("worklog")?.description).toBe("overlay");
+
+      registry.pauseReloads();
+      await Bun.write(overlayPath, "---\nname: mismatch\nenabled: true\n---\nbroken");
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      expect(registry.get("worklog")?.description).toBe("overlay");
+      expect(registry.getErrors()).toHaveLength(0);
+
+      await registry.resumeReloads();
+      expect(registry.get("worklog")?.description).toBe("overlay");
+      expect(registry.getErrors()).toHaveLength(1);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   it("blocks public fallback on cold boot when an overlay exists but is invalid", async () => {
     const dir = await mkdtemp(join(tmpdir(), "junior-workflows-"));
     try {

--- a/src/workflows/registry.ts
+++ b/src/workflows/registry.ts
@@ -39,6 +39,8 @@ export class WorkflowRegistry {
   private watchers: FSWatcher[] = [];
   private reloadTimer: ReturnType<typeof setTimeout> | null = null;
   private reloadsPaused = false;
+  private pauseDepth = 0;
+  private writeLock: Promise<void> = Promise.resolve();
 
   constructor(options: WorkflowRegistryOptions) {
     this.roots = options.roots ?? [
@@ -73,6 +75,7 @@ export class WorkflowRegistry {
   }
 
   pauseReloads(): void {
+    this.pauseDepth += 1;
     this.reloadsPaused = true;
     if (this.reloadTimer) {
       clearTimeout(this.reloadTimer);
@@ -80,9 +83,26 @@ export class WorkflowRegistry {
     }
   }
 
-  async resumeReloads(): Promise<void> {
+  async resumeReloads(options?: { reload?: boolean }): Promise<void> {
+    if (this.pauseDepth > 0) this.pauseDepth -= 1;
+    if (this.pauseDepth > 0) return;
     this.reloadsPaused = false;
+    if (options?.reload === false) return;
     await this.reload();
+  }
+
+  async withWriteLock<T>(fn: () => Promise<T>): Promise<T> {
+    let release!: () => void;
+    const previous = this.writeLock;
+    this.writeLock = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await fn();
+    } finally {
+      release();
+    }
   }
 
   snapshot(): WorkflowRegistrySnapshot {

--- a/src/workflows/registry.ts
+++ b/src/workflows/registry.ts
@@ -38,6 +38,7 @@ export class WorkflowRegistry {
   private listeners: Array<(event: WorkflowRegistryEvent) => void> = [];
   private watchers: FSWatcher[] = [];
   private reloadTimer: ReturnType<typeof setTimeout> | null = null;
+  private reloadsPaused = false;
 
   constructor(options: WorkflowRegistryOptions) {
     this.roots = options.roots ?? [
@@ -65,6 +66,23 @@ export class WorkflowRegistry {
 
   getErrors(): WorkflowValidationError[] {
     return [...this.errors];
+  }
+
+  validationContext(): { repos: RepoConfig[]; builtInCommands: Set<string> } {
+    return { repos: this.repos, builtInCommands: this.builtInCommands };
+  }
+
+  pauseReloads(): void {
+    this.reloadsPaused = true;
+    if (this.reloadTimer) {
+      clearTimeout(this.reloadTimer);
+      this.reloadTimer = null;
+    }
+  }
+
+  async resumeReloads(): Promise<void> {
+    this.reloadsPaused = false;
+    await this.reload();
   }
 
   snapshot(): WorkflowRegistrySnapshot {
@@ -174,6 +192,7 @@ export class WorkflowRegistry {
   }
 
   private scheduleReload(rootPath: string): void {
+    if (this.reloadsPaused) return;
     if (this.reloadTimer) clearTimeout(this.reloadTimer);
     log.info(
       "workflow",

--- a/src/workflows/scheduler.ts
+++ b/src/workflows/scheduler.ts
@@ -94,6 +94,71 @@ export class WorkflowScheduler {
     }
   }
 
+  async enqueueManualRun(options: {
+    name: string;
+    actorSlackUserId?: string | null;
+    instructions?: string | null;
+  }): Promise<
+    | { status: "skipped"; runId: ""; summary: string }
+    | { status: "started"; runId: string; summary: string }
+  > {
+    const definition = this.registry.get(options.name);
+    if (!definition) throw new Error(`Unknown workflow: ${options.name}`);
+    if (!definition.enabled) {
+      throw new Error(`Workflow ${definition.name} is disabled in its workflow file.`);
+    }
+    const state = await this.ensureState(definition);
+    if (state.status === "invalid") {
+      throw new Error(`Workflow ${definition.name} is invalid and cannot run.`);
+    }
+    if (!this.tryClaimRun(definition)) {
+      await this.markSkipped(state, "Workflow already running.");
+      return {
+        status: "skipped",
+        runId: "",
+        summary: `Skipped *${definition.name}*: already running.`,
+      };
+    }
+    try {
+      const request = {
+        definition,
+        reason: "manual" as const,
+        actorSlackUserId: options.actorSlackUserId ?? null,
+        instructions: options.instructions ?? null,
+      };
+      const run = await this.executor.persistNewRun(request);
+      // schedule / lastRunStatus / releaseRun hang on this promise, not enqueue.
+      void this.executor.executePersistedRun(run, request)
+        .then(() => this.schedule(definition))
+        .catch(async (err) => {
+          const latest = await this.store.getState(definition.name);
+          if (latest) {
+            await this.store.setState({
+              ...latest,
+              lastError: formatError(err),
+              lastRunStatus: "failed",
+              lastRunAt: this.now().getTime(),
+            });
+          }
+        })
+        .finally(() => {
+          this.releaseRun(definition);
+        });
+      return {
+        status: "started",
+        runId: run.id,
+        summary: `Started *${definition.name}*.`,
+      };
+    } catch (err) {
+      this.releaseRun(definition);
+      throw err;
+    }
+  }
+
+  activeRunCount(name: string): number {
+    return this.activeRunCounts.get(name) ?? 0;
+  }
+
   async stopWorkflow(name: string): Promise<void> {
     const definition = this.registry.get(name);
     const state = definition

--- a/src/workflows/scheduler.ts
+++ b/src/workflows/scheduler.ts
@@ -127,18 +127,31 @@ export class WorkflowScheduler {
         instructions: options.instructions ?? null,
       };
       const run = await this.executor.persistNewRun(request);
-      // schedule / lastRunStatus / releaseRun hang on this promise, not enqueue.
+      // releaseRun hangs on execute, not enqueue. schedule is not on this chain.
       void this.executor.executePersistedRun(run, request)
-        .then(() => this.schedule(definition))
+        .then(() => {
+          this.schedule(definition).catch((err) => {
+            log.warn(
+              "workflow",
+              `continuation schedule failed workflow=${definition.name}: ${formatError(err)}`,
+            );
+          });
+        })
         .catch(async (err) => {
-          const latest = await this.store.getState(definition.name);
-          if (latest) {
+          try {
+            const latest = await this.store.getState(definition.name);
+            if (!latest) return;
             await this.store.setState({
               ...latest,
               lastError: formatError(err),
               lastRunStatus: "failed",
               lastRunAt: this.now().getTime(),
             });
+          } catch (storeErr) {
+            log.warn(
+              "workflow",
+              `failed-run status persist failed workflow=${definition.name}: ${formatError(storeErr)}`,
+            );
           }
         })
         .finally(() => {


### PR DESCRIPTION
Attribution-only Slack record, then `injectDashboardContinue`. Stop reuses `!stop`.

Part of execute-plan `06ec4caa` (PR 4/7).