### PR TITLE
fix(dashboard): declare pipelineViewMode before app.js boots

### DIFF
--- a/public/js/api.js
+++ b/public/js/api.js
@@ -139,6 +139,8 @@ var pipelineFetchError = null;
 var pipelineFetchGeneration = 0;
 var selectedPipelineId = null;
 var renderedPipelineListSignature = null;
+var pipelineViewMode = "swimlane";
+var renderedSwimlaneSignature = null;
 var logEntries = [];
 var logErrorCount = 0;
 var logFetchError = null;
@@ -286,7 +288,7 @@ async function refreshPipelineControlPlane() {
   applyAttentionPipelineResponse(attn);
   renderSidebar();
   renderOverview();
-  renderPipelines();
+  if (typeof renderPipelines === "function") renderPipelines();
   if (!response.ok && pipelines.length === 0) {
     $("pipeline-status").textContent = "Failed to load pipeline control plane.";
     $("pipeline-runs").innerHTML = '<div class="empty">Failed to load pipelines.</div>';
@@ -331,8 +333,8 @@ async function refreshMain() {
   renderDevServers();
   renderWorkflows();
   if (currentView() === "pipelines") {
-    renderPipelines();
-    await loadPipelineSpend();
+    if (typeof renderPipelines === "function") renderPipelines();
+    if (typeof loadPipelineSpend === "function") await loadPipelineSpend();
   }
   if (currentView() === "spend") await loadSpend();
   if (currentView() === "runbooks" && runbooksLoaded) await loadRunbooks();

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -6,11 +6,13 @@ function show(view) {
   if (view === "pipelines") {
     const pipelineId = hashQuery().get("id");
     if (pipelineId && !pipelineDetailErrors.has(pipelineId)) selectedPipelineId = pipelineId;
-    if (pipelineViewMode === "topology") {
+    if (pipelineViewMode === "topology" && typeof resizePipeline === "function") {
       resizePipeline();
       invalidatePipeline();
     }
-    if (pipelines.length || selectedPipelineId) renderPipelines();
+    if ((pipelines.length || selectedPipelineId) && typeof renderPipelines === "function") {
+      renderPipelines();
+    }
     void loadPipelineSpend();
   }
   if (view === "workflows") {

--- a/public/js/pipelines.js
+++ b/public/js/pipelines.js
@@ -15,13 +15,11 @@ const PIPE = {
   lastFrameAt: 0, needsRender: true, frameRequest: null,
   worker: null, layoutRequestId: 0, layoutResolvers: new Map(),
   buildGeneration: 0, buildingSignature: null,
-  width: 1, height: 1, target: new THREE.Vector3(),
+  width: 1, height: 1, target: null,
   yaw: 0, pitch: 0, distance: 14, desiredDistance: 14,
   drag: null,
 };
 const pipelineColor = (status) => PIPELINE_COLORS[status] || 0x999999;
-var pipelineViewMode = "swimlane";
-var renderedSwimlaneSignature = null;
 
 function pipelineEmptyCopy() {
   const copy = "No typed pipeline runs. Default-kind durability is hidden unless you enable it.";
@@ -54,6 +52,7 @@ function setPipelineViewMode(mode) {
 
 function ensurePipelineRenderer() {
   if (PIPE.renderer) return;
+  if (!PIPE.target) PIPE.target = new THREE.Vector3();
   PIPE.renderer = new THREE.WebGLRenderer({
     canvas: PIPE.canvas, antialias: true, alpha: true, powerPreference: "high-performance",
   });

--- a/src/http/dashboard-html.test.ts
+++ b/src/http/dashboard-html.test.ts
@@ -125,5 +125,9 @@ describe("dashboard operator views", () => {
     }
     const pipelines = await Bun.file(resolve(publicDir, "js/pipelines.js")).text();
     expect(pipelines).toContain("function renderPipelines(");
+    const api = await Bun.file(resolve(publicDir, "js/api.js")).text();
+    expect(api).toMatch(/var pipelineViewMode = "swimlane"/);
+    expect(pipelines).not.toMatch(/var pipelineViewMode/);
+    expect(pipelines).toMatch(/target:\s*null/);
   });
 });


### PR DESCRIPTION
`show()` in `app.js` reads `pipelineViewMode` on boot. The binding lived in `pipelines.js` after `new THREE.Vector3()`, so if that file aborted the Pipelines view threw `pipelineViewMode is not defined`.

Move the flag into `api.js` (first script) and construct the camera target only when topology is actually opened.

Hard-refresh `#pipelines` after this lands (or now if the bot serves this checkout).