### PR TITLE
fix: terminate orphaned runner process groups

### DIFF
--- a/docs/code_index/process-lifecycle.md
+++ b/docs/code_index/process-lifecycle.md
@@ -9,6 +9,7 @@ Timeout guards, graceful shutdown, stale session cleanup, orphan detection, and 
 | Symbol | File | Purpose |
 |---|---|---|
 | `withTimeout(handle, timeoutMs, onTimeout?)` | `timeout.ts` | Wraps `SpawnHandle`; kills + resolves with `error: "Process timed out..."` after timeout |
+| `terminateProcessGroup(pid, opts)` | `process-tree.ts` | Health-only teardown for descendants whose recorded detached-group leader has already exited; never falls back to the reusable positive PID |
 | workflow runner idle recovery | `src/workflows/executor.ts` | For workflow runner configs with `idleTimeoutMs`, sends SIGINT after a silent period, SIGKILL after 10s grace if needed, then respawns with provider-native resume and a continuation prompt up to `maxIdleInterrupts`. |
 | `setupGracefulShutdown(manager, devServerManager?, extraShutdown?)` | `shutdown.ts` | SIGINT/SIGTERM handler — terminates active runner trees, kills managed dev servers and runs optional teardown, hard exit after 30s |
 | `cleanupStaleSessions(store, staleTimeoutMs)` | `cleanup.ts` | Deletes stale idle sessions; skips top-level busy/draining and rows with any busy persistent agent |
