### PR TITLE
fix(slack): preserve ignored dotenv files during cleanup

### DIFF
--- a/docs/code_index/worktree-manager.md
+++ b/docs/code_index/worktree-manager.md
@@ -13,6 +13,7 @@ Creates, removes, and inspects git worktrees in target repos for per-thread code
 | `removeWorktree(repoName, threadId)` | `manager.ts` | `git worktree remove --force` + `git branch -D` (queries actual branch name from the worktree first to handle `branchOverride`) |
 | `worktreeExists(repoName, threadId)` | `manager.ts` | Filesystem check via `node:fs/promises.stat` |
 | `isWorktreeDirty(worktreePath)` | `manager.ts` | `git status --porcelain` |
+| `getWorktreeStatus(worktreePath, repoName?)` | `manager.ts` | Reports tracked/untracked changes, unpushed commits, and ignored dotenv paths (path names only; contents are never read). |
 | `getWorktreePath(repoName, threadId)` | `manager.ts` | `<repo.path>.junior-worktrees/slack-<threadId>` — sibling, NOT under `.claude/` |
 | `getBranchName(threadId)` | `manager.ts` | `slack/<threadId>` |
 | `getRepo(name)` | `manager.ts` | Lookup in `repos` |
@@ -62,7 +63,9 @@ from `REPOS`, so workflows can perform the routine Git work in one process and
 leave only preservation exceptions and reporting to the runner. The engine
 allows generated PNG artifacts and `next-env.d.ts` as harmless residual state;
 other meaningful changes, ignored dotenv files, locks, active processes, and
-unmerged worktrees remain protected.
+unmerged worktrees remain protected. The Slack cleanup action uses the same
+ignored-dotenv path classifier and refuses cleanup when those paths are
+present, without logging their contents.
 
 ## Key Concepts
 

--- a/docs/features/agent-action-buttons.md
+++ b/docs/features/agent-action-buttons.md
@@ -49,6 +49,10 @@ Junior validates the JSON, strips it from the Slack-visible text, renders Slack 
 - `Re-review` resumes an active durable run when one exists. If the original review run is already terminal, it dispatches a direct review follow-up and does not create a second generic default run.
 - `cleanup_worktree` may be clicked by any thread participant.
 - Worktree cleanup refuses tracked changes and unknown untracked files.
+- Cleanup also enumerates ignored `.env` / `.env.*` paths without reading their
+  contents and refuses removal when any are present. This keeps credentials
+  and multiline dotenv values in place for preservation review; diagnostics
+  contain only the path names.
 - Cleanup may proceed when the only untracked paths are `learnings.md`, `.codex/`, `.claude/`, or `.DS_Store`.
 - `review: approved` does **not** automatically clean up worktrees. Cleanup is explicit via the Cleanup worktree button (or a later terminal-pipeline transition). Merge/retry buttons stay available after approval.
 - Mutating PR actions (`review:merge-gxt-admin`) require a complete structured `resourceAnchor` (`repo`, `prNumber`, `headSha`, `expectedBase`). Generic merge buttons without an exact anchor are not rendered.
@@ -75,6 +79,8 @@ Validation:
 - No persistent agent in the thread may be busy.
 - Tracked changes refuse cleanup.
 - Unknown untracked files refuse cleanup.
+- Ignored dotenv files refuse cleanup, including nested paths and files with
+  multiline values.
 
 ## Storage
 

--- a/src/slack/action-buttons.test.ts
+++ b/src/slack/action-buttons.test.ts
@@ -1,5 +1,14 @@
 import { describe, expect, it } from "bun:test";
