### PR TITLE
feat: fully cancel durable pipelines

### DIFF
--- a/docs/code_index/pipelines.md
+++ b/docs/code_index/pipelines.md
@@ -17,6 +17,7 @@ disabled by default (`PIPELINE_RUNTIME_MODE=off`) and can run in `shadow` or
 | Slack/`!status` summary | `src/pipelines/projection.ts` | Human-readable `projectRunSummary` for Slack status. Not the dashboard HTTP projector. |
 | Dashboard operator projection | `src/http/routes/pipelines.ts` | List + detail + artifact read. Hides `kind=default` unless `includeDefault=1` or `kind=default`. Detail expands leases, full-run outbox (payload stripped), attempt-scoped gates, GitHub resources, dev-server jobs, artifact refs. |
 | Retention cleanup | `src/pipelines/gc.ts` | Pipeline retention GC (`PIPELINE_RETENTION_DAYS`). |
+| Full cancellation | `PipelineStore.cancelRun`, `SessionManager` `!stop` handling | Atomically abandons the run, cancels live assignments/jobs, dead-letters pending or leased wakes, deactivates GitHub tracking, clears session invocation state, and interrupts runner handles. |
 | Legacy bridge | `src/pipelines/legacy-directives.ts`, `src/support/pipeline-guard.ts` | Safely maps selected legacy directives while preserving existing routing. |
 | MCP tools | `src/pipelines/tools.ts` | Runner-facing pipeline read/write tools with scope and idempotency checks. |
 

--- a/docs/features/thread-commands.md
+++ b/docs/features/thread-commands.md
@@ -31,7 +31,11 @@ Users need to control thread behavior beyond just sending messages. Reset a brok
 - `!help` — List available commands
 - `!provider <name>` — Switch the thread's runner provider (`claude`,
   `opencode`, `opencode-sdk`, or `codex-app-server`)
-- `!stop` — Stop the active runner/driver
+- `!stop` — Stop every active runner/driver and atomically abandon the thread's durable pipeline, cancelling assignments, queued wakes, dev-server jobs, and GitHub reconciliation
+
+The same full cancellation is applied by `!cancel` and by unambiguous standalone
+requests such as `stop`, `stop. exit this conversation`, or `cancel the pipeline`.
+Longer conversational phrases are left to normal routing to avoid false stops.
 - `!driver <headless|tmux>` — Select Claude's driver mode for the thread (admin only)
 - `!workflow ...` / `!workflows` — Inspect and control dynamic workflows
 

