### PR TITLE
Fix pipeline assignments missing outcome reporting tools

### DIFF
--- a/docs/code_index/pipelines.md
+++ b/docs/code_index/pipelines.md
@@ -19,7 +19,7 @@ disabled by default (`PIPELINE_RUNTIME_MODE=off`) and can run in `shadow` or
 | Retention cleanup | `src/pipelines/gc.ts` | Pipeline retention GC (`PIPELINE_RETENTION_DAYS`). |
 | Full cancellation | `PipelineStore.cancelRun`, `SessionManager` `!stop` handling | Atomically abandons the run, cancels live assignments/jobs, dead-letters pending or leased wakes, deactivates GitHub tracking, clears session invocation state, and interrupts runner handles. |
 | Legacy bridge | `src/pipelines/legacy-directives.ts`, `src/support/pipeline-guard.ts` | Safely maps selected legacy directives while preserving existing routing. |
-| MCP tools | `src/pipelines/tools.ts` | Runner-facing pipeline read/write tools with scope and idempotency checks. |
+| MCP tools | `src/pipelines/tools.ts`, `src/session/manager.ts` | Runner-facing pipeline read/write tools with scope and idempotency checks. Every durable assignment receives `pipeline_get_state` and `pipeline_report_outcome` in its provider permission envelope, including repo-backed workers. |
 
 ## Runtime contract
 

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -937,6 +937,13 @@ describe("SessionManager", () => {
     expect(runSession.targetRepo).toBe("frontend");
     expect(runSession.worktreePath).toBe(paths.frontend);
     expect(runSession.worktreePaths).toEqual(paths);
+    expect(runSession.agentPermissions?.mcp).toContain("slack-bot");
+    expect(runSession.agentPermissions?.tools).toEqual(
+      expect.arrayContaining([
+        "mcp__slack-bot__pipeline_get_state",
+        "mcp__slack-bot__pipeline_report_outcome",
+      ]),
+    );
   });
 
   it("keeps the onboarding agent repo-less outside a pipeline", async () => {

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -2107,6 +2107,30 @@ export class SessionManager {
         };
       }
 
+      // Every durable pipeline assignment must be able to settle itself.
+      // Repo-backed assignments used to inherit the agent definition verbatim,
+      // so review/build workers could finish useful work but had no explicit
+      // pipeline_report_outcome tool in their provider permission envelope.
+      // Keep the agent's intent and declared tools, then add only the two
+      // control-plane tools needed by every pipeline worker.
+      if (pipelineInvocation) {
+        const permissions = runSession.agentPermissions ?? {
+          intent: null,
+          mcp: [],
+          tools: [],
+        };
+        runSession.agentPermissions = {
+          ...permissions,
+          mcp: [...new Set([...permissions.mcp, "slack-bot"])],
+          tools: [
+            ...new Set([
+              ...permissions.tools,
+              ...PIPELINE_CONTROL_MCP_TOOLS,
+            ]),
+          ],
+        };
+      }
+
       // Build the prompt. When the provider will not resume a prior model
       // session, inject the preamble blocks the agent asked for. On resumed
       // turns, provider-native resume already carries identity/context/history —


### PR DESCRIPTION
## Summary
- grant every durable pipeline assignment access to pipeline_get_state and pipeline_report_outcome
- preserve agent-declared permissions while adding the control-plane tools
- add regression coverage for repo-backed pipeline workers

## Verification
- bun test src/session/manager.test.ts
- bun run typecheck

## Root cause
Repo-backed assignments inherited the agent definition permissions verbatim. The repo-less pipeline path injected the pipeline tools, but review/build assignments with a repository did not, so the worker could complete work without producing a typed pipeline outcome.