### PR TITLE
fix(codex): disable default environments on thread lifecycle

### DIFF
--- a/docs/code_index/codex-app-server.md
+++ b/docs/code_index/codex-app-server.md
@@ -34,6 +34,11 @@ Generated Codex config sets `[features].multi_agent = false`; provider-native
 subagents would bypass Junior's durable assignment, context, and settlement
 contracts.
 
+Thread creation and resume explicitly send `environments: []`. This disables
+Codex's default local command environment so the thread's tool surface stays
+limited to Junior's scoped MCP configuration; the invariant is covered by the
+app-server spawner regression tests for both fresh and resumed threads.
+
 Native `requestApproval` server callbacks are not auto-denied. The provider
 posts a scoped Allow/Deny action in the originating Slack thread, waits on the
 same in-process resolver used by Claude's permission tool, and returns the

--- a/docs/code_index/codex-app-server.md
+++ b/docs/code_index/codex-app-server.md
@@ -39,6 +39,14 @@ Codex's default local command environment so the thread's tool surface stays
 limited to Junior's scoped MCP configuration; the invariant is covered by the
 app-server spawner regression tests for both fresh and resumed threads.
 
+Before release, run `CODEX_APP_SMOKE_SLACK_CHANNEL_ID=<approved-test-channel>
+CODEX_APP_SMOKE_RELEASE_GATE=1 bun run codex:release-gate` with an authenticated
+Codex CLI and a running Junior MCP server. This opt-in live gate requires an
+approved `slack_send_message` dynamic-tool call, then asks Codex to execute a
+forced `touch`; it fails if no MCP tool item is observed, if any command item is
+emitted, or if the probe file appears. The gate uses a temporary directory and
+removes it on exit.
+
 Native `requestApproval` server callbacks are not auto-denied. The provider
 posts a scoped Allow/Deny action in the originating Slack thread, waits on the
 same in-process resolver used by Claude's permission tool, and returns the

--- a/docs/code_index/codex-app-server.md
+++ b/docs/code_index/codex-app-server.md
@@ -43,9 +43,11 @@ Before release, run `CODEX_APP_SMOKE_SLACK_CHANNEL_ID=<approved-test-channel>
 CODEX_APP_SMOKE_RELEASE_GATE=1 bun run codex:release-gate` with an authenticated
 Codex CLI and a running Junior MCP server. This opt-in live gate requires an
 approved `slack_send_message` dynamic-tool call, then asks Codex to execute a
-forced `touch`; it fails if no MCP tool item is observed, if any command item is
-emitted, or if the probe file appears. The gate uses a temporary directory and
-removes it on exit.
+forced `touch`; it fails unless the MCP item completes successfully with a
+concrete result, and unless the shell turn provides explicit refusal or
+terminal-failure evidence. It also fails if any command item is emitted or if
+the probe file appears. The gate uses a temporary directory and removes it on
+exit.
 
 Native `requestApproval` server callbacks are not auto-denied. The provider
 posts a scoped Allow/Deny action in the originating Slack thread, waits on the

--- a/docs/features/codex-runner.md
+++ b/docs/features/codex-runner.md
@@ -150,6 +150,18 @@ tool access is limited to the scoped MCP configuration that Junior generates
 for the run. The spawner tests assert this on fresh threads and on the
 missing-rollout resume fallback.
 
+The release gate is intentionally opt-in because it posts a real test message:
+
+```sh
+CODEX_APP_SMOKE_SLACK_CHANNEL_ID=<approved-test-channel> \
+CODEX_APP_SMOKE_RELEASE_GATE=1 bun run codex:release-gate
+```
+
+It requires an authenticated Codex CLI and a running Junior MCP server. The
+positive probe requires an observed `slack-bot/slack_send_message` MCP item;
+the negative probe asks for a shell `touch` and fails if a command item or
+filesystem side effect appears. The probe path is temporary and cleaned up.
+
 Current `.mcp.json` (unchanged):
 
 ```json

--- a/docs/features/codex-runner.md
+++ b/docs/features/codex-runner.md
@@ -144,6 +144,12 @@ Then:
 
 ## MCP Configuration
 
+The app-server adapter sends `environments: []` on both `thread/start` and
+`thread/resume`. Codex's default local environment is therefore disabled, and
+tool access is limited to the scoped MCP configuration that Junior generates
+for the run. The spawner tests assert this on fresh threads and on the
+missing-rollout resume fallback.
+
 Current `.mcp.json` (unchanged):
 
 ```json