--- a/src/pipelines/store/interface.ts
+++ b/src/pipelines/store/interface.ts
@@ -48,6 +48,18 @@ export interface PipelineStore {
   countOpenRuns(filter?: { kind?: PipelineRun["kind"] }): Promise<number>;
 
   /**
+   * Atomically abandon a live run and disable every durable continuation.
+   * Idempotent: cancelling an already-terminal run reports no changes.
+   */
+  cancelRun(runId: string, reason: string): Promise<{
+    cancelled: boolean;
+    assignmentsCancelled: number;
+    outboxDeadLettered: number;
+    devServerJobsCancelled: number;
+    githubResourcesDeactivated: number;
+  }>;
+
+  /**
    * Atomically create a run + initial assignment (and optional seed events).
    * Rolls back entirely on failure so no assignment-less active run remains.
    */

--- a/src/pipelines/store/memory.test.ts
+++ b/src/pipelines/store/memory.test.ts
@@ -27,6 +27,29 @@ function baseOutcome(overrides: Partial<AgentOutcome> = {}): AgentOutcome {
 }
 
 describe("InMemoryPipelineStore", () => {
+  it("fully cancels a run and all durable continuation work", async () => {
+    const store = new InMemoryPipelineStore(fakeClock(2_000));
+    await store.createRun(makeProductRun());
+    await store.createAssignment(makeAssignmentCreate());
+    await store.enqueueOutbox({
+      id: "wake-1", runId: "run-1", assignmentId: "asg-1",
+      eventType: "assignment.dispatch", payload: {}, idempotencyKey: "wake-key",
+    });
+
+    expect(await store.cancelRun("run-1", "user stopped thread")).toMatchObject({
+      cancelled: true, assignmentsCancelled: 1, outboxDeadLettered: 1,
+    });
+    expect(await store.getRun("run-1")).toMatchObject({
+      status: "terminal", phase: "abandoned", terminalOutcome: "abandoned",
+      terminalReason: "user stopped thread", stateVersion: 1,
+    });
+    expect(await store.getAssignment("asg-1")).toMatchObject({ status: "cancelled", leaseOwner: null });
+    expect(await store.listOutbox("run-1")).toEqual([
+      expect.objectContaining({ status: "dead", leaseOwner: null }),
+    ]);
+    expect((await store.cancelRun("run-1", "again")).cancelled).toBe(false);
+  });
+
   it("expands run repository refs atomically and idempotently", async () => {
     const clock = fakeClock(2_000);
     const store = new InMemoryPipelineStore(clock);

--- a/src/pipelines/store/memory.ts
+++ b/src/pipelines/store/memory.ts
@@ -226,6 +226,53 @@ export class InMemoryPipelineStore implements PipelineStore {
     return this.getRun(id);
   }
 
+  async cancelRun(runId: string, reason: string) {
+    const run = this.runs.get(runId);
+    const empty = {
+      cancelled: false,
+      assignmentsCancelled: 0,
+      outboxDeadLettered: 0,
+      devServerJobsCancelled: 0,
+      githubResourcesDeactivated: 0,
+    };
+    if (!run || run.status === "terminal") return empty;
+
+    const now = this.clock.now();
+    run.status = "terminal";
+    run.phase = "abandoned";
+    run.terminalOutcome = "abandoned";
+    run.terminalReason = reason;
+    run.stateVersion += 1;
+    run.updatedAt = now;
+    this.runs.set(runId, cloneRun(run));
+
+    let assignmentsCancelled = 0;
+    for (const [id, assignment] of this.assignments) {
+      if (assignment.runId !== runId || ["completed", "failed", "cancelled"].includes(assignment.status)) continue;
+      this.assignments.set(id, { ...assignment, status: "cancelled", leaseOwner: null, leaseExpiresAt: null, updatedAt: now });
+      assignmentsCancelled++;
+    }
+    let outboxDeadLettered = 0;
+    for (const [id, record] of this.outbox) {
+      if (record.runId !== runId || ["delivered", "failed", "dead"].includes(record.status)) continue;
+      this.outbox.set(id, { ...record, status: "dead", leaseOwner: null, leaseExpiresAt: null, lastError: reason });
+      outboxDeadLettered++;
+    }
+    let devServerJobsCancelled = 0;
+    for (const [id, job] of this.devServerJobs) {
+      if (job.runId !== runId || isTerminalDevServerStatus(job.status)) continue;
+      this.devServerJobs.set(id, { ...job, status: "cancelled", leaseOwner: null, leaseExpiresAt: null, releasedAt: now, releaseReason: reason, updatedAt: now });
+      devServerJobsCancelled++;
+    }
+    let githubResourcesDeactivated = 0;
+    for (const [id, association] of this.pipelineGithub) {
+      if (association.runId !== runId || !association.active) continue;
+      this.pipelineGithub.set(id, { ...association, active: false, updatedAt: now });
+      githubResourcesDeactivated++;
+    }
+    return { cancelled: true, assignmentsCancelled, outboxDeadLettered, devServerJobsCancelled, githubResourcesDeactivated };
+  }
+
   async expandRunRepoRefs(runId: string, repoRefs: string[]): Promise<PipelineRun> {
     const run = this.runs.get(runId);
     if (!run) throw new Error(`pipeline run not found: ${runId}`);

--- a/src/pipelines/store/sqlite.test.ts
+++ b/src/pipelines/store/sqlite.test.ts
@@ -45,6 +45,29 @@ describe("SqlitePipelineStore", () => {
     rmSync(tmpDir, { recursive: true, force: true });
   });
 
+  it("fully cancels a run and all durable continuation work", async () => {
+    await store.createRun(makeProductRun());
+    await store.createAssignment(makeAssignmentCreate());
+    await store.enqueueOutbox({
+      id: "wake-1", runId: "run-1", assignmentId: "asg-1",
+      eventType: "assignment.dispatch", payload: {}, idempotencyKey: "wake-key",
+    });
+
+    expect(await store.cancelRun("run-1", "user stopped thread")).toMatchObject({
+      cancelled: true, assignmentsCancelled: 1, outboxDeadLettered: 1,
+    });
+    expect(await store.getRun("run-1")).toMatchObject({
+      status: "terminal", phase: "abandoned", terminalOutcome: "abandoned",
+      terminalReason: "user stopped thread", stateVersion: 1,
+    });
+    expect(await store.getAssignment("asg-1")).toMatchObject({ status: "cancelled", leaseOwner: null });
+    expect(await store.listOutbox("run-1")).toEqual([
+      expect.objectContaining({ status: "dead", leaseOwner: null }),
+    ]);
+    expect((await store.cancelRun("run-1", "again")).cancelled).toBe(false);
+  });
+
+
   it("expands run repository refs atomically and idempotently", async () => {
     await store.createRun(makeDefaultRun({ repoRefs: ["GrowthX-Club/junior"] }));
     const expanded = await store.expandRunRepoRefs("default-run-1", [

--- a/src/pipelines/store/sqlite.ts
+++ b/src/pipelines/store/sqlite.ts
@@ -1030,6 +1030,22 @@ export class SqlitePipelineStore implements PipelineStore {
     return row ? runFromRow(row) : undefined;
   }
 
+  async cancelRun(runId: string, reason: string) {
+    const cancel = this.db.transaction(() => {
+      const run = this.db.query<RunRow, [string]>("SELECT * FROM pipeline_runs WHERE id = ?").get(runId);
+      const empty = { cancelled: false, assignmentsCancelled: 0, outboxDeadLettered: 0, devServerJobsCancelled: 0, githubResourcesDeactivated: 0 };
+      if (!run || run.status === "terminal") return empty;
+      const now = this.clock.now();
+      this.db.query(`UPDATE pipeline_runs SET status = 'terminal', phase = 'abandoned', terminal_outcome = 'abandoned', terminal_reason = ?, state_version = state_version + 1, updated_at = ? WHERE id = ? AND status != 'terminal'`).run(reason, now, runId);
+      const assignments = this.db.query(`UPDATE pipeline_assignments SET status = 'cancelled', lease_owner = NULL, lease_expires_at = NULL, updated_at = ? WHERE run_id = ? AND status NOT IN ('completed', 'failed', 'cancelled')`).run(now, runId);
+      const outbox = this.db.query(`UPDATE pipeline_outbox SET status = 'dead', lease_owner = NULL, lease_expires_at = NULL, last_error = ? WHERE run_id = ? AND status NOT IN ('delivered', 'failed', 'dead')`).run(reason, runId);
+      const jobs = this.db.query(`UPDATE dev_server_jobs SET status = 'cancelled', lease_owner = NULL, lease_expires_at = NULL, released_at = ?, release_reason = ?, updated_at = ? WHERE run_id = ? AND status NOT IN ('released', 'failed', 'cancelled', 'deadline')`).run(now, reason, now, runId);
+      const github = this.db.query(`UPDATE pipeline_github_resources SET active = 0, updated_at = ? WHERE run_id = ? AND active = 1`).run(now, runId);
+      return { cancelled: true, assignmentsCancelled: assignments.changes, outboxDeadLettered: outbox.changes, devServerJobsCancelled: jobs.changes, githubResourcesDeactivated: github.changes };
+    });
+    return cancel.immediate();
+  }
+
   async expandRunRepoRefs(runId: string, repoRefs: string[]): Promise<PipelineRun> {
     const tx = this.db.transaction(() => {
       const row = this.db

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -2361,6 +2361,33 @@ describe("SessionManager", () => {
       );
       expect((await store.get("thread-1"))!.status).toBe("idle");
     });
+
+    it("!stop terminalizes and detaches the thread's durable pipeline", async () => {
+      const pipelineStore = new InMemoryPipelineStore();
+      manager.pipelineStore = pipelineStore;
+      await pipelineStore.createRun(makeProductRun({ id: "run-stop", threadId: "thread-1" }));
+      await pipelineStore.createAssignment(makeAssignmentCreate({ id: "asg-stop", runId: "run-stop" }));
+      await pipelineStore.enqueueOutbox({
+        id: "wake-stop", runId: "run-stop", assignmentId: "asg-stop",
+        eventType: "assignment.dispatch", payload: {}, idempotencyKey: "wake-stop-key",
+      });
+      await manager.handleMessage(makeEvent({ text: "go" }));
+      const session = (await store.get("thread-1"))!;
+      session.activeRunId = "run-stop";
+      session.activePipelineRunId = "run-stop";
+      session.activePipelineKind = "product";
+      await store.set("thread-1", session);
+      const onCmd = mock((_e: SlackMessageEvent, _r: string) => {});
+      manager.onCommandResponse = onCmd;
+
+      await manager.handleMessage(makeEvent({ command: "stop", text: "", ts: "ts-stop-pipeline" }));
+
+      expect(await pipelineStore.getRun("run-stop")).toMatchObject({ status: "terminal", terminalOutcome: "abandoned" });
+      expect(await pipelineStore.getAssignment("asg-stop")).toMatchObject({ status: "cancelled" });
+      expect((await pipelineStore.listOutbox("run-stop"))[0]?.status).toBe("dead");
+      expect(await store.get("thread-1")).toMatchObject({ activeRunId: null, activePipelineRunId: null, activePipelineKind: null });
+      expect(onCmd.mock.calls[0]?.[1]).toContain("Pipeline fully cancelled");
+    });
   });
 
   describe("!reset", () => {

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -860,6 +860,26 @@ export class SessionManager {
     return touched;
   }
 
+  private async cancelThreadPipeline(threadId: string): Promise<boolean> {
+    if (!this.pipelineStore) return false;
+    const session = await this.store.get(threadId);
+    const runId = session?.activeRunId ?? session?.activePipelineRunId;
+    if (!session || !runId) return false;
+    const result = await this.pipelineStore.cancelRun(runId, "Cancelled by user with !stop");
+    await this.mutateSession(threadId, (s) => {
+      s.activeRunId = null;
+      s.activePipelineRunId = null;
+      s.activePipelineKind = null;
+      s.activePipelineInvocation = null;
+      s.pendingMessages = s.pendingMessages.filter((message) => !message.pipelineInvocation || message.pipelineInvocation.runId !== runId);
+      for (const agentSession of Object.values(s.agentSessions ?? {})) {
+        if (agentSession.activePipelineInvocation?.runId === runId) agentSession.activePipelineInvocation = null;
+        agentSession.pendingMessages = agentSession.pendingMessages.filter((message) => !message.pipelineInvocation || message.pipelineInvocation.runId !== runId);
+      }
+    });
+    return result.cancelled;
+  }
+
   async getSession(threadId: string): Promise<ThreadSession | undefined> {
     return this.store.get(threadId);
   }
@@ -1067,15 +1087,9 @@ export class SessionManager {
   ): Promise<boolean> {
     switch (event.command) {
       case "cancel": {
-        let killed = 0;
-        for (const [key, handle] of this.handles) {
-          if (!key.startsWith(`${session.threadId}:`)) continue;
-          handle.kill();
-          this.handles.delete(key);
-          killed++;
-        }
+        const pipelineCancelled = await this.cancelThreadPipeline(session.threadId);
+        const killed = await this.interruptThread(session.threadId);
         await this.mutateSession(session.threadId, (s) => {
-          s.status = "idle";
           s.pid = null;
           s.pendingMessages = [];
           for (const agentSession of Object.values(s.agentSessions ?? {})) {
@@ -1086,7 +1100,9 @@ export class SessionManager {
         });
         this.onCommandResponse?.(
           event,
-          killed === 0 ? "Nothing running." : `Cancelled (${killed} process${killed === 1 ? "" : "es"}).`,
+          pipelineCancelled
+            ? `Pipeline fully cancelled. Cancelled (${killed} process${killed === 1 ? "" : "es"}).`
+            : killed === 0 ? "Nothing running." : `Cancelled (${killed} process${killed === 1 ? "" : "es"}).`,
         );
         return true;
       }
@@ -1423,8 +1439,14 @@ export class SessionManager {
       }
 
       case "stop": {
+        const pipelineCancelled = await this.cancelThreadPipeline(session.threadId);
         const touched = await this.interruptThread(session.threadId);
-        this.onCommandResponse?.(event, formatStopReply(touched));
+        this.onCommandResponse?.(
+          event,
+          pipelineCancelled
+            ? `Pipeline fully cancelled. ${formatStopReply(touched)}`
+            : formatStopReply(touched),
+        );
         return true;
       }
 

--- a/src/slack/commands.test.ts
+++ b/src/slack/commands.test.ts
@@ -37,6 +37,14 @@ describe("parseCommand", () => {
     });
   });
 
+  it("treats unambiguous standalone stop requests as !stop", () => {
+    for (const text of ["stop", "stop.", "stop. exit this conversation", "stop the pipeline", "cancel the pipeline"]) {
+      expect(parseCommand(text)).toEqual({ command: "stop", text: "" });
+    }
+    expect(parseCommand("don't stop")).toEqual({ command: null, text: "don't stop" });
+    expect(parseCommand("stop after review")).toEqual({ command: null, text: "stop after review" });
+  });
+
   it("handles empty string", () => {
     expect(parseCommand("")).toEqual({
       command: null,

--- a/src/slack/commands.ts
+++ b/src/slack/commands.ts
@@ -53,6 +53,12 @@ function stripAsidePrefix(text: string): string {
 
 export function parseCommand(text: string): ParsedCommand {
   if (!text.startsWith("!")) {
+    // Treat only unambiguous standalone human stop instructions as control
+    // plane input. This intentionally does not match conversational text such
+    // as "don't stop" or "stop after review".
+    if (/^(?:stop|cancel)(?:(?:[.!]\s*|\s+)(?:the\s+pipeline|exit\s+this\s+conversation))?[.!]?$/i.test(text.trim())) {
+      return { command: "stop", text: "" };
+    }
     return { command: null, text };
   }
 


### PR DESCRIPTION
## Summary
- atomically abandon durable runs and cancel all assignments and dev-server jobs
- dead-letter queued/leased wakes, deactivate GitHub reconciliation, and clear session invocation state
- support `!stop`, `!cancel`, and unambiguous standalone stop requests including the wording from the incident

## Verification
- `bun test`
- `bun run typecheck`
- `git diff --check`