### PR TITLE
fix(dashboard): parse pipelines.js so renderPipelines exists

### DIFF
--- a/public/js/pipelines.js
+++ b/public/js/pipelines.js
@@ -730,7 +730,7 @@ function renderAssignmentRail(run, assignment) {
         const blockers = (outcome.blockers || []).map((blocker) => blocker.kind).join(", ");
         const checks = (outcome.checks || []).map((check) => check.name + ":" + check.status).join(", ");
         return '<div class="rail-item"><div class="meta">' + esc(outcome.action) + " · " +
-          esc(outcome.status) + "</div><div class="objective">' + esc(outcome.reason || "") +
+          esc(outcome.status) + '</div><div class="objective">' + esc(outcome.reason || "") +
           "</div>" +
           (blockers ? '<div class="meta">blockers ' + esc(blockers) + "</div>" : "") +
           (checks ? '<div class="meta">checks ' + esc(checks) + "</div>" : "") +

--- a/src/http/dashboard-html.test.ts
+++ b/src/http/dashboard-html.test.ts
@@ -100,4 +100,30 @@ describe("dashboard operator views", () => {
     expect(audit).toBeGreaterThan(runbooks);
     expect(app).toBeGreaterThan(audit);
   });
+
+  it("parses every public/js module so a quote typo cannot hide renderPipelines", async () => {
+    const files = [
+      "api.js",
+      "markdown.js",
+      "threads.js",
+      "workflows.js",
+      "pipeline-layout.js",
+      "pipelines.js",
+      "galaxy.js",
+      "spend.js",
+      "runbooks.js",
+      "audit.js",
+      "app.js",
+    ];
+    for (const name of files) {
+      const source = await Bun.file(resolve(publicDir, "js", name)).text();
+      try {
+        new Function(source);
+      } catch (err) {
+        throw new Error(`${name}: ${(err as Error).message}`);
+      }
+    }
+    const pipelines = await Bun.file(resolve(publicDir, "js/pipelines.js")).text();
+    expect(pipelines).toContain("function renderPipelines(");
+  });
 });


### PR DESCRIPTION
`public/js/pipelines.js` failed to parse because `class="objective"` sat inside a `"` string. The module never executed, so `renderPipelines` was undefined and the Pipelines view stayed on “loading pipeline control plane…”.

Hard refresh `http://localhost:4000/#pipelines` after this lands (or now, if the bot is serving this checkout).