### PR TITLE
fix: pin trusted agent definitions to default branch

### DIFF
--- a/docs/code_index/agent-routing.md
+++ b/docs/code_index/agent-routing.md
@@ -12,6 +12,7 @@ Resolves agent definitions across a layered search chain (target repo → privat
 | `AgentRouter.resolveAgent(session)` | `router.ts` | Searches target repo → org overlay → public fallback. First match wins. Returns `AgentDefinition \| null`. |
 | `AgentRouter.composeSystemPrompt(session)` | `router.ts` | Builds the system prompt = selected shared playbooks + agent body. Each `common:` name resolves target-repo common first, then the canonical `support/skills/<name>/SKILL.md`; matching org common overlays append additively. |
 | `loadAgentDefinition(filePath)` | `loader.ts` | Reads a `.md` file, parses frontmatter (flat `key: value`, dot-notation `context.<flag>`, quoted-value strip). Returns `null` if missing. |
+| `inspectAgentDefinitionProvenance(path)` | `manifest.ts` | Compares an authority-bearing definition's on-disk bytes to its own default-branch Git blob. Reports `published` or `unpublished`; the catalog ignores unpublished entries. |
 | `DEFAULT_CONTEXT_PROFILE` | `loader.ts` | All five flags (`identity`, `slack`, `workspace`, `threadHistory`, `agentState`) set to `true`. |
 
 ### Types
@@ -52,6 +53,14 @@ runClaudeWithAgent(session)
 ### Layered load chain
 
 Agent definitions use **exclusive resolution** (first match wins). Shared playbooks are selected by each agent's `common:` frontmatter profile. Each selected name is loaded from target-repo common when present, otherwise canonical `support/skills/<name>/SKILL.md`; matching org overlay common files append additively. Adding a skill does nothing until an agent profile names it.
+
+The operational catalog has a separate publication gate: a Junior or
+`agents-org` definition with `operational.enabled: true` is compiled only when
+its bytes exactly match the definition at that repository's default remote
+branch (or local `main`/`master` when no remote ref exists). Dirty files,
+untracked files, and commits visible only from a feature branch are reported as
+unpublished and ignored. A missing published `default` role is a startup error,
+so local authority changes cannot silently take effect.
 
 ### Common profile
 

--- a/docs/code_index/agent-routing.md
+++ b/docs/code_index/agent-routing.md
@@ -59,7 +59,8 @@ The operational catalog has a separate publication gate: a Junior or
 its bytes exactly match the definition at that repository's default remote
 branch (or local `main`/`master` when no remote ref exists). Dirty files,
 untracked files, and commits visible only from a feature branch are reported as
-unpublished and ignored. A missing published `default` role is a startup error,
+unpublished and ignored. The configured definition must be a tracked regular
+file, never a symlink to some other tracked payload. A missing published `default` role is a startup error,
 so local authority changes cannot silently take effect.
 
 ### Common profile

--- a/docs/features/agent-definitions.md
+++ b/docs/features/agent-definitions.md
@@ -61,7 +61,9 @@ repository's default remote ref (`origin/HEAD`, then `origin/main` or
 `origin/master`; local `main`/`master` only when no remote ref exists) and
 compares the on-disk file bytes with `git show
 <default-ref>:<path>`. A mismatch, missing blob, unavailable ref, or non-Git
-path is **unpublished**. Unpublished definitions do not add capabilities,
+path is **unpublished**. The configured `.md` path must also be a tracked,
+non-symlink regular file; resolving a link to another tracked payload never
+publishes an authority-bearing definition. Unpublished definitions do not add capabilities,
 permissions, mutation policy, aliases, variants, or handoff edges. If this
 removes the required `default` orchestrator, startup fails closed.
 