-import { resolveDispatchAgent, shouldBypassDefaultRun } from "./action-buttons.ts";
+import {
+  cleanupThreadWorktrees,
+  resolveDispatchAgent,
+  shouldBypassDefaultRun,
+  unsafeCleanupReason,
+} from "./action-buttons.ts";
+import type { WorktreeStatus } from "../worktree/manager.ts";
+import type { SessionManager } from "../session/manager.ts";
+import type { WorktreeManager } from "../worktree/manager.ts";
+import { createSession } from "../session/types.ts";
 
 describe("resolveDispatchAgent", () => {
   it("routes review make-fix to default outside support channels", () => {
@@ -98,5 +107,67 @@ describe("shouldBypassDefaultRun", () => {
         prompt: "fix it",
       }),
     ).toBe(false);
+  });
+});
+
+describe("unsafeCleanupReason", () => {
+  it("refuses ignored dotenv files and never includes their multiline contents", () => {
+    const secret = "API_KEY=one\nPRIVATE_KEY=two\n";
+    const status: WorktreeStatus = {
+      tracked: [],
+      untracked: [],
+      ignoredDotenv: [".env.local"],
+      unpushedCommits: 0,
+      unpushedBase: "origin/main",
+    };
+
+    const reason = unsafeCleanupReason(status);
+
+    expect(reason).toContain("ignored dotenv files present (.env.local)");
+    expect(reason).not.toContain(secret);
+  });
+
+  it("continues to allow unrelated ignored-file state", () => {
+    const status: WorktreeStatus = {
+      tracked: [],
+      untracked: [],
+      ignoredDotenv: [],
+      unpushedCommits: 0,
+      unpushedBase: "origin/main",
+    };
+
+    expect(unsafeCleanupReason(status)).toBeNull();
+  });
+
+  it("does not call removeWorktree when cleanup discovers ignored dotenv state", async () => {
+    const session = createSession("thread-env", "C123");
+    session.targetRepo = "backend";
+    session.worktreePath = "/tmp/backend.junior-worktrees/slack-thread-env";
+    session.worktreePaths = { backend: session.worktreePath };
+    let removed = false;
+    const status: WorktreeStatus = {
+      tracked: [],
+      untracked: [],
+      ignoredDotenv: [".env.local"],
+      unpushedCommits: 0,
+      unpushedBase: "origin/main",
+    };
+    const sessionManager = {
+      getSession: async () => session,
+      updateSession: async () => undefined,
+    } as unknown as SessionManager;
+    const worktreeManager = {
+      getWorktreeStatus: async () => status,
+      removeWorktree: async () => { removed = true; },
+    } as unknown as WorktreeManager;
+
+    const result = await cleanupThreadWorktrees(
+      session.threadId,
+      sessionManager,
+      worktreeManager,
+    );
+
+    expect(result).toContain("ignored dotenv files present (.env.local)");
+    expect(removed).toBe(false);
   });
 });

--- a/src/slack/action-buttons.ts
+++ b/src/slack/action-buttons.ts
@@ -252,12 +252,15 @@ function registeredWorktrees(session: ThreadSession): Array<{ repo: string; path
   return [];
 }
 
