### PR TITLE
docs(dashboard): document write surface, spend ledger, and pipeline operator view

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -28,7 +28,11 @@ indexes, and the source links in those documents.
 - [MCP server](features/mcp-server.md): loopback Slack, agent, memory,
   pipeline, GitHub, MongoDB, and WhatsApp tool surfaces.
 - [Dynamic workflows](features/dynamic-workflows.md): markdown definitions,
-  registry overlays, scheduler, executor, and dashboard state.
+  registry overlays, scheduler, executor, Slack `!workflow`, and dashboard
+  enqueue/create/edit.
+- [HTTP dashboard](features/http-dashboard.md): loopback operator console —
+  session continue/stop, pipeline swimlane, spend ledger, runbook viewer,
+  Git-backed workflow writes, and `dashboard_audit`.
 - [Pipeline implementation](features/agent-product-debugging-pipeline-implementation-plan.md):
   typed product/bug runs, assignments, outbox delivery, recovery, and GC.
 - [GitHub reconciliation](code_index/github-reconciliation.md): review-state
@@ -65,13 +69,7 @@ The remaining indexes are listed by module in `docs/code_index/`.
 
 ## Historical and proposal documents
 
-Active proposals (designed, not implemented):
-
-- [Operator dashboard redesign](features/operator-dashboard-redesign.md):
-  continue sessions, pipeline swimlane, spend ledger, Git-backed workflow
-  edits, and a runbook viewer on the localhost console.
-
-The claim dedup write guard, pre-recall synthesis, and task
+The operator dashboard redesign, claim dedup write guard, pre-recall synthesis, and task
 routes all graduated out of this list — they are shipped and listed under
 [current runtime surfaces](#current-runtime-surfaces).
 

--- a/docs/code_index/http-dashboard.md
+++ b/docs/code_index/http-dashboard.md
@@ -1,6 +1,8 @@
 # Code Index: HTTP Dashboard
 
-Localhost-only HTTP server for operator inspection (sessions, dev-servers, workflows, pipelines, logs, docs, profiles, and memory projections). Off by default; enabled via `HTTP_DASHBOARD_PORT`. Binds 127.0.0.1 and intentionally has no auth; do not expose it beyond a trusted local operator environment.
+Localhost-only HTTP server for operator inspection and a bounded write surface (session continue/stop, workflow enqueue/start/stop/reload/create/edit). Off by default; enabled via `HTTP_DASHBOARD_PORT`. Binds 127.0.0.1 and intentionally has no auth; do not expose it beyond a trusted local operator environment. Mutating calls write `dashboard_audit`. Session continue/stop also post to the Slack thread. Workflow mutations post to a Slack output channel only when the definition has one — otherwise git + audit is a weaker trail than Slack `!` commands.
+
+Spend capture (`usage_events`) and audit retention deletes are always-on: they are not gated on `HTTP_DASHBOARD_PORT`.
 
 ## Code Index
 
@@ -8,14 +10,21 @@ Localhost-only HTTP server for operator inspection (sessions, dev-servers, workf
 
 | Symbol | File | Purpose |
 |---|---|---|
-| `startHttpServer(deps)` | `server.ts` | Bun.serve on 127.0.0.1:port; routes API + serves `public/index.html`, `public/js/*`, leftover `public/assets/*` |
+| `startHttpServer(deps)` | `server.ts` | Bun.serve on 127.0.0.1:port; `matchApi` + method 405; serves `public/index.html`, `public/js/*`, leftover `public/assets/*` |
 | `resolvePublicStaticPath(pathname)` | `server.ts` | Resolves `/js/*` and leftover `/assets/*` under `public/`; rejects `..`, `.`, empty segments, and null bytes |
-| `HttpServerDeps` | `server.ts` | `{ store, config, devServerManager, devServerQueue, repos, workflowRegistry, workflowScheduler, workflowStore, memoryStore?, profileStore?, pipelineStore, resolveSlackPermalink?, usageStore, auditStore, runbookCatalog? }` |
+| `matchApi(pathname)` / `allowedMethods(kind)` | `match-api.ts` | Nested session/workflow/pipeline paths; 405 on wrong method |
+| `HttpServerDeps` | `server.ts` | `{ store, config, devServerManager, devServerQueue, repos, workflowRegistry, workflowScheduler, workflowStore, memoryStore?, profileStore?, pipelineStore, resolveSlackPermalink?, sessionManager, slackPoster, usageStore, auditStore, runbookCatalog?, projectRoot? }` |
 | `handleHealth(store, config, startedAt, extras?)` | `routes/health.ts` | `GET /api/health` — uptime, session counts, agent counts, repo list, `pipeline.runtimeMode`, spend/audit today counters |
 | `handleSessions(store, usageStore?)` | `routes/sessions.ts` | `GET /api/sessions` — allowlist projection + numeric pending + spend summary |
 | `handleSessionDetail(store, threadId, resolveSlackPermalink?, usageStore?)` | `routes/sessions.ts` | `GET /api/sessions/:threadId` — same allowlist plus `resumeCwd`, spend, and a best-effort Slack permalink |
+| `handleSessionContinue(req, threadId, deps)` | `routes/sessions.ts` | `POST /api/sessions/:threadId/continue` — attribution Slack post, then `injectDashboardContinue` |
+| `handleSessionStop(threadId, deps)` | `routes/sessions.ts` | `POST /api/sessions/:threadId/stop` — `interruptThread` + `formatStopReply` Slack post |
+| `dashboardActor(config)` / `CONTINUE_PROMPT_MAX` | `routes/sessions.ts` | `ADMIN_SLACK_USER_ID` or `dashboard-operator`; 8000-char prompt cap |
 | `handleDevServers(manager, queue, repos)` | `routes/dev-server.ts` | `GET /api/dev-server` — per-repo state, idle TTL remaining, queue depth |
-| `handleWorkflows(registry, store, scheduler)` | `routes/workflows.ts` | `GET /api/workflows` — definitions, persisted state, recent runs, registry errors, and live scheduler-derived display status |
+| `handleWorkflows(registry, store, scheduler, projectRoot?)` | `routes/workflows.ts` | `GET /api/workflows` — definitions, persisted state, recent runs, registry errors, live `displayStatus`, overlay/junior git probes |
+| `handleWorkflowDetail(name, deps)` | `routes/workflows.ts` | `GET /api/workflows/:name` — on-disk markdown + both hashes + git + last 20 runs |
+| `handleWorkflowRun` / `handleWorkflowStart` / `handleWorkflowStop` / `handleWorkflowReload` | `routes/workflows.ts` | Dashboard mutations; run uses `enqueueManualRun`, not blocking `runNow` |
+| `handleWorkflowCreate` / `handleWorkflowPut` | `routes/workflows.ts` | Git-backed create (201) / edit (200); `?validate=1` dry-run |
 | `handlePipelines(store, params, runId?, options?)` | `routes/pipelines.ts` | `GET /api/pipelines` and `GET /api/pipelines/:runId` — summaries hide default-kind unless `includeDefault=1` or `kind=default`; detail expands leases/outbox/gates |
 | `handlePipelineArtifact(store, runId, params, options?)` | `routes/pipelines.ts` | `GET /api/pipelines/:runId/artifacts?ref=` — relative-to-run-root file read, 256 KiB cap |
 | `handleSpend(store, params)` | `routes/spend.ts` | `GET /api/spend` — usage `groupBy` over a host-local window (max 90 days) |
@@ -27,50 +36,126 @@ Localhost-only HTTP server for operator inspection (sessions, dev-servers, workf
 | `handleMemoryRead(filePath)` | `routes/memory.ts` | `GET /api/memory/:path` — read a doc file (path-traversal guarded) |
 | `handleMemoryRecall(store, params)` | `routes/memory.ts` | `GET /api/memory/recall` — semantic claim recall without recording dashboard usage |
 | `handleMemoryProjection(store, params?)` | `routes/memory.ts` | `GET /api/memory/projection` — 3D PCA + spread + KNN projection for the memory galaxy; memoised per claim set, `?refresh=1` rebuilds |
-| `resumeCmd(provider, sessionId, resumeCwd)` | `public/js/threads.js` | Renders provider-correct Claude, OpenCode, or Codex resume commands from detail `resumeCwd`. |
+| `parseLimit` / `parseTimeBound` / `startOfLocalDay` | `query.ts` | Shared query parsing (host-local day bounds) |
+| `resumeCmd(provider, sessionId, resumeCwd)` | `public/js/threads.js` | Renders provider-correct Claude, OpenCode, or Codex resume commands from detail `resumeCwd`. Continue/stop composer lives in the same module. |
 | `projectClaims(claims, k?, spread?)` | `projection.ts` | PCA to 3D (power iteration + deflation) → separation relaxation → cosine KNN edges |
+
+### src/http/audit
+
+| Symbol | File | Purpose |
+|---|---|---|
+| `DashboardAuditStore` | `audit/interface.ts` | `record` / `list` / `count` / `deleteOlderThan` |
+| `SqliteDashboardAuditStore` | `audit/sqlite.ts` | `dashboard_audit` in `SESSION_DB_PATH` |
+| `InMemoryDashboardAuditStore` | `audit/memory.ts` | Tests / `SESSION_STORE=memory` |
+| `createDashboardAuditStore` | `audit/factory.ts` | memory vs sqlite |
+
+### Supporting control plane (not under `src/http`)
+
+| Symbol | File | Purpose |
+|---|---|---|
+| `injectDashboardContinue` / `interruptThread` | `src/session/manager.ts` | Dedicated inject (returns accepted/buffered/muted) and extracted `!stop` body |
+| `toDashboardSlackEvent` | `src/session/inject.ts` | Attribution inject event; `dashboardContinue: true`; dedupe `dashboard:${threadId}:${postedTs}` |
+| `resolveContinueRoute` | `src/session/continue-route.ts` | `junior`/`default` → top-level default; `lead` → lead; else existing `agentSessions` row |
+| `enqueueManualRun` | `src/workflows/scheduler.ts` | Await durable `persistNewRun`, void `executePersistedRun` |
+| `persistNewRun` / `executePersistedRun` | `src/workflows/executor.ts` | Split so HTTP can 202 only after the run row exists |
+| `writeDashboardWorkflow` / `probeWorkflowRepo` / `preflightGitRepo` | `src/workflows/git-commit.ts` | Scoped commit; refuse detached HEAD / merge / rebase; overlay parent pointer |
+| `pauseReloads` / `resumeReloads` | `src/workflows/registry.ts` | Pause watcher reloads across write+commit |
+| `normalizeRunnerUsage` | `src/usage/normalize.ts` | Provider blobs → one ledger row; Claude `costUsd` only |
+| `sessionTurnSourceId` | `src/usage/source-id.ts` | Unique turn key with specified fallbacks |
+| `UsageStore` | `src/usage/store/*` | Idempotent upsert + sum on `(source_kind, source_id)` |
+| `cleanupOperationalTables` | `src/lifecycle/cleanup.ts` | Delete usage older than 90d, audit older than 180d |
 
 ## Routes
 
 ```
-GET /                       → public/index.html
-GET /api/health             → handleHealth
-GET /api/sessions           → handleSessions
-GET /api/sessions/<id>      → handleSessionDetail
-GET /api/dev-server         → handleDevServers
-GET /api/workflows          → handleWorkflows
-GET /api/pipelines          → handlePipelines (runtimeMode + default-kind hide)
-GET /api/pipelines/<runId>  → handlePipelines (detail)
-GET /api/pipelines/<runId>/artifacts?ref= → handlePipelineArtifact
-GET /api/spend              → handleSpend
-GET /api/runbooks           → handleRunbooks
-GET /api/runbooks/<name>    → handleRunbookDetail
-GET /api/audit              → handleAudit
-GET /api/logs?date=...      → handleLogs
-GET /api/profiles[?kind=…]  → handleProfiles
-GET /api/memory             → handleMemoryList
-GET /api/memory/<path>      → handleMemoryRead
-GET /api/memory/recall      → handleMemoryRecall (503 if unavailable)
-GET /api/memory/projection  → handleMemoryProjection (503 if unavailable)
+GET    /                       → public/index.html
+GET    /api/health             → handleHealth
+GET    /api/sessions           → handleSessions
+GET    /api/sessions/<id>      → handleSessionDetail
+POST   /api/sessions/<id>/continue → handleSessionContinue
+POST   /api/sessions/<id>/stop     → handleSessionStop
+GET    /api/dev-server         → handleDevServers
+GET    /api/workflows          → handleWorkflows
+POST   /api/workflows          → handleWorkflowCreate
+GET    /api/workflows/<name>   → handleWorkflowDetail
+PUT    /api/workflows/<name>   → handleWorkflowPut
+POST   /api/workflows/<name>/run   → handleWorkflowRun (enqueueManualRun)
+POST   /api/workflows/<name>/start → handleWorkflowStart
+POST   /api/workflows/<name>/stop  → handleWorkflowStop
+POST   /api/workflows/reload   → handleWorkflowReload
+GET    /api/pipelines          → handlePipelines (runtimeMode + default-kind hide)
+GET    /api/pipelines/<runId>  → handlePipelines (detail)
+GET    /api/pipelines/<runId>/artifacts?ref= → handlePipelineArtifact
+GET    /api/spend              → handleSpend
+GET    /api/runbooks           → handleRunbooks
+GET    /api/runbooks/<name>    → handleRunbookDetail
+GET    /api/audit              → handleAudit
+GET    /api/logs?date=...      → handleLogs
+GET    /api/profiles[?kind=…]  → handleProfiles
+GET    /api/memory             → handleMemoryList
+GET    /api/memory/<path>      → handleMemoryRead
+GET    /api/memory/recall      → handleMemoryRecall (503 if unavailable)
+GET    /api/memory/projection  → handleMemoryProjection (503 if unavailable)
     ?refresh=1                force a rebuild instead of the memoised result
-GET /js/*                  → public/js/* (text/javascript, Cache-Control: no-cache)
-GET /assets/*              → leftover public/assets/* (same headers; three.* and pipeline-worker stay dedicated)
-GET /assets/three.module.js → locally served pinned Three.js module
-GET /assets/three.core.min.js → locally served pinned Three.js core module
-GET /assets/pipeline-worker.js → locally served pipeline worker
+GET    /js/*                   → public/js/* (text/javascript, Cache-Control: no-cache)
+GET    /assets/*               → leftover public/assets/* (same headers; three.* and pipeline-worker stay dedicated)
+GET    /assets/three.module.js → locally served pinned Three.js module
+GET    /assets/three.core.min.js → locally served pinned Three.js core module
+GET    /assets/pipeline-worker.js → locally served pipeline worker
 ```
+
+Wrong method on a known `/api/*` path → 405 `{ error: "method not allowed" }`.
+
+## Frontend modules (`public/js/`)
+
+| File | Role |
+|---|---|
+| `api.js` | `safeFetch`, poll, error toast |
+| `app.js` | hash router, nav, overview |
+| `threads.js` | list, drawer, continue/stop, `resumeCmd` |
+| `pipelines.js` | list + **swimlane default** + Topology toggle |
+| `pipeline-layout.js` | swimlane/tape geometry helpers |
+| `workflows.js` | list, markdown editor, run, git status, create |
+| `runbooks.js` | list + viewer |
+| `spend.js` | KPI + `groupBy` table (no canvas chart) |
+| `audit.js` | audit table |
+| `markdown.js` | shared markdown renderer |
+| `galaxy.js` | Three.js memory scene |
+
+`pipelineViewMode` defaults to `"swimlane"`. 3D topology is opt-in.
 
 ## Key Concepts
 
 ### Loopback-only threat model
 
-Binds `127.0.0.1`. No CORS headers — same-origin from `public/index.html`. Don't expose this port. No auth. The internal MCP server is a separate loopback-only service.
+Binds `127.0.0.1`. No CORS headers — same-origin from `public/index.html`. Don't expose this port. No auth. Writes raise the cost of a compromised localhost tab; compensating controls are `dashboard_audit`, Slack posts for continue/stop, and optional Slack one-liners for workflows that declare an output channel. The internal MCP server is a separate loopback-only service.
+
+### Session allowlist
+
+List and detail share `projectSession`. Explicitly **omit**: `worktreePath`, `worktreePaths`, `cwd`, thread and per-agent `pid`, `systemPrompt`, `slackIdentity`, pending bodies, `activeTurnInput`, `activeTurnAuthor`, `activePipelineInvocation`, assignment capability envelopes. Detail-only: `resumeCwd`, `slackPermalink`. `pendingMessages` is a number.
+
+### Continue / stop
+
+Attribution Slack body is `*Dashboard continue*` plus a `>`-quoted preview so `containsDispatchDirective` cannot match. Event API also drops texts that start with `*Dashboard continue*`. Inject uses `dashboardContinue: true` to skip default-run hijack and short-followup. Stop reuses `interruptThread`; it does not invent a second kill path.
+
+### Workflow enqueue vs `runNow`
+
+`runNow` awaits the whole executor (Slack `!workflow run`). `enqueueManualRun` awaits only `persistNewRun`, then backgrounds `executePersistedRun` with `.then(schedule)` / `.catch` (failed-run status) / `.finally(releaseRun)`. HTTP 202 only after `store.getRun(runId)` would succeed. Skip-concurrency already-running is 200 `{ status: "skipped", runId: "" }`.
+
+### Git detached-HEAD and overlay parent pointer
+
+`writeDashboardWorkflow` / `preflightGitRepo` refuse detached HEAD, merge, rebase, and unresolved conflicts. Overlay writes preflight Junior as well, then after a successful `agents-org` commit do `git add -- agents-org` only on Junior. Parent-pointer failure does not roll back the overlay commit. Registry reloads are paused across the critical section.
+
+### Spend and audit retention
+
+`usage_events` 90 days, `dashboard_audit` 180 days, both swept by `cleanupOperationalTables` from the existing cleanup interval and `bun run cleanup`. Capture is inside `SessionManager` (session turns, including quiet) and once per workflow run from `SpawnResult`.
 
 ### Path traversal guards
 
 - Logs: `date` must match `^\d{4}-\d{2}-\d{2}$` exactly.
 - Memory: rejects `..` and absolute paths; verifies resolved path stays inside `docs/`.
 - Dashboard JS/assets: `resolvePublicStaticPath` rejects empty/`.`/`..` segments and null bytes, then requires the resolved path stay inside `public/`.
+- Pipeline artifacts: `ref` is relative to `data/pipelines/<runId>/`; absolute paths, `..`, and strings that start with `data/pipelines/` are 400. Assignment-registered alternate roots are not readable (`resolvePipelineArtifactPath` is called without an assignment).
 
 ### Memory galaxy projection
 
@@ -99,9 +184,9 @@ overlays on that single graph scene.
 
 ### Boot wiring
 
-`index.ts` dynamic-imports `./http/server.ts` inside a try/catch — a port conflict on dashboard must not crash the bot.
+`index.ts` dynamic-imports `./http/server.ts` inside a try/catch — a port conflict on dashboard must not crash the bot. `UsageStore` and `DashboardAuditStore` are constructed next to the session/workflow sqlite path regardless of whether the dashboard port is set.
 
 ## Dependencies
 
-- **Uses**: `Bun.serve`, `SessionStore`, `DevServerManager`, `DevServerQueue`, `WorkflowRegistry`, `WorkflowScheduler`, `WorkflowStore`, `PipelineStore`, `UsageStore`, `DashboardAuditStore`, optional `MemoryStore`, `ProfileStore`, and runbook `CatalogStore`, optional Slack permalink resolver, `RepoConfig`, `logger`
-- **Used by**: `src/index.ts` (gated on `config.http.enabled`)
+- **Uses**: `Bun.serve`, `SessionStore`, `SessionManager` (`injectDashboardContinue`, `interruptThread`, `isAdmin`, `isExplicitAdmin`, `getSession`), Slack poster, `DevServerManager`, `DevServerQueue`, `WorkflowRegistry`, `WorkflowScheduler`, `WorkflowStore`, `PipelineStore`, `UsageStore`, `DashboardAuditStore`, optional `MemoryStore`, `ProfileStore`, and runbook `CatalogStore`, optional Slack permalink resolver, `RepoConfig`, `logger`
+- **Used by**: `src/index.ts` (gated on `config.http.enabled` for the listener; usage/audit stores are always constructed)

--- a/docs/code_index/pipelines.md
+++ b/docs/code_index/pipelines.md
@@ -14,7 +14,9 @@ disabled by default (`PIPELINE_RUNTIME_MODE=off`) and can run in `shadow` or
 | Persistence | `src/pipelines/store/*` | Memory and SQLite stores, versioned writes, and transactional outcome handling. |
 | Reliability | `src/pipelines/outbox.ts`, `recovery.ts`, `settlement-recovery` paths | At-least-once outbox delivery, lease recovery, and settlement repair. |
 | Outcomes | `src/pipelines/outcomes.ts`, `revision.ts`, `artifacts.ts` | Idempotent agent outcomes, revisions, artifacts, and handoffs. |
-| Projection and cleanup | `src/pipelines/projection.ts`, `src/pipelines/gc.ts` | Dashboard projections and retention cleanup. |
+| Slack/`!status` summary | `src/pipelines/projection.ts` | Human-readable `projectRunSummary` for Slack status. Not the dashboard HTTP projector. |
+| Dashboard operator projection | `src/http/routes/pipelines.ts` | List + detail + artifact read. Hides `kind=default` unless `includeDefault=1` or `kind=default`. Detail expands leases, full-run outbox (payload stripped), attempt-scoped gates, GitHub resources, dev-server jobs, artifact refs. |
+| Retention cleanup | `src/pipelines/gc.ts` | Pipeline retention GC (`PIPELINE_RETENTION_DAYS`). |
 | Legacy bridge | `src/pipelines/legacy-directives.ts`, `src/support/pipeline-guard.ts` | Safely maps selected legacy directives while preserving existing routing. |
 | MCP tools | `src/pipelines/tools.ts` | Runner-facing pipeline read/write tools with scope and idempotency checks. |
 
@@ -32,6 +34,13 @@ consumers and outcome writes must remain idempotent; version/CAS checks prevent
 stale workers from overwriting newer state. Retention is controlled by
 `PIPELINE_RETENTION_DAYS`.
 
-See [the implementation plan](../features/agent-product-debugging-pipeline-implementation-plan.md)
-for design history and [GitHub reconciliation](github-reconciliation.md) for
+The localhost dashboard default is an assignment **swimlane + phase tape**
+(`public/js/pipelines.js`, `pipelineViewMode = "swimlane"`). The older 3D
+topology graph stays behind a Topology toggle and still uses
+`public/pipeline-worker.js`. There are no pipeline writes from the dashboard
+(no force-transition, no outbox replay); those stay in Slack / MCP.
+
+See [the HTTP index](http-dashboard.md) for the operator routes,
+[the implementation plan](../features/agent-product-debugging-pipeline-implementation-plan.md)
+for design history, and [GitHub reconciliation](github-reconciliation.md) for
 the external review boundary.

--- a/docs/code_index/workflows.md
+++ b/docs/code_index/workflows.md
@@ -2,16 +2,21 @@
 
 Dynamic workflows are markdown-defined, typed runs scheduled and executed by
 Junior. Definitions are data; the runtime owns validation, scheduling,
-execution, persistence, and dashboard projection.
+execution, persistence, and dashboard projection. The localhost dashboard can
+also enqueue, start, stop, reload, create, and edit workflows; see
+[the HTTP index](http-dashboard.md).
 
 ## Sources
 
 | Symbol/area | File | Purpose |
 |---|---|---|
-| `WorkflowRegistry` | `src/workflows/registry.ts` | Loads definitions, applies overlay precedence, and watches for changes. |
-| Definition parser | `src/workflows/definition.ts` | Parses and validates frontmatter/body workflow definitions. |
+| `WorkflowRegistry` | `src/workflows/registry.ts` | Loads definitions, applies overlay precedence, and watches for changes. `pauseReloads` / `resumeReloads` wrap dashboard git writes so the 350 ms watcher cannot load uncommitted bytes. |
+| Definition parser | `src/workflows/definition.ts` | Parses and validates frontmatter/body workflow definitions. `WORKFLOW_NAME_RE` is the HTTP name guard. |
 | `WorkflowScheduler` | `src/workflows/scheduler.ts` | Computes due work, persists scheduler state, and tracks live per-workflow run counts for operator projections. |
-| `WorkflowExecutor` | `src/workflows/executor.ts` | Runs a validated workflow step through the configured runner boundary. |
+| `runNow` | `src/workflows/scheduler.ts` | Blocking manual/scheduled entry. Slack `!workflow run` still uses this. |
+| `enqueueManualRun` | `src/workflows/scheduler.ts` | Dashboard fire-and-forget: await `persistNewRun`, void `executePersistedRun` with `.then(schedule)` / `.catch` (failed-run status) / `.finally(releaseRun)`. Returns `{ status: "started", runId }` or `{ status: "skipped", runId: "" }`. |
+| `persistNewRun` / `executePersistedRun` | `src/workflows/executor.ts` | Split so HTTP can 202 only after the `workflow_runs` row is durable. `run()` still does persist then execute. Persists usage once from `SpawnResult` (or a zero-token native-handler row). |
+| `writeDashboardWorkflow` / `preflightGitRepo` / `probeWorkflowRepo` | `src/workflows/git-commit.ts` | Scoped `git add -- <path>` + isolated identity commit. Refuses detached HEAD, merge, rebase, conflicts. Overlay: preflight Junior, then parent-pointer `git add -- agents-org` only; parent failure does not roll back the overlay. No push. |
 | Controller | `src/workflows/controller.ts` | Coordinates registry, scheduler, executor, and store. |
 | Store | `src/workflows/store.ts` | Persists workflow state and run history; definitions remain file-backed in the registry. |
 | Types | `src/workflows/types.ts` | Workflow definition, trigger/output, state, run, and execution contracts. |
@@ -33,8 +38,18 @@ Private overlay definitions may be loaded from `agents-org/workflows/` when
 that directory exists. Overlay precedence and file-watch reload behavior are
 implemented in the registry, not in individual workflow files.
 
-The localhost dashboard exposes workflow state at `/api/workflows`; see
-[the HTTP index](http-dashboard.md). Its `displayStatus` uses the scheduler's
-live run count rather than persisted `running` history, which may be stale after
-a hard restart. Workflow utility runs with an explicit cwd intentionally do not
-inherit Junior's project MCP wiring.
+The localhost dashboard exposes workflow state at `/api/workflows` and mutations
+at `/api/workflows` (POST create), `/api/workflows/:name` (PUT edit, `?validate=1`
+dry-run), `/api/workflows/:name/run|start|stop`, and `/api/workflows/reload`.
+`displayStatus` uses the scheduler's live run count rather than persisted
+`running` history, which may be stale after a hard restart. Dashboard **run**
+calls `enqueueManualRun`, not blocking `runNow`. Create/edit refuse detached
+HEAD and pause registry reloads around the commit.
+
+Workflow mutations write `dashboard_audit`. They post a one-liner to a
+definition Slack output channel when one exists; **without that channel the
+trail is weaker than Slack `!` commands** (git + audit only). Actor is
+`ADMIN_SLACK_USER_ID` or `dashboard-operator`.
+
+Workflow utility runs with an explicit cwd intentionally do not inherit Junior's
+project MCP wiring.

--- a/docs/features/dynamic-workflows.md
+++ b/docs/features/dynamic-workflows.md
@@ -1,13 +1,13 @@
 # Dynamic Workflows
 
-> **Current status (2026-08-15):** Shipped. The registry, SQLite state/run store, hot reload, scheduler, Slack commands, and localhost dashboard endpoint are live. Current definitions include `worklog`, `release-notes`, `memory-consolidation`, `memory-dedup-sweep`, `slack-archive-maintenance`, and `worktree-prune`; private overlays may add or override definitions. `slack-archive-maintenance` is a native deterministic handler, not an agent-run workflow.
+> **Current status (2026-08-15):** Shipped. The registry, SQLite state/run store, hot reload, scheduler, Slack commands, and localhost dashboard (read + enqueue/start/stop/reload + Git-backed create/edit) are live. Current definitions include `worklog`, `release-notes`, `memory-consolidation`, `memory-dedup-sweep`, `slack-archive-maintenance`, and `worktree-prune`; private overlays may add or override definitions. `slack-archive-maintenance` is a native deterministic handler, not an agent-run workflow.
 
 ## Problem
 
 Junior needs recurring and on-demand workflows that can be added without restarting the bot. The first workflow is a daily worklog: collect my PRs and commits, turn them into grouped "things I did", store a markdown artifact, and post a Slack summary.
 
 **Who has this problem:** Junior operators who need repeatable automation.
-**What happens today:** Workflow definitions are discovered from `workflows/` and `agents-org/workflows/`, reloaded on file changes, persisted in SQLite, and controllable through `!workflow` / `!workflows`. The dashboard exposes the same state at `GET /api/workflows`.
+**What happens today:** Workflow definitions are discovered from `workflows/` and `agents-org/workflows/`, reloaded on file changes, persisted in SQLite, and controllable through `!workflow` / `!workflows` and the localhost dashboard. Slack `!workflow run` still awaits blocking `runNow`. The dashboard calls `enqueueManualRun` (durable `persistNewRun`, then background `executePersistedRun`) so a long worklog does not hold the HTTP request. Create/edit write `*.workflow.md` and commit on a named branch (detached HEAD refused); overlay writes also try a Junior submodule-pointer commit.
 **Painful part:** Every new cron-like behavior currently risks becoming a code deploy.
 **"Finally" moment:** Add or edit `workflows/worklog.workflow.md`; Junior reloads it, schedules it, and owners can `!workflow run worklog` or `!workflow stop worklog` from Slack.
 
@@ -203,6 +203,8 @@ Admin-only commands:
 
 Authorization uses existing Junior admins plus `ownerSlackUserIds` from the workflow file. Non-authorized mutating commands are rejected with a reaction and no workflow run.
 
+The dashboard uses the same `canManage` / admin checks with actor `ADMIN_SLACK_USER_ID` or `dashboard-operator`. Create/edit/reload require admin (open-mode still allows them, matching Slack). Dashboard run/start/stop/reload/create/edit write `dashboard_audit`. If the definition has a `slack` or `slack-thread` output, the dashboard also posts a one-liner there. **If it has none, git + `dashboard_audit` is a weaker trail than Slack `!` commands** — accepted for the no-auth loopback console, not Slack-parity. Continue/stop on sessions remain full Slack-thread records; see [http-dashboard.md](http-dashboard.md).
+
 ## Hot Reload
 
 Junior uses `fs.watch` on both fixed workflow roots. Watch events are debounced and followed by a full rescan of each root because file watchers can coalesce, duplicate, or miss exact filenames across platforms.
@@ -278,13 +280,14 @@ This is a CLI fallback, not OpenCode's native server interrupt. The implemented 
 
 ## Cut List
 
-- Interactive workflow creation from Slack.
+- Interactive workflow creation from Slack (the dashboard can already create/edit Git-backed files).
 - Multi-step workflow DAGs.
-- Retrying failed workflow runs.
+- Retrying failed workflow runs from the UI.
 - Per-output templates.
 - Workflow-specific secrets.
-- A UI for workflow states and history.
+- Automatic `git push` / PR after a dashboard create or edit. Commits stay local and unpushed. Detached HEAD, merge, and rebase are refused; overlay writes also commit the Junior `agents-org` pointer (`git add -- agents-org` only) and report — without rolling back the overlay — if that parent commit fails.
+- Slack-parity conversation-of-record for dashboard workflow writes that have no Slack output channel. Today those leave only git + `dashboard_audit`.
 
-The localhost dashboard already exposes workflow definitions, state, recent runs,
-and registry errors through `GET /api/workflows`; a richer interactive UI remains
-out of scope.
+The localhost dashboard lists definitions, state, recent runs, and registry
+errors, and can enqueue (`enqueueManualRun`), start, stop, reload, create, and
+edit workflows. See [http-dashboard.md](http-dashboard.md).

--- a/docs/features/http-dashboard.md
+++ b/docs/features/http-dashboard.md
@@ -2,65 +2,197 @@
 
 ## Problem
 
-Operators running junior on a server have no live view of what's happening: which threads are active, which agents are busy, which dev-servers are running and on what branch, what the recent logs look like. The Slack home tab covers thread-list use cases but doesn't surface dev-server queue state, structured logs, or per-agent run state.
+Operators running junior on a server have no live view of what's happening: which threads are active, which agents are busy, which pipeline holds a lease, what today cost, which workflow is running, and what the recent logs look like. The Slack home tab covers thread-list use cases but does not surface spend, pipeline leases/gates, runbooks, or dashboard-originated mutations.
 
 **Who has this problem:** The operator (Pranav, mostly) tailing logs and `ps`ing for stuck processes.
-**What happens today:** SSH + `tail -f logs/<date>.log` + `sqlite3 data/sessions.db`.
-**"Finally" moment:** Open `http://127.0.0.1:<port>` on the host, see sessions / dev-servers / logs / docs in one page.
+**What happens today:** Open `http://127.0.0.1:<port>` on the host. The console lists sessions, continues or stops a thread, inspects pipelines, queries spend, triggers or edits Git-backed workflows, and browses runbooks and the audit log.
+**"Finally" moment:** Continue a stuck thread, see who holds a pipeline lease, and check today's tokens without SSH + sqlite3.
+
+This page documents the shipped operator console. The design record is [operator-dashboard-redesign.md](operator-dashboard-redesign.md).
 
 ## Shape
 
 ```
 src/http/
-├── server.ts              -- Bun.serve, route table, single fetch handler
+├── server.ts              -- Bun.serve, matchApi route table, /js/* + /assets/*
+├── match-api.ts           -- pathname + method matching; 405 on mismatch
+├── query.ts               -- shared limit / host-local day / time-bound parsers
 ├── projection.ts          -- 3D PCA + spread + KNN for the memory galaxy
+├── audit/                 -- DashboardAuditStore (memory + sqlite + factory)
 └── routes/
-    ├── health.ts          -- uptime + session/agent counters
-    ├── sessions.ts        -- list + per-thread detail
+    ├── health.ts          -- uptime, session/agent counters, spend/audit today
+    ├── sessions.ts        -- allowlist list/detail + continue/stop
     ├── dev-server.ts      -- DevServerManager + DevServerQueue state
     ├── logs.ts            -- tail logs/<date>.log with tag/level filters
     ├── profiles.ts        -- read-only person/repo/project/situation browser
-    ├── pipelines.ts       -- read-only product/bug pipeline run + assignment views
+    ├── pipelines.ts       -- operator projection + relative artifact reads
+    ├── workflows.ts       -- list/detail + enqueue/start/stop/reload + create/edit
+    ├── spend.ts           -- usage groupBy over a host-local window
+    ├── runbooks.ts        -- registry + catalog + metrics (view only)
+    ├── audit.ts           -- newest-first dashboard_audit rows
     └── memory.ts          -- docs browser + claim recall + galaxy projection
+
+src/usage/                 -- always-on spend ledger (not gated on the dashboard port)
+src/workflows/git-commit.ts
+public/
+├── index.html             -- shell, CSS, nav, view mounts
+├── pipeline-worker.js     -- 3D topology layout worker
+└── js/                    -- same-origin modules (no bundler)
 ```
 
-Bun-native: no router framework, no auth, no CORS. Static `public/index.html` is served at `/` from the same origin as the API, so cross-origin access has no reason to exist.
+Bun-native: no router framework, no auth, no CORS. Static `public/index.html` plus `public/js/*` are served from the same origin as the API.
 
 Junior is intentionally insecure as a networked product. The dashboard assumes a trusted local operator and host-level access control; exposing it beyond loopback requires adding authentication, authorization, and a real security review.
 
 ## Security posture
 
-- **Loopback-only.** Binds `127.0.0.1` — never reachable off-host without an explicit SSH tunnel. This is the entire threat model; there is intentionally no auth layer behind it.
+- **Loopback-only.** Binds `127.0.0.1` — never reachable off-host without an explicit SSH tunnel. This is the entire threat model; there is intentionally no auth layer behind it. Do not tunnel the port without adding auth.
+- **Writes are in scope.** Continue, stop, workflow run/start/stop/reload, and Git-backed create/edit are first-class. They do not invent a second control plane: they call `SessionManager` / `WorkflowScheduler` / the git helper the Slack path already uses.
+- **Audit is required, Slack-parity is not.** Every mutating call writes `dashboard_audit`. Session continue/stop also post to the Slack thread (conversation of record). Workflow mutations post a one-liner to a `slack` / `slack-thread` output **when the definition has one**. Workflows without an output channel leave only git + `dashboard_audit` — **weaker than Slack `!` commands**, accepted for a no-auth loopback console, and must not be documented as Slack-parity.
+- **Actor is loopback identity.** `ADMIN_SLACK_USER_ID` when set, else `dashboard-operator`. Fail closed when the `admins` table is non-empty but the env admin is unset. Open-mode (neither tier configured) matches Slack open-mode.
 - **Profiles are private operator data.** `/api/profiles` can include derived context about real people. It is available only inside the same loopback-only console and must not be exposed through a public bind or permissive CORS.
 - **Same-origin.** Dashboard HTML is served by the same Bun process. No CORS headers — adding `Access-Control-Allow-Origin: *` would only let arbitrary websites the operator visits read this server's data.
-- **Path-traversal rejection at the input layer.** `/api/logs?date=` accepts only `YYYY-MM-DD` (strict regex); `/api/memory/<path>` rejects `..` and absolute paths and verifies the resolved path stays inside `docs/`. Reject early, don't sanitize after concatenation.
-- **Projection on `/api/sessions`.** Filesystem paths (`worktreePath`, `cwd`), PIDs (`pid`), prompt-engineering details (`systemPrompt`), and `slackIdentity` are stripped before serialization. `pendingMessages` is reduced to a length count — message bodies never leave the box.
-- **Provider-aware resume commands.** Session and agent cards use the CLI that owns the session: `claude --resume`, `opencode --session`, or `codex resume`. Codex app-server IDs are never presented as OpenCode commands.
+- **Path-traversal rejection at the input layer.** `/api/logs?date=` accepts only `YYYY-MM-DD`; `/api/memory/<path>` rejects `..` and absolute paths and verifies the resolved path stays inside `docs/`. Pipeline artifact `ref` is relative to `data/pipelines/<runId>/` only. Workflow/runbook names must match `^[a-z0-9][a-z0-9-]*$`. Reject early, don't sanitize after concatenation.
+- **Allowlist projection on `/api/sessions`.** Filesystem paths (`worktreePath`, `cwd`) stay off the list. Detail-only `resumeCwd` is the one path the resume CLI needs. PIDs, `systemPrompt`, `slackIdentity`, pending bodies, `activeTurnInput`, and assignment capability envelopes never leave the box. `pendingMessages` is a length.
+
+## Write contract
+
+Dashboard writes keep the loopback threat model. They do **not** stay read-only so Slack can be the only audit trail. Compensation, by action:
+
+| Action | Slack conversation of record | Other trail |
+|---|---|---|
+| `session.continue` | Attribution-only post in the thread (no raw `!` lines) | `dashboard_audit` + `injectDashboardContinue` |
+| `session.stop` | Same “Interrupted (N agents)” / “Nothing running.” line `!stop` posts | `dashboard_audit` + `slack_ts` |
+| `workflow.run` / `start` / `stop` / `reload` | One-liner to the workflow’s Slack output channel **if present** | `dashboard_audit`; weaker than Slack if no output channel |
+| `workflow.create` / `update` | Same optional one-liner | **git commit** is the reviewable record + `dashboard_audit` |
+
+Pipeline, spend, runbook, profile, memory, log, and docs routes stay read-only. Killing a worktree, evicting a dev-server slot, and `!reset` / `!cancel` stay Slack-only.
+
+### Continue / stop
+
+`POST /api/sessions/:threadId/continue` `{ prompt, agentName? }`:
+
+1. Validate prompt (non-empty, ≤ 8000 chars) and resolve the agent **before** Slack. `"junior"` / `"default"` / missing → top-level `handleMessage`. `"lead"` → `handleLeadMessage`. Any other name must already have an `agentSessions` row; otherwise 400. `"junior"` is never passed to `handleAgentMessage`.
+2. Muted → 409, no Slack post.
+3. Raw `chat.postMessage` of an attribution-only record (`*Dashboard continue* · local operator · …` plus a `>`-quoted 240-char preview). Slack body contains no line matching `^!(\S+)`. Slack failure → 502, **do not inject**.
+4. `SessionManager.injectDashboardContinue` returns `{ accepted | buffered | muted }`. HTTP 202 for accepted/buffered. The Event API also drops posts that start with `*Dashboard continue*` so the echo cannot re-enter. `dashboardContinue` skips `routeDirectTaskThroughDefaultRun` and is ineligible for short-followup interrupt.
+5. Dormant sessions proceed: clear `dormant` and set `needsThreadCatchup` (same as `!listen` / @mention). Do not change `targetRepo` / worktrees.
+
+`POST /api/sessions/:threadId/stop` calls the same `interruptThread` body `!stop` uses (driver interrupt + `handle.kill`, keep the session), then posts `formatStopReply`. Slack post failure is `partial` on the audit row; the interrupt still happened. `!cancel` stays Slack-only.
+
+### Workflow enqueue and Git writes
+
+Slack `!workflow run` still awaits blocking `WorkflowScheduler.runNow`. The dashboard must not: Bun.serve’s idle timeout would kill a worklog-length request.
+
+`POST /api/workflows/:name/run` calls `WorkflowScheduler.enqueueManualRun`:
+
+- Same pre-checks as `runNow` (`enabled`, not `invalid`; `reason` is always `"manual"`, so `stopped` still allows a one-shot).
+- Await `persistNewRun` so the `workflow_runs` row is durable **before** HTTP 202 `{ status: "started", runId }`.
+- `void` only `executePersistedRun`. `schedule` / failed-run status / `releaseRun` hang on that promise, not on the HTTP method.
+- `concurrency === "skip"` and already running → 200 `{ status: "skipped", runId: "" }` after `markSkipped`.
+- `concurrency === "parallel"` may start a second overlapping run (202 after the new row is durable). Native handlers reject `instructions` (400). `enabled: false` is 409.
+
+Create/edit write `*.workflow.md` and make a scoped git commit. Git is the source of authority; SQLite `workflow_states` / `workflow_runs` remain runtime.
+
+| Policy | Behavior |
+|---|---|
+| Named branch only | Refuse detached HEAD (`git rev-parse --abbrev-ref HEAD` is `HEAD` or empty). Overlay also refuses unless that name is a real branch. Do not auto-checkout. |
+| Repo safety | Refuse merge / rebase / unresolved conflicts (`UU`/`AA`/`DD`/`AU`/`UA`) on **any** path in the target repo. |
+| Scoped add | `git add -- <relativePath>` only. Never `-A`. Isolated `user.name=Junior Dashboard` / `user.email=junior-dashboard@localhost`. No push, no PR, no force-push, no new branch. |
+| Pause reloads | `registry.pauseReloads()` around write+commit so the 350 ms watcher cannot load uncommitted bytes. `resumeReloads()` reloads whatever is now on disk. Commit failure restores the file to HEAD (or deletes a new file) before resume. |
+| Overlay parent pointer | Preflight **both** `agents-org` and Junior before writing the overlay file. After overlay `ok`, `git add -- agents-org` only on Junior’s named branch. Parent failure after overlay success is **not** rolled back: HTTP 200 with `overlayCommitted: true, parentPointerCommitted: false`. Public-root writes skip this step. |
+| Non-`main`/`master` | Save requires an explicit `commitHereAnyway` checkbox (default off). Detached / merging / rebasing on either repo disable Save. |
+
+Optimistic concurrency on PUT compares `expectedVersionHash` to the **on-disk** `fileVersionHash`, not last-known-good. GET detail always returns on-disk markdown plus both hashes and `runtimeUsesFile`.
+
+## Session allowlist
+
+Shared list + detail projector (`projectSession` in `routes/sessions.ts`):
+
+```
+threadId, channel, provider, sessionId, leadSessionId, status,
+agentType, defaultAgent, activeAgentName, targetRepo, baseRef,
+muted, dormant, verbosity, driverMode, lastActivity, createdAt,
+lastError                      -- type + message only
+pendingMessages                -- length, never bodies
+hasWorktree                    -- Boolean(worktreePath || worktreePaths)
+agents[]                       -- agentName, sessionId, status, lastActivity,
+                                  pendingMessages (length), provider
+spend                          -- { inputTokens, outputTokens, costUsd, turns }
+```
+
+Detail only: `resumeCwd` (`worktreePath || cwd`) and `slackPermalink`. List never emits filesystem paths.
+
+## Pipeline operator view
+
+Default UI is an **assignment swimlane + phase tape**, not the 3D topology graph. Topology stays behind a toggle (`public/js/pipelines.js`, `pipelineViewMode = "swimlane"`).
+
+- Lanes are `assignment.targetAgent` (`lead`, `default`, then A–Z).
+- Bars encode lease / pending / waiting / terminal; unleased pending is hollow.
+- Phase tape is `transitions[]`. Click an assignment to load the rail (objective, lease, dispatch, outcomes, artifacts, attempt-scoped gates).
+- `GET /api/pipelines` hides `kind=default` unless `includeDefault=1` or `kind=default`. `limit` default 50, max 200. Response includes `runtimeMode` from config (never inferred) and `openCount`.
+- `GET /api/pipelines/:runId` expands leases, full-run outbox **without payload**, outcomes, gates, GitHub resources, dev-server jobs, and artifact refs. No pipeline writes (no force-transition, no replay).
+- `GET /api/pipelines/:runId/artifacts?ref=` reads a path relative to `data/pipelines/<runId>/` only, 256 KiB cap. 400 on traversal, 404 if missing.
+
+Empty copy: “No typed pipeline runs. Default-run durability is hidden unless you enable it.”
+
+## Spend ledger
+
+Usage capture is **always-on** — not gated on `HTTP_DASHBOARD_PORT`. Tables live in `SESSION_DB_PATH` (`data/sessions.db`).
+
+- Session turns: `SessionManager` records `done` via `normalizeRunnerUsage` + `sessionTurnSourceId` (unique `(source_kind, source_id)`; later `done` events for the same turn **sum**). Quiet verbosity cannot skip it.
+- Workflow runs: once from `SpawnResult` after `runWithRunner`, keyed by `workflowRunId`. Native handlers insert a zero-token row with `raw: { nativeHandler }`.
+- Pipeline assignment rows are not a third writer; session-turn rows already carry invocation ids.
+- `costUsd` is Claude `total_cost_usd` only. `costEstimatedUsd` is always null. No `rates.ts`. Missing usage still inserts a row so “turns without telemetry” is visible.
+- Retention: **90 days** for `usage_events`, **180 days** for `dashboard_audit`. `cleanupOperationalTables` runs from the same interval as stale-session cleanup and from `runCleanupFromEnv`.
+- `GET /api/spend?from=&to=&groupBy=day|session|agent|provider|workflow|pipeline`. Default window is today 00:00 in the **host local** timezone (shown in the UI). Max range 90 days.
+
+UI is table-first (KPI strip + `groupBy` chips + sortable buckets). No canvas chart.
+
+## Runbook viewer
+
+Runbooks stay a separate registry (`src/runbooks/`). The dashboard does not merge them with workflows and does not author or execute them.
+
+- `GET /api/runbooks` — `searchRunbooks` (default 25 / max 100) joined with `getRunbook` (`filePath`), catalog, and `computeMetrics`. Empty registry is 200 `{ runbooks: [], errors: [] }`, not 503.
+- `GET /api/runbooks/:name` — definition (including prompt body), catalog, metrics, git provenance. 404 if not loaded.
 
 ## Endpoints
 
 | Endpoint | Returns |
 |---|---|
 | `GET /` | `public/index.html` (dashboard UI) |
-| `GET /api/health` | `{ status, uptime, startedAt, sessions: {total,busy,idle,draining,errors}, agents: {total,busy}, repos[], pipeline: {runtimeMode, bugPipelineEnabled, productPipelineEnabled, githubReconcileEnabled, githubEventWakeEnabled, sessionsWithActiveRun} }` |
-| `GET /api/sessions` | Sessions sorted by `lastActivity` desc, with filtered projection and a reshaped `agents[]` array per session |
-| `GET /api/sessions/:threadId` | Full `ThreadSession` plus a best-effort Slack permalink for the detail view |
+| `GET /js/*` | same-origin modules from `public/js/` (`Cache-Control: no-cache`) |
+| `GET /api/health` | `{ status, uptime, startedAt, sessions, agents, repos[], pipeline: { runtimeMode, … }, spend: { eventsToday }, audit: { writesToday } }` |
+| `GET /api/sessions` | Allowlisted sessions sorted by `lastActivity` desc, numeric pending, spend summary |
+| `GET /api/sessions/:threadId` | Same allowlist plus `resumeCwd`, spend, and a best-effort Slack permalink |
+| `POST /api/sessions/:threadId/continue` | `{ status: "accepted" \| "buffered" }` 202; 409 muted; 502 Slack failed |
+| `POST /api/sessions/:threadId/stop` | `{ status: "ok", interrupted, message }` |
 | `GET /api/dev-server` | Per-repo `{ devCommand, devPort, readyUrl, running, pid, branch, startedAt, lastUsedAt, idleMsRemaining, holder, waiters }` plus top-level `idleTtlMs` |
-| `GET /api/workflows` | Definitions, persisted scheduler state, five recent runs, registry errors, and a live `displayStatus` from scheduler activity |
-| `GET /api/pipelines` | Pipeline run summaries, filterable by `status` (`active|waiting|needs-human|terminal`) and `kind` (`default|product|bug`), with assignment/artifact state |
-| `GET /api/pipelines/:runId` | One pipeline run with its assignment and artifact detail |
+| `GET /api/workflows` | Definitions (`nativeHandler`, owners, permissions, concurrency), state, five recent runs, registry errors, live `displayStatus`, overlay/junior git probes |
+| `GET /api/workflows/:name` | LKG/live projection (or null) + on-disk `source` (both hashes) + git + last 20 runs |
+| `POST /api/workflows` | Create + scoped commit. 201. `sourceRoot` required (`public` \| `overlay`) |
+| `PUT /api/workflows/:name` | Edit + scoped commit. `?validate=1` dry-run does not write |
+| `POST /api/workflows/:name/run` | `enqueueManualRun` — 202 started or 200 skipped |
+| `POST /api/workflows/:name/start` | `{ name, status: "active" }` |
+| `POST /api/workflows/:name/stop` | `{ name, status: "stopped" }` |
+| `POST /api/workflows/reload` | Admin `registry.reload()` + `scheduler.reconcile` |
+| `GET /api/pipelines` | Summaries; default-kind hidden unless `includeDefault=1` or `kind=default` |
+| `GET /api/pipelines/:runId` | Operator projection (leases, outbox without payload, gates, artifacts, …) |
+| `GET /api/pipelines/:runId/artifacts?ref=` | `{ ref, content, truncated }` — 256 KiB cap |
+| `GET /api/spend?from=&to=&groupBy=` | `{ from, to, totals, buckets }` |
+| `GET /api/runbooks` | List + catalog + metrics |
+| `GET /api/runbooks/:name` | Definition + catalog + metrics + git |
+| `GET /api/audit?action=&targetType=&from=&to=&limit=` | Newest-first audit rows (default 100, max 500) |
 | `GET /api/logs?date=YYYY-MM-DD&tail=N&tag=&level=` | Parsed entries from `logs/<date>.log` |
-| `GET /api/profiles[?kind=person|repo|project|situation]` | Derived profiles plus per-kind counts; inspection does not bump recall usage |
+| `GET /api/profiles[?kind=person\|repo\|project\|situation]` | Derived profiles plus per-kind counts; inspection does not bump recall usage |
 | `GET /api/memory` | List of `docs/**/*.md` paths |
 | `GET /api/memory/:path` | Contents of one doc file |
 | `GET /api/memory/recall?query=&tags=&kinds=&repo=&limit=` | Cosine-ranked claims; the route embeds the query, recall never records dashboard usage |
 | `GET /api/memory/projection[?refresh=1]` | `{ points[{id,x,y,z,kind,text,tags,repo,weight,createdAt,lastUsedAt}], edges[{a,b,sim}], facets{tags,kinds,repos} }` |
 
-`OPTIONS *` returns 204 (preflight handler kept for browsers that probe; no CORS headers attached). Unknown paths return JSON `{ error: "not found" }` 404. Handler exceptions log to the `http` tag and return JSON 500 — the bot does not die on a route bug.
+`OPTIONS *` returns 204 (preflight handler kept for browsers that probe; no CORS headers attached). Unknown paths return JSON `{ error: "not found" }` 404. Wrong method on a known `/api/*` path returns 405 `{ error: "method not allowed" }`. Handler exceptions log to the `http` tag and return JSON 500 — the bot does not die on a route bug. Mutations also log on the `dashboard` tag.
 
-The server also serves the locally pinned Three.js modules and pipeline worker
-under `/assets/`; these are fixed allowlisted paths, not a general static-file
-server.
+The server also serves the locally pinned Three.js modules and pipeline worker under `/assets/`; these are fixed allowlisted paths, not a general static-file server.
 
 ## Memory galaxy
 
@@ -103,30 +235,41 @@ HTTP_DASHBOARD_PORT=4567  # positive integer 1-65535. Unset = disabled.
 - Unset/empty → `{ enabled: false }`, `startHttpServer` is never called from `index.ts`.
 - Anything other than a positive integer in range throws at config load — better to fail boot than silently bind to a surprise port.
 - `Bun.serve` startup failures (port in use, permissions) are caught and logged; the bot continues without the dashboard.
+- Unsetting the port hides the UI. It does **not** stop `usage_events` / `dashboard_audit` writes; those are wired in `SessionManager`, `WorkflowExecutor`, and cleanup regardless of the port.
 
 ## Integration points
 
-- **`SessionStore` ([session-persistence.md](session-persistence.md), [session-management.md](session-management.md)).** All session reads go through the interface — sqlite in production, in-memory in dev/tests. `/api/health` and `/api/sessions` call `getAll()`; `/api/sessions/:id` calls `get(threadId)`. The detail route resolves the thread's Slack permalink on demand; Slack API failures leave the session readable with a null link. `agentSessions` is flattened into `agents[]` so the UI can render multi-agent threads without knowing the storage shape.
-- **`DevServerManager` ([process-lifecycle.md](process-lifecycle.md)).** `/api/dev-server` calls `manager.status()` for live `DevServerState` and `manager.getIdleTtlMs()` for the configured TTL (no hard-coded 20 min in the route — single source of truth).
-- **`DevServerQueue`.** `queue.readQueueDepth(repo)` supplies `{ holder, waiters }` so the dashboard can show "you're 3rd in line" parity with `!devserver status`.
-- **`WorkflowScheduler`.** `/api/workflows` uses the scheduler's process-local
-  active-run count for `displayStatus`. Persisted run history remains historical
-  evidence and is not treated as a liveness signal after restart.
-- **`PipelineStore`.** `/api/pipelines` reads durable product/bug pipeline
-  state; the route is read-only and does not dispatch or mutate runs.
-- **`logs/<date>.log`.** Written by `src/logger.ts`. The route is read-only and parses the same line format the logger emits (`<iso> [LEVEL] [tag] message`).
+- **`SessionStore` / `SessionManager` ([session-persistence.md](session-persistence.md), [session-management.md](session-management.md)).** Reads go through the store. Writes go through `injectDashboardContinue` and `interruptThread` — not a second spawn path. HTTP never talks to a runner CLI.
+- **`DevServerManager` ([process-lifecycle.md](process-lifecycle.md)).** `/api/dev-server` calls `manager.status()` and `manager.getIdleTtlMs()`.
+- **`DevServerQueue`.** `queue.readQueueDepth(repo)` supplies `{ holder, waiters }`.
+- **`WorkflowScheduler` / `WorkflowRegistry` ([dynamic-workflows.md](dynamic-workflows.md)).** List `displayStatus` uses the process-local active-run count. Dashboard run is `enqueueManualRun`; Slack keeps blocking `runNow`. Create/edit pause the registry, commit, then resume+reload.
+- **`PipelineStore`.** Operator reads only. The HTTP projector is `src/http/routes/pipelines.ts`; `src/pipelines/projection.ts` remains the Slack/`!status` human summary.
+- **`UsageStore`.** Always-on ledger in `data/sessions.db`. Dashboard queries it; capture does not depend on the port.
+- **`DashboardAuditStore`.** Same DB. Required once write routes exist (no 503).
+- **Runbook registry + `CatalogStore`.** View-only HTTP over the existing MCP/registry surface.
+- **`logs/<date>.log`.** Written by `src/logger.ts`. Read-only parse of `<iso> [LEVEL] [tag] message`.
 - **`docs/`.** Read-only doc browser, scoped to the project's `docs/` directory.
 
 ## Dependencies
 
-- [session-management.md](session-management.md) — shape of `ThreadSession` / `AgentSession` consumed by `/api/sessions`.
-- [session-persistence.md](session-persistence.md) — the `SessionStore` interface backing those reads.
-- [process-lifecycle.md](process-lifecycle.md) — `DevServerManager` / `DevServerQueue` invariants surfaced by `/api/dev-server`.
+- [session-management.md](session-management.md) — `ThreadSession` / inject / interrupt.
+- [session-persistence.md](session-persistence.md) — `SessionStore`.
+- [dynamic-workflows.md](dynamic-workflows.md) — registry, scheduler, git-backed definitions.
+- [process-lifecycle.md](process-lifecycle.md) — `DevServerManager` / `DevServerQueue` / operational cleanup.
+- [agent-product-debugging-pipeline-implementation-plan.md](agent-product-debugging-pipeline-implementation-plan.md) — typed run/assignment/outbox shape the swimlane reads.
 - `three` — locally served WebGL runtime for the memory graph.
 
 ## Cut list (true v2)
 
-- Auth (token, OAuth). Loopback binding is enough until junior runs on a multi-tenant host.
-- Server-Sent Events / WebSocket push for live updates. Today the UI polls.
-- Write endpoints (kill a session, evict a dev-server slot). Stays read-only — destructive ops go through Slack `!` commands so they're auditable.
-- Per-thread message-body view. `pendingMessages` lengths only, by design.
+- Auth (token, OAuth). Loopback binding is enough until junior runs on a multi-tenant host. A same-origin token would be theater.
+- Server-Sent Events / WebSocket push. The UI still polls (~2s).
+- Per-thread pending-message body view. Lengths only, by design.
+- Kill a worktree, evict a dev-server slot, or `!reset` / `!cancel` from the dashboard. Those stay Slack `!` commands.
+- Starting a new Slack thread from the dashboard. Continue existing sessions only.
+- Dashboard-authored runbooks, runbook PRs, or merging runbooks into the workflow registry.
+- Push / open a PR after a workflow commit. Commits stay local and unpushed.
+- Binding the dashboard off loopback.
+- Spend bar chart, estimated USD (`rates.ts`), or accurate cost for providers that do not emit `total_cost_usd`.
+- Pipeline writes (force-transition, replay outbox) from the dashboard.
+
+The previous cut-list line “write endpoints stay read-only — destructive ops go through Slack so they're auditable” is **superseded**. The compensating control is loopback + `dashboard_audit` + Slack posts where a destination exists. Workflow writes without a Slack output channel are an accepted weaker trail than Slack `!` commands.

--- a/docs/features/http-dashboard.md
+++ b/docs/features/http-dashboard.md
@@ -47,7 +47,7 @@ Junior is intentionally insecure as a networked product. The dashboard assumes a
 ## Security posture
 
 - **Loopback-only.** Binds `127.0.0.1` — never reachable off-host without an explicit SSH tunnel. This is the entire threat model; there is intentionally no auth layer behind it. Do not tunnel the port without adding auth.
-- **Writes are in scope.** Continue, stop, workflow run/start/stop/reload, and Git-backed create/edit are first-class. They do not invent a second control plane: they call `SessionManager` / `WorkflowScheduler` / the git helper the Slack path already uses.
+- **Writes are in scope.** Continue, stop, workflow run/start/stop/reload, and Git-backed create/edit are first-class. They do not invent a second session/workflow runtime: continue/stop go through `SessionManager` (`injectDashboardContinue` / `interruptThread`); run/start/stop reuse scheduler enablement and `canManage` checks. Dashboard **run** is `enqueueManualRun` — Slack `!workflow run` still blocks on `runNow`. Create/edit use a dashboard-only scoped git helper (`src/workflows/git-commit.ts`); Slack never commits workflow files.
 - **Audit is required, Slack-parity is not.** Every mutating call writes `dashboard_audit`. Session continue/stop also post to the Slack thread (conversation of record). Workflow mutations post a one-liner to a `slack` / `slack-thread` output **when the definition has one**. Workflows without an output channel leave only git + `dashboard_audit` — **weaker than Slack `!` commands**, accepted for a no-auth loopback console, and must not be documented as Slack-parity.
 - **Actor is loopback identity.** `ADMIN_SLACK_USER_ID` when set, else `dashboard-operator`. Fail closed when the `admins` table is non-empty but the env admin is unset. Open-mode (neither tier configured) matches Slack open-mode.
 - **Profiles are private operator data.** `/api/profiles` can include derived context about real people. It is available only inside the same loopback-only console and must not be exposed through a public bind or permissive CORS.
@@ -134,7 +134,7 @@ Default UI is an **assignment swimlane + phase tape**, not the 3D topology graph
 - `GET /api/pipelines/:runId` expands leases, full-run outbox **without payload**, outcomes, gates, GitHub resources, dev-server jobs, and artifact refs. No pipeline writes (no force-transition, no replay).
 - `GET /api/pipelines/:runId/artifacts?ref=` reads a path relative to `data/pipelines/<runId>/` only, 256 KiB cap. 400 on traversal, 404 if missing.
 
-Empty copy: “No typed pipeline runs. Default-run durability is hidden unless you enable it.”
+Empty copy: “No typed pipeline runs. Default-kind durability is hidden unless you enable it.”
 
 ## Spend ledger
 
@@ -235,7 +235,7 @@ HTTP_DASHBOARD_PORT=4567  # positive integer 1-65535. Unset = disabled.
 - Unset/empty → `{ enabled: false }`, `startHttpServer` is never called from `index.ts`.
 - Anything other than a positive integer in range throws at config load — better to fail boot than silently bind to a surprise port.
 - `Bun.serve` startup failures (port in use, permissions) are caught and logged; the bot continues without the dashboard.
-- Unsetting the port hides the UI. It does **not** stop `usage_events` / `dashboard_audit` writes; those are wired in `SessionManager`, `WorkflowExecutor`, and cleanup regardless of the port.
+- Unsetting the port hides the UI. Spend capture (`usage_events` from `SessionManager` / `WorkflowExecutor`) and 90-day/180-day retention deletes stay always-on. `dashboard_audit` **inserts** happen only when a mutating HTTP route runs; they do not fire when the dashboard is off. `cleanupOperationalTables` deletes old usage/audit rows — it does not write them.
 
 ## Integration points
 

--- a/docs/features/operator-dashboard-redesign.md
+++ b/docs/features/operator-dashboard-redesign.md
@@ -5,14 +5,14 @@
 | **Title** | Redesign Junior's HTML dashboard, HTTP API, and supporting codebase |
 | **Author** | Junior dashboard redesign |
 | **Date** | 2026-08-15 |
-| **Status** | Draft |
+| **Status** | Implemented. Current behavior lives in [http-dashboard.md](http-dashboard.md). This file is the design record. |
 | **Supersedes** | `docs/features/http-dashboard.md` cut list item "Write endpoints stay read-only". The localhost dashboard becomes a first-class operator control surface. Session continue/stop post to the Slack thread (parity with `!` commands). Workflow mutations write `dashboard_audit` and a git commit; they post to a workflow Slack output channel when one exists, and are otherwise an accepted weaker trail than Slack (loopback-only identity). |
 
 ---
 
 ## Overview
 
-The localhost dashboard (`HTTP_DASHBOARD_PORT`, binds `127.0.0.1`) is a trusted-operator console. Today it is almost entirely read-only: sessions list + a Slack permalink, a copy-paste resume CLI command, a thin workflow card list, a 3D pipeline dispatch graph that omits leases / artifacts / blockers / gates, no spend ledger, and no runbook browser. Mutations go through Slack so they stay auditable.
+The localhost dashboard (`HTTP_DASHBOARD_PORT`, binds `127.0.0.1`) is a trusted-operator console. **Baseline below (`main` @ `77076fe`, 2026-08-15) was almost entirely read-only:** sessions list + a Slack permalink, a copy-paste resume CLI command, a thin workflow card list, a 3D pipeline dispatch graph that omits leases / artifacts / blockers / gates, no spend ledger, and no runbook browser. Mutations went through Slack so they stayed auditable. That surface is what this redesign replaced; see [http-dashboard.md](http-dashboard.md) for what shipped.
 
 This redesign keeps the loopback threat model and the existing control plane. It adds five operator capabilities — continue a session, inspect a live pipeline, query token/cost spend, trigger/edit/create Git-backed workflows, and view runbooks — by extending the existing Bun HTTP server, session manager, workflow controller, pipeline store, and runbook registry. Dashboard-originated turns go through a new `SessionManager.injectDashboardContinue` that resolves the `junior`/`default`/`lead` alias, skips default-run hijack, and returns `{ accepted | buffered | muted }` — it does not call `handleAgentMessage("junior")` and does not invent a fire-and-forget result from void `handle*` methods. Workflow **trigger** uses a new `WorkflowScheduler.enqueueManualRun` (because `runNow` awaits the whole executor). Creates and edits write `*.workflow.md` files and make a scoped git commit only on a named branch. Every mutating call writes a durable audit row.
 
@@ -22,7 +22,7 @@ The UI stays a no-build vanilla operator console. `public/index.html` is already
 
 ## Background & Motivation
 
-### Current state (verified 2026-08-15, `main` @ `77076fe`)
+### Baseline before this work (verified 2026-08-15, `main` @ `77076fe`)
 
 | Surface | What exists | Gap |
 |---|---|---|
@@ -398,7 +398,7 @@ Justification:
 | Phase tape | One cell per `transitions[]` entry, labeled `toPhase`, width proportional to time until the next transition (last cell stretches to now). |
 | Pins | Blocker kinds on the assignment bar; `needs-human` run status is an amber pin on the tape. |
 | Click | Selects the assignment; the right rail shows objective, lease, dispatch, outcomes, artifact refs, gates for `run.activeAttemptId`. No “agent chat” pane in v1. |
-| Empty | “No typed pipeline runs. Default-run durability is hidden unless you enable it.” |
+| Empty | “No typed pipeline runs. Default-kind durability is hidden unless you enable it.” |
 
 ```mermaid
 flowchart LR
@@ -508,7 +508,7 @@ No pipeline writes from the dashboard in v1 (no force-transition, no replay outb
 
 ### UI states
 
-- Empty: "No typed pipeline runs. Default-run durability is hidden unless you enable it."
+- Empty: "No typed pipeline runs. Default-kind durability is hidden unless you enable it."
 - `runtimeMode=off` and no rows: same empty, plus a hint that controllers are off.
 - Loading detail: keep the current summary skeleton; do not blank the list.
 - Failed detail: "Failed to load run. Retry." (existing `pipelineDetailErrors` set).

--- a/docs/features/session-management.md
+++ b/docs/features/session-management.md
@@ -88,7 +88,7 @@ Admins: bootstrap one in `ADMIN_SLACK_USER_ID`; the rest live in the `admins` SQ
 ## Observability
 
 - Per-agent status pills stream via `onEvent` (see [stream-to-slack.md](stream-to-slack.md)).
-- HTTP dashboard reads `getRecent` and surfaces `defaultAgent` + `agentSessions`.
+- HTTP dashboard lists sessions via `store.getAll()` and `projectSession` (allowlist: numeric `pendingMessages`, `agents[]` without bodies/paths/`pid`; detail-only `resumeCwd`). See [http-dashboard.md](http-dashboard.md).
 - `!status` prints status, muted, agentType, defaultAgent, repo, worktree, last activity, pending count.
 
 ## Cleanup

--- a/docs/features/v2-backlog.md
+++ b/docs/features/v2-backlog.md
@@ -4,7 +4,7 @@ Features explicitly deferred from MVP. To be scoped when MVP is running.
 
 ## Admin Dashboard (DONE)
 
-**Status:** Completed as the [HTTP Dashboard](./http-dashboard.md). Surfaces live sessions, dev-server queue, workflows/pipelines, logs, docs, profiles, and memory projections.
+**Status:** Completed as the [HTTP Dashboard](./http-dashboard.md). Surfaces live sessions (allowlisted), a swimlane pipeline operator view, spend ledger, runbook viewer, audit log, logs, docs, profiles, and memory projections. Session continue/stop go through `SessionManager` and post to the Slack thread. Workflow enqueue/start/stop/reload/create/edit are loopback writes with `dashboard_audit`; they post to a workflow Slack output channel only when one exists — otherwise the trail is weaker than Slack `!` commands. Remaining dashboard items (auth, SSE, pending-body viewer, worktree/dev-server kill, push/PR) stay on that feature doc's cut list.
 
 ## Batch User Resolution in Thread Context
 
@@ -30,7 +30,7 @@ Features explicitly deferred from MVP. To be scoped when MVP is running.
 **Open questions:**
 - Should active sessions pin the identity/prompt version they started with, or adopt new identity data on the next turn?
 - Should invalid org overlays fail closed for private assets, or fall back to public defaults?
-- Which command surface owns this: a general `!org reload`, per-asset commands, or an admin dashboard action?
+- Which command surface owns this: a general `!org reload`, per-asset commands, or an admin dashboard action? (Workflow files already hot-reload via `fs.watch`, and the dashboard exposes `POST /api/workflows/reload` as the same diagnostic as `!workflow reload`. That does not extend to other org assets.)
 
 ## Per-agent mute
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -8,7 +8,7 @@ Do not expose Junior, its dashboard, or its MCP server to untrusted networks wit
 The [HTTP Dashboard](./features/http-dashboard.md) binds only to `127.0.0.1` by default.
 - **No Remote Access**: It is not reachable from the internet without an explicit SSH tunnel.
 - **No Auth by Design**: Because Junior assumes a trusted local operator, the dashboard does not include an authentication layer.
-- **No CORS Opt-in**: The dashboard does not emit CORS headers, so arbitrary websites cannot read API responses from a browser. The current dashboard is read-only; it does not validate `Origin` or `Sec-Fetch-Site` as a CSRF defense.
+- **No CORS Opt-in**: The dashboard does not emit CORS headers, so arbitrary websites cannot read API responses from a browser. It does not validate `Origin` or `Sec-Fetch-Site` as a CSRF defense. Writes (session continue/stop, workflow enqueue/edit) are allowed from any local process that can reach `127.0.0.1`; compensating controls are `dashboard_audit` plus Slack posts where a destination exists. Do not tunnel the port without adding auth.
 
 ## 2. Worktree Isolation
 Target repositories are never edited in their original paths.


### PR DESCRIPTION
Replace the read-only cut list with the loopback + audit contract.

Part of execute-plan `06ec4caa` (PR 7/7).