### PR TITLE
fix: preserve Slack attachments in default durable runs

### DIFF
--- a/docs/code_index/pipelines.md
+++ b/docs/code_index/pipelines.md
@@ -10,7 +10,8 @@ disabled by default (`PIPELINE_RUNTIME_MODE=off`) and can run in `shadow` or
 |---|---|---|
 | Types and definitions | `src/pipelines/types.ts`, `src/pipelines/bug/definition.ts`, `src/pipelines/product/definition.ts` | Run, assignment, outcome, artifact, transition, and pipeline-specific state. |
 | Controllers | `src/pipelines/bug/controller.ts`, `src/pipelines/product/controller.ts` | Start typed runs, apply transitions, and enqueue work. |
-| Dispatch | `src/pipelines/dispatch.ts`, `src/pipelines/pump.ts` | Claim assignments and deliver them to agent sessions. |
+| Dispatch | `src/pipelines/dispatch.ts`, `src/pipelines/pump.ts` | Claim assignments and deliver them to agent sessions, restoring bounded Slack attachments from durable state. |
+| Slack attachment durability | `src/slack/files.ts`, `src/pipelines/default/controller.ts`, `src/session/manager.ts` | Bounds the existing `SlackFileAttachment` contract, stores refs on default assignments/outbox payloads, and restores them on synthetic dispatch events. |
 | Structured monitoring | `src/pipelines/logging.ts`, dispatch, settlement, outcome, and GitHub review modules | Emits searchable `event=...` lifecycle records keyed by run, thread, assignment, and agent. |
 | Persistence | `src/pipelines/store/*` | Memory and SQLite stores, versioned writes, and transactional outcome handling. |
 | Reliability | `src/pipelines/outbox.ts`, `recovery.ts`, `settlement-recovery` paths | At-least-once outbox delivery, lease recovery, and settlement repair. |
@@ -35,6 +36,12 @@ Assignments use leases and idempotency keys. The outbox is at-least-once, so
 consumers and outcome writes must remain idempotent; version/CAS checks prevent
 stale workers from overwriting newer state. Retention is controlled by
 `PIPELINE_RETENTION_DAYS`.
+
+Ordinary Slack messages routed through an active default run retain up to eight
+attachment references (bounded URL, filename, and MIME type fields) on the
+assignment and its dispatch outbox item. The pump validates those JSON refs and
+reconstructs `SlackMessageEvent.files` before `SessionManager` downloads them;
+missing refs remain backward-compatible with older outbox rows.
 
 The localhost dashboard defaults to a readable **dispatch trace** in
 `public/js/pipelines.js`: run start/end, assignment source→target agents,

--- a/docs/code_index/slack-event-handler.md
+++ b/docs/code_index/slack-event-handler.md
@@ -20,7 +20,8 @@ Slack Bolt app setup, event filtering (with self-bot directive escape hatch), ho
 
 | Type | File | Shape |
 |---|---|---|
-| `SlackMessageEvent` | `events.ts` | `{ threadId, channel, user, text, ts, command, files?, isSelfBot?, botId?, botUsername?, mentionsJunior?, dedupeKey?, pipelineInvocation?, attributionUserId?, conversationalText? }` |
+| `SlackMessageEvent` | `events.ts` | `{ threadId, channel, user, text, ts, command, files?, isSelfBot?, botId?, botUsername?, mentionsJunior?, dedupeKey?, pipelineInvocation?, attributionUserId?, conversationalText? }`; durable default runs bound the `files` refs before persistence and restore them on pump dispatch. |
+| `boundSlackFileAttachments` / `parseSlackFileAttachments` | `files.ts` | Caps serialized Slack file refs and validates JSON-restored refs before they re-enter a synthetic event. |
 | `SlackFileAttachment` | `events.ts` | `{ url, name, mimetype }` |
 | `OnMessageCallback` | `events.ts` | `(event: SlackMessageEvent) => void` |
 

--- a/src/pipelines/default/controller.ts
+++ b/src/pipelines/default/controller.ts
@@ -1,5 +1,7 @@
 import type { Clock } from "../../time/clock.ts";
 import { systemClock } from "../../time/clock.ts";