--- a/docs/features/codex-runner.md
+++ b/docs/features/codex-runner.md
@@ -158,9 +158,11 @@ CODEX_APP_SMOKE_RELEASE_GATE=1 bun run codex:release-gate
 ```
 
 It requires an authenticated Codex CLI and a running Junior MCP server. The
-positive probe requires an observed `slack-bot/slack_send_message` MCP item;
-the negative probe asks for a shell `touch` and fails if a command item or
-filesystem side effect appears. The probe path is temporary and cleaned up.
+positive probe requires a completed `slack-bot/slack_send_message` MCP item
+with no error and a concrete result; the negative probe asks for a shell
+`touch` and requires explicit refusal or terminal-failure evidence, then fails
+if a command item or filesystem side effect appears. The probe path is
+temporary and cleaned up.
 
 Current `.mcp.json` (unchanged):
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "typecheck": "tsc --noEmit",
     "test": "bun test",
     "build": "bun build ./src/index.ts --outdir ./dist --target bun",
+    "codex:release-gate": "CODEX_APP_SMOKE_RELEASE_GATE=1 node scripts/codex-app-server-smoke.mjs",
     "cleanup": "bun run src/lifecycle/cleanup.ts",
     "mixpanel:oauth": "bun run src/mcp/mixpanel-oauth-cli.ts",
     "memory:reembed": "bun run src/memory/reembed-retrieval.ts",

--- a/scripts/codex-app-server-smoke.mjs
+++ b/scripts/codex-app-server-smoke.mjs
@@ -380,8 +380,16 @@ async function main() {
       n.params.item.server === "slack-bot" &&
       n.params.item.tool === "slack_send_message",
     );
-    if (slackItems.length === 0) {
-      throw new Error("Release gate failed: approved dynamic Slack MCP tool did not execute");
+    const successfulSlackItems = slackItems.filter((n) =>
+      n.method === "item/completed" &&
+      n.params.item.error == null &&
+      n.params.item.result != null &&
+      JSON.stringify(n.params.item.result).length > 2,
+    );
+    if (successfulSlackItems.length === 0) {
+      throw new Error(
+        "Release gate failed: approved dynamic Slack MCP tool did not complete with a result",
+      );
     }
     if (shellCommands.length > 0) {
       throw new Error("Release gate failed: shell command item was emitted with environments=[]");
@@ -389,10 +397,36 @@ async function main() {
     if (existsSync(releaseShellProbePath)) {
       throw new Error("Release gate failed: forced shell probe created a side-effect file");
     }
+    const shellTurnCompleted = notifications.find((n) =>
+      n.method === "turn/completed" &&
+      n.params.threadId === threadId &&
+      n.params.turn.id === shellTurn.turn.id,
+    );
+    const shellResponse = notifications
+      .filter((n) =>
+        (n.method === "item/agentMessage/delta" || n.method === "item/agentMessage/completed") &&
+        n.params.threadId === threadId &&
+        n.params.turnId === shellTurn.turn.id,
+      )
+      .map((n) => n.params.delta ?? n.params.item?.text ?? "")
+      .join("");
+    const explicitShellDenial =
+      /\b(?:cannot|can't|unable|no access|not available|not have access|do not have access)\b/i
+        .test(shellResponse);
+    const terminalShellFailure =
+      shellTurnCompleted?.params?.turn?.status === "failed" ||
+      shellTurnCompleted?.params?.turn?.error != null;
+    if (!explicitShellDenial && !terminalShellFailure) {
+      throw new Error(
+        "Release gate failed: shell probe had no concrete tool-unavailable or terminal-failure evidence",
+      );
+    }
     optionalTurns.push({
       kind: "release-gate",
       dynamicTool: "slack-bot/slack_send_message",
+      dynamicToolCompleted: successfulSlackItems.length,
       shellCommandItems: shellCommands.length,
+      shellDenialEvidence: explicitShellDenial ? "agent-refusal" : "terminal-failure",
       shellProbePath: releaseShellProbePath,
     });
   }

--- a/scripts/codex-app-server-smoke.mjs
+++ b/scripts/codex-app-server-smoke.mjs
@@ -1,12 +1,26 @@
 #!/usr/bin/env node
 
 import { spawn } from "node:child_process";
-import { existsSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { resolve } from "node:path";
 import { createInterface } from "node:readline";
 
 const cwd = process.cwd();
 const timeoutMs = Number(process.env.CODEX_APP_SMOKE_TIMEOUT_MS ?? "120000");
+const releaseGate = process.env.CODEX_APP_SMOKE_RELEASE_GATE === "1";
+if (releaseGate && !process.env.CODEX_APP_SMOKE_SLACK_CHANNEL_ID) {
+  throw new Error(
+    "CODEX_APP_SMOKE_RELEASE_GATE=1 requires CODEX_APP_SMOKE_SLACK_CHANNEL_ID " +
+      "for the approved dynamic-tool probe",
+  );
+}
+const releaseProbeDir = releaseGate
+  ? mkdtempSync(resolve(tmpdir(), "junior-codex-release-gate-"))
+  : null;
+const releaseShellProbePath = releaseProbeDir
+  ? resolve(releaseProbeDir, "should-not-exist")
+  : null;
 const isolatedHome = process.env.CODEX_ISOLATED_HOME_PATH
   ? resolve(process.env.CODEX_ISOLATED_HOME_PATH)
   : null;
@@ -159,6 +173,7 @@ async function main() {
     model: process.env.CODEX_APP_SMOKE_MODEL ?? null,
     approvalPolicy: "never",
     sandbox: "read-only",
+    environments: [],
     baseInstructions: "You are a protocol smoke-test assistant.",
     developerInstructions: `For every response in this thread, include the exact marker ${marker}.`,
     ephemeral: false,
@@ -234,6 +249,7 @@ async function main() {
     cwd,
     approvalPolicy: "never",
     sandbox: "read-only",
+    environments: [],
     developerInstructions: `For every response in this thread, include the exact marker ${marker}.`,
     excludeTurns: true,
     persistExtendedHistory: false,
@@ -317,6 +333,70 @@ async function main() {
     optionalTurns.push({ kind: "slack", turnId: slackTurn.turn.id, text });
   }
 
+  if (releaseGate) {
+    const shellTurn = await send("turn/start", {
+      threadId,
+      input: [
+        {
+          type: "text",
+          text: [
+            "This is a negative isolation probe.",
+            `Use a shell/command tool to run: touch ${releaseShellProbePath}`,
+            "Do not merely describe the command; attempt to execute it.",
+          ].join("\n"),
+          text_elements: [],
+        },
+      ],
+      approvalPolicy: "never",
+      sandboxPolicy: {
+        type: "readOnly",
+        networkAccess: false,
+        excludeTmpdirEnvVar: false,
+        excludeSlashTmp: false,
+      },
+    });
+    await waitFor(
+      () => notifications.find((n) => {
+        if (n.method !== "turn/completed") return false;
+        return n.params.threadId === threadId && n.params.turn.id === shellTurn.turn.id;
+      }),
+      "release shell-denial turn/completed",
+      30000,
+    );
+
+    const shellItems = notifications.filter((n) =>
+      (n.method === "item/started" || n.method === "item/completed") &&
+      n.params.threadId === threadId &&
+      n.params.turnId === shellTurn.turn.id,
+    );
+    const shellCommands = shellItems.filter((n) =>
+      n.params.item.type === "command_execution" ||
+      n.params.item.type === "shell_command",
+    );
+    const slackItems = notifications.filter((n) =>
+      (n.method === "item/started" || n.method === "item/completed") &&
+      n.params.threadId === threadId &&
+      (n.params.item.type === "mcp_tool_call" || n.params.item.type === "mcp_tool_use") &&
+      n.params.item.server === "slack-bot" &&
+      n.params.item.tool === "slack_send_message",
+    );
+    if (slackItems.length === 0) {
+      throw new Error("Release gate failed: approved dynamic Slack MCP tool did not execute");
+    }
+    if (shellCommands.length > 0) {
+      throw new Error("Release gate failed: shell command item was emitted with environments=[]");
+    }
+    if (existsSync(releaseShellProbePath)) {
+      throw new Error("Release gate failed: forced shell probe created a side-effect file");
+    }
+    optionalTurns.push({
+      kind: "release-gate",
+      dynamicTool: "slack-bot/slack_send_message",
+      shellCommandItems: shellCommands.length,
+      shellProbePath: releaseShellProbePath,
+    });
+  }
+
   const agentDeltas = notifications
     .filter((n) => n.method === "item/agentMessage/delta")
     .map((n) => n.params.delta)
@@ -360,6 +440,9 @@ async function main() {
     notificationMethods: [...new Set(notifications.map((n) => n.method))].sort(),
     serverRequestMethods: [...new Set(serverRequests.map((r) => r.method))].sort(),
     serverRequests,
+    releaseGate: releaseGate
+      ? { environments: [], dynamicTool: "slack-bot/slack_send_message", shellCommandItems: 0 }
+      : null,
     stderr: stderr.trim().slice(0, 2000),
   }, null, 2));
 }
@@ -378,4 +461,5 @@ main()
   .finally(() => {
     clearTimeout(hardTimeout);
     proc.kill("SIGTERM");
+    if (releaseProbeDir) rmSync(releaseProbeDir, { recursive: true, force: true });
   });

--- a/src/codex-app-server/spawner.test.ts
+++ b/src/codex-app-server/spawner.test.ts
@@ -216,6 +216,7 @@ describe("spawnCodexAppServer", () => {
       );
       expect(threadStart.params.sandbox).toBe("danger-full-access");
       expect(threadStart.params.sandboxPolicy).toEqual({ type: "dangerFullAccess" });
+      expect(threadStart.params.environments).toEqual([]);
       expect(turnStart.params.sandboxPolicy).toEqual({ type: "dangerFullAccess" });
     } finally {
       fakeCodex.cleanup();
@@ -299,6 +300,10 @@ describe("spawnCodexAppServer", () => {
         "thread/start",
         "turn/start",
       ]);
+      expect(requests.find((request) => request.method === "thread/resume").params.environments)
+        .toEqual([]);
+      expect(requests.find((request) => request.method === "thread/start").params.environments)
+        .toEqual([]);
       expect(requests.find((request) => request.method === "turn/start").params.threadId)
         .toBe("thread-created");
     } finally {

--- a/src/codex-app-server/spawner.ts
+++ b/src/codex-app-server/spawner.ts
@@ -239,6 +239,9 @@ export function spawnCodexAppServer(
             approvalPolicy: policy.approvalPolicy,
             sandbox: policy.sandbox,
             sandboxPolicy: policy.sandboxPolicy,
+            // Do not expose Codex's default local environment. Junior's
+            // scoped MCP wiring is the only tool surface for this thread.
+            environments: [],
             developerInstructions: developerInstructions(session),
             excludeTurns: true,
             persistExtendedHistory: false,
@@ -407,6 +410,9 @@ function threadStartParams(options: {
     approvalPolicy: options.policy.approvalPolicy,
     sandbox: options.policy.sandbox,
     sandboxPolicy: options.policy.sandboxPolicy,
+    // Keep the built-in local command environment disabled. Tool access must
+    // come from Junior's scoped MCP contract.
+    environments: [],
     // Omit baseInstructions so Codex retains its native coding-agent operating
     // prompt. Junior is an additive developer layer, not a replacement for
     // Codex's tool, persistence, safety, and editing contract.


### PR DESCRIPTION
## Summary
- disable Codex's default local environment on thread start and resume
- add regression assertions for fresh and resumed app-server threads
- document the tool-isolation contract

## Validation
- `bun test src/codex-app-server/spawner.test.ts`
- `bun run typecheck`