-function unsafeCleanupReason(status: WorktreeStatus): string | null {
+export function unsafeCleanupReason(status: WorktreeStatus): string | null {
   if (status.unpushedCommits > 0) {
     return `branch has ${status.unpushedCommits} commit${status.unpushedCommits === 1 ? "" : "s"} not in ${status.unpushedBase ?? "upstream"}`;
   }
   if (status.tracked.length > 0) {
     return `tracked changes present (${status.tracked.join(", ")})`;
+  }
+  if (status.ignoredDotenv.length > 0) {
+    return `ignored dotenv files present (${status.ignoredDotenv.join(", ")}); preservation review required`;
   }
   const unsafeUntracked = status.untracked.filter((path) => !isAllowedUntracked(path));
   if (unsafeUntracked.length > 0) {

--- a/src/worktree/manager.test.ts
+++ b/src/worktree/manager.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeAll, afterAll } from "bun:test";
 import {
   mkdtempSync,
+  mkdirSync,
   rmSync,
   writeFileSync,
   readFileSync,
@@ -39,6 +40,7 @@ beforeAll(async () => {
   await runIn(repoRoot, ["git", "config", "user.email", "test@example.com"]);
   await runIn(repoRoot, ["git", "config", "user.name", "test"]);
   writeFileSync(join(repoRoot, "README.md"), "hello\n");
+  writeFileSync(join(repoRoot, ".gitignore"), ".env*\n.cache/\n");
   await runIn(repoRoot, ["git", "add", "."]);
   await runIn(repoRoot, ["git", "commit", "-q", "-m", "init"]);
   // Add a second commit on a different ref so we can test baseRef forwarding.
@@ -713,10 +715,52 @@ git worktree add "$TARGET" -b "$BRANCH" "$BASE"
 
     expect(status.tracked).toEqual([]);
     expect(status.untracked).toEqual([]);
+    expect(status.ignoredDotenv).toEqual([]);
     expect(status.unpushedCommits).toBe(0);
     expect(status.unpushedBase).toBe("origin/main");
 
     await wm.removeWorktree("clean-status", "clean-status-thread");
+  });
+
+  it("enumerates ignored dotenv paths without reading multiline secret contents", async () => {
+    const repos: RepoConfig[] = [
+      { name: "dotenv-status", path: repoRoot, defaultBase: "origin/main" },
+    ];
+    const wm = new WorktreeManager(repos);
+
+    const wtPath = await wm.createWorktree("dotenv-status", "dotenv-status-thread");
+    const secret = "API_KEY=one\nPRIVATE_KEY=two\n";
+    writeFileSync(join(wtPath, ".env.local"), secret);
+
+    const status = await wm.getWorktreeStatus(wtPath, "dotenv-status");
+
+    expect(status.ignoredDotenv).toEqual([".env.local"]);
+    expect(JSON.stringify(status)).not.toContain(secret);
+
+    await wm.removeWorktree("dotenv-status", "dotenv-status-thread");
+  });
+
+  it("finds dotenv state even when unrelated ignored output exceeds the git stream cap", async () => {
+    const repos: RepoConfig[] = [
+      { name: "dotenv-noise-status", path: repoRoot, defaultBase: "origin/main" },
+    ];
+    const wm = new WorktreeManager(repos);
+    const wtPath = await wm.createWorktree(
+      "dotenv-noise-status",
+      "dotenv-noise-status-thread",
+    );
+    const noiseDir = join(wtPath, ".cache");
+    mkdirSync(noiseDir);
+    for (let i = 0; i < 5_000; i += 1) {
+      writeFileSync(join(noiseDir, `ignored-${i.toString().padStart(5, "0")}`), "x");
+    }
+    writeFileSync(join(wtPath, ".env.local"), "SECRET=preserve\n");
+
+    const status = await wm.getWorktreeStatus(wtPath, "dotenv-noise-status");
+
+    expect(status.ignoredDotenv).toEqual([".env.local"]);
+
+    await wm.removeWorktree("dotenv-noise-status", "dotenv-noise-status-thread");
   });
 
   it("detects committed local-only work when no upstream branch is configured", async () => {

--- a/src/worktree/manager.ts
+++ b/src/worktree/manager.ts
@@ -10,6 +10,7 @@ import {
 } from "node:fs";
 import { basename, join } from "node:path";
 import { terminateProcessTree } from "../lifecycle/process-tree.ts";
+import { ignoredDotenvPaths } from "./safety.ts";
 
 const DEFAULT_SETUP_MIN_FREE_BYTES = 2 * 1024 * 1024 * 1024;
 const DEFAULT_GIT_COMMAND_TIMEOUT_MS = 30_000;
@@ -36,6 +37,8 @@ export interface WorktreeManagerOptions {
 export interface WorktreeStatus {
   tracked: string[];
   untracked: string[];
+  /** Ignored dotenv paths are enumerated without reading their contents. */
+  ignoredDotenv: string[];
   unpushedCommits: number;
   unpushedBase: string | null;
 }
@@ -254,9 +257,17 @@ export class WorktreeManager {
     repoName?: string,
   ): Promise<WorktreeStatus> {
     const output = await this.runGit(["status", "--porcelain"], worktreePath);
+    const ignored = await this.runGit(
+      [
+        "ls-files", "--others", "--ignored", "--exclude-standard", "--",
+        ".env", ":(glob)**/.env", ":(glob)**/.env.*",
+      ],
+      worktreePath,
+    );
     const status: WorktreeStatus = {
       tracked: [],
       untracked: [],
+      ignoredDotenv: ignoredDotenvPaths(ignored),
       ...(await this.getUnpushedStatus(worktreePath, repoName)),
     };
     for (const line of output.split(/\r?\n/)) {

--- a/src/worktree/prune.ts
+++ b/src/worktree/prune.ts
@@ -3,6 +3,7 @@ import { realpath } from "node:fs/promises";
 import { basename } from "node:path";
 import type { RepoConfig } from "../config.ts";
 import { cleanGitHubEnvironment, GitHubAuthResolver } from "../github/auth.ts";
+import { isDotenvPath } from "./safety.ts";
 
 export interface WorktreePruneScope {
   repoNames?: readonly string[];
@@ -151,10 +152,6 @@ function isDevServerWorktree(worktree: ListedWorktree): boolean {
   return worktree.branch === "slack-dev-server" ||
     worktree.branch?.startsWith("dev-server-slot/") === true ||
     basename(worktree.path) === "slack-dev-server";
-}
-
-function isDotenvPath(path: string): boolean {
-  return basename(path) === ".env" || basename(path).startsWith(".env.");
 }
 
 function isPrunableResidualPath(path: string): boolean {

--- a/src/worktree/safety.ts
+++ b/src/worktree/safety.ts
@@ -1,0 +1,19 @@
+import { basename } from "node:path";
+
+/**
+ * Return true for dotenv files regardless of their directory. The contents
+ * are deliberately never read: these paths may contain credentials.
+ */
+export function isDotenvPath(path: string): boolean {
+  const name = basename(path);
+  return name === ".env" || name.startsWith(".env.");
+}
+
+/**
+ * Extract ignored dotenv paths from `git ls-files --ignored` output without
+ * inspecting file contents. Git emits one path per line for the command used
+ * by the worktree safety checks.
+ */
+export function ignoredDotenvPaths(output: string): string[] {
+  return output.split(/\r?\n/).filter(Boolean).filter(isDotenvPath);
+}


### PR DESCRIPTION
## Summary
- enumerate ignored `.env` / `.env.*` paths in `WorktreeManager.getWorktreeStatus` without reading file contents
- make Slack Cleanup worktree refuse removal when ignored dotenv state exists
- share the dotenv classifier with scheduled worktree pruning
- add multiline-secret, unrelated-ignored-file, and direct action-path regression coverage

## Verification
- `bun run typecheck`
- `bun test src/worktree/manager.test.ts src/worktree/prune.test.ts src/slack/action-buttons.test.ts` (33 pass)
- `bun test` (2,153 pass; 66 unrelated baseline failures in private-overlay/runbook tests on this checkout; 4 skipped)

Fixes audit finding F08.