+import { boundSlackFileAttachments } from "../../slack/files.ts";
+import type { SlackFileAttachment } from "../../slack/events.ts";
 import type { PipelineStore } from "../store/interface.ts";
 import {
   PIPELINE_DEFINITION_VERSION,
@@ -16,6 +18,7 @@ export type CreateDefaultRunInput = {
   sourceAgent?: string | "human" | "system";
   /** Original human Slack user ID for prompt attribution. */
   sourceSlackUserId?: string | null;
+  files?: SlackFileAttachment[];
   repoRefs?: string[];
   acceptanceCriteria?: string[];
   runId?: string;
@@ -51,6 +54,7 @@ export async function createDefaultRun(
 
   const runId = input.runId ?? crypto.randomUUID();
   const assignmentId = crypto.randomUUID();
+  const files = boundSlackFileAttachments(input.files);
   const run: DefaultRun = {
     id: runId,
     kind: "default",
@@ -83,6 +87,7 @@ export async function createDefaultRun(
       sourceSlackUserId: input.sourceSlackUserId ?? null,
       targetAgent: input.targetAgent,
       objective: input.objective,
+      files,
       contextRefs: [`source-message:${input.messageTs}`],
       artifactRefs: [],
       acceptanceCriteria: input.acceptanceCriteria ?? [],
@@ -126,6 +131,7 @@ export async function createDefaultRun(
         targetAgent: input.targetAgent,
         sourceMessageTs: input.messageTs,
         sourceSlackUserId: input.sourceSlackUserId ?? null,
+        ...(files.length > 0 ? { files } : {}),
       },
       idempotencyKey: `default-dispatch:${assignmentKey}`,
     }],

--- a/src/pipelines/dispatch.ts
+++ b/src/pipelines/dispatch.ts
@@ -4,6 +4,8 @@
  */
 
 import type { SlackMessageEvent } from "../slack/events.ts";
+import type { SlackFileAttachment } from "../slack/events.ts";
+import { boundSlackFileAttachments } from "../slack/files.ts";
 import type { PipelineInvocationRef, ThreadSession } from "../session/types.ts";
 import type { Assignment, PipelineRun } from "./types.ts";
 import {
@@ -52,6 +54,8 @@ export type DispatchAssignmentInput = {
   conversationalText?: string;
   /** Shared idempotency / dedupe key for the synthetic Slack event. */
   dedupeKey?: string;
+  /** Bounded Slack files restored from the durable assignment/outbox. */
+  files?: SlackFileAttachment[];
   pipelineInvocation?: PipelineInvocationRef;
 };
 
@@ -187,6 +191,7 @@ export async function dispatchAssignment(
   const syntheticTs =
     input.sourceMessageTs ??
     `pipeline:${run.id}:${assignment.id}:${assignment.updatedAt}`;
+  const files = boundSlackFileAttachments(input.files ?? assignment.files);
 
   const event: SlackMessageEvent = {
     threadId: run.threadId,
@@ -197,6 +202,7 @@ export async function dispatchAssignment(
     text: prompt,
     ts: syntheticTs,
     command: null,
+    ...(files.length > 0 ? { files } : {}),
     isSelfBot: true,
     botUsername: "pipeline",
     dedupeKey,

--- a/src/pipelines/pump.ts
+++ b/src/pipelines/pump.ts
@@ -7,6 +7,7 @@
 import type { Clock } from "../time/clock.ts";
 import { systemClock } from "../time/clock.ts";
 import { log } from "../logger.ts";
+import { parseSlackFileAttachments } from "../slack/files.ts";
 import type { PipelineStore } from "./store/interface.ts";
 import type { Assignment, PipelineOutboxRecord } from "./types.ts";
 import {
@@ -279,6 +280,9 @@ async function handleOutboxItem(
         // Control-plane routing remains synthetic while trusted provenance
         // supplies the conversational author for prompt attribution.
         userId: sourceSlackUserId,
+        files: Array.isArray(item.payload.files)
+          ? parseSlackFileAttachments(item.payload.files)
+          : undefined,
         dedupeKey: `pipeline-outbox:${item.idempotencyKey}`,
         pipelineInvocation: {
           runId: run.id,

--- a/src/pipelines/store/memory.ts
+++ b/src/pipelines/store/memory.ts
@@ -161,6 +161,7 @@ export class InMemoryPipelineStore implements PipelineStore {
         capabilityRefs: [...(assignmentInput.capabilityRefs ?? [])],
         status: assignmentInput.status ?? "pending",
         objective: assignmentInput.objective,
+        files: [...(assignmentInput.files ?? [])],
         contextRefs: [...assignmentInput.contextRefs],
         artifactRefs: [...assignmentInput.artifactRefs],
         acceptanceCriteria: [...assignmentInput.acceptanceCriteria],
@@ -309,6 +310,7 @@ export class InMemoryPipelineStore implements PipelineStore {
       capabilityRefs: [...(input.capabilityRefs ?? [])],
       status: input.status ?? "pending",
       objective: input.objective,
+      files: [...(input.files ?? [])],
       contextRefs: [...input.contextRefs],
       artifactRefs: [...input.artifactRefs],
       acceptanceCriteria: [...input.acceptanceCriteria],
@@ -1540,6 +1542,7 @@ function cloneAssignment(a: Assignment): Assignment {
   return {
     ...a,
     capabilityRefs: [...a.capabilityRefs],
+    files: [...(a.files ?? [])],
     contextRefs: [...a.contextRefs],
     artifactRefs: [...a.artifactRefs],
     acceptanceCriteria: [...a.acceptanceCriteria],

--- a/src/pipelines/store/sqlite.ts
+++ b/src/pipelines/store/sqlite.ts
@@ -86,6 +86,7 @@ type AssignmentRow = {
   capability_refs_json: string;
   status: string;
   objective: string;
+  files_json: string;
   context_refs_json: string;
   artifact_refs_json: string;
   acceptance_json: string;
@@ -394,6 +395,7 @@ export class SqlitePipelineStore implements PipelineStore {
         capability_refs_json TEXT NOT NULL DEFAULT '[]',
         status TEXT NOT NULL,
         objective TEXT NOT NULL,
+        files_json TEXT NOT NULL DEFAULT '[]',
         context_refs_json TEXT NOT NULL DEFAULT '[]',
         artifact_refs_json TEXT NOT NULL DEFAULT '[]',
         acceptance_json TEXT NOT NULL DEFAULT '[]',
@@ -428,6 +430,11 @@ export class SqlitePipelineStore implements PipelineStore {
     if (!assignmentColumns.some((column) => column.name === "capability_refs_json")) {
       this.db.run(
         `ALTER TABLE pipeline_assignments ADD COLUMN capability_refs_json TEXT NOT NULL DEFAULT '[]'`,
+      );
+    }
+    if (!assignmentColumns.some((column) => column.name === "files_json")) {
+      this.db.run(
+        `ALTER TABLE pipeline_assignments ADD COLUMN files_json TEXT NOT NULL DEFAULT '[]'`,
       );
     }
 
@@ -951,6 +958,7 @@ export class SqlitePipelineStore implements PipelineStore {
         capabilityRefs: [...(assignmentInput.capabilityRefs ?? [])],
         status: assignmentInput.status ?? "pending",
         objective: assignmentInput.objective,
+        files: [...(assignmentInput.files ?? [])],
         contextRefs: [...assignmentInput.contextRefs],
         artifactRefs: [...assignmentInput.artifactRefs],
         acceptanceCriteria: [...assignmentInput.acceptanceCriteria],
@@ -1095,6 +1103,7 @@ export class SqlitePipelineStore implements PipelineStore {
       capabilityRefs: [...(input.capabilityRefs ?? [])],
       status: input.status ?? "pending",
       objective: input.objective,
+      files: [...(input.files ?? [])],
       contextRefs: [...input.contextRefs],
       artifactRefs: [...input.artifactRefs],
       acceptanceCriteria: [...input.acceptanceCriteria],
@@ -1132,6 +1141,7 @@ export class SqlitePipelineStore implements PipelineStore {
             skillRef: input.assignment.skillRef ?? null,
             capabilityRefs: [...(input.assignment.capabilityRefs ?? [])],
             status: input.assignment.status ?? ("pending" as const),
+            files: [...(input.assignment.files ?? [])],
             leaseOwner: input.assignment.leaseOwner ?? null,
             leaseExpiresAt: input.assignment.leaseExpiresAt ?? null,
             createdAt: now,
@@ -2930,11 +2940,11 @@ export class SqlitePipelineStore implements PipelineStore {
         `INSERT INTO pipeline_assignments (
           id, run_id, parent_assignment_id, source_agent, source_slack_user_id,
           target_agent, skill_ref, capability_refs_json,
-          status, objective, context_refs_json, artifact_refs_json,
+          status, objective, files_json, context_refs_json, artifact_refs_json,
           acceptance_json, mutation_scope_json, dependencies_json,
           attempt_number, attempt_id, candidate_revision_digest, deadline_at,
           lease_owner, lease_expires_at, idempotency_key, created_at, updated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         ON CONFLICT(idempotency_key) DO NOTHING`,
       )
       .run(
@@ -2948,6 +2958,7 @@ export class SqlitePipelineStore implements PipelineStore {
         JSON.stringify(assignment.capabilityRefs),
         assignment.status,
         assignment.objective,
+        JSON.stringify(assignment.files ?? []),
         JSON.stringify(assignment.contextRefs),
         JSON.stringify(assignment.artifactRefs),
         JSON.stringify(assignment.acceptanceCriteria),
@@ -3091,6 +3102,7 @@ function assignmentFromRow(row: AssignmentRow): Assignment {
     ) as Assignment["capabilityRefs"],
     status: row.status as Assignment["status"],
     objective: row.objective,
+    files: parseJsonArray(row.files_json) as unknown as Assignment["files"],
     contextRefs: parseJsonArray(row.context_refs_json),
     artifactRefs: parseJsonArray(row.artifact_refs_json),
     acceptanceCriteria: parseJsonArray(row.acceptance_json),

--- a/src/pipelines/types.ts
+++ b/src/pipelines/types.ts
@@ -3,6 +3,8 @@
  * Phase 2 substrate — not wired into live Slack routing yet.
  */
 
+import type { SlackFileAttachment } from "../slack/events.ts";
+
 /** Bump only when the controller contract itself changes incompatibly. */
 export const PIPELINE_DEFINITION_VERSION = 1;
 
@@ -272,6 +274,8 @@ export type Assignment = {
   capabilityRefs: import("../agents/manifest.ts").AgentCapability[];
   status: AssignmentStatus;
   objective: string;
+  /** Bounded Slack attachments retained for the assignment's runner turn. */
+  files?: SlackFileAttachment[];
   contextRefs: string[];
   artifactRefs: string[];
   acceptanceCriteria: string[];
@@ -299,6 +303,7 @@ export type AssignmentCreate = Omit<
   | "createdAt"
   | "updatedAt"
 > & {
+  files?: SlackFileAttachment[];
   skillRef?: string | null;
   capabilityRefs?: import("../agents/manifest.ts").AgentCapability[];
   status?: AssignmentStatus;

--- a/src/session/manager.test.ts
+++ b/src/session/manager.test.ts
@@ -431,6 +431,49 @@ describe("SessionManager", () => {
     expect(mockSpawnFn.mock.calls[0][1]).toContain("make the small config change");
   });
 
+  it("preserves Slack attachments through the durable default run", async () => {
+    const pipelineStore = new InMemoryPipelineStore();
+    manager = createTestManager(store, cloneConfig({
+      pipeline: {
+        runtimeMode: "active",
+        legacyDirectivesEnabled: true,
+        bugPipelineEnabled: true,
+        productPipelineEnabled: true,
+        retentionDays: 90,
+      },
+    }));
+    manager.pipelineStore = pipelineStore;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = mock(async () => new Response("a,b\n1,2\n", { status: 200 })) as unknown as typeof fetch;
+    try {
+      await manager.handleMessage(makeEvent({
+        text: "review this csv",
+        files: [{
+          url: "https://files.slack.com/files-pri/T/F/download/input.csv",
+          name: "input.csv",
+          mimetype: "text/csv",
+        }],
+      }));
+      await waitFor(() => mockSpawnFn.mock.calls.length === 1);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    const run = await pipelineStore.getRunByThread("thread-1");
+    const assignment = run
+      ? (await pipelineStore.listAssignments(run.id))[0]
+      : undefined;
+    const outbox = run ? (await pipelineStore.listOutbox(run.id))[0] : undefined;
+    expect(assignment?.files).toEqual([{
+      url: "https://files.slack.com/files-pri/T/F/download/input.csv",
+      name: "input.csv",
+      mimetype: "text/csv",
+    }]);
+    expect(outbox?.payload.files).toEqual(assignment?.files);
+    expect(mockSpawnFn.mock.calls[0][1]).toContain("The user shared files.");
+    expect(mockSpawnFn.mock.calls[0][1]).toContain("/tmp/junior-files/thread-1/input.csv");
+  });
+
   it("does not create a second default run for Re-review after a terminal run", async () => {
     const pipelineStore = new InMemoryPipelineStore();
     manager = createTestManager(store, cloneConfig({

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -77,7 +77,11 @@ import {
   resolveEffectivePermissionIntent,
   type AgentContextProfile,
 } from "../agents/loader.ts";
-import { downloadSlackFiles, sanitizeFileName } from "../slack/files.ts";
+import {
+  boundSlackFileAttachments,
+  downloadSlackFiles,
+  sanitizeFileName,
+} from "../slack/files.ts";
 import { log as _log } from "../logger.ts";
 import {
   inferReviewRepo,
@@ -3899,9 +3903,7 @@ export class SessionManager {
     agentName: string,
     session: ThreadSession,
   ): Promise<boolean> {
-    // TODO: Persist and forward event.files through default-run outbox dispatches.
-    // The synthetic assignment event currently keeps only text/metadata, so an
-    // image attached to the original Slack message is invisible to the runner.
+    const files = boundSlackFileAttachments(event.files);
     if (event.dashboardContinue) return false;
     if (event.pipelineInvocation || !this.pipelineStore) return false;
     if ((this.config.pipeline?.runtimeMode ?? "off") !== "active") return false;
@@ -3968,6 +3970,7 @@ export class SessionManager {
               sourceSlackUserId: event.isSelfBot ? null : event.user,
               targetAgent: durableTarget,
               objective: recoveryContext,
+              files,
               contextRefs: [
                 ...(parent?.contextRefs ?? []),
                 "control-branch:human-input",
@@ -4002,6 +4005,7 @@ export class SessionManager {
                 prompt: event.text,
                 sourceMessageTs: event.ts,
                 sourceSlackUserId: event.isSelfBot ? null : event.user,
+                ...(files.length > 0 ? { files } : {}),
                 resumeReason: "human follow-up on active durable task",
               },
               idempotencyKey:
@@ -4020,6 +4024,7 @@ export class SessionManager {
               prompt: event.text,
               sourceMessageTs: event.ts,
               sourceSlackUserId: event.isSelfBot ? null : event.user,
+              ...(files.length > 0 ? { files } : {}),
               resumeReason: "human follow-up on active durable task",
             },
             idempotencyKey:
@@ -4056,6 +4061,7 @@ export class SessionManager {
         targetAgent: durableTarget,
         sourceAgent: event.isSelfBot ? "system" : "human",
         sourceSlackUserId: event.isSelfBot ? null : event.user,
+        files,
         repoRefs,
       },
     );

--- a/src/slack/files.test.ts
+++ b/src/slack/files.test.ts
@@ -1,6 +1,11 @@
 import { afterEach, describe, expect, it, mock } from "bun:test";
 import { readFile } from "node:fs/promises";
-import { downloadSlackFiles } from "./files.ts";
+import {
+  boundSlackFileAttachments,
+  downloadSlackFiles,
+  MAX_DURABLE_SLACK_FILES,
+  parseSlackFileAttachments,
+} from "./files.ts";
 
 const originalFetch = globalThis.fetch;
 
@@ -78,5 +83,22 @@ describe("sanitizeFileName", () => {
     expect(paths).toEqual([
       "/tmp/junior-files/thread-files-sanitize-test/_buffered-message_.png",
     ]);
+  });
+});
+
+describe("durable Slack attachment refs", () => {
+  it("bounds and validates refs before pipeline persistence", () => {
+    const files = Array.from({ length: MAX_DURABLE_SLACK_FILES + 2 }, (_, index) => ({
+      url: ` https://files/${index} `,
+      name: `file-${index}.txt`,
+      mimetype: "text/plain",
+    }));
+    const bounded = boundSlackFileAttachments(files);
+    expect(bounded).toHaveLength(MAX_DURABLE_SLACK_FILES);
+    expect(bounded[0]?.url).toBe("https://files/0");
+    expect(parseSlackFileAttachments([
+      ...bounded,
+      { url: 42, name: "bad", mimetype: "text/plain" },
+    ])).toEqual(bounded);
   });
 });

--- a/src/slack/files.ts
+++ b/src/slack/files.ts
@@ -1,10 +1,56 @@
 import { mkdir } from "node:fs/promises";
 import { basename, join } from "node:path";
+import type { SlackFileAttachment } from "./events.ts";
 
 export interface SlackFile {
   url: string;
   name: string;
   mimetype: string;
+}
+
+/**
+ * Durable pipeline state must not accept an unbounded copy of a Slack event.
+ * Keep the existing attachment contract, but cap both collection and field
+ * sizes before it crosses the assignment/outbox boundary.
+ */
+export const MAX_DURABLE_SLACK_FILES = 8;
+export const MAX_DURABLE_SLACK_FILE_URL = 2_048;
+export const MAX_DURABLE_SLACK_FILE_NAME = 256;
+export const MAX_DURABLE_SLACK_FILE_MIMETYPE = 128;
+
+export function boundSlackFileAttachments(
+  files: readonly SlackFileAttachment[] | undefined,
+): SlackFileAttachment[] {
+  if (!files?.length) return [];
+  return files
+    .slice(0, MAX_DURABLE_SLACK_FILES)
+    .map((file) => ({
+      url: file.url.trim().slice(0, MAX_DURABLE_SLACK_FILE_URL),
+      name: file.name.slice(0, MAX_DURABLE_SLACK_FILE_NAME),
+      mimetype: file.mimetype.slice(0, MAX_DURABLE_SLACK_FILE_MIMETYPE),
+    }))
+    .filter((file) => file.url.length > 0 && file.name.length > 0);
+}
+
+/** Validate JSON restored from a pipeline outbox before it becomes an event. */
+export function parseSlackFileAttachments(value: unknown): SlackFileAttachment[] {
+  if (!Array.isArray(value)) return [];
+  const files: SlackFileAttachment[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== "object") continue;
+    const file = item as Record<string, unknown>;
+    if (
+      typeof file.url !== "string" ||
+      typeof file.name !== "string" ||
+      typeof file.mimetype !== "string"
+    ) continue;
+    files.push({
+      url: file.url,
+      name: file.name,
+      mimetype: file.mimetype,
+    });
+  }
+  return boundSlackFileAttachments(files);
 }
 
 /**


### PR DESCRIPTION
## Summary
- persist bounded SlackFileAttachment refs on default assignments and outbox payloads
- restore validated refs on synthetic pump dispatches so runners download attachments
- cover the full default-run route plus SQLite and bounds behavior

## Verification
- `bun run typecheck`
- `bun test src/session/manager.test.ts -t "preserves Slack attachments through the durable default run"`
- `bun test src/slack/files.test.ts src/pipelines/store/sqlite.test.ts -t "durable Slack attachment refs|round-trips runs and assignments"`

The selected broader suite also exposed five unrelated existing SessionManager failures in onboarding/Codex isolation tests; no changes were made to those paths.