--- a/docs/features/agent-definitions.md
+++ b/docs/features/agent-definitions.md
@@ -14,7 +14,10 @@ The spawned Claude Code instances need personality and context. A bare `claude -
 then the private `agents-org` overlay, then its public fallback definitions;
 it composes the selected common profile and injects the result into the
 provider session. Target-repository operational metadata cannot widen the
-trusted catalog.
+trusted catalog. Operational frontmatter in Junior and `agents-org` is active
+only when its exact file bytes match the respective repository's default
+branch. Dirty, untracked, and branch-only definitions are marked unpublished
+and excluded from the trusted catalog until merged.
 **Painful part:** Agent definitions for Example Org repos live in THOSE repos. Junior should not duplicate them. But junior needs its own agents for: (a) generic tasks not tied to a specific repo, (b) developing the bot itself, (c) fallback when target repo has no matching agent.
 **"Finally" moment:** `!build` in a example-backend thread → loads example-backend's build.md agent. `!review` in a junior thread → loads junior's own review.md agent. No duplication. No drift.
 
@@ -49,6 +52,22 @@ Contains org-specific agents and common preamble files that don't belong in the 
 **Loading order for common preamble:**
 1. Per-file fallback tier — for each selected common profile name, the target repo's `.claude/agents/common/<name>.md` wins when present; otherwise Junior's public `.claude/agents/common/<name>.md` supplies that file.
 2. Additive tier — org overlay's `<orgAgentsDir>/common/*.md` (always appended when overlay is configured).
+
+### Trusted-definition publication gate
+
+The trusted catalog is an authority boundary, not a prompt-discovery index.
+For every definition with `operational.enabled: true`, Junior discovers the
+repository's default remote ref (`origin/HEAD`, then `origin/main` or
+`origin/master`; local `main`/`master` only when no remote ref exists) and
+compares the on-disk file bytes with `git show
+<default-ref>:<path>`. A mismatch, missing blob, unavailable ref, or non-Git
+path is **unpublished**. Unpublished definitions do not add capabilities,
+permissions, mutation policy, aliases, variants, or handoff edges. If this
+removes the required `default` orchestrator, startup fails closed.
+
+This check is performed independently for the public Junior checkout and the
+`agents-org` submodule checkout. Target-repository definitions remain
+prompt-only and are never catalog sources.
 
 **Per-agent context profile:**
 

--- a/src/agents/manifest.test.ts
+++ b/src/agents/manifest.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it } from "bun:test";
+import { execFileSync } from "node:child_process";
 import {
   mkdirSync,
   mkdtempSync,
@@ -7,7 +8,10 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { loadTrustedAgentCatalog } from "./manifest.ts";
+import {
+  inspectAgentDefinitionProvenance,
+  loadTrustedAgentCatalog,
+} from "./manifest.ts";
 
 const roots: string[] = [];
 
@@ -23,8 +27,24 @@ function fixture(): { root: string; publicDir: string; orgDir: string } {
   const orgDir = join(root, "org");
   mkdirSync(publicDir);
   mkdirSync(orgDir);
+  execFileSync("git", ["init", "-q", "-b", "main"], { cwd: root });
+  execFileSync("git", ["config", "user.email", "tests@junior.local"], { cwd: root });
+  execFileSync("git", ["config", "user.name", "Junior tests"], { cwd: root });
   roots.push(root);
   return { root, publicDir, orgDir };
+}
+
+function publish(root: string): void {
+  execFileSync("git", ["add", "."], { cwd: root });
+  execFileSync("git", ["commit", "-qm", "publish definitions"], { cwd: root });
+}
+
+function loadPublishedCatalog(input: ReturnType<typeof fixture>) {
+  publish(input.root);
+  return loadTrustedAgentCatalog({
+    publicAgentsDir: input.publicDir,
+    orgAgentsDir: input.orgDir,
+  });
 }
 
 function definition(options: {
@@ -58,7 +78,7 @@ operational.maxParallel: 0
 
 describe("trusted operational frontmatter", () => {
   it("compiles public and private definitions with path-derived trust", () => {
-    const { publicDir, orgDir } = fixture();
+    const { root, publicDir, orgDir } = fixture();
     writeFileSync(
       join(publicDir, "default.md"),
       definition({
@@ -78,10 +98,7 @@ describe("trusted operational frontmatter", () => {
       }),
     );
 
-    const catalog = loadTrustedAgentCatalog({
-      publicAgentsDir: publicDir,
-      orgAgentsDir: orgDir,
-    });
+    const catalog = loadPublishedCatalog({ root, publicDir, orgDir });
 
     expect(catalog.map((entry) => entry.name)).toEqual([
       "default",
@@ -94,7 +111,7 @@ describe("trusted operational frontmatter", () => {
   });
 
   it("fails fast when a trusted operational field is missing", () => {
-    const { publicDir, orgDir } = fixture();
+    const { root, publicDir, orgDir } = fixture();
     writeFileSync(
       join(publicDir, "default.md"),
       definition({ name: "default" }).replace(
@@ -104,15 +121,12 @@ describe("trusted operational frontmatter", () => {
     );
 
     expect(() =>
-      loadTrustedAgentCatalog({
-        publicAgentsDir: publicDir,
-        orgAgentsDir: orgDir,
-      }),
+      loadPublishedCatalog({ root, publicDir, orgDir }),
     ).toThrow("missing required 'operational.mutationPolicy'");
   });
 
   it("rejects shell or filesystem tools for mcp-only agents", () => {
-    const { publicDir, orgDir } = fixture();
+    const { root, publicDir, orgDir } = fixture();
     writeFileSync(join(publicDir, "default.md"), definition({ name: "default" }));
     writeFileSync(
       join(orgDir, "unsafe.md"),
@@ -124,15 +138,12 @@ describe("trusted operational frontmatter", () => {
     );
 
     expect(() =>
-      loadTrustedAgentCatalog({
-        publicAgentsDir: publicDir,
-        orgAgentsDir: orgDir,
-      }),
+      loadPublishedCatalog({ root, publicDir, orgDir }),
     ).toThrow("mcp-only agent 'unsafe' cannot safely request 'Read'");
   });
 
   it("rejects mutating MCP tools for mcp-only agents", () => {
-    const { publicDir, orgDir } = fixture();
+    const { root, publicDir, orgDir } = fixture();
     writeFileSync(
       join(publicDir, "default.md"),
       definition({ name: "default", delegates: "unsafe, human" }),
@@ -148,17 +159,14 @@ describe("trusted operational frontmatter", () => {
     );
 
     expect(() =>
-      loadTrustedAgentCatalog({
-        publicAgentsDir: publicDir,
-        orgAgentsDir: orgDir,
-      }),
+      loadPublishedCatalog({ root, publicDir, orgDir }),
     ).toThrow(
       "mcp-only agent 'unsafe' cannot safely request 'mcp__mongodb__update-one'",
     );
   });
 
   it("requires an MCP-only tool's granting capability", () => {
-    const { publicDir, orgDir } = fixture();
+    const { root, publicDir, orgDir } = fixture();
     writeFileSync(
       join(publicDir, "default.md"),
       definition({ name: "default", delegates: "unsafe, human" }),
@@ -174,17 +182,14 @@ describe("trusted operational frontmatter", () => {
     );
 
     expect(() =>
-      loadTrustedAgentCatalog({
-        publicAgentsDir: publicDir,
-        orgAgentsDir: orgDir,
-      }),
+      loadPublishedCatalog({ root, publicDir, orgDir }),
     ).toThrow(
       "mcp-only agent 'unsafe' cannot safely request 'mcp__mongodb__find'",
     );
   });
 
   it("rejects unresolved handoffs when the private overlay is mounted", () => {
-    const { publicDir, orgDir } = fixture();
+    const { root, publicDir, orgDir } = fixture();
     writeFileSync(join(orgDir, "README.md"), "# Mounted private overlay\n");
     writeFileSync(
       join(publicDir, "default.md"),
@@ -192,10 +197,7 @@ describe("trusted operational frontmatter", () => {
     );
 
     expect(() =>
-      loadTrustedAgentCatalog({
-        publicAgentsDir: publicDir,
-        orgAgentsDir: orgDir,
-      }),
+      loadPublishedCatalog({ root, publicDir, orgDir }),
     ).toThrow("references unknown handoff target 'missing-worker'");
   });
 
@@ -208,20 +210,82 @@ describe("trusted operational frontmatter", () => {
     );
 
     expect(
-      loadTrustedAgentCatalog({
-        publicAgentsDir: publicDir,
-        orgAgentsDir: missingOrgDir,
-      }).map((entry) => entry.name),
+      loadPublishedCatalog({ root, publicDir, orgDir: missingOrgDir }).map((entry) => entry.name),
     ).toEqual(["default"]);
   });
 
   it("treats an empty uninitialized submodule directory as optional", () => {
-    const { publicDir, orgDir } = fixture();
+    const { root, publicDir, orgDir } = fixture();
     writeFileSync(
       join(publicDir, "default.md"),
       definition({ name: "default", delegates: "private-worker, human" }),
     );
 
+    expect(
+      loadPublishedCatalog({ root, publicDir, orgDir }).map((entry) => entry.name),
+    ).toEqual(["default"]);
+  });
+
+  it("fails closed when a published authority-bearing definition is dirty", () => {
+    const { root, publicDir, orgDir } = fixture();
+    const defaultPath = join(publicDir, "default.md");
+    writeFileSync(defaultPath, definition({ name: "default" }));
+    publish(root);
+    writeFileSync(defaultPath, `${definition({ name: "default" })}\nLocal authority edit\n`);
+
+    expect(
+      inspectAgentDefinitionProvenance(defaultPath),
+    ).toMatchObject({
+      status: "unpublished",
+      defaultBranchRef: "main",
+      reason: "definition bytes differ from main",
+    });
+    expect(() =>
+      loadTrustedAgentCatalog({
+        publicAgentsDir: publicDir,
+        orgAgentsDir: orgDir,
+      }),
+    ).toThrow("Trusted agent catalog must define the default orchestrator");
+  });
+
+  it("ignores untracked authority-bearing definitions", () => {
+    const { root, publicDir, orgDir } = fixture();
+    writeFileSync(join(publicDir, "default.md"), definition({ name: "default" }));
+    publish(root);
+    const roguePath = join(publicDir, "rogue.md");
+    writeFileSync(roguePath, definition({ name: "rogue" }));
+
+    expect(
+      inspectAgentDefinitionProvenance(roguePath),
+    ).toMatchObject({
+      status: "unpublished",
+      reason: "definition does not exist on main",
+    });
+    expect(
+      loadTrustedAgentCatalog({
+        publicAgentsDir: publicDir,
+        orgAgentsDir: orgDir,
+      }).map((entry) => entry.name),
+    ).toEqual(["default"]);
+  });
+
+  it("ignores definitions committed only on the current feature branch", () => {
+    const { root, publicDir, orgDir } = fixture();
+    writeFileSync(join(publicDir, "default.md"), definition({ name: "default" }));
+    publish(root);
+    execFileSync("git", ["checkout", "-qb", "feature/branch-only-agent"], {
+      cwd: root,
+    });
+    const branchOnlyPath = join(publicDir, "branch-only.md");
+    writeFileSync(branchOnlyPath, definition({ name: "branch-only" }));
+    publish(root);
+
+    expect(
+      inspectAgentDefinitionProvenance(branchOnlyPath),
+    ).toMatchObject({
+      status: "unpublished",
+      reason: "definition does not exist on main",
+    });
     expect(
       loadTrustedAgentCatalog({
         publicAgentsDir: publicDir,

--- a/src/agents/manifest.test.ts
+++ b/src/agents/manifest.test.ts
@@ -4,6 +4,7 @@ import {
   mkdirSync,
   mkdtempSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -259,7 +260,27 @@ describe("trusted operational frontmatter", () => {
       inspectAgentDefinitionProvenance(roguePath),
     ).toMatchObject({
       status: "unpublished",
-      reason: "definition does not exist on main",
+      reason: "definition path is not tracked",
+    });
+    expect(
+      loadTrustedAgentCatalog({
+        publicAgentsDir: publicDir,
+        orgAgentsDir: orgDir,
+      }).map((entry) => entry.name),
+    ).toEqual(["default"]);
+  });
+
+  it("rejects an untracked definition symlink to a tracked payload", () => {
+    const { root, publicDir, orgDir } = fixture();
+    writeFileSync(join(publicDir, "default.md"), definition({ name: "default" }));
+    writeFileSync(join(publicDir, "payload.txt"), definition({ name: "rogue" }));
+    publish(root);
+    const roguePath = join(publicDir, "rogue.md");
+    symlinkSync("payload.txt", roguePath);
+
+    expect(inspectAgentDefinitionProvenance(roguePath)).toMatchObject({
+      status: "unpublished",
+      reason: "definition is not a regular file",
     });
     expect(
       loadTrustedAgentCatalog({

--- a/src/agents/manifest.ts
+++ b/src/agents/manifest.ts
@@ -1,6 +1,12 @@
 import { execFileSync } from "node:child_process";
-import { existsSync, readFileSync, readdirSync, realpathSync } from "node:fs";
-import { relative, resolve } from "node:path";
+import {
+  existsSync,
+  lstatSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+} from "node:fs";
+import { basename, resolve } from "node:path";
 import {
   parseAgentFrontmatter,
   parseFrontmatterCsv,
@@ -257,6 +263,27 @@ function defaultBranchRef(repoRoot: string): string | null {
 export function inspectAgentDefinitionProvenance(
   sourcePath: string,
 ): AgentDefinitionProvenance {
+  // Never canonicalize the definition path: `realpath` would turn an
+  // untracked `rogue.md -> tracked-payload.txt` symlink into the tracked
+  // payload's path. Authority belongs to the configured .md path itself.
+  let sourceStat: ReturnType<typeof lstatSync>;
+  try {
+    sourceStat = lstatSync(sourcePath);
+  } catch {
+    return {
+      status: "unpublished",
+      defaultBranchRef: null,
+      reason: "definition does not exist",
+    };
+  }
+  if (!sourceStat.isFile() || sourceStat.isSymbolicLink()) {
+    return {
+      status: "unpublished",
+      defaultBranchRef: null,
+      reason: "definition is not a regular file",
+    };
+  }
+
   const repoRoot = gitText(resolve(sourcePath, ".."), [
     "rev-parse",
     "--show-toplevel",
@@ -268,7 +295,10 @@ export function inspectAgentDefinitionProvenance(
       reason: "definition is not inside a Git checkout",
     };
   }
-  const ref = defaultBranchRef(repoRoot);
+  // Git canonicalizes the checkout root on macOS (`/private/var`), but not the
+  // configured definition path; path identity stays anchored to the .md name.
+  const canonicalRepoRoot = realpathSync(repoRoot);
+  const ref = defaultBranchRef(canonicalRepoRoot);
   if (!ref) {
     return {
       status: "unpublished",
@@ -277,18 +307,26 @@ export function inspectAgentDefinitionProvenance(
     };
   }
 
-  // macOS commonly exposes temporary files through `/var` while Git returns
-  // `/private/var`; canonicalize before deriving the tree path.
-  const resolvedSourcePath = realpathSync(sourcePath);
-  const repoRelativePath = relative(repoRoot, resolvedSourcePath).replaceAll("\\", "/");
-  if (!repoRelativePath || repoRelativePath === ".." || repoRelativePath.startsWith("../")) {
+  const prefix = gitText(resolve(sourcePath, ".."), [
+    "rev-parse",
+    "--show-prefix",
+  ]);
+  const repoRelativePath = `${prefix ?? ""}${basename(sourcePath)}`;
+  const trackedPath = gitText(canonicalRepoRoot, [
+    "ls-files",
+    "--error-unmatch",
+    "--full-name",
+    "--",
+    repoRelativePath,
+  ]);
+  if (trackedPath !== repoRelativePath) {
     return {
       status: "unpublished",
       defaultBranchRef: ref,
-      reason: "definition is outside its Git checkout",
+      reason: "definition path is not tracked",
     };
   }
-  const published = gitOutput(repoRoot, ["show", `${ref}:${repoRelativePath}`]);
+  const published = gitOutput(canonicalRepoRoot, ["show", `${ref}:${repoRelativePath}`]);
   if (published === null) {
     return {
       status: "unpublished",
@@ -296,7 +334,7 @@ export function inspectAgentDefinitionProvenance(
       reason: `definition does not exist on ${ref}`,
     };
   }
-  if (!published.equals(readFileSync(resolvedSourcePath))) {
+  if (!published.equals(readFileSync(sourcePath))) {
     return {
       status: "unpublished",
       defaultBranchRef: ref,

--- a/src/agents/manifest.ts
+++ b/src/agents/manifest.ts
@@ -1,5 +1,6 @@
-import { existsSync, readFileSync, readdirSync } from "node:fs";
-import { resolve } from "node:path";
+import { execFileSync } from "node:child_process";
+import { existsSync, readFileSync, readdirSync, realpathSync } from "node:fs";
+import { relative, resolve } from "node:path";
 import {
   parseAgentFrontmatter,
   parseFrontmatterCsv,
@@ -201,6 +202,110 @@ export interface TrustedCatalogOptions {
   orgAgentsDir: string;
 }
 
+/**
+ * A trusted definition is active only when its exact bytes are present on the
+ * repository's default branch. This deliberately treats dirty, untracked, and
+ * feature-branch-only files as unpublished: prompt content can be developed
+ * locally, but it cannot grant runtime authority before review and merge.
+ */
+export interface AgentDefinitionProvenance {
+  status: "published" | "unpublished";
+  defaultBranchRef: string | null;
+  reason: string | null;
+}
+
+function gitOutput(cwd: string, args: string[]): Buffer | null {
+  try {
+    return execFileSync("git", args, {
+      cwd,
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return null;
+  }
+}
+
+function gitText(cwd: string, args: string[]): string | null {
+  const output = gitOutput(cwd, args);
+  return output === null ? null : output.toString("utf8").trim();
+}
+
+function defaultBranchRef(repoRoot: string): string | null {
+  const candidates = [
+    gitText(repoRoot, ["symbolic-ref", "--quiet", "--short", "refs/remotes/origin/HEAD"]),
+    "origin/main",
+    "origin/master",
+    // Source checkouts and isolated test repositories may not have a remote.
+    // These are still stable branch refs, unlike the current HEAD.
+    "main",
+    "master",
+  ];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    if (gitText(repoRoot, ["rev-parse", "--verify", "--quiet", `${candidate}^{commit}`])) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+/**
+ * Inspect a definition without activating it. Consumers can expose this state
+ * in diagnostics; the catalog compiler below fails closed on unpublished
+ * authority-bearing files.
+ */
+export function inspectAgentDefinitionProvenance(
+  sourcePath: string,
+): AgentDefinitionProvenance {
+  const repoRoot = gitText(resolve(sourcePath, ".."), [
+    "rev-parse",
+    "--show-toplevel",
+  ]);
+  if (!repoRoot) {
+    return {
+      status: "unpublished",
+      defaultBranchRef: null,
+      reason: "definition is not inside a Git checkout",
+    };
+  }
+  const ref = defaultBranchRef(repoRoot);
+  if (!ref) {
+    return {
+      status: "unpublished",
+      defaultBranchRef: null,
+      reason: "default branch ref is unavailable",
+    };
+  }
+
+  // macOS commonly exposes temporary files through `/var` while Git returns
+  // `/private/var`; canonicalize before deriving the tree path.
+  const resolvedSourcePath = realpathSync(sourcePath);
+  const repoRelativePath = relative(repoRoot, resolvedSourcePath).replaceAll("\\", "/");
+  if (!repoRelativePath || repoRelativePath === ".." || repoRelativePath.startsWith("../")) {
+    return {
+      status: "unpublished",
+      defaultBranchRef: ref,
+      reason: "definition is outside its Git checkout",
+    };
+  }
+  const published = gitOutput(repoRoot, ["show", `${ref}:${repoRelativePath}`]);
+  if (published === null) {
+    return {
+      status: "unpublished",
+      defaultBranchRef: ref,
+      reason: `definition does not exist on ${ref}`,
+    };
+  }
+  if (!published.equals(readFileSync(resolvedSourcePath))) {
+    return {
+      status: "unpublished",
+      defaultBranchRef: ref,
+      reason: `definition bytes differ from ${ref}`,
+    };
+  }
+  return { status: "published", defaultBranchRef: ref, reason: null };
+}
+
 function required(
   frontmatter: Record<string, string>,
   key: string,
@@ -244,6 +349,14 @@ function parseCatalogEntry(
   const content = readFileSync(sourcePath, "utf8");
   const { frontmatter } = parseAgentFrontmatter(content);
   if (frontmatter["operational.enabled"] !== "true") return [];
+
+  const provenance = inspectAgentDefinitionProvenance(sourcePath);
+  if (provenance.status === "unpublished") {
+    console.warn(
+      `[agents] unpublished trusted definition ignored: ${sourcePath} (${provenance.reason})`,
+    );
+    return [];
+  }
 
   const name = required(frontmatter, "name", sourcePath);
   const capabilities = parseFrontmatterCsv(


### PR DESCRIPTION
## Summary
- activate operational agent definitions only when their on-disk bytes exactly match the owning repository default branch
- mark dirty, untracked, and feature-branch-only definitions unpublished and exclude them from the trusted catalog
- fail closed when this removes the required default orchestrator

## Verification
- `bun test src/agents/manifest.test.ts`
- `bun run typecheck`
- `bun run build`

## Notes
`bun test` was attempted but cannot complete in this isolated worktree because the private `agents-org` submodule clone is unavailable to this environment; pre-existing runbook tests require its pinned private agents.