### PR TITLE
Prune merged worktrees with generated residuals

### DIFF
--- a/docs/code_index/worktree-manager.md
+++ b/docs/code_index/worktree-manager.md
@@ -48,7 +48,10 @@ Before delegated setup, Junior requires 2 GiB of free space by default (`WORKTRE
 
 `scripts/worktree-prune.ts` runs the deterministic prune engine directly
 from `REPOS`, so workflows can perform the routine Git work in one process and
-leave only preservation exceptions and reporting to the runner.
+leave only preservation exceptions and reporting to the runner. The engine
+allows generated PNG artifacts and `next-env.d.ts` as harmless residual state;
+other meaningful changes, ignored dotenv files, locks, active processes, and
+unmerged worktrees remain protected.
 
 ## Key Concepts
 

--- a/docs/features/worktree-manager.md
+++ b/docs/features/worktree-manager.md
@@ -73,10 +73,13 @@ The MCP tool `mcp__slack-bot__register_worktree({ thread_id, repo, branch? })` (
 `worktree-prune` workflow. It loads `REPOS` and calls
 `src/worktree/prune.ts`, which fetches and resolves each configured default
 base, parses porcelain worktree records, and removes only secondary worktrees
-that are unlocked, present, merged, clean, and free of ignored dotenv files.
+that are unlocked, present, merged, free of meaningful changes, and free of
+ignored dotenv files.
 It never deletes branches and reports every skip or command failure. Ignored
-dotenv files, visible changes, and any other preservation-sensitive state stay
-for the workflow's small review/reporting phase.
+dotenv files, meaningful visible changes, and any other preservation-sensitive
+state stay for the workflow's small review/reporting phase. Untracked or
+modified PNG artifacts and `next-env.d.ts` are treated as generated residual
+state and do not block removal once the worktree is otherwise safe and merged.
 
 ## Iterations
 

--- a/src/worktree/prune.test.ts
+++ b/src/worktree/prune.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { realpath } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -52,5 +52,30 @@ describe("pruneWorktrees", () => {
       repo: "repo", path: canonicalDotenvPath, reason: "ignored dotenv files require preservation review",
     });
     await git(repoPath, ["worktree", "remove", "--force", dotenvPath]);
+  });
+
+  it("removes a merged worktree containing only PNG artifacts", async () => {
+    const artifactsPath = `${repoPath}.png-artifacts`;
+    await git(repoPath, ["worktree", "add", "-b", "png-artifacts", artifactsPath, "main"]);
+    const canonicalArtifactsPath = await realpath(artifactsPath);
+    mkdirSync(join(artifactsPath, ".junior-artifacts"));
+    writeFileSync(join(artifactsPath, ".junior-artifacts", "screenshot.png"), "png");
+
+    const report = await pruneWorktrees([{ name: "repo", path: repoPath, defaultBase: "origin/main" }]);
+
+    expect(report.removed).toEqual([{ repo: "repo", path: canonicalArtifactsPath, branch: "png-artifacts" }]);
+    expect(existsSync(artifactsPath)).toBe(false);
+  });
+
+  it("removes a merged worktree containing only next-env.d.ts", async () => {
+    const nextEnvPath = `${repoPath}.next-env`;
+    await git(repoPath, ["worktree", "add", "-b", "next-env", nextEnvPath, "main"]);
+    const canonicalNextEnvPath = await realpath(nextEnvPath);
+    writeFileSync(join(nextEnvPath, "next-env.d.ts"), "// generated\n");
+
+    const report = await pruneWorktrees([{ name: "repo", path: repoPath, defaultBase: "origin/main" }]);
+
+    expect(report.removed).toEqual([{ repo: "repo", path: canonicalNextEnvPath, branch: "next-env" }]);
+    expect(existsSync(nextEnvPath)).toBe(false);
   });
 });

--- a/src/worktree/prune.ts
+++ b/src/worktree/prune.ts
@@ -24,8 +24,10 @@ interface ListedWorktree {
 /**
  * Deterministic, conservative half of worktree pruning. It only removes a
  * present, unlocked secondary worktree when its HEAD is merged into the
- * configured base and it has neither visible changes nor ignored dotenv files.
- * Anything needing preservation or interpretation is reported as skipped.
+ * configured base and it has neither meaningful changes nor ignored dotenv
+ * files. Generated PNGs and next-env.d.ts are harmless residual state and do
+ * not prevent pruning. Anything needing preservation or interpretation is
+ * reported as skipped.
  */
 export async function pruneWorktrees(
   repos: readonly RepoConfig[],
@@ -68,9 +70,11 @@ export async function pruneWorktrees(
           report.skipped.push({ repo: repo.name, path: worktree.path, reason: `HEAD is not merged into ${base}` });
           continue;
         }
-        const dirty = await git(worktree.path, ["status", "--porcelain"]);
-        if (dirty.trim()) {
-          report.skipped.push({ repo: repo.name, path: worktree.path, reason: `meaningful changes: ${statusPaths(dirty).join(", ")}` });
+        const dirty = await git(worktree.path, ["status", "--porcelain", "--untracked-files=all"]);
+        const dirtyPaths = statusPaths(dirty);
+        const meaningfulPaths = dirtyPaths.filter((path) => !isPrunableResidualPath(path));
+        if (meaningfulPaths.length) {
+          report.skipped.push({ repo: repo.name, path: worktree.path, reason: `meaningful changes: ${meaningfulPaths.join(", ")}` });
           continue;
         }
         const ignored = await git(worktree.path, ["ls-files", "--others", "--ignored", "--exclude-standard"]);
@@ -78,7 +82,10 @@ export async function pruneWorktrees(
           report.skipped.push({ repo: repo.name, path: worktree.path, reason: "ignored dotenv files require preservation review" });
           continue;
         }
-        await git(repo.path, ["worktree", "remove", worktree.path]);
+        // The force is scoped to this exact worktree. It is required when the
+        // only residual files are the generated paths allowed above; all
+        // meaningful and preservation-sensitive state has already been gated.
+        await git(repo.path, ["worktree", "remove", "--force", worktree.path]);
         if (existsSync(worktree.path)) {
           throw new Error(`git worktree remove succeeded but path remains: ${worktree.path}`);
         }
@@ -145,6 +152,10 @@ function isDevServerWorktree(worktree: ListedWorktree): boolean {
 
 function isDotenvPath(path: string): boolean {
   return basename(path) === ".env" || basename(path).startsWith(".env.");
+}
+
+function isPrunableResidualPath(path: string): boolean {
+  return path.toLowerCase().endsWith(".png") || basename(path) === "next-env.d.ts";
 }
 
 function statusPaths(output: string): string[] {

--- a/workflows/worktree-prune.workflow.md
+++ b/workflows/worktree-prune.workflow.md
@@ -46,8 +46,10 @@ Slack report in this workflow.
 
 For merge-triggered runs, resolve the event owner/repo only against the exact
 case-insensitive `repo.githubRepo`, then pass that configured repo and branch to
-the script. Do not broaden the run. The script conservatively skips all dirty,
-locked, unmerged, missing, dev-server, and dotenv-bearing worktrees.
+the script. Do not broaden the run. The script conservatively skips all
+meaningful dirty state, locked, unmerged, missing, dev-server, and dotenv-bearing
+worktrees. PNG artifacts and `next-env.d.ts` are treated as harmless generated
+residuals.
 
 After it finishes, use the script output directly in a compact Slack-ready
 summary: repos inspected, removals, skips with reasons, and failures. Do not


### PR DESCRIPTION
## Summary
- Treat PNG artifacts and `next-env.d.ts` as harmless generated residuals during merged worktree pruning.
- Preserve existing safety gates for meaningful changes, dotenv files, locks, active processes, and unmerged branches.
- Add regression coverage and update pruning documentation.

## Validation
- `bun run typecheck`
- `bun test src/worktree`
