### PR TITLE
feat: route Codex approvals through Slack

### DIFF
--- a/docs/code_index/codex-app-server.md
+++ b/docs/code_index/codex-app-server.md
@@ -45,7 +45,9 @@ errors, timeouts, and handler failures all deny the request and clear the
 resolver. Each pending approval is also owned by the provider process: process
 exit or an explicit stop aborts the resolver, disables any stored actions, and
 removes the Slack buttons before a late click can grant access. JSON-RPC
-responses are not written after the process enters a terminal state.
+responses are not written after the process enters a terminal state. Ordinary
+approval timeout/default-deny settlement performs the same idempotent action
+disablement and button removal.
 
 Codex continuity is provider-native and optional. Durable session, workflow,
 pipeline, and artifact state remains authoritative when a process or provider

--- a/docs/code_index/codex-app-server.md
+++ b/docs/code_index/codex-app-server.md
@@ -12,6 +12,7 @@ not the same as the historical standalone `src/codex` runner plan.
 | Protocol parsing | `src/codex-app-server/parser.ts` | Parses JSONL app-server messages into normalized events. |
 | Configuration | `src/codex-app-server/config.ts` | Builds app-server launch and MCP configuration. |
 | Policy | `src/codex-app-server/policy.ts` | Maps sandbox, approval, search, and agent policy to Codex options. |
+| Slack approval bridge | `src/mcp/slack-approval-bridge.ts`, `src/mcp/approval.ts` | Converts native app-server approval callbacks into blocking Slack Allow/Deny actions and defaults closed. |
 | Shared boundary | `src/runners/types.ts`, `src/runners/index.ts` | Provider-neutral `SpawnHandle`, events, resume, and provider selection. |
 
 ## Configuration
@@ -32,6 +33,12 @@ before starting or resuming a thread.
 Generated Codex config sets `[features].multi_agent = false`; provider-native
 subagents would bypass Junior's durable assignment, context, and settlement
 contracts.
+
+Native `requestApproval` server callbacks are not auto-denied. The provider
+posts a scoped Allow/Deny action in the originating Slack thread, waits on the
+same in-process resolver used by Claude's permission tool, and returns the
+human decision to app-server. Missing context, post/store errors, timeouts, and
+handler failures all deny the request.
 
 Codex continuity is provider-native and optional. Durable session, workflow,
 pipeline, and artifact state remains authoritative when a process or provider

--- a/docs/code_index/codex-app-server.md
+++ b/docs/code_index/codex-app-server.md
@@ -37,8 +37,12 @@ contracts.
 Native `requestApproval` server callbacks are not auto-denied. The provider
 posts a scoped Allow/Deny action in the originating Slack thread, waits on the
 same in-process resolver used by Claude's permission tool, and returns the
-human decision to app-server. Missing context, post/store errors, timeouts, and
-handler failures all deny the request.
+human decision using the exact callback schema: command and file callbacks
+return `decision`, while permissions callbacks return the granted requested
+`permissions` for the current turn. The pending resolver is registered before
+the message or action records can become clickable. Missing context, post/store
+errors, timeouts, and handler failures all deny the request and clear the
+resolver.
 
 Codex continuity is provider-native and optional. Durable session, workflow,
 pipeline, and artifact state remains authoritative when a process or provider

--- a/docs/code_index/codex-app-server.md
+++ b/docs/code_index/codex-app-server.md
@@ -42,7 +42,10 @@ return `decision`, while permissions callbacks return the granted requested
 `permissions` for the current turn. The pending resolver is registered before
 the message or action records can become clickable. Missing context, post/store
 errors, timeouts, and handler failures all deny the request and clear the
-resolver.
+resolver. Each pending approval is also owned by the provider process: process
+exit or an explicit stop aborts the resolver, disables any stored actions, and
+removes the Slack buttons before a late click can grant access. JSON-RPC
+responses are not written after the process enters a terminal state.
 
 Codex continuity is provider-native and optional. Durable session, workflow,
 pipeline, and artifact state remains authoritative when a process or provider

--- a/docs/code_index/mcp-server.md
+++ b/docs/code_index/mcp-server.md
@@ -44,6 +44,7 @@ operations using the bot token and signed run context.
 | `.mcp.json` | Root config contains `slack-bot`, Figma, and Notion servers. Per-agent generated configs add Playwright/MongoDB as needed. |
 | `.claude/settings.json` | `permissions.allow: ["mcp__slack-bot__*"]` |
 | `src/claude/spawner.ts` | Passes `--mcp-config` for worktree spawns |
+| `src/codex-app-server/spawner.ts` | Routes native approval callbacks through the shared Slack approval bridge |
 
 ## Key Concepts
 

--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -98,7 +98,8 @@ Status pill updates that agents post mid-run go through `slack_send_message` wit
   delivery/storage errors, expiry, or handler failure defaults to denial and
   resolver cleanup. Codex process exit and explicit stop also cancel the
   approval, disable its stored actions, and remove its buttons; a delayed Slack
-  decision cannot outlive the provider process that requested it.
+  decision cannot outlive the provider process that requested it. An ordinary
+  approval timeout/default deny performs the same idempotent cleanup.
 - MongoDB MCP uses `MDB_MCP_CONNECTION_STRING` from the process environment.
   `.env.example` includes a placeholder; real values belong only in local
   `.env` or secret managers. Junior exposes a shared read-only HTTP proxy at

