### PR TITLE
feat: add multi-region Mixpanel MCP proxy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,11 @@ OPENCODE_SLACK_MCP_ENABLED=true
 OPENCODE_PLAYWRIGHT_MCP_ENABLED=true
 OPENCODE_MIXPANEL_MCP_ENABLED=true
 OPENCODE_MONGODB_MCP_ENABLED=true
+# Mixpanel service-account credentials, encoded as base64(username:secret).
+# Optional alternative to OAuth; a regional token takes precedence when set.
+# MIXPANEL_MCP_US_TOKEN=
+# MIXPANEL_MCP_EU_TOKEN=
+# MIXPANEL_MCP_IN_TOKEN=
 # Optional OpenCode SDK binary override.
 # OPENCODE_BIN=~/.opencode/bin/opencode
 
@@ -112,6 +117,7 @@ MCP_PORT=3456
 # Optional endpoint overrides; defaults derive from MCP_PORT.
 # SLACK_MCP_URL=http://localhost:3456/mcp
 # MONGODB_MCP_URL=http://localhost:3456/mcp/mongodb
+# MIXPANEL_MCP_URL=http://localhost:3456/mcp/mixpanel
 # Optional stable HMAC secret for signed MCP run context. When unset, Junior
 # generates a process-local secret. It is never passed to child runners.
 # Generate a stable value once with: openssl rand -hex 32
@@ -121,6 +127,14 @@ MCP_PORT=3456
 MDB_MCP_CONNECTION_STRING=mongodb+srv://<readonly-user>:<password>@<cluster>/<database>?retryWrites=true&w=majority
 MONGODB_MCP_PROXY_IDLE_TTL_MS=600000
 MONGODB_MCP_PROXY_REQUEST_TIMEOUT_MS=120000
+
+# Mixpanel MCP proxy. Each token is base64(username:secret) for a service
+# account in that data-residency region. OAuth setup: bun run mixpanel:oauth
+MIXPANEL_MCP_REGIONS=us,eu,in
+MIXPANEL_MCP_OAUTH_DIR=data/mixpanel-oauth
+MIXPANEL_MCP_OAUTH_CALLBACK_PORT=3458
+MIXPANEL_MCP_PROXY_IDLE_TTL_MS=600000
+MIXPANEL_MCP_PROXY_REQUEST_TIMEOUT_MS=120000
 
 # WhatsApp message archive (read-only; exposed via whatsapp_* MCP tools).
 # Pair once with: bun run src/whatsapp/pair.ts

--- a/docs/code_index/mcp-server.md
+++ b/docs/code_index/mcp-server.md
@@ -14,6 +14,11 @@ operations using the bot token and signed run context.
 | `registerTools(server)` (internal) | `slack-server.ts` | Registers Slack, worktree, and agent-registry tools on a fresh `McpServer` per request. |
 | `handleMongoMcpRequest(req, res)` | `mongodb-proxy.ts` | Serves `/mcp/mongodb` as a stateless HTTP MCP proxy to one shared read-only MongoDB stdio backend; hides upstream connection selection and injects the environment-backed `preconfigured` ID. |
 | `closeMongoMcpBackend()` | `mongodb-proxy.ts` | Closes the shared backend immediately; also used by the idle TTL. |
+| `handleMixpanelMcpRequest(req, res)` | `mixpanel-proxy.ts` | Serves `/mcp/mixpanel` as one signed read-only MCP surface over all configured Mixpanel regions. |
+| `createMixpanelProxyServer(...)` | `mixpanel-proxy.ts` | Unions safe upstream tools, adds the required `region` selector, strips it before forwarding, and rejects write tools. |
+| `closeMixpanelMcpBackends()` | `mixpanel-proxy.ts` | Closes the shared per-region HTTP clients immediately; also used by the idle TTL. |
+| `MixpanelOAuthProvider` | `mixpanel-oauth.ts` | Persists region-isolated OAuth client registrations, PKCE verifiers, and refreshable tokens with restricted filesystem permissions. |
+| `bun run mixpanel:oauth` | `mixpanel-oauth-cli.ts` | Opens and completes US, EU, and IN OAuth authorization sequentially through a validated loopback callback. |
 | `searchAgentDefinitions(options)` | `slack-server.ts` | Reads public/private agent markdown files and returns matching definitions plus dispatch registration state. |
 
 ### Tools
@@ -41,7 +46,7 @@ operations using the bot token and signed run context.
 
 | File | What |
 |---|---|
-| `.mcp.json` | Root config contains `slack-bot`, Figma, and Notion servers. Per-agent generated configs add Playwright/MongoDB as needed. |
+| `.mcp.json` | Root config contains `slack-bot`, Figma, and Notion servers. Per-agent generated configs add Playwright, MongoDB, and the multi-region Mixpanel proxy as needed. |
 | `.claude/settings.json` | `permissions.allow: ["mcp__slack-bot__*"]` |
 | `src/claude/spawner.ts` | Passes `--mcp-config` for worktree spawns |
 | `src/codex-app-server/spawner.ts` | Routes native approval callbacks through the shared Slack approval bridge |
@@ -50,7 +55,7 @@ operations using the bot token and signed run context.
 
 ### Stateless per request
 
-Each HTTP request creates a fresh `McpServer` + `StreamableHTTPServerTransport` (`sessionIdGenerator: undefined`). No MCP session state is kept between requests. Slack requests share the same `WebClient` (module-level singleton). MongoDB proxy requests share one lazily started wrapped stdio backend and close it after an idle TTL. Run context is HMAC-signed per spawn and validated before thread/agent-sensitive tools execute.
+Each HTTP request creates a fresh `McpServer` + `StreamableHTTPServerTransport` (`sessionIdGenerator: undefined`). No MCP session state is kept between requests. Slack requests share the same `WebClient` (module-level singleton). MongoDB proxy requests share one lazily started wrapped stdio backend. Mixpanel proxy requests share one lazily started hosted-MCP client per configured region. Both proxy types close idle backends after a TTL. Run context is HMAC-signed per spawn and validated before thread/agent-sensitive tools execute.
 
 ### Identity model
 

