### PR TITLE
fix: automatically dispatch repo-less Mongo reads

### DIFF
--- a/docs/code_index/mcp-server.md
+++ b/docs/code_index/mcp-server.md
@@ -30,7 +30,7 @@ operations using the bot token and signed run context.
 | `agent_search` | Junior internal | — | `query`, `include_public`, `include_private`, `limit` |
 | `reload_agent_registry` | Junior internal | — | — |
 | `slack_send_dm` | Slack Web API | `user_id`, `text` | identity fields |
-| `agent_dispatch` | Junior internal | agent, prompt, thread context | repo refs, `workspace_mode: repo-less` for Mongo-only reads, synthetic user/timestamp |
+| `agent_dispatch` | Junior internal | agent, prompt, thread context | repo refs; automatic repo-less isolation for Mongo-read agents with no repo, optional explicit `workspace_mode`; synthetic user/timestamp |
 | `memory_recall` / `memory_add` / `memory_consolidate` | Memory v3 | tool-specific | filters/options; `fact_kinds` exposes procedure/routing/curated-fact subtypes |
 | `runbook_select` | Runbooks + Memory v3 | `request` | Select reviewed runbook; on miss perform procedure-memory recall |
 | `github_read_pr_review_state` / `github_post_review` | Fixed GitHub API surface | review-specific | inline comments |

--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -120,10 +120,13 @@ human-input recovery assignment can retry an escalated run with corrected
 `repo_refs`; default runs resume to `working`, while typed runs require an
 explicit legal `to_phase`.
 
-For a bounded MongoDB read, a target with the `mongodb-read` capability may be
-dispatched with `workspace_mode: "repo-less"`. That assignment receives only
-the MongoDB capability envelope, an empty mutation scope, and no target-repo
-worktree; code or migration work continues to require managed mode.
+For a bounded MongoDB read, a target with the `mongodb-read` capability is
+automatically dispatched repo-less when the run and dispatch contain no
+repository refs and `workspace_mode` is omitted. The caller may also request
+`workspace_mode: "repo-less"` explicitly. That assignment receives only the
+MongoDB capability envelope, an empty mutation scope, and no target-repo
+worktree. Explicit `workspace_mode: "managed"`, or any bound/requested
+repository ref, preserves managed worktree behavior for code and migrations.
 
 ### WhatsApp tools
 