--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -96,7 +96,9 @@ Status pill updates that agents post mid-run go through `slack_send_message` wit
   methods retain their native response contracts (`decision` for command/file,
   requested `permissions` for permissions). Missing Slack context,
   delivery/storage errors, expiry, or handler failure defaults to denial and
-  resolver cleanup.
+  resolver cleanup. Codex process exit and explicit stop also cancel the
+  approval, disable its stored actions, and remove its buttons; a delayed Slack
+  decision cannot outlive the provider process that requested it.
 - MongoDB MCP uses `MDB_MCP_CONNECTION_STRING` from the process environment.
   `.env.example` includes a placeholder; real values belong only in local
   `.env` or secret managers. Junior exposes a shared read-only HTTP proxy at

--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -91,9 +91,12 @@ Status pill updates that agents post mid-run go through `slack_send_message` wit
   `OPENCODE_MIXPANEL_MCP_ENABLED=false`.
 - Human-gated Codex app-server commands use the same blocking Slack Allow/Deny
   actions and pending-approval registry as Claude's permission prompt tool.
-  Missing Slack context, delivery/storage errors, expiry, or handler failure
-  defaults to denial; the adapter no longer unconditionally rejects native
-  `requestApproval` callbacks.
+  The registry entry exists before a prompt can become actionable, preventing
+  immediate clicks from racing resolver setup. Exact app-server callback
+  methods retain their native response contracts (`decision` for command/file,
+  requested `permissions` for permissions). Missing Slack context,
+  delivery/storage errors, expiry, or handler failure defaults to denial and
+  resolver cleanup.
 - MongoDB MCP uses `MDB_MCP_CONNECTION_STRING` from the process environment.
   `.env.example` includes a placeholder; real values belong only in local
   `.env` or secret managers. Junior exposes a shared read-only HTTP proxy at

--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -89,6 +89,11 @@ Status pill updates that agents post mid-run go through `slack_send_message` wit
   OpenCode session is `feature-metrics`, using Mixpanel's official hosted MCP
   through `npx -y mcp-remote https://mcp.mixpanel.com/mcp`. Disable with
   `OPENCODE_MIXPANEL_MCP_ENABLED=false`.
+- Human-gated Codex app-server commands use the same blocking Slack Allow/Deny
+  actions and pending-approval registry as Claude's permission prompt tool.
+  Missing Slack context, delivery/storage errors, expiry, or handler failure
+  defaults to denial; the adapter no longer unconditionally rejects native
+  `requestApproval` callbacks.
 - MongoDB MCP uses `MDB_MCP_CONNECTION_STRING` from the process environment.
   `.env.example` includes a placeholder; real values belong only in local
   `.env` or secret managers. Junior exposes a shared read-only HTTP proxy at

--- a/src/codex-app-server/spawner.test.ts
+++ b/src/codex-app-server/spawner.test.ts
@@ -90,6 +90,69 @@ describe("spawnCodexAppServer", () => {
     });
   }
 