--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -84,11 +84,25 @@ Status pill updates that agents post mid-run go through `slack_send_message` wit
   `OPENCODE_CONFIG_CONTENT` for all normal runs, including initial lead intake
   from Junior's project root. Explicit `session.cwd` utility runs still skip
   Junior's local MCP wiring.
-- The Mixpanel MCP is intentionally **not** in `.mcp.json` and is not part of
-  default Junior's OpenCode config. It is injected only when the active
-  OpenCode session is `feature-metrics`, using Mixpanel's official hosted MCP
-  through `npx -y mcp-remote https://mcp.mixpanel.com/mcp`. Disable with
-  `OPENCODE_MIXPANEL_MCP_ENABLED=false`.
+- The Mixpanel MCP is intentionally **not** in `.mcp.json` and is injected only
+  for `feature-metrics` sessions. Junior exposes one signed, read-only HTTP MCP
+  at `/mcp/mixpanel`; it maintains one upstream connection for each configured
+  Mixpanel data-residency region (US, EU, and/or IN), combines their safe tool
+  schemas, and adds a required `region` argument to every tool. Configure
+  `bun run mixpanel:oauth` performs the three independent regional OAuth flows
+  sequentially and persists each client registration, access token, refresh
+  token, and PKCE state under mode-0700 `data/mixpanel-oauth` with mode-0600
+  files. The runtime refreshes each grant independently. Optional
+  `MIXPANEL_MCP_US_TOKEN`, `MIXPANEL_MCP_EU_TOKEN`, and
+  `MIXPANEL_MCP_IN_TOKEN` service-account credentials take precedence per
+  region. User OAuth cannot combine multiple regional authorization servers
+  into one grant, so initial setup still requires one approval per region.
+  Interrupted setup is resumable, and specific regions can be retried with
+  `bun run mixpanel:oauth -- eu in`.
+  New upstream tools fail closed until
+  explicitly classified as read-only. Disable runner injection with
+  `OPENCODE_MIXPANEL_MCP_ENABLED=false` /
+  `CODEX_MIXPANEL_MCP_ENABLED=false`.
 - Human-gated Codex app-server commands use the same blocking Slack Allow/Deny
   actions and pending-approval registry as Claude's permission prompt tool.
   The registry entry exists before a prompt can become actionable, preventing

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "bun test",
     "build": "bun build ./src/index.ts --outdir ./dist --target bun",
     "cleanup": "bun run src/lifecycle/cleanup.ts",
+    "mixpanel:oauth": "bun run src/mcp/mixpanel-oauth-cli.ts",
     "memory:reembed": "bun run src/memory/reembed-retrieval.ts",
     "memory:benchmark:lesson-cues": "bun run src/memory/lesson-retrieval-benchmark.ts",
     "slack:archive:import": "bun run src/slack/archive-cli.ts import",