@@ -48,7 +49,7 @@ On timeout: `handle.kill()`, result resolves with `{ exitCode: null, error: "Pro
 
 ### Orphan detection
 
-A session/agent is "orphaned" when `status === "busy"` but `process.kill(pid, 0)` throws. `health.ts` walks both the top-level `session.pid` and every `agentSessions[*].pid`, marking each idle and recording `lastError: "orphaned"` on the parent session.
+A session/agent is "orphaned" when `status === "busy"` but `process.kill(pid, 0)` throws. `health.ts` walks both the top-level `session.pid` and every `agentSessions[*].pid`; before it clears the dead leader's state, it sends `SIGTERM` to its surviving detached process group (with SIGKILL fallback). This prevents a wrapper that exited first from leaving helpers behind. It then marks the lead idle or the agent failed and records the interruption on the parent session.
 
 ### Stale cleanup
 

--- a/docs/code_index/process-lifecycle.md
+++ b/docs/code_index/process-lifecycle.md
@@ -49,7 +49,7 @@ On timeout: `handle.kill()`, result resolves with `{ exitCode: null, error: "Pro
 
 ### Orphan detection
 
-A session/agent is "orphaned" when `status === "busy"` but `process.kill(pid, 0)` throws. `health.ts` walks both the top-level `session.pid` and every `agentSessions[*].pid`; before it clears the dead leader's state, it sends `SIGTERM` to its surviving detached process group (with SIGKILL fallback). This prevents a wrapper that exited first from leaving helpers behind. It then marks the lead idle or the agent failed and records the interruption on the parent session.
+A session/agent is "orphaned" when `status === "busy"` but `process.kill(pid, 0)` throws. `health.ts` walks both the top-level `session.pid` and every `agentSessions[*].pid`; before it clears the dead leader's state, it sends `SIGTERM` to its surviving detached process group (with SIGKILL fallback). This prevents a wrapper that exited first from leaving helpers behind. The final state mutation must match the snapshot's `stateVersion` as well as status/PID, so a replacement turn with a recycled PID is never cleared. It then marks the lead idle or the agent failed and records the interruption on the parent session.
 
 ### Stale cleanup
 

--- a/docs/features/process-lifecycle.md
+++ b/docs/features/process-lifecycle.md
@@ -31,6 +31,8 @@ is historical.
   state and artifacts remain authoritative.
 - Stale cleanup must not delete an idle parent thread while any persistent agent session is still busy.
 - Health check: periodic scan for orphaned processes
+- Orphan repair: when a recorded wrapper PID is dead, terminate any surviving
+  descendants in its detached process group before clearing the session state
 - Metrics: track success/failure/timeout rates per agent type
 - Graceful bot shutdown: on SIGINT/SIGTERM, wait for running processes to finish
 

--- a/docs/features/process-tree-cleanup.md
+++ b/docs/features/process-tree-cleanup.md
@@ -27,6 +27,10 @@ The shared helper is `src/lifecycle/process-tree.ts`:
   direct-PID fallback for non-detached or test handles.
 - `terminateProcessTree(pid, opts)` sends a graceful signal, waits, then sends
   `SIGKILL` if anything in the group is still alive.
+- `terminateProcessGroup(pid, opts)` is the health-repair variant for a dead
+  recorded leader. It addresses only the original negative process-group id;
+  it must not fall back to the former positive PID because that PID could be
+  reused before repair runs.
 - `isProcessTreeAlive(pid)` checks the process group first, then the direct PID.
 
 Spawner-owned `kill()` methods are synchronous handles, so they call
@@ -63,4 +67,5 @@ Regression coverage includes:
 - workflow shutdown terminating active workflow runner handles while preserving
   `providerSessionId`
 - dev-server kill and killAll paths using process-tree termination
-
+- orphan repair terminating a helper that survives its recorded wrapper before
+  the session is cleared

--- a/src/lifecycle/health.test.ts
+++ b/src/lifecycle/health.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "bun:test";
+import { checkOrphanedSessions } from "./health.ts";
+import { isProcessTreeAlive, terminateProcessGroup } from "./process-tree.ts";
+import { InMemorySessionStore } from "../session/store/memory.ts";
+import { createSession } from "../session/types.ts";
+
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 5_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error("Timed out waiting for condition");
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+}
+
+async function spawnOrphanedWrapper(): Promise<{ leaderPid: number; helperPid: number }> {
+  const proc = Bun.spawn(["sh", "-c", "sleep 60 & echo $!"], {
+    stdout: "pipe",
+    stderr: "pipe",
+    stdin: "ignore",
+    detached: true,
+  });
+  const reader = proc.stdout.getReader();
+  const { value } = await reader.read();
+  const helperPid = Number(new TextDecoder().decode(value).trim());
+  await proc.exited;
+  return { leaderPid: proc.pid, helperPid };
+}
+
+describe("checkOrphanedSessions", () => {
+  it("terminates helper descendants before clearing an orphaned leader", async () => {
+    const { leaderPid, helperPid } = await spawnOrphanedWrapper();
+
+    const store = new InMemorySessionStore();
+    const session = createSession("thread-orphan", "channel-1");
+    session.status = "busy";
+    session.pid = leaderPid;
+    await store.set(session.threadId, session);
+
+    try {
+      expect(helperPid).toBeGreaterThan(0);
+      expect(isPidAlive(leaderPid)).toBe(false);
+      expect(isProcessTreeAlive(leaderPid)).toBe(true);
+
+      await expect(checkOrphanedSessions(store)).resolves.toEqual([session.threadId]);
+      await waitFor(() => !isPidAlive(helperPid));
+
+      const repaired = (await store.get(session.threadId))!;
+      expect(repaired.status).toBe("idle");
+      expect(repaired.pid).toBeNull();
+      expect(repaired.lastError?.type).toBe("interrupted");
+    } finally {
+      await terminateProcessGroup(leaderPid, {
+        signal: "SIGKILL",
+        forceAfterMs: 100,
+        waitAfterForceMs: 100,
+      });
+    }
+  });
+
+  it("terminates helper descendants before failing an orphaned persistent agent", async () => {
+    const { leaderPid, helperPid } = await spawnOrphanedWrapper();
+    const store = new InMemorySessionStore();
+    const session = createSession("thread-agent-orphan", "channel-1");
+    session.agentSessions.worker = {
+      agentName: "worker",
+      provider: "claude",
+      sessionId: null,
+      status: "busy",
+      pendingMessages: [],
+      lastActivity: Date.now(),
+      pid: leaderPid,
+    };
+    await store.set(session.threadId, session);
+
+    try {
+      await expect(checkOrphanedSessions(store)).resolves.toEqual([session.threadId]);
+      await waitFor(() => !isPidAlive(helperPid));
+
+      const repaired = (await store.get(session.threadId))!;
+      expect(repaired.agentSessions.worker.status).toBe("failed");
+      expect(repaired.agentSessions.worker.pid).toBeNull();
+      expect(repaired.lastError?.message).toContain("Agent worker");
+    } finally {
+      await terminateProcessGroup(leaderPid, {
+        signal: "SIGKILL",
+        forceAfterMs: 100,
+        waitAfterForceMs: 100,
+      });
+    }
+  });
+});