--- a/src/mcp/slack-server.ts
+++ b/src/mcp/slack-server.ts
@@ -989,7 +989,7 @@ export function registerTools(server: McpServer, runContext: SlackMcpRunContext 
         artifact_refs: z.array(z.string()).optional().describe("Durable artifact references inherited by the child assignment"),
         acceptance_criteria: z.array(z.string()).optional().describe("Acceptance criteria for the child assignment"),
         repo_refs: z.array(z.string().min(1).max(200)).max(20).optional().describe("Repositories to validate and atomically bind to the durable run before dispatch"),
-        workspace_mode: z.enum(["managed", "repo-less"]).optional().describe("Use repo-less only for a read-only MongoDB lookup that does not need repository files; managed is the default."),
+        workspace_mode: z.enum(["managed", "repo-less"]).optional().describe("MongoDB-read agents automatically use repo-less mode when no repository is bound. Set managed for repository code or migrations, or repo-less explicitly for a bounded read."),
         channel_id: z.string().optional().describe("Deprecated; authenticated channel is derived from signed context"),
         thread_ts: z.string().optional().describe("Deprecated; authenticated thread is derived from signed context"),
         user_id: z.string().optional().describe("User id to record on the synthetic internal event (default: mcp-internal)"),

--- a/src/pipelines/tools-dispatch.test.ts
+++ b/src/pipelines/tools-dispatch.test.ts
@@ -137,12 +137,13 @@ describe("durable agent_dispatch", () => {
     };
     await sessions.set(THREAD, session);
 
-    const result = body(await pipelineDispatchAgent({
+    const runtime: PipelineToolRuntime = {
       store,
       sessionStore: sessions,
       runtimeMode: "active",
       githubTrackingEnabled: false,
-    }, {
+    };
+    const context = {
       agent: "default",
       channel: CHANNEL,
       threadId: THREAD,
@@ -150,7 +151,19 @@ describe("durable agent_dispatch", () => {
       assignmentId: started.assignment.id,
       dispatchKey: "repo-less-dispatch",
       signed: true,
-    }, {
+    } as const;
+    const invalidRepoLess = body(await pipelineDispatchAgent(runtime, context, {
+      target_agent: "build",
+      objective: "Implement the scoped change",
+      mode: "delegate",
+      reason: "The plan is ready",
+      idempotency_key: "invalid-repo-less-build",
+      workspace_mode: "repo-less",
+    }));
+    expect(invalidRepoLess.ok).toBe(false);
+    expect(invalidRepoLess.reason).toContain("without the mongodb-read capability");
+
+    const result = body(await pipelineDispatchAgent(runtime, context, {
       target_agent: "build",
       objective: "Implement the scoped change",
       mode: "delegate",
@@ -172,7 +185,7 @@ describe("durable agent_dispatch", () => {
     expect(await store.listAssignments(started.run.id)).toHaveLength(1);
   });
 
-  it("dispatches a MongoDB-only assignment without provisioning a repository", async () => {
+  it("automatically dispatches a MongoDB-only assignment without provisioning a repository", async () => {
     const store = new InMemoryPipelineStore();
     const sessions = new InMemorySessionStore();
     const started = await createDefaultRun(
@@ -214,7 +227,6 @@ describe("durable agent_dispatch", () => {
       mode: "delegate",
       reason: "The answer requires a production read",
       idempotency_key: "member-roadmap-read",
-      workspace_mode: "repo-less",
     }));
 
     expect(result.ok).toBe(true);
@@ -225,6 +237,88 @@ describe("durable agent_dispatch", () => {
       mutationScope: [],
       contextRefs: expect.arrayContaining(["workspace-mode:repo-less"]),
     });
+  });
+
+  it("preserves managed worktree behavior for MongoDB agents when explicitly requested or repo-backed", async () => {
+    async function setup(dispatchKey: string, repoRefs: string[] = []) {
+      const store = new InMemoryPipelineStore();
+      const sessions = new InMemorySessionStore();
+      const started = await createDefaultRun(
+        { store },
+        {
+          channelId: CHANNEL,
+          threadId: THREAD,
+          objective: "inspect data while working in the repository",
+          messageTs: "1700000000.105",
+          targetAgent: "default",
+          repoRefs,
+        },
+      );
+      const session = createSession(THREAD, CHANNEL);
+      session.activePipelineInvocation = {
+        runId: started.run.id,
+        assignmentId: started.assignment.id,
+        dispatchKey,
+        outcomeCountAtDispatch: 0,
+        retryCount: 0,
+      };
+      await sessions.set(THREAD, session);
+      return { store, sessions, started };
+    }
+
+    const managed = await setup("managed-mongo");
+    const rejected = body(await pipelineDispatchAgent({
+      store: managed.store,
+      sessionStore: managed.sessions,
+      runtimeMode: "active",
+      githubTrackingEnabled: false,
+    }, {
+      agent: "default",
+      channel: CHANNEL,
+      threadId: THREAD,
+      runId: managed.started.run.id,
+      assignmentId: managed.started.assignment.id,
+      dispatchKey: "managed-mongo",
+      signed: true,
+    }, {
+      target_agent: "db-executioner",
+      objective: "Run a migration from the managed repository",
+      mode: "delegate",
+      reason: "Repository execution is required",
+      idempotency_key: "managed-mongo",
+      workspace_mode: "managed",
+    }));
+    expect(rejected.ok).toBe(false);
+    expect(rejected.reason).toContain("retry agent_dispatch with repo_refs");
+
+    const repoBacked = await setup("repo-backed-mongo", ["GrowthX-Club/gx-backend"]);
+    const accepted = body(await pipelineDispatchAgent({
+      store: repoBacked.store,
+      sessionStore: repoBacked.sessions,
+      runtimeMode: "active",
+      githubTrackingEnabled: false,
+    }, {
+      agent: "default",
+      channel: CHANNEL,
+      threadId: THREAD,
+      runId: repoBacked.started.run.id,
+      assignmentId: repoBacked.started.assignment.id,
+      dispatchKey: "repo-backed-mongo",
+      signed: true,
+    }, {
+      target_agent: "db-executioner",
+      objective: "Inspect data in the context of the repository",
+      mode: "delegate",
+      reason: "Repository context is already bound",
+      idempotency_key: "repo-backed-mongo",
+    }));
+    expect(accepted.ok).toBe(true);
+    expect(await repoBacked.store.getAssignment(accepted.targetAssignmentId as string))
+      .toMatchObject({
+        targetAgent: "db-executioner",
+        capabilityRefs: [],
+        mutationScope: ["worktree-code"],
+      });
   });
 
   it("dispatches the repo-less onboarding agent without repository refs", async () => {

--- a/src/pipelines/tools.ts
+++ b/src/pipelines/tools.ts
@@ -769,8 +769,8 @@ export async function pipelineDispatchAgent(
       true,
     );
   }
-  const repoLessAssignment = args.workspace_mode === "repo-less";
-  if (repoLessAssignment && !hasCapability(target, "mongodb-read")) {
+  const explicitlyRepoLess = args.workspace_mode === "repo-less";
+  if (explicitlyRepoLess && !hasCapability(target, "mongodb-read")) {
     return textResult(
       {
         ok: false,
@@ -785,6 +785,11 @@ export async function pipelineDispatchAgent(
   const effectiveRepoRefs = [
     ...new Set([...run.repoRefs, ...requestedRepoRefs]),
   ];
+  const repoLessAssignment = explicitlyRepoLess ||
+    (args.workspace_mode === undefined &&
+      effectiveRepoRefs.length === 0 &&
+      requiresManagedWorktree(target) &&
+      hasCapability(target, "mongodb-read"));
   if (runtime.repos) {
     const resolution = resolvePipelineRepos(runtime.repos, effectiveRepoRefs);
     if (resolution.unresolvedRefs.length > 0) {


### PR DESCRIPTION
## Summary
- Fix automatic repo-less dispatch for `db-executioner`; repo-less support was opt-in, and the orchestrator omitted `workspace_mode`, causing managed-worktree rejection.
- Derive repo-less mode only when `workspace_mode` is omitted and there are no effective repository refs.
- Preserve managed behavior for explicit `managed` requests and all repository-bound code or migration work.

## Test plan
- [x] `bun run typecheck` (twice)
- [x] `bun test src/pipelines/tools-dispatch.test.ts src/mcp/slack-server.test.ts` (twice; 29 passed each run)