+  it("cancels an outstanding approval when app-server exits", async () => {
+    const fakeCodex = installFakeCodex(exitingApprovalFakeCodexScript());
+    process.env.CODEX_BIN = fakeCodex.command;
+    const rows: CreateSlackActionRecord[] = [];
+    const disabled: Array<[string, string]> = [];
+    const store = {
+      createMany: mock(async (records: CreateSlackActionRecord[]) => {
+        rows.push(...records);
+      }),
+      disableMessageActions: mock(async (channel: string, messageTs: string) => {
+        disabled.push([channel, messageTs]);
+      }),
+    } as unknown as SlackActionStore;
+    const update = mock(async () => ({ ok: true }));
+    const client = {
+      chat: {
+        postMessage: mock(async () => ({ ok: true, ts: "10.20" })),
+        update,
+      },
+    } as unknown as WebClient;
+    configureSlackApprovalBridge(client, store);
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      const session = createSession("thread-approval-exit", "C01");
+      session.provider = "codex-app-server";
+      const config = {
+        ...testConfig,
+        codex: {
+          ...testConfig.codex,
+          isolatedHomePath: join(fakeCodex.root, "codex-home"),
+        },
+      };
+      await spawnCodexAppServer(session, "needs approval", config).result;
+      await Bun.sleep(25);
+
+      expect(rows).toHaveLength(2);
+      const allow = rows.find((row) =>
+        row.action.type === "request_permission" && row.action.decision === "allow"
+      );
+      if (allow?.action.type !== "request_permission") {
+        throw new Error("missing allow action");
+      }
+      expect(resolvePendingApproval(allow.action.approvalToken, "allow")).toBe(false);
+      expect(disabled).toEqual([["C01", "10.20"]]);
+      expect(update).toHaveBeenCalledWith({
+        channel: "C01",
+        ts: "10.20",
+        text: expect.any(String),
+        blocks: [],
+      });
+      const messages = readFileSync(join(fakeCodex.root, "requests.jsonl"), "utf8")
+        .trim().split("\n").map((line) => JSON.parse(line));
+      expect(messages.some((message) => message.id === 900 && !message.method)).toBe(false);
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+      fakeCodex.cleanup();
+    }
+  });
+
   it("fails pending JSON-RPC requests when the process exits before responding", async () => {
     const fakeCodex = installFakeCodex();
     process.env.CODEX_BIN = fakeCodex.command;
@@ -397,6 +460,45 @@ rl.on("line", (line) => {
       params: { thread: { id: "thread-created" }, finalResponse: "done" },
     });
     setTimeout(() => process.exit(0), 10);
+  }
+});
+`;
+}
+
+function exitingApprovalFakeCodexScript(): string {
+  return `#!/usr/bin/env node
+const fs = require("node:fs");
+const readline = require("node:readline");
+const root = __ROOT__;
+const requestsPath = root + "/requests.jsonl";
+const rl = readline.createInterface({ input: process.stdin });
+
+function send(message) {
+  process.stdout.write(JSON.stringify(message) + "\\n");
+}
+
+rl.on("line", (line) => {
+  const request = JSON.parse(line);
+  fs.appendFileSync(requestsPath, JSON.stringify(request) + "\\n");
+  if (request.method === "initialize") {
+    send({ jsonrpc: "2.0", id: request.id, result: {} });
+  } else if (request.method === "thread/start") {
+    send({ jsonrpc: "2.0", id: request.id, result: { thread: { id: "thread-created" } } });
+  } else if (request.method === "turn/start") {
+    send({ jsonrpc: "2.0", id: request.id, result: { turn: { id: "turn-created" } } });
+    send({
+      jsonrpc: "2.0",
+      id: 900,
+      method: "item/commandExecution/requestApproval",
+      params: {
+        threadId: "thread-created",
+        turnId: "turn-created",
+        itemId: "item-approval",
+        startedAtMs: 1,
+        command: "git fetch",
+      },
+    });
+    setTimeout(() => process.exit(17), 20);
   }
 });
 `;

--- a/src/codex-app-server/spawner.test.ts
+++ b/src/codex-app-server/spawner.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it, mock } from "bun:test";
 import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -6,10 +6,15 @@ import type { Config } from "../config.ts";
 import { createSession } from "../session/types.ts";
 import { resolveCodexModel, spawnCodexAppServer } from "./spawner.ts";
 import { resolveTrustedSkill } from "../skills/registry.ts";
+import { configureSlackApprovalBridge } from "../mcp/slack-approval-bridge.ts";
+import { resolvePendingApproval } from "../mcp/approval.ts";
+import type { CreateSlackActionRecord, SlackActionStore } from "../slack/action-store.ts";
+import type { WebClient } from "@slack/web-api";
 
 const originalCodexBin = process.env.CODEX_BIN;
 
 afterEach(() => {
+  configureSlackApprovalBridge(undefined, undefined);
   if (originalCodexBin == null) {
     delete process.env.CODEX_BIN;
   } else {
@@ -18,6 +23,73 @@ afterEach(() => {
 });
 
 describe("spawnCodexAppServer", () => {
+  const approvalCases = [
+    {
+      method: "item/commandExecution/requestApproval",
+      params: { command: "git fetch" },
+      expected: { decision: "accept" },
+    },
+    {
+      method: "item/fileChange/requestApproval",
+      params: { reason: "edit source" },
+      expected: { decision: "accept" },
+    },
+    {
+      method: "item/permissions/requestApproval",
+      params: { permissions: { network: { enabled: true } } },
+      expected: {
+        permissions: { network: { enabled: true } },
+        scope: "turn",
+      },
+    },
+  ] as const;
+
+  for (const approvalCase of approvalCases) {
+    it(`returns the protocol response for ${approvalCase.method}`, async () => {
+      const fakeCodex = installFakeCodex(approvalFakeCodexScript(
+        approvalCase.method,
+        approvalCase.params,
+      ));
+      process.env.CODEX_BIN = fakeCodex.command;
+      const store = {
+        createMany: mock(async (records: CreateSlackActionRecord[]) => {
+          const allow = records.find((row) =>
+            row.action.type === "request_permission" && row.action.decision === "allow"
+          );
+          if (allow?.action.type !== "request_permission") {
+            throw new Error("missing allow action");
+          }
+          resolvePendingApproval(allow.action.approvalToken, "allow");
+        }),
+      } as unknown as SlackActionStore;
+      const client = {
+        chat: { postMessage: mock(async () => ({ ok: true, ts: "10.20" })) },
+      } as unknown as WebClient;
+      configureSlackApprovalBridge(client, store);
+
+      try {
+        const session = createSession("thread-approval", "C01");
+        session.provider = "codex-app-server";
+        const config = {
+          ...testConfig,
+          codex: {
+            ...testConfig.codex,
+            isolatedHomePath: join(fakeCodex.root, "codex-home"),
+          },
+        };
+        const result = await spawnCodexAppServer(session, "needs approval", config).result;
+        expect(result.error).toBeNull();
+
+        const messages = readFileSync(join(fakeCodex.root, "requests.jsonl"), "utf8")
+          .trim().split("\n").map((line) => JSON.parse(line));
+        const response = messages.find((message) => message.id === 900 && !message.method);
+        expect(response).toEqual({ jsonrpc: "2.0", id: 900, result: approvalCase.expected });
+      } finally {
+        fakeCodex.cleanup();
+      }
+    });
+  }
+
   it("fails pending JSON-RPC requests when the process exits before responding", async () => {
     const fakeCodex = installFakeCodex();
     process.env.CODEX_BIN = fakeCodex.command;
@@ -272,6 +344,57 @@ rl.on("line", (line) => {
       jsonrpc: "2.0",
       method: "turn/completed",
       params: { thread: { id: "thread-created" }, finalResponse: "done after fallback" },
+    });
+    setTimeout(() => process.exit(0), 10);
+  }
+});
+`;
+}
+
+function approvalFakeCodexScript(
+  method: string,
+  extraParams: Record<string, unknown>,
+): string {
+  return `#!/usr/bin/env node
+const fs = require("node:fs");
+const readline = require("node:readline");
+const root = __ROOT__;
+const requestsPath = root + "/requests.jsonl";
+const rl = readline.createInterface({ input: process.stdin });
+const method = ${JSON.stringify(method)};
+const extraParams = ${JSON.stringify(extraParams)};
+
+function send(message) {
+  process.stdout.write(JSON.stringify(message) + "\\n");
+}
+
+rl.on("line", (line) => {
+  const request = JSON.parse(line);
+  fs.appendFileSync(requestsPath, JSON.stringify(request) + "\\n");
+  if (request.method === "initialize") {
+    send({ jsonrpc: "2.0", id: request.id, result: {} });
+  } else if (request.method === "thread/start") {
+    send({ jsonrpc: "2.0", id: request.id, result: { thread: { id: "thread-created" } } });
+  } else if (request.method === "turn/start") {
+    send({ jsonrpc: "2.0", id: request.id, result: { turn: { id: "turn-created" } } });
+    send({
+      jsonrpc: "2.0",
+      id: 900,
+      method,
+      params: {
+        threadId: "thread-created",
+        turnId: "turn-created",
+        itemId: "item-approval",
+        startedAtMs: 1,
+        ...extraParams,
+        ...(method === "item/permissions/requestApproval" ? { cwd: process.cwd() } : {}),
+      },
+    });
+  } else if (request.id === 900) {
+    send({
+      jsonrpc: "2.0",
+      method: "turn/completed",
+      params: { thread: { id: "thread-created" }, finalResponse: "done" },
     });
     setTimeout(() => process.exit(0), 10);
   }

--- a/src/codex-app-server/spawner.ts
+++ b/src/codex-app-server/spawner.ts
@@ -91,6 +91,8 @@ export function spawnCodexAppServer(
   let activeTurnId: string | null = null;
   let processKilled = false;
   let processExitError: Error | null = null;
+  let acceptsServerResponses = true;
+  const approvalControllers = new Set<AbortController>();
 
   const emit = (event: RunnerEvent) => {
     events.push(event);
@@ -126,16 +128,34 @@ export function spawnCodexAppServer(
     proc.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`);
   };
 