--- a/src/lifecycle/health.test.ts
+++ b/src/lifecycle/health.test.ts
@@ -4,6 +4,28 @@ import { isProcessTreeAlive, terminateProcessGroup } from "./process-tree.ts";
 import { InMemorySessionStore } from "../session/store/memory.ts";
 import { createSession } from "../session/types.ts";
 
+class SnapshotBarrierStore extends InMemorySessionStore {
+  private snapshotReadyResolve!: () => void;
+  private continueResolve!: () => void;
+  readonly snapshotReady = new Promise<void>((resolve) => {
+    this.snapshotReadyResolve = resolve;
+  });
+  private readonly continue = new Promise<void>((resolve) => {
+    this.continueResolve = resolve;
+  });
+
+  override async getAll() {
+    const snapshot = await super.getAll();
+    this.snapshotReadyResolve();
+    await this.continue;
+    return snapshot;
+  }
+
+  releaseHealthCheck(): void {
+    this.continueResolve();
+  }
+}
+
 function isPidAlive(pid: number): boolean {
   try {
     process.kill(pid, 0);
@@ -90,6 +112,44 @@ describe("checkOrphanedSessions", () => {
       expect(repaired.agentSessions.worker.pid).toBeNull();
       expect(repaired.lastError?.message).toContain("Agent worker");
     } finally {
+      await terminateProcessGroup(leaderPid, {
+        signal: "SIGKILL",
+        forceAfterMs: 100,
+        waitAfterForceMs: 100,
+      });
+    }
+  });
+
+  it("does not clear a replacement turn that reused the orphan PID", async () => {
+    const { leaderPid, helperPid } = await spawnOrphanedWrapper();
+    const store = new SnapshotBarrierStore();
+    const session = createSession("thread-pid-reuse", "channel-1");
+    session.status = "busy";
+    session.pid = leaderPid;
+    await store.set(session.threadId, session);
+
+    try {
+      const healthCheck = checkOrphanedSessions(store);
+      await store.snapshotReady;
+
+      // Simulate a reset/restart between the health snapshot and orphan
+      // teardown. The numerical PID is deliberately unchanged to model reuse;
+      // only the durable ownership version distinguishes this new turn.
+      const replacement = { ...(await store.get(session.threadId))! };
+      replacement.sessionId = "new-turn";
+      replacement.activeTurnGeneration = "new-generation";
+      await store.set(session.threadId, replacement);
+      store.releaseHealthCheck();
+
+      await expect(healthCheck).resolves.toEqual([]);
+      await waitFor(() => !isPidAlive(helperPid));
+
+      const current = (await store.get(session.threadId))!;
+      expect(current.status).toBe("busy");
+      expect(current.pid).toBe(leaderPid);
+      expect(current.sessionId).toBe("new-turn");
+    } finally {
+      store.releaseHealthCheck();
       await terminateProcessGroup(leaderPid, {
         signal: "SIGKILL",
         forceAfterMs: 100,

--- a/src/lifecycle/health.ts
+++ b/src/lifecycle/health.ts
@@ -21,6 +21,11 @@ export async function checkOrphanedSessions(
 
   for (const [threadId, session] of sessions) {
     let mutated = false;
+    // `getAll()` is only a snapshot. A reset/restart can replace a dead PID
+    // with a new turn (and, in the extreme, a recycled numeric PID) while its
+    // old process group is being torn down. Every repair below therefore uses
+    // this durable version as its ownership token before clearing state.
+    let expectedStateVersion = session.stateVersion ?? 0;
 
     // Lead pid (top-level session)
     if (session.status === "busy" && session.pid !== null) {
@@ -29,10 +34,16 @@ export async function checkOrphanedSessions(
         // A wrapper can exit while descendants keep its detached process group
         // alive. Tear down that group before advertising the thread as usable.
         await terminateProcessGroup(orphanPid, { signal: "SIGTERM" });
-        await store.mutateThread(threadId, (current) => {
+        let repairedLead = false;
+        const repaired = await store.mutateThread(threadId, (current) => {
           // Do not clear a newly-owned turn if another path repaired/restarted
-          // this thread while process-group teardown was in flight.
-          if (current.status !== "busy" || current.pid !== orphanPid) return;
+          // this thread while process-group teardown was in flight. The state
+          // version is required in addition to pid: PIDs can be recycled.
+          if (
+            current.stateVersion !== expectedStateVersion ||
+            current.status !== "busy" ||
+            current.pid !== orphanPid
+          ) return;
           current.status = "idle";
           current.pid = null;
           current.lastError = {
@@ -41,7 +52,12 @@ export async function checkOrphanedSessions(
             timestamp: now,
           };
           mutated = true;
+          repairedLead = true;
         });
+        // A replacement turn owns this thread now. Do not inspect stale agent
+        // snapshot entries from the same health-check pass.
+        if (!repairedLead) continue;
+        expectedStateVersion = repaired.stateVersion ?? expectedStateVersion;
       }
     }
 
@@ -53,11 +69,17 @@ export async function checkOrphanedSessions(
         // See the top-level repair above: persistent agent wrappers can leave
         // helpers behind after their recorded leader dies.
         await terminateProcessGroup(orphanPid, { signal: "SIGTERM" });
-        await store.mutateThread(threadId, (current) => {
+        let repairedAgent = false;
+        const repaired = await store.mutateThread(threadId, (current) => {
           const currentAgent = current.agentSessions?.[agentName];
           // Same generation guard as the top-level repair: a restarted agent
-          // must not be downgraded by a stale health-check snapshot.
-          if (currentAgent?.status !== "busy" || currentAgent.pid !== orphanPid) return;
+          // must not be downgraded by a stale health-check snapshot. The
+          // version additionally protects against a recycled numeric PID.
+          if (
+            current.stateVersion !== expectedStateVersion ||
+            currentAgent?.status !== "busy" ||
+            currentAgent.pid !== orphanPid
+          ) return;
           // Not silent idle: mark failed so pipeline/status surfaces interruption.
           currentAgent.status = "failed";
           currentAgent.pid = null;
@@ -67,7 +89,11 @@ export async function checkOrphanedSessions(
             timestamp: now,
           };
           mutated = true;
+          repairedAgent = true;
         });
+        // Any concurrent write invalidates the remaining snapshot too.
+        if (!repairedAgent) break;
+        expectedStateVersion = repaired.stateVersion ?? expectedStateVersion;
       }
     }
 

--- a/src/lifecycle/health.ts
+++ b/src/lifecycle/health.ts
@@ -1,4 +1,6 @@
 import type { SessionStore } from "../session/store/interface.ts";
+import { isPidAlive } from "./process-utils.ts";
+import { terminateProcessGroup } from "./process-tree.ts";
 
 /**
  * Detect dead runner PIDs and mark them interrupted rather than silently idle.
@@ -22,48 +24,54 @@ export async function checkOrphanedSessions(
 
     // Lead pid (top-level session)
     if (session.status === "busy" && session.pid !== null) {
-      let alive = true;
-      try {
-        process.kill(session.pid, 0);
-      } catch {
-        alive = false;
-      }
-      if (!alive) {
-        session.status = "idle";
-        session.pid = null;
-        session.lastError = {
-          type: "interrupted",
-          message: "Process died unexpectedly",
-          timestamp: now,
-        };
-        mutated = true;
+      const orphanPid = session.pid;
+      if (!isPidAlive(orphanPid)) {
+        // A wrapper can exit while descendants keep its detached process group
+        // alive. Tear down that group before advertising the thread as usable.
+        await terminateProcessGroup(orphanPid, { signal: "SIGTERM" });
+        await store.mutateThread(threadId, (current) => {
+          // Do not clear a newly-owned turn if another path repaired/restarted
+          // this thread while process-group teardown was in flight.
+          if (current.status !== "busy" || current.pid !== orphanPid) return;
+          current.status = "idle";
+          current.pid = null;
+          current.lastError = {
+            type: "interrupted",
+            message: "Process died unexpectedly",
+            timestamp: now,
+          };
+          mutated = true;
+        });
       }
     }
 
     // Per-agent pids (persistent agent sessions)
-    for (const agentSession of Object.values(session.agentSessions ?? {})) {
+    for (const [agentName, agentSession] of Object.entries(session.agentSessions ?? {})) {
       if (agentSession.status !== "busy" || agentSession.pid === null) continue;
-      let alive = true;
-      try {
-        process.kill(agentSession.pid, 0);
-      } catch {
-        alive = false;
-      }
-      if (!alive) {
-        // Not silent idle: mark failed so pipeline/status surfaces interruption.
-        agentSession.status = "failed";
-        agentSession.pid = null;
-        session.lastError = {
-          type: "interrupted",
-          message: `Agent ${agentSession.agentName} process died unexpectedly`,
-          timestamp: now,
-        };
-        mutated = true;
+      const orphanPid = agentSession.pid;
+      if (!isPidAlive(orphanPid)) {
+        // See the top-level repair above: persistent agent wrappers can leave
+        // helpers behind after their recorded leader dies.
+        await terminateProcessGroup(orphanPid, { signal: "SIGTERM" });
+        await store.mutateThread(threadId, (current) => {
+          const currentAgent = current.agentSessions?.[agentName];
+          // Same generation guard as the top-level repair: a restarted agent
+          // must not be downgraded by a stale health-check snapshot.
+          if (currentAgent?.status !== "busy" || currentAgent.pid !== orphanPid) return;
+          // Not silent idle: mark failed so pipeline/status surfaces interruption.
+          currentAgent.status = "failed";
+          currentAgent.pid = null;
+          current.lastError = {
+            type: "interrupted",
+            message: `Agent ${currentAgent.agentName} process died unexpectedly`,
+            timestamp: now,
+          };
+          mutated = true;
+        });
       }
     }
 
     if (mutated) {
-      await store.set(threadId, session);
       orphaned.push(threadId);
     }
   }

--- a/src/lifecycle/process-tree.ts
+++ b/src/lifecycle/process-tree.ts
@@ -23,12 +23,7 @@ export function signalProcessTree(
   signal: RunnerKillSignal = "SIGINT",
 ): void {
   if (!pid) return;
-  try {
-    process.kill(-pid, signal);
-    return;
-  } catch {
-    // Fall back below.
-  }
+  if (signalProcessGroup(pid, signal)) return;
   try {
     process.kill(pid, signal);
   } catch {
@@ -52,20 +47,52 @@ export async function terminateProcessTree(
   await waitForExit(pid, waitAfterForceMs);
 }
 
+/**
+ * Terminate a detached process group without ever falling back to its former
+ * leader PID.
+ *
+ * Health repair calls this after it has established that the recorded leader
+ * exited. At that point a direct PID signal could race PID reuse; the only
+ * process we still own is the group identified by the original leader PID.
+ */
+export async function terminateProcessGroup(
+  pid: number | null | undefined,
+  options: TerminateProcessTreeOptions = {},
+): Promise<void> {
+  if (!pid || !isProcessGroupAlive(pid)) return;
+  const signal = options.signal ?? "SIGINT";
+  const forceAfterMs = options.forceAfterMs ?? DEFAULT_FORCE_AFTER_MS;
+  const waitAfterForceMs = options.waitAfterForceMs ?? DEFAULT_WAIT_AFTER_FORCE_MS;
+
+  signalProcessGroup(pid, signal);
+  if (await waitForProcessGroupExit(pid, forceAfterMs)) return;
+
+  signalProcessGroup(pid, "SIGKILL");
+  await waitForProcessGroupExit(pid, waitAfterForceMs);
+}
+
 export function isProcessTreeAlive(pid: number | null | undefined): boolean {
   if (!pid) return false;
-  try {
-    process.kill(-pid, 0);
-    return true;
-  } catch {
-    // Fall back below.
-  }
+  if (isProcessGroupAlive(pid)) return true;
   try {
     process.kill(pid, 0);
     return true;
   } catch {
     return false;
   }
+}
+
+function signalProcessGroup(pid: number, signal: RunnerKillSignal | 0): boolean {
+  try {
+    process.kill(-pid, signal);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isProcessGroupAlive(pid: number): boolean {
+  return signalProcessGroup(pid, 0);
 }
 
 async function waitForExit(pid: number, timeoutMs: number): Promise<boolean> {
@@ -75,6 +102,15 @@ async function waitForExit(pid: number, timeoutMs: number): Promise<boolean> {
     await sleep(100);
   }
   return !isProcessTreeAlive(pid);
+}
+
+async function waitForProcessGroupExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isProcessGroupAlive(pid)) return true;
+    await sleep(100);
+  }
+  return !isProcessGroupAlive(pid);
 }
 
 function sleep(ms: number): Promise<void> {


### PR DESCRIPTION
## Summary\n- terminate a surviving detached process group before orphan repair clears top-level or persistent-agent session state\n- avoid a direct-PID fallback once the recorded leader has exited, preventing PID-reuse risk\n- add real detached wrapper/helper regression coverage and document the lifecycle invariant\n\n## Verification\n- bun test v1.2.17 (282dda62)\n- 