--- a/src/claude/spawner.ts
+++ b/src/claude/spawner.ts
@@ -15,7 +15,7 @@ import { buildClaudeArgs } from "./args.ts";
 import { createStreamParser } from "./parser.ts";
 import { signalProcessTree } from "../lifecycle/process-tree.ts";
 import {
-  mixpanelMcpCommand,
+  mixpanelMcpUrl,
   mongoMcpUrl,
   needsUserSettings,
   playwrightMcpCommand,
@@ -232,7 +232,7 @@ export function writeClaudeMcpConfig(
     mcpServers.playwright = playwrightMcpCommand();
   }
   if (wantsMcp(session, "mixpanel") && isFeatureMetricsSession(session)) {
-    mcpServers.mixpanel = mixpanelMcpCommand();
+    mcpServers.mixpanel = { type: "http", url: mixpanelMcpUrl(session) };
   }
   if (wantsMcp(session, "mongodb")) {
     mcpServers.mongodb = {

--- a/src/codex-app-server/config.ts
+++ b/src/codex-app-server/config.ts
@@ -4,7 +4,7 @@ import type { Config } from "../config.ts";
 import type { ThreadSession } from "../session/types.ts";
 import type { CodexApprovalPolicy, CodexSandbox } from "./policy.ts";
 import {
-  mixpanelMcpCommand,
+  mixpanelMcpUrl,
   mongoMcpUrl,
   playwrightMcpCommand,
   slackMcpUrl,
@@ -39,7 +39,7 @@ export function buildCodexMcpConfig(
     mcp.playwright = playwrightMcpCommand();
   }
   if (config.codex.mixpanelMcpEnabled && wantsMcp(session, "mixpanel") && isFeatureMetricsSession(session)) {
-    mcp.mixpanel = mixpanelMcpCommand();
+    mcp.mixpanel = { transport: "http", url: mixpanelMcpUrl(session) };
   }
   if (config.codex.mongodbMcpEnabled && wantsMcp(session, "mongodb")) {
     mcp.mongodb = {

--- a/src/mcp/context.test.ts
+++ b/src/mcp/context.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import { createSession } from "../session/types.ts";
 import {
+  buildMixpanelMcpUrl,
   buildMongoMcpUrl,
   buildSlackMcpUrl,
   mcpContextSecret,
@@ -53,6 +54,19 @@ describe("Slack MCP run context", () => {
 
     expect(parsed.pathname).toBe("/mcp/mongodb");
     expect(parsed.searchParams.get("agent")).toBe("default");
+    expect(parsed.searchParams.get("channel")).toBe("C01");
+    expect(parsed.searchParams.get("thread")).toBe("thread-1");
+  });
+
+  it("encodes trusted run context in the Mixpanel MCP proxy URL", () => {
+    const session = createSession("thread-1", "C01");
+    session.activeAgentName = "default";
+    session.agentType = "feature-metrics";
+
+    const parsed = new URL(buildMixpanelMcpUrl(session));
+
+    expect(parsed.pathname).toBe("/mcp/mixpanel");
+    expect(parsed.searchParams.get("agent")).toBe("feature-metrics");
     expect(parsed.searchParams.get("channel")).toBe("C01");
     expect(parsed.searchParams.get("thread")).toBe("thread-1");
   });

--- a/src/mcp/context.ts
+++ b/src/mcp/context.ts
@@ -4,6 +4,7 @@ import type { ThreadSession } from "../session/types.ts";
 const MCP_PORT = Number(process.env.MCP_PORT ?? "3456");
 const DEFAULT_SLACK_MCP_URL = `http://localhost:${MCP_PORT}/mcp`;
 const DEFAULT_MONGODB_MCP_URL = `http://localhost:${MCP_PORT}/mcp/mongodb`;
+const DEFAULT_MIXPANEL_MCP_URL = `http://localhost:${MCP_PORT}/mcp/mixpanel`;
 
 /** Default token lifetime for signed MCP run context (2 hours). */
 const MCP_CONTEXT_TTL_MS = 2 * 60 * 60 * 1000;
@@ -75,6 +76,20 @@ export function buildMongoMcpUrl(session: ThreadSession): string {
     threadId: session.threadId,
     messageTs:
       session.currentMessageTs ?? session.activeTopLevelMessageTs ?? null,
+    runId: session.activePipelineInvocation?.runId ?? null,
+    assignmentId: session.activePipelineInvocation?.assignmentId ?? null,
+    dispatchKey: session.activePipelineInvocation?.dispatchKey ?? null,
+  });
+  return url.toString();
+}
+
+export function buildMixpanelMcpUrl(session: ThreadSession): string {
+  const url = new URL(process.env.MIXPANEL_MCP_URL ?? DEFAULT_MIXPANEL_MCP_URL);
+  applySignedRunContext(url, {
+    agent: slackMcpAgentForSession(session),
+    channel: session.channel,
+    threadId: session.threadId,
+    messageTs: session.currentMessageTs ?? session.activeTopLevelMessageTs ?? null,
     runId: session.activePipelineInvocation?.runId ?? null,
     assignmentId: session.activePipelineInvocation?.assignmentId ?? null,
     dispatchKey: session.activePipelineInvocation?.dispatchKey ?? null,

--- a/src/mcp/mixpanel-oauth-cli.ts
+++ b/src/mcp/mixpanel-oauth-cli.ts
@@ -1,0 +1,93 @@
+import { createServer } from "node:http";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import {
+  MIXPANEL_OAUTH_CALLBACK_PORT,
+  MixpanelOAuthProvider,
+} from "./mixpanel-oauth.ts";
+import { mixpanelRegionUrl, type MixpanelRegion } from "./mixpanel-proxy.ts";
+
+const ALL_REGIONS: MixpanelRegion[] = ["us", "eu", "in"];
+const requested = process.argv.slice(2).map((value) => value.toLowerCase());
+const invalid = requested.filter((value) => !ALL_REGIONS.includes(value as MixpanelRegion));
+if (invalid.length > 0) throw new Error(`Unknown Mixpanel region(s): ${invalid.join(", ")}`);
+const REGIONS = requested.length > 0 ? requested as MixpanelRegion[] : ALL_REGIONS;
+
+for (const region of REGIONS) await authorize(region);
+console.log(`Mixpanel OAuth connected for ${REGIONS.map((region) => region.toUpperCase()).join(", ")}.`);
+
+async function authorize(region: MixpanelRegion): Promise<void> {
+  let callbackPromise: Promise<string> | null = null;
+  const provider = await MixpanelOAuthProvider.create(region, async (url) => {
+    callbackPromise = waitForCallback(provider.expectedState());
+    console.log(`\nAuthorize Mixpanel ${region.toUpperCase()}:\n${url}`);
+    await openBrowser(url);
+  });
+  const client = new Client({ name: `junior-mixpanel-oauth-${region}`, version: "0.1.0" });
+  let transport = new StreamableHTTPClientTransport(new URL(mixpanelRegionUrl(region)), {
+    authProvider: provider,
+  });
+  try {
+    await client.connect(transport);
+  } catch (err) {
+    if (!(err instanceof UnauthorizedError) || !callbackPromise) throw err;
+    const code = await callbackPromise;
+    await transport.finishAuth(code);
+    transport = new StreamableHTTPClientTransport(new URL(mixpanelRegionUrl(region)), {
+      authProvider: provider,
+    });
+    await client.connect(transport);
+  }
+  await client.listTools();
+  await client.close();
+  console.log(`Connected ${region.toUpperCase()}.`);
+}
+
+function waitForCallback(expectedState: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const server = createServer((req, res) => {
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      if (url.pathname !== "/oauth/callback") {
+        res.writeHead(404).end();
+        return;
+      }
+      const error = url.searchParams.get("error");
+      const errorDescription = url.searchParams.get("error_description");
+      const code = url.searchParams.get("code");
+      const state = url.searchParams.get("state");
+      if (error || !code || state !== expectedState) {
+        const reason = error
+          ? `${error}${errorDescription ? `: ${errorDescription}` : ""}`
+          : !code
+            ? "authorization code was missing"
+            : "OAuth state did not match";
+        res.writeHead(400, { "content-type": "text/plain" });
+        res.end(`Mixpanel authorization failed: ${reason}. Return to the terminal.`);
+        server.close();
+        reject(new Error(`Mixpanel OAuth callback failed: ${reason}`));
+        return;
+      }
+      res.writeHead(200, { "content-type": "text/html" });
+      res.end("<h1>Mixpanel connected</h1><p>You can close this tab.</p>");
+      server.close();
+      resolve(code);
+    });
+    server.on("error", reject);
+    server.listen(MIXPANEL_OAUTH_CALLBACK_PORT, "127.0.0.1");
+  });
+}
+
+async function openBrowser(url: URL): Promise<void> {
+  const platform = process.platform;
+  const command = platform === "darwin"
+    ? ["open", url.toString()]
+    : platform === "win32"
+      ? ["cmd", "/c", "start", "", url.toString()]
+      : ["xdg-open", url.toString()];
+  try {
+    await Bun.spawn(command, { stdout: "ignore", stderr: "ignore" }).exited;
+  } catch {
+    // The printed URL remains usable on headless systems.
+  }
+}

--- a/src/mcp/mixpanel-oauth.ts
+++ b/src/mcp/mixpanel-oauth.ts
@@ -1,0 +1,103 @@
+import { chmod, mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { randomBytes } from "node:crypto";
+import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
+import type {
+  OAuthClientInformationMixed,
+  OAuthClientMetadata,
+  OAuthTokens,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+import type { MixpanelRegion } from "./mixpanel-proxy.ts";
+
+interface StoredOAuthState {
+  clientInformation?: OAuthClientInformationMixed;
+  tokens?: OAuthTokens;
+  codeVerifier?: string;
+}
+
+export const MIXPANEL_OAUTH_CALLBACK_PORT = Number(
+  process.env.MIXPANEL_MCP_OAUTH_CALLBACK_PORT ?? "3458",
+);
+export const MIXPANEL_OAUTH_CALLBACK_URL =
+  `http://127.0.0.1:${MIXPANEL_OAUTH_CALLBACK_PORT}/oauth/callback`;
+
+export class MixpanelOAuthProvider implements OAuthClientProvider {
+  readonly redirectUrl = MIXPANEL_OAUTH_CALLBACK_URL;
+  readonly clientMetadata: OAuthClientMetadata = {
+    client_name: "Junior Mixpanel MCP proxy",
+    redirect_uris: [MIXPANEL_OAUTH_CALLBACK_URL],
+    grant_types: ["authorization_code", "refresh_token"],
+    response_types: ["code"],
+    token_endpoint_auth_method: "none",
+  };
+  private stored: StoredOAuthState = {};
+  private readonly oauthState = randomBytes(32).toString("hex");
+
+  private constructor(
+    readonly region: MixpanelRegion,
+    private readonly path: string,
+    private readonly onRedirect: (url: URL) => void | Promise<void>,
+  ) {}
+
+  static async create(
+    region: MixpanelRegion,
+    onRedirect: (url: URL) => void | Promise<void> = () => {
+      throw new Error(`Mixpanel ${region.toUpperCase()} OAuth is not connected; run bun run mixpanel:oauth`);
+    },
+  ): Promise<MixpanelOAuthProvider> {
+    const provider = new MixpanelOAuthProvider(region, oauthPath(region), onRedirect);
+    try {
+      provider.stored = JSON.parse(await readFile(provider.path, "utf8")) as StoredOAuthState;
+    } catch (err) {
+      if (!(err instanceof Error && "code" in err && err.code === "ENOENT")) throw err;
+    }
+    return provider;
+  }
+
+  state(): string { return this.oauthState; }
+  expectedState(): string { return this.oauthState; }
+  clientInformation(): OAuthClientInformationMixed | undefined { return this.stored.clientInformation; }
+  async saveClientInformation(value: OAuthClientInformationMixed): Promise<void> {
+    this.stored.clientInformation = value;
+    await this.persist();
+  }
+  tokens(): OAuthTokens | undefined { return this.stored.tokens; }
+  async saveTokens(value: OAuthTokens): Promise<void> {
+    this.stored.tokens = value;
+    delete this.stored.codeVerifier;
+    await this.persist();
+  }
+  redirectToAuthorization(url: URL): void | Promise<void> { return this.onRedirect(url); }
+  async saveCodeVerifier(value: string): Promise<void> {
+    this.stored.codeVerifier = value;
+    await this.persist();
+  }
+  codeVerifier(): string {
+    if (!this.stored.codeVerifier) throw new Error(`Missing Mixpanel ${this.region} PKCE verifier`);
+    return this.stored.codeVerifier;
+  }
+  async invalidateCredentials(scope: "all" | "client" | "tokens" | "verifier" | "discovery"): Promise<void> {
+    if (scope === "all" || scope === "client") delete this.stored.clientInformation;
+    if (scope === "all" || scope === "tokens") delete this.stored.tokens;
+    if (scope === "all" || scope === "verifier") delete this.stored.codeVerifier;
+    await this.persist();
+  }
+
+  private async persist(): Promise<void> {
+    await mkdir(dirname(this.path), { recursive: true, mode: 0o700 });
+    await chmod(dirname(this.path), 0o700);
+    const temporary = `${this.path}.${process.pid}.tmp`;
+    await writeFile(temporary, `${JSON.stringify(this.stored, null, 2)}\n`, { mode: 0o600 });
+    await rename(temporary, this.path);
+    await chmod(this.path, 0o600);
+  }
+}
+
+export async function hasMixpanelOAuthTokens(region: MixpanelRegion): Promise<boolean> {
+  return Boolean((await MixpanelOAuthProvider.create(region)).tokens());
+}
+
+function oauthPath(region: MixpanelRegion): string {
+  const root = resolve(process.env.MIXPANEL_MCP_OAUTH_DIR ?? "data/mixpanel-oauth");
+  return join(root, `${region}.json`);
+}

--- a/src/mcp/mixpanel-proxy.test.ts
+++ b/src/mcp/mixpanel-proxy.test.ts
@@ -5,7 +5,11 @@ import { join } from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import type { SlackMcpRunContext } from "./context.ts";
-import { createMixpanelProxyServer, type MixpanelRegion } from "./mixpanel-proxy.ts";
+import {
+  createMixpanelProxyServer,
+  mixpanelAuthorizationHeader,
+  type MixpanelRegion,
+} from "./mixpanel-proxy.ts";
 import { MixpanelOAuthProvider } from "./mixpanel-oauth.ts";
 
 let oauthTestDir: string | null = null;
@@ -23,6 +27,12 @@ const RUN_CONTEXT: SlackMcpRunContext = {
 };
 
 describe("Mixpanel multi-region read-only proxy", () => {
+  it("uses Basic auth for documented service-account credentials", () => {
+    expect(mixpanelAuthorizationHeader("dXNlcjpzZWNyZXQ=")).toBe("Basic dXNlcjpzZWNyZXQ=");
+    expect(mixpanelAuthorizationHeader("Basic dXNlcjpzZWNyZXQ=")).toBe("Basic dXNlcjpzZWNyZXQ=");
+    expect(mixpanelAuthorizationHeader("Bearer oauth-token")).toBe("Bearer oauth-token");
+  });
+
   it("persists independent OAuth clients and tokens with restricted permissions", async () => {
     oauthTestDir = await mkdtemp(join(tmpdir(), "junior-mixpanel-oauth-"));
     process.env.MIXPANEL_MCP_OAUTH_DIR = oauthTestDir;

--- a/src/mcp/mixpanel-proxy.test.ts
+++ b/src/mcp/mixpanel-proxy.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { SlackMcpRunContext } from "./context.ts";
+import { createMixpanelProxyServer, type MixpanelRegion } from "./mixpanel-proxy.ts";
+import { MixpanelOAuthProvider } from "./mixpanel-oauth.ts";
+
+let oauthTestDir: string | null = null;
+afterEach(async () => {
+  delete process.env.MIXPANEL_MCP_OAUTH_DIR;
+  if (oauthTestDir) await rm(oauthTestDir, { recursive: true, force: true });
+  oauthTestDir = null;
+});
+
+const RUN_CONTEXT: SlackMcpRunContext = {
+  agent: "feature-metrics",
+  channel: "C01",
+  threadId: "thread-1",
+  signed: true,
+};
+
+describe("Mixpanel multi-region read-only proxy", () => {
+  it("persists independent OAuth clients and tokens with restricted permissions", async () => {
+    oauthTestDir = await mkdtemp(join(tmpdir(), "junior-mixpanel-oauth-"));
+    process.env.MIXPANEL_MCP_OAUTH_DIR = oauthTestDir;
+    const us = await MixpanelOAuthProvider.create("us");
+    await us.saveClientInformation({ client_id: "us-client" });
+    await us.saveTokens({ access_token: "us-access", token_type: "bearer", refresh_token: "us-refresh" });
+    const eu = await MixpanelOAuthProvider.create("eu");
+    await eu.saveTokens({ access_token: "eu-access", token_type: "bearer", refresh_token: "eu-refresh" });
+
+    expect((await MixpanelOAuthProvider.create("us")).tokens()?.refresh_token).toBe("us-refresh");
+    expect((await MixpanelOAuthProvider.create("eu")).tokens()?.refresh_token).toBe("eu-refresh");
+    expect((await stat(join(oauthTestDir, "us.json"))).mode & 0o777).toBe(0o600);
+  });
+
+  it("combines region tools and routes calls using a required region argument", async () => {
+    const calls: Array<{ region: MixpanelRegion; request: unknown }> = [];
+    const provider = async (region: MixpanelRegion) => ({
+      client: {
+        async listTools() {
+          return { tools: [{
+            name: "Run-Query",
+            description: "Run an analysis",
+            inputSchema: {
+              type: "object" as const,
+              properties: { project_id: { type: "string" } },
+              required: ["project_id"],
+            },
+          }] };
+        },
+        async callTool(request: unknown) {
+          calls.push({ region, request });
+          return { content: [{ type: "text" as const, text: region }] };
+        },
+        async close() {},
+      } as never,
+    });
+    const server = createMixpanelProxyServer(RUN_CONTEXT, provider, ["us", "eu"]);
+    const client = new Client({ name: "mixpanel-proxy-test", version: "0.1.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      const tools = await client.listTools();
+      expect(tools.tools).toHaveLength(1);
+      expect(tools.tools[0]?.inputSchema).toMatchObject({
+        properties: { region: { type: "string", enum: ["us", "eu"] } },
+        required: ["region", "project_id"],
+      });
+      const result = await client.callTool({
+        name: "Run-Query",
+        arguments: { region: "eu", project_id: "123" },
+      });
+      expect(result.isError).not.toBe(true);
+      expect(calls).toEqual([{ region: "eu", request: {
+        name: "Run-Query",
+        arguments: { project_id: "123" },
+      } }]);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it("rejects unconfigured regions and write tools", async () => {
+    let called = false;
+    const server = createMixpanelProxyServer(RUN_CONTEXT, async () => ({
+      client: {
+        async listTools() { return { tools: [] }; },
+        async callTool() {
+          called = true;
+          return { content: [{ type: "text" as const, text: "unexpected" }] };
+        },
+        async close() {},
+      } as never,
+    }), ["us"]);
+    const client = new Client({ name: "mixpanel-proxy-test", version: "0.1.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      expect((await client.callTool({
+        name: "Run-Query",
+        arguments: { region: "eu" },
+      })).isError).toBe(true);
+      expect((await client.callTool({
+        name: "Create-Dashboard",
+        arguments: { region: "us" },
+      })).isError).toBe(true);
+      expect(called).toBe(false);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it("requires authenticated run context before forwarding calls", async () => {
+    let called = false;
+    const server = createMixpanelProxyServer(null, async () => ({
+      client: {
+        async listTools() { return { tools: [] }; },
+        async callTool() {
+          called = true;
+          return { content: [{ type: "text" as const, text: "unexpected" }] };
+        },
+        async close() {},
+      } as never,
+    }), ["us"]);
+    const client = new Client({ name: "mixpanel-proxy-test", version: "0.1.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      expect((await client.callTool({
+        name: "Run-Query",
+        arguments: { region: "us" },
+      })).isError).toBe(true);
+      expect(called).toBe(false);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});

--- a/src/mcp/mixpanel-proxy.ts
+++ b/src/mcp/mixpanel-proxy.ts
@@ -201,7 +201,7 @@ async function startMixpanelBackend(region: MixpanelRegion): Promise<MixpanelBac
   const token = tokenForRegion(region);
   const transport = token
     ? new StreamableHTTPClientTransport(new URL(REGION_URLS[region]), {
-      requestInit: { headers: { Authorization: authorizationHeader(token) } },
+      requestInit: { headers: { Authorization: mixpanelAuthorizationHeader(token) } },
     })
     : new StreamableHTTPClientTransport(new URL(REGION_URLS[region]), {
       authProvider: await MixpanelOAuthProvider.create(region),
@@ -226,8 +226,9 @@ function tokenForRegion(region: MixpanelRegion): string {
   return region === "us" ? process.env.MIXPANEL_MCP_TOKEN?.trim() ?? "" : "";
 }
 
-function authorizationHeader(token: string): string {
-  return /^Bearer\s+/i.test(token) ? token : `Bearer Basic ${token}`;
+export function mixpanelAuthorizationHeader(token: string): string {
+  if (/^(?:Bearer|Basic)\s+/i.test(token)) return token;
+  return `Basic ${token}`;
 }
 
 function mixpanelProxyError(message: string): CallToolResult {

--- a/src/mcp/mixpanel-proxy.ts
+++ b/src/mcp/mixpanel-proxy.ts
@@ -1,0 +1,245 @@
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  type CallToolResult,
+} from "@modelcontextprotocol/sdk/types.js";
+import { log } from "../logger.ts";
+import { parseSlackMcpRunContext, type SlackMcpRunContext } from "./context.ts";
+import { MixpanelOAuthProvider } from "./mixpanel-oauth.ts";
+
+export type MixpanelRegion = "us" | "eu" | "in";
+
+const REGION_URLS: Record<MixpanelRegion, string> = {
+  us: "https://mcp.mixpanel.com/mcp",
+  eu: "https://mcp-eu.mixpanel.com/mcp",
+  in: "https://mcp-in.mixpanel.com/mcp",
+};
+const MIXPANEL_PROXY_IDLE_TTL_MS = Number(process.env.MIXPANEL_MCP_PROXY_IDLE_TTL_MS ?? "600000");
+const MIXPANEL_PROXY_REQUEST_TIMEOUT_MS = Number(process.env.MIXPANEL_MCP_PROXY_REQUEST_TIMEOUT_MS ?? "120000");
+
+// Feature-metrics is a read path. Fail closed when Mixpanel adds new tools;
+// write-capable tools need a separate human-gated capability before exposure.
+const READ_ONLY_TOOLS = new Set([
+  "Run-Query",
+  "Get-Query-Schema",
+  "Get-Report",
+  "Display-Query",
+  "List-Dashboards",
+  "Get-Dashboard",
+  "Get-Business-Context",
+  "Get-Projects",
+  "List-Organizations",
+  "Get-Events",
+  "List-Properties",
+  "Get-Property-Values",
+  "Search-Entities",
+  "Get-Issues",
+  "Get-Lexicon-URL",
+  "Find-Duplicate-Groups",
+  "Get-Custom-Property",
+  "Get-Cohort",
+  "List-Cohorts",
+  "Describe-Cohort-Schema",
+  "Get-Lookup-Table",
+  "Get-Metric",
+  "List-Metrics",
+  "Get-User-Replays-Data",
+  "List-Experiments",
+  "Get-Experiment",
+  "Get-Experiment-Setup-Guidance",
+  "Get-Experiment-Results-Interpretation-Guidance",
+  "Explain-Experiment-Health-Check",
+  "Run-Experiment-Pre-Launch-Checks",
+  "Search-Prior-Experiments",
+  "List-Feature-Flags",
+  "Get-Feature-Flag",
+  "Get-Feature-Flag-Setup-Guidance",
+  "Get-Feature-Flag-Lifecycle-Guidance",
+]);
+
+type MixpanelBackendClient = Pick<Client, "callTool" | "listTools" | "close">;
+type MixpanelBackendProvider = (region: MixpanelRegion) => Promise<{ client: MixpanelBackendClient }>;
+interface MixpanelBackend {
+  client: Client;
+  transport: StreamableHTTPClientTransport;
+}
+
+const backends = new Map<MixpanelRegion, Promise<MixpanelBackend>>();
+let idleTimer: ReturnType<typeof setTimeout> | null = null;
+
+export async function handleMixpanelMcpRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  const server = createMixpanelProxyServer(parseSlackMcpRunContext(req.url));
+  const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+  await server.connect(transport);
+  await transport.handleRequest(req, res);
+}
+
+export function createMixpanelProxyServer(
+  runContext: SlackMcpRunContext | null,
+  backendProvider: MixpanelBackendProvider = getMixpanelBackend,
+  configuredRegions: MixpanelRegion[] = configuredMixpanelRegions(),
+): Server {
+  const server = new Server(
+    { name: "mixpanel", version: "0.1.0" },
+    { capabilities: { tools: {} } },
+  );
+
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    if (configuredRegions.length === 0) return { tools: [] };
+    const byRegion = await Promise.all(configuredRegions.map(async (region) => ({
+      region,
+      tools: (await (await backendProvider(region)).client.listTools()).tools,
+    })));
+    armIdleTimer();
+    const union = new Map<string, (typeof byRegion)[number]["tools"][number]>();
+    for (const { tools } of byRegion) {
+      for (const tool of tools) {
+        if (READ_ONLY_TOOLS.has(tool.name) && !union.has(tool.name)) union.set(tool.name, tool);
+      }
+    }
+    return {
+      tools: [...union.values()].map((tool) => addRegionToSchema(tool, configuredRegions)),
+    };
+  });
+
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    if (!READ_ONLY_TOOLS.has(request.params.name)) {
+      return mixpanelProxyError(`tool "${request.params.name}" is not available through the read-only proxy.`);
+    }
+    if (!runContext?.signed) {
+      return mixpanelProxyError("Mixpanel MCP signed run context missing; refused to proxy request.");
+    }
+    const args = { ...(request.params.arguments ?? {}) };
+    const region = args.region;
+    delete args.region;
+    if (typeof region !== "string" || !configuredRegions.includes(region as MixpanelRegion)) {
+      return mixpanelProxyError(
+        `region must be one of the configured regions: ${configuredRegions.join(", ") || "none"}.`,
+      );
+    }
+    try {
+      const { client } = await backendProvider(region as MixpanelRegion);
+      armIdleTimer();
+      return await client.callTool(
+        { name: request.params.name, arguments: args },
+        undefined,
+        { timeout: MIXPANEL_PROXY_REQUEST_TIMEOUT_MS },
+      ) as CallToolResult;
+    } catch (err) {
+      return mixpanelProxyError(
+        `Mixpanel MCP proxy (${region}) error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  });
+
+  return server;
+}
+
+export function configuredMixpanelRegions(): MixpanelRegion[] {
+  const requested = (process.env.MIXPANEL_MCP_REGIONS ?? "us,eu,in")
+    .split(",")
+    .map((value) => value.trim().toLowerCase());
+  return (["us", "eu", "in"] as const).filter((region) => requested.includes(region));
+}
+
+export function mixpanelRegionUrl(region: MixpanelRegion): string {
+  return REGION_URLS[region];
+}
+
+export async function closeMixpanelMcpBackends(): Promise<void> {
+  if (idleTimer) clearTimeout(idleTimer);
+  idleTimer = null;
+  const active = [...backends.values()];
+  backends.clear();
+  await Promise.all(active.map(async (pending) => {
+    const value = await pending.catch(() => null);
+    await value?.client.close().catch(() => undefined);
+    await value?.transport.close().catch(() => undefined);
+  }));
+}
+
+function addRegionToSchema<T extends { inputSchema: Record<string, unknown> }>(
+  tool: T,
+  regions: MixpanelRegion[],
+): T {
+  const schema = tool.inputSchema;
+  const properties = schema.properties && typeof schema.properties === "object"
+    ? { ...(schema.properties as Record<string, unknown>) }
+    : {};
+  properties.region = {
+    type: "string",
+    enum: regions,
+    description: "Mixpanel data-residency region for this request.",
+  };
+  const required = Array.isArray(schema.required) ? [...schema.required] : [];
+  if (!required.includes("region")) required.unshift("region");
+  return { ...tool, inputSchema: { ...schema, type: "object", properties, required } };
+}
+
+function getMixpanelBackend(region: MixpanelRegion): Promise<MixpanelBackend> {
+  let current = backends.get(region);
+  if (!current) {
+    current = startMixpanelBackend(region).catch((err) => {
+      backends.delete(region);
+      throw err;
+    });
+    backends.set(region, current);
+  }
+  armIdleTimer();
+  return current;
+}
+
+async function startMixpanelBackend(region: MixpanelRegion): Promise<MixpanelBackend> {
+  const token = tokenForRegion(region);
+  const transport = token
+    ? new StreamableHTTPClientTransport(new URL(REGION_URLS[region]), {
+      requestInit: { headers: { Authorization: authorizationHeader(token) } },
+    })
+    : new StreamableHTTPClientTransport(new URL(REGION_URLS[region]), {
+      authProvider: await MixpanelOAuthProvider.create(region),
+    });
+  transport.onerror = (err) => log.warn("mixpanel-mcp", `${region} backend error: ${err.message}`);
+  transport.onclose = () => {
+    backends.delete(region);
+    log.info("mixpanel-mcp", `${region} backend closed`);
+  };
+  const client = new Client(
+    { name: `junior-mixpanel-${region}-proxy`, version: "0.1.0" },
+    { capabilities: {} },
+  );
+  await client.connect(transport);
+  log.info("mixpanel-mcp", `${region} backend started`);
+  return { client, transport };
+}
+
+function tokenForRegion(region: MixpanelRegion): string {
+  const regional = process.env[`MIXPANEL_MCP_${region.toUpperCase()}_TOKEN`]?.trim();
+  if (regional) return regional;
+  return region === "us" ? process.env.MIXPANEL_MCP_TOKEN?.trim() ?? "" : "";
+}
+
+function authorizationHeader(token: string): string {
+  return /^Bearer\s+/i.test(token) ? token : `Bearer Basic ${token}`;
+}
+
+function mixpanelProxyError(message: string): CallToolResult {
+  return { isError: true, content: [{ type: "text", text: `Error: ${message}` }] };
+}
+
+function armIdleTimer(): void {
+  if (idleTimer) clearTimeout(idleTimer);
+  idleTimer = setTimeout(() => {
+    void closeMixpanelMcpBackends().catch((err) => {
+      log.warn("mixpanel-mcp", `idle close failed: ${err instanceof Error ? err.message : String(err)}`);
+    });
+  }, MIXPANEL_PROXY_IDLE_TTL_MS);
+  idleTimer.unref?.();
+}

--- a/src/mcp/slack-server.ts
+++ b/src/mcp/slack-server.ts
@@ -58,6 +58,7 @@ import { registerWhatsAppTools } from "./whatsapp-tools.ts";
 import { registerSlackArchiveTools } from "./slack-archive-tools.ts";
 import { registerTaskRouteTools } from "../routes/tools.ts";
 import { handleMongoMcpRequest } from "./mongodb-proxy.ts";
+import { handleMixpanelMcpRequest } from "./mixpanel-proxy.ts";
 import { registerPendingApproval } from "./approval.ts";
 import { configureSlackApprovalBridge } from "./slack-approval-bridge.ts";
 import { prepareSlackResponseWithActions, type SlackActionButtonSpec } from "../slack/formatting.ts";
@@ -2486,6 +2487,10 @@ export function startMcpServer(
     const pathname = new URL(req.url ?? "/", `http://${req.headers.host ?? "localhost"}`).pathname;
     if (pathname === "/mcp/mongodb") {
       await handleMongoMcpRequest(req, res);
+      return;
+    }
+    if (pathname === "/mcp/mixpanel") {
+      await handleMixpanelMcpRequest(req, res);
       return;
     }
 

--- a/src/runners/index.test.ts
+++ b/src/runners/index.test.ts
@@ -59,15 +59,8 @@ describe("buildOpenCodeMcpConfig", () => {
 
     expect(mainMcp?.mixpanel).toBeUndefined();
     expect(featureMetricsMcp?.mixpanel).toEqual({
-      type: "local",
-      command: [
-        expect.stringContaining("junior-mcp-stdio-wrapper.js"),
-        "--",
-        "npx",
-        "-y",
-        "mcp-remote",
-        "https://mcp.mixpanel.com/mcp",
-      ],
+      type: "remote",
+      url: expect.stringContaining("http://localhost:3456/mcp/mixpanel?agent=default&channel=C01&thread=thread-1"),
       enabled: true,
     });
   });

--- a/src/runners/mcp-config.ts
+++ b/src/runners/mcp-config.ts
@@ -2,7 +2,7 @@ import { resolve } from "node:path";
 import type { Config } from "../config.ts";
 import type { OpenCodeMcpConfig } from "../opencode/config.ts";
 import type { ThreadSession } from "../session/types.ts";
-import { buildMongoMcpUrl, buildSlackMcpUrl } from "../mcp/context.ts";
+import { buildMixpanelMcpUrl, buildMongoMcpUrl, buildSlackMcpUrl } from "../mcp/context.ts";
 import { subjectHasCapability } from "../agents/capabilities.ts";
 
 export type McpServerName = "slack-bot" | "playwright" | "mixpanel" | "mongodb" | "figma" | "notion";
@@ -50,17 +50,12 @@ export function mongoMcpUrl(session: ThreadSession): string {
   return buildMongoMcpUrl(session);
 }
 
-export function playwrightMcpCommand(): StdioMcpCommand {
-  return wrappedStdioMcpCommand(["npx", "@playwright/mcp", "--headless"]);
+export function mixpanelMcpUrl(session: ThreadSession): string {
+  return buildMixpanelMcpUrl(session);
 }
 
-export function mixpanelMcpCommand(): StdioMcpCommand {
-  return wrappedStdioMcpCommand([
-    "npx",
-    "-y",
-    "mcp-remote",
-    "https://mcp.mixpanel.com/mcp",
-  ]);
+export function playwrightMcpCommand(): StdioMcpCommand {
+  return wrappedStdioMcpCommand(["npx", "@playwright/mcp", "--headless"]);
 }
 
 export function needsUserSettings(): boolean {
@@ -96,10 +91,9 @@ export function buildOpenCodeMcpConfig(
     wantsMcp(session, "mixpanel") &&
     isFeatureMetricsSession(session)
   ) {
-    const command = mixpanelMcpCommand();
     mcp.mixpanel = {
-      type: "local",
-      command: [command.command, ...command.args],
+      type: "remote",
+      url: mixpanelMcpUrl(session),
       enabled: true,
     };
   }


### PR DESCRIPTION
## Summary
- add one signed, read-only Mixpanel MCP proxy spanning US, EU, and India
- add persistent per-region OAuth with a resumable browser setup command and optional service-account fallback
- wire the proxy into OpenCode, Claude, and Codex runner configurations
- document configuration, auth storage, and regional routing

## Verification
- `bun run typecheck`
- `bun test src/mcp/mixpanel-proxy.test.ts src/mcp/context.test.ts src/runners/index.test.ts` (21 pass)
- `bun run build`
- live `Get-Projects` smoke test succeeded through the proxy for US, EU, and India