-  const respond = (id: number, result: Record<string, unknown>) => {
-    proc.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`);
+  const respond = (id: number, result: Record<string, unknown>): boolean => {
+    if (!acceptsServerResponses || processExitError) return false;
+    try {
+      const write = proc.stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`);
+      if (write instanceof Promise) {
+        void write.catch((err) => {
+          terminatePending(err instanceof Error ? err : new Error(String(err)));
+        });
+      }
+      return true;
+    } catch (err) {
+      terminatePending(err instanceof Error ? err : new Error(String(err)));
+      return false;
+    }
+  };
+
+  const terminatePending = (err: Error) => {
+    acceptsServerResponses = false;
+    processExitError ??= err;
+    for (const controller of approvalControllers) controller.abort();
+    approvalControllers.clear();
+    rejectPending(pending, processExitError);
   };
 
   proc.exited.then((exitCode) => {
-    processExitError = new Error(`Codex app-server exited before replying to pending requests (exit ${exitCode})`);
-    rejectPending(pending, processExitError);
+    terminatePending(new Error(`Codex app-server exited before replying to pending requests (exit ${exitCode})`));
   }).catch(() => {
-    processExitError = new Error("Codex app-server exited before replying to pending requests");
-    rejectPending(pending, processExitError);
+    terminatePending(new Error("Codex app-server exited before replying to pending requests"));
   });
 
   const stdoutDone = consumeStdout(proc.stdout, (message) => {
@@ -147,12 +167,15 @@ export function spawnCodexAppServer(
     if ("id" in message && typeof message.id === "number" && typeof message.method === "string") {
       const method = message.method;
       if (isApprovalRequestMethod(method)) {
+        const controller = new AbortController();
+        approvalControllers.add(controller);
         void requestSlackApproval({
           channel: session.channel,
           threadTs: session.threadId,
           agent: session.activeAgentName ?? session.agentType ?? "default",
           toolName: approvalToolName(method, message.params),
           input: message.params,
+          signal: controller.signal,
         }).then((approved) => {
           respond(
             message.id as number,
@@ -163,6 +186,8 @@ export function spawnCodexAppServer(
             message.id as number,
             approvalResponse(method, message.params, false),
           );
+        }).finally(() => {
+          approvalControllers.delete(controller);
         });
       } else {
         respond(message.id, responseForServerRequest(method));
@@ -290,6 +315,9 @@ export function spawnCodexAppServer(
       listeners.push(cb);
     },
     kill: (signal) => {
+      acceptsServerResponses = false;
+      for (const controller of approvalControllers) controller.abort();
+      approvalControllers.clear();
       if (
         signal === "SIGINT" &&
         config.codex.appServerContinuityEnabled &&

--- a/src/codex-app-server/spawner.ts
+++ b/src/codex-app-server/spawner.ts
@@ -145,19 +145,27 @@ export function spawnCodexAppServer(
     }
 
     if ("id" in message && typeof message.id === "number" && typeof message.method === "string") {
-      if (message.method.includes("requestApproval")) {
+      const method = message.method;
+      if (isApprovalRequestMethod(method)) {
         void requestSlackApproval({
           channel: session.channel,
           threadTs: session.threadId,
           agent: session.activeAgentName ?? session.agentType ?? "default",
-          toolName: approvalToolName(message.method, message.params),
+          toolName: approvalToolName(method, message.params),
           input: message.params,
-        }).then(
-          (approved) => respond(message.id as number, { approved }),
-          () => respond(message.id as number, { approved: false }),
-        );
+        }).then((approved) => {
+          respond(
+            message.id as number,
+            approvalResponse(method, message.params, approved),
+          );
+        }, () => {
+          respond(
+            message.id as number,
+            approvalResponse(method, message.params, false),
+          );
+        });
       } else {
-        respond(message.id, responseForServerRequest(message.method));
+        respond(message.id, responseForServerRequest(method));
       }
       return;
     }
@@ -409,6 +417,35 @@ function responseForServerRequest(method: string): Record<string, unknown> {
 function approvalToolName(method: string, params: unknown): string {
   const payload = record(params);
   return stringValue(payload?.command) ?? stringValue(payload?.toolName) ?? method;
+}
+
+const APPROVAL_REQUEST_METHODS = new Set([
+  "item/commandExecution/requestApproval",
+  "item/fileChange/requestApproval",
+  "item/permissions/requestApproval",
+]);
+
+function isApprovalRequestMethod(method: string): boolean {
+  return APPROVAL_REQUEST_METHODS.has(method);
+}
+
+function approvalResponse(
+  method: string,
+  params: unknown,
+  approved: boolean,
+): Record<string, unknown> {
+  if (method === "item/commandExecution/requestApproval" ||
+      method === "item/fileChange/requestApproval") {
+    return { decision: approved ? "accept" : "decline" };
+  }
+  if (method === "item/permissions/requestApproval") {
+    const requested = record(params)?.permissions;
+    return {
+      permissions: approved && isRecord(requested) ? requested : {},
+      scope: "turn",
+    };
+  }
+  return {};
 }
 
 async function consumeStdout(

--- a/src/codex-app-server/spawner.ts
+++ b/src/codex-app-server/spawner.ts
@@ -12,6 +12,7 @@ import { mapCodexRunPolicy } from "./policy.ts";
 import { signalProcessTree } from "../lifecycle/process-tree.ts";
 import { resolveTrustedSkill } from "../skills/registry.ts";
 import { skillInvocationPrompt } from "../skills/runtime.ts";
+import { requestSlackApproval } from "../mcp/slack-approval-bridge.ts";
 
 interface JsonRpcResponse {
   id: number;
@@ -144,7 +145,20 @@ export function spawnCodexAppServer(
     }
 
     if ("id" in message && typeof message.id === "number" && typeof message.method === "string") {
-      respond(message.id, responseForServerRequest(message.method));
+      if (message.method.includes("requestApproval")) {
+        void requestSlackApproval({
+          channel: session.channel,
+          threadTs: session.threadId,
+          agent: session.activeAgentName ?? session.agentType ?? "default",
+          toolName: approvalToolName(message.method, message.params),
+          input: message.params,
+        }).then(
+          (approved) => respond(message.id as number, { approved }),
+          () => respond(message.id as number, { approved: false }),
+        );
+      } else {
+        respond(message.id, responseForServerRequest(message.method));
+      }
       return;
     }
 
@@ -385,12 +399,16 @@ function isMissingRolloutError(err: unknown): boolean {
 }
 
 function responseForServerRequest(method: string): Record<string, unknown> {
-  if (method.includes("requestApproval")) return { approved: false };
   if (method === "item/tool/requestUserInput") return { input: null };
   if (method === "mcpServer/elicitation/request") {
     return { action: "accept", content: {}, _meta: null };
   }
   return {};
+}
+
+function approvalToolName(method: string, params: unknown): string {
+  const payload = record(params);
+  return stringValue(payload?.command) ?? stringValue(payload?.toolName) ?? method;
 }
 
 async function consumeStdout(

--- a/src/mcp/approval.ts
+++ b/src/mcp/approval.ts
@@ -83,3 +83,12 @@ export function resolvePendingApproval(
   entry.resolve(decision);
   return true;
 }
+
+/**
+ * Default-deny and remove a pending approval when its Slack prompt could not be
+ * made actionable. This shares the normal resolution path so the waiter is
+ * always released and its timeout is cleared.
+ */
+export function cancelPendingApproval(token: string): boolean {
+  return resolvePendingApproval(token, "deny");
+}

--- a/src/mcp/slack-approval-bridge.test.ts
+++ b/src/mcp/slack-approval-bridge.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, mock } from "bun:test";
+import type { WebClient } from "@slack/web-api";
+import { resolvePendingApproval } from "./approval.ts";
+import {
+  configureSlackApprovalBridge,
+  requestSlackApproval,
+} from "./slack-approval-bridge.ts";
+import type { CreateSlackActionRecord, SlackActionStore } from "../slack/action-store.ts";
+
+afterEach(() => {
+  configureSlackApprovalBridge(undefined, undefined);
+});
+
+describe("Slack approval bridge", () => {
+  it("fails closed when Slack approval dependencies are unavailable", async () => {
+    configureSlackApprovalBridge(undefined, undefined);
+    expect(await requestSlackApproval({
+      channel: "C01",
+      threadTs: "1.2",
+      agent: "db-executioner",
+      toolName: "git fetch",
+    })).toBe(false);
+  });
+
+  it("posts buttons and resolves an allowed Codex request", async () => {
+    const rows: CreateSlackActionRecord[] = [];
+    const store = {
+      createMany: mock(async (records: CreateSlackActionRecord[]) => {
+        rows.push(...records);
+      }),
+    } as unknown as SlackActionStore;
+    const postMessage = mock(async () => ({ ok: true, ts: "10.20" }));
+    const client = { chat: { postMessage } } as unknown as WebClient;
+    configureSlackApprovalBridge(client, store);
+
+    const pending = requestSlackApproval({
+      channel: "C01",
+      threadTs: "1.2",
+      agent: "db-executioner",
+      toolName: "exec_command",
+      input: { cmd: "git fetch" },
+    });
+    await Bun.sleep(5);
+    expect(rows).toHaveLength(2);
+    const allow = rows.find((row) =>
+      row.action.type === "request_permission" && row.action.decision === "allow"
+    );
+    expect(allow).toBeDefined();
+    if (allow?.action.type !== "request_permission") throw new Error("missing allow action");
+    expect(resolvePendingApproval(allow.action.approvalToken, "allow")).toBe(true);
+
+    expect(await pending).toBe(true);
+    expect(postMessage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/mcp/slack-approval-bridge.test.ts
+++ b/src/mcp/slack-approval-bridge.test.ts
@@ -7,8 +7,15 @@ import {
 } from "./slack-approval-bridge.ts";
 import type { CreateSlackActionRecord, SlackActionStore } from "../slack/action-store.ts";
 
+const originalApprovalTimeout = process.env.CLAUDE_APPROVAL_TIMEOUT_MS;
+
 afterEach(() => {
   configureSlackApprovalBridge(undefined, undefined);
+  if (originalApprovalTimeout === undefined) {
+    delete process.env.CLAUDE_APPROVAL_TIMEOUT_MS;
+  } else {
+    process.env.CLAUDE_APPROVAL_TIMEOUT_MS = originalApprovalTimeout;
+  }
 });
 
 describe("Slack approval bridge", () => {
@@ -74,5 +81,36 @@ describe("Slack approval bridge", () => {
     })).toBe(false);
     expect(approvalToken).not.toBe("");
     expect(resolvePendingApproval(approvalToken, "allow")).toBe(false);
+  });
+
+  it("disables actions and removes buttons after default-deny timeout", async () => {
+    process.env.CLAUDE_APPROVAL_TIMEOUT_MS = "5";
+    const disableMessageActions = mock(async () => {});
+    const store = {
+      createMany: mock(async () => {}),
+      disableMessageActions,
+    } as unknown as SlackActionStore;
+    const update = mock(async () => ({ ok: true }));
+    const client = {
+      chat: {
+        postMessage: mock(async () => ({ ok: true, ts: "10.20" })),
+        update,
+      },
+    } as unknown as WebClient;
+    configureSlackApprovalBridge(client, store);
+
+    expect(await requestSlackApproval({
+      channel: "C01",
+      threadTs: "1.2",
+      agent: "default",
+      toolName: "exec_command",
+    })).toBe(false);
+    expect(disableMessageActions).toHaveBeenCalledWith("C01", "10.20");
+    expect(update).toHaveBeenCalledWith({
+      channel: "C01",
+      ts: "10.20",
+      text: expect.any(String),
+      blocks: [],
+    });
   });
 });

--- a/src/mcp/slack-approval-bridge.test.ts
+++ b/src/mcp/slack-approval-bridge.test.ts
@@ -27,6 +27,13 @@ describe("Slack approval bridge", () => {
     const store = {
       createMany: mock(async (records: CreateSlackActionRecord[]) => {
         rows.push(...records);
+        const allow = records.find((row) =>
+          row.action.type === "request_permission" && row.action.decision === "allow"
+        );
+        if (allow?.action.type !== "request_permission") {
+          throw new Error("missing allow action");
+        }
+        expect(resolvePendingApproval(allow.action.approvalToken, "allow")).toBe(true);
       }),
     } as unknown as SlackActionStore;
     const postMessage = mock(async () => ({ ok: true, ts: "10.20" }));
@@ -40,16 +47,32 @@ describe("Slack approval bridge", () => {
       toolName: "exec_command",
       input: { cmd: "git fetch" },
     });
-    await Bun.sleep(5);
-    expect(rows).toHaveLength(2);
-    const allow = rows.find((row) =>
-      row.action.type === "request_permission" && row.action.decision === "allow"
-    );
-    expect(allow).toBeDefined();
-    if (allow?.action.type !== "request_permission") throw new Error("missing allow action");
-    expect(resolvePendingApproval(allow.action.approvalToken, "allow")).toBe(true);
-
     expect(await pending).toBe(true);
+    expect(rows).toHaveLength(2);
     expect(postMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("cleans up the pending resolver when action storage fails", async () => {
+    let approvalToken = "";
+    const store = {
+      createMany: mock(async (records: CreateSlackActionRecord[]) => {
+        const action = records[0]?.action;
+        if (action?.type === "request_permission") approvalToken = action.approvalToken;
+        throw new Error("store unavailable");
+      }),
+    } as unknown as SlackActionStore;
+    const client = {
+      chat: { postMessage: mock(async () => ({ ok: true, ts: "10.20" })) },
+    } as unknown as WebClient;
+    configureSlackApprovalBridge(client, store);
+
+    expect(await requestSlackApproval({
+      channel: "C01",
+      threadTs: "1.2",
+      agent: "default",
+      toolName: "exec_command",
+    })).toBe(false);
+    expect(approvalToken).not.toBe("");
+    expect(resolvePendingApproval(approvalToken, "allow")).toBe(false);
   });
 });

--- a/src/mcp/slack-approval-bridge.ts
+++ b/src/mcp/slack-approval-bridge.ts
@@ -1,5 +1,8 @@
 import type { WebClient } from "@slack/web-api";
-import { registerPendingApproval } from "./approval.ts";
+import {
+  cancelPendingApproval,
+  registerPendingApproval,
+} from "./approval.ts";
 import type { SlackActionStore } from "../slack/action-store.ts";
 import { buildActionBlocks } from "../slack/responder.ts";
 import type { SlackActionButtonSpec } from "../slack/formatting.ts";
@@ -61,26 +64,37 @@ export async function requestSlackApproval(options: {
       style: action.style,
     })),
   );
-  const posted = await slackClient.chat.postMessage({
-    channel: options.channel,
-    thread_ts: options.threadTs,
-    text,
-    blocks,
-  } as Parameters<WebClient["chat"]["postMessage"]>[0]);
-  if (!posted.ts) return false;
+  // Register before the Slack message can become clickable. In particular,
+  // createMany implementations may expose/resolve the actions synchronously.
+  const pendingDecision = registerPendingApproval(approvalToken);
+  try {
+    const posted = await slackClient.chat.postMessage({
+      channel: options.channel,
+      thread_ts: options.threadTs,
+      text,
+      blocks,
+    } as Parameters<WebClient["chat"]["postMessage"]>[0]);
+    if (!posted.ts) {
+      cancelPendingApproval(approvalToken);
+      return false;
+    }
 
-  await actionStore.createMany(
-    buttons.map(({ action, token }) => ({
-      token,
-      channelId: options.channel,
-      threadTs: options.threadTs,
-      messageTs: posted.ts!,
-      messageText: text,
-      action,
-      sourceAgent: options.agent,
-    })),
-  );
-  return (await registerPendingApproval(approvalToken)) === "allow";
+    await actionStore.createMany(
+      buttons.map(({ action, token }) => ({
+        token,
+        channelId: options.channel,
+        threadTs: options.threadTs,
+        messageTs: posted.ts!,
+        messageText: text,
+        action,
+        sourceAgent: options.agent,
+      })),
+    );
+    return (await pendingDecision) === "allow";
+  } catch {
+    cancelPendingApproval(approvalToken);
+    return false;
+  }
 }
 
 function renderInput(input: unknown): string {

--- a/src/mcp/slack-approval-bridge.ts
+++ b/src/mcp/slack-approval-bridge.ts
@@ -24,8 +24,12 @@ export async function requestSlackApproval(options: {
   agent: string;
   toolName: string;
   input?: unknown;
+  signal?: AbortSignal;
 }): Promise<boolean> {
-  if (!slackClient || !actionStore) return false;
+  if (!slackClient || !actionStore || options.signal?.aborted) return false;
+
+  const client = slackClient;
+  const store = actionStore;
 
   const approvalToken = crypto.randomUUID();
   const preview = renderInput(options.input);
@@ -67,8 +71,14 @@ export async function requestSlackApproval(options: {
   // Register before the Slack message can become clickable. In particular,
   // createMany implementations may expose/resolve the actions synchronously.
   const pendingDecision = registerPendingApproval(approvalToken);
+  let messageTs: string | null = null;
+  let actionsStored = false;
+  const cancel = () => {
+    cancelPendingApproval(approvalToken);
+  };
+  options.signal?.addEventListener("abort", cancel, { once: true });
   try {
-    const posted = await slackClient.chat.postMessage({
+    const posted = await client.chat.postMessage({
       channel: options.channel,
       thread_ts: options.threadTs,
       text,
@@ -78,8 +88,14 @@ export async function requestSlackApproval(options: {
       cancelPendingApproval(approvalToken);
       return false;
     }
+    messageTs = posted.ts;
+    if (options.signal?.aborted) {
+      cancel();
+      await disableApprovalActions(client, store, options.channel, messageTs, text, false);
+      return false;
+    }
 
-    await actionStore.createMany(
+    await store.createMany(
       buttons.map(({ action, token }) => ({
         token,
         channelId: options.channel,
@@ -90,11 +106,52 @@ export async function requestSlackApproval(options: {
         sourceAgent: options.agent,
       })),
     );
-    return (await pendingDecision) === "allow";
+    actionsStored = true;
+    if (options.signal?.aborted) cancel();
+    const approved = (await pendingDecision) === "allow";
+    if (options.signal?.aborted) {
+      await disableApprovalActions(client, store, options.channel, messageTs, text, true);
+    }
+    return approved;
   } catch {
-    cancelPendingApproval(approvalToken);
+    cancel();
+    if (messageTs) {
+      await disableApprovalActions(
+        client,
+        store,
+        options.channel,
+        messageTs,
+        text,
+        actionsStored,
+      );
+    }
     return false;
+  } finally {
+    options.signal?.removeEventListener("abort", cancel);
   }
+}
+
+async function disableApprovalActions(
+  client: WebClient,
+  store: SlackActionStore,
+  channel: string,
+  messageTs: string,
+  text: string,
+  actionsStored: boolean,
+): Promise<void> {
+  await Promise.allSettled([
+    ...(actionsStored
+      ? [Promise.resolve().then(() => store.disableMessageActions(channel, messageTs))]
+      : []),
+    Promise.resolve().then(() =>
+      client.chat.update({
+        channel,
+        ts: messageTs,
+        text,
+        blocks: [],
+      })
+    ),
+  ]);
 }
 
 function renderInput(input: unknown): string {

--- a/src/mcp/slack-approval-bridge.ts
+++ b/src/mcp/slack-approval-bridge.ts
@@ -109,7 +109,7 @@ export async function requestSlackApproval(options: {
     actionsStored = true;
     if (options.signal?.aborted) cancel();
     const approved = (await pendingDecision) === "allow";
-    if (options.signal?.aborted) {
+    if (!approved) {
       await disableApprovalActions(client, store, options.channel, messageTs, text, true);
     }
     return approved;

--- a/src/mcp/slack-approval-bridge.ts
+++ b/src/mcp/slack-approval-bridge.ts
@@ -1,0 +1,98 @@
+import type { WebClient } from "@slack/web-api";
+import { registerPendingApproval } from "./approval.ts";
+import type { SlackActionStore } from "../slack/action-store.ts";
+import { buildActionBlocks } from "../slack/responder.ts";
+import type { SlackActionButtonSpec } from "../slack/formatting.ts";
+
+let slackClient: WebClient | undefined;
+let actionStore: SlackActionStore | undefined;
+
+export function configureSlackApprovalBridge(
+  client: WebClient | undefined,
+  store: SlackActionStore | undefined,
+): void {
+  slackClient = client;
+  actionStore = store;
+}
+
+export async function requestSlackApproval(options: {
+  channel: string;
+  threadTs: string;
+  agent: string;
+  toolName: string;
+  input?: unknown;
+}): Promise<boolean> {
+  if (!slackClient || !actionStore) return false;
+
+  const approvalToken = crypto.randomUUID();
+  const preview = renderInput(options.input);
+  const text =
+    `:lock: *Permission requested* by \`${options.agent}\`\n\`${options.toolName}\`` +
+    (preview ? `\n${preview}` : "");
+  const buttons: Array<{ action: SlackActionButtonSpec; token: string }> = [
+    {
+      action: {
+        id: "permission-allow",
+        label: "Allow",
+        style: "primary",
+        type: "request_permission",
+        approvalToken,
+        decision: "allow",
+      },
+      token: crypto.randomUUID(),
+    },
+    {
+      action: {
+        id: "permission-deny",
+        label: "Deny",
+        style: "danger",
+        type: "request_permission",
+        approvalToken,
+        decision: "deny",
+      },
+      token: crypto.randomUUID(),
+    },
+  ];
+  const blocks = buildActionBlocks(
+    text,
+    buttons.map(({ action, token }) => ({
+      token,
+      label: action.label,
+      style: action.style,
+    })),
+  );
+  const posted = await slackClient.chat.postMessage({
+    channel: options.channel,
+    thread_ts: options.threadTs,
+    text,
+    blocks,
+  } as Parameters<WebClient["chat"]["postMessage"]>[0]);
+  if (!posted.ts) return false;
+
+  await actionStore.createMany(
+    buttons.map(({ action, token }) => ({
+      token,
+      channelId: options.channel,
+      threadTs: options.threadTs,
+      messageTs: posted.ts!,
+      messageText: text,
+      action,
+      sourceAgent: options.agent,
+    })),
+  );
+  return (await registerPendingApproval(approvalToken)) === "allow";
+}
+
+function renderInput(input: unknown): string {
+  if (input === undefined) return "";
+  let rendered: string;
+  try {
+    rendered = JSON.stringify(input, null, 2);
+  } catch {
+    rendered = String(input);
+  }
+  const bounded = rendered.length > 1_200
+    ? `${rendered.slice(0, 1_197)}...`
+    : rendered;
+  return `\`\`\`\n${bounded.replace(/\`\`\`/g, "\` \` \`")}\n\`\`\``;
+}

--- a/src/mcp/slack-server.ts
+++ b/src/mcp/slack-server.ts
@@ -59,6 +59,7 @@ import { registerSlackArchiveTools } from "./slack-archive-tools.ts";
 import { registerTaskRouteTools } from "../routes/tools.ts";
 import { handleMongoMcpRequest } from "./mongodb-proxy.ts";
 import { registerPendingApproval } from "./approval.ts";
+import { configureSlackApprovalBridge } from "./slack-approval-bridge.ts";
 import { prepareSlackResponseWithActions, type SlackActionButtonSpec } from "../slack/formatting.ts";
 import { buildActionBlocks, splitActionMessageText } from "../slack/responder.ts";
 import type { SlackActionStore } from "../slack/action-store.ts";
@@ -2467,6 +2468,7 @@ export function startMcpServer(
   archiveApprovedChannelIds: string[] = [],
 ): void {
   slack = new WebClient(botToken);
+  configureSlackApprovalBridge(slack, actionStore);
   sessionStore = store;
   worktreeManager = wtManager;
   sessionManager = manager;


### PR DESCRIPTION
## Summary
- route Codex app-server approval callbacks to blocking Slack Allow/Deny actions
- fail closed when Slack context, delivery, storage, or human approval is unavailable
- document the shared approval path for the Codex and MCP boundaries

## Test plan
- [x] `bun run typecheck`
- [x] `bun test src/mcp/slack-approval-bridge.test.ts src/codex-app-server/spawner.test.ts src/slack/action-buttons.test.ts`