### PR TITLE
fix(github): fail closed on unbound gh identity

### DIFF
--- a/docs/code_index/github-reconciliation.md
+++ b/docs/code_index/github-reconciliation.md
@@ -15,7 +15,7 @@ webhook to keep pipeline state correct.
 | Merge-prune trigger | `src/github/prune-trigger.ts` | Extracts exact merged PR repo/branch targets for scoped worktree pruning. |
 | Review comments | `src/github/review-comments.ts` | Scopes comments to an exact head SHA and avoids duplicate writes. |
 | Types | `src/github/types.ts` | GitHub resource, review, and reconciliation contracts. |
-| Repo-scoped auth | `src/github/auth.ts`, `src/config.ts` | Resolves each configured `RepoConfig.githubUser` with `gh auth token --user`, verifies the account, and injects only that token into repo-scoped child processes. |
+| Repo-scoped auth | `src/github/auth.ts`, `src/config.ts` | Resolves each configured `RepoConfig.githubUser` with `gh auth token --user`, verifies the account with `gh api user`, and injects only that token plus an isolated `GH_CONFIG_DIR` into repo-scoped `gh` children. Unknown repo mappings and repos without `githubUser` are rejected before `gh` runs. |
 
 ## Configuration
 
@@ -28,6 +28,13 @@ comment operations; arbitrary GitHub mutation is not part of the contract.
 The pipeline layer consumes reconciled state through typed resources and
 outcomes. Failures are recoverable and must not be treated as proof that the
 external review state changed.
+
+CLI fallback is development-only and is identity-bound: requests without an
+exact `owner/repo` mapping (including node-ID-only queries) fail closed rather
+than using the host's active `gh` account. The normal HTTP reconciler remains
+available with its explicit `GITHUB_RECONCILE_TOKEN`; it does not use `gh`.
+Runner environments use empty token sentinels plus an isolated config directory
+unless the selected target repo supplied a verified auth environment.
 
 When a reconcile pass observes an `OPEN`/`CLOSED` to `MERGED` transition,
 Junior starts `worktree-prune` with structured trigger context containing the

--- a/docs/features/worktree-manager.md
+++ b/docs/features/worktree-manager.md
@@ -61,7 +61,13 @@ The bug-pipeline + dev-server fields are optional. Repos that only need the `!re
 
 - `createWorktree(repoName, threadId, baseRef?, branchOverride?) → Promise<worktreePath>` — creates a worktree at `<repo.path>.junior-worktrees/slack-<threadId>` (or whatever path `getWorktreePath` derives — note this is a sibling directory to the repo, deliberately outside `.claude/`). The new branch is `branchOverride ?? slack/<threadId>`; the starting ref is `baseRef ?? repo.defaultBase`. If `repo.worktreeSetupCommand` is set, the manager runs `<repo.path>/<command> <worktreePath> <branch>` instead of `git fetch + git worktree add`.
 - `syncRepo(repoName) → Promise<void>` — refreshes `origin/*` from the configured checkout before any reused managed worktree is handed to a runner. Pipeline dispatch refreshes every reused repo; ordinary `!repo` and inferred-review turns refresh their selected repo. Sandboxed providers cannot update the shared Git metadata behind linked worktrees, so this pre-turn fetch belongs to Junior rather than the model process.
-- When `githubUser` is set, Junior resolves that account with `gh auth token --user`, verifies it with `gh api user`, and applies the resulting `GH_TOKEN` only to that repo's worktree setup, runner, and GitHub API child processes. It never switches the host-wide active `gh` account. Repos without `githubUser` retain the existing host-auth fallback.
+- GitHub CLI/API operations require both the exact configured `githubRepo` and
+  `githubUser`. Junior resolves that account with `gh auth token --user`,
+  verifies it with `gh api user`, and applies the resulting `GH_TOKEN` only to
+  that repo's worktree setup, runner, and GitHub API child processes. Each
+  `gh` child gets an isolated `GH_CONFIG_DIR`; inherited GitHub tokens and
+  account/config selectors are removed. Unknown repos or repos without
+  `githubUser` fail closed rather than using the host's active `gh` account.
 - Delegated setup requires 2 GiB of free filesystem headroom by default (`WORKTREE_SETUP_MIN_FREE_BYTES` overrides it). Junior streams stdout and stderr concurrently into a restricted transcript while retaining only bounded tails in memory, so verbose installers cannot deadlock on full pipes or exhaust the bot heap. If the setup script fails after registering a worktree, Junior transactionally removes that worktree and its new branch; the surfaced error is a bounded per-stream tail plus a pointer to the complete owner-only (`0600`) transcript under `logs/worktree-setup/`.
 - Every Git command and delegated setup script runs in its own process group with
   a hard wall-clock bound. Git defaults to 30 seconds

--- a/src/github/auth.test.ts
+++ b/src/github/auth.test.ts
@@ -13,8 +13,16 @@ const repo: RepoConfig = {
 describe("GitHubAuthResolver", () => {
   it("resolves and caches the configured account without changing global gh state", async () => {
     const calls: Array<{ args: string[]; env: Record<string, string> }> = [];
-    const previousToken = process.env.GITHUB_TOKEN;
+    const previous = {
+      GH_TOKEN: process.env.GH_TOKEN,
+      GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+      GH_ENTERPRISE_TOKEN: process.env.GH_ENTERPRISE_TOKEN,
+      GH_CONFIG_DIR: process.env.GH_CONFIG_DIR,
+    };
+    process.env.GH_TOKEN = "wrong-global-token";
     process.env.GITHUB_TOKEN = "wrong-account-token";
+    process.env.GH_ENTERPRISE_TOKEN = "wrong-enterprise-token";
+    process.env.GH_CONFIG_DIR = "/tmp/wrong-gh-config";
     try {
       const resolver = new GitHubAuthResolver([repo], async (args, env) => {
         calls.push({ args, env });
@@ -28,10 +36,12 @@ describe("GitHubAuthResolver", () => {
         "growthx-club/gx-client-next",
       );
 
-      expect(first).toEqual({
+      if (!first) throw new Error("configured repository did not resolve an identity");
+      expect(first).toMatchObject({
         GH_TOKEN: "selected-token",
         GH_PROMPT_DISABLED: "1",
       });
+      expect(first.GH_CONFIG_DIR).toContain("junior-gh-isolated");
       expect(second).toEqual(first);
       expect(calls).toHaveLength(2);
       expect(calls[0]?.args).toEqual([
@@ -40,11 +50,17 @@ describe("GitHubAuthResolver", () => {
         "--user",
         "pranav-growthx",
       ]);
+      expect(calls[0]?.env.GH_TOKEN).toBeUndefined();
       expect(calls[0]?.env.GITHUB_TOKEN).toBeUndefined();
+      expect(calls[0]?.env.GH_ENTERPRISE_TOKEN).toBeUndefined();
+      expect(calls[0]?.env.GH_CONFIG_DIR).toBeUndefined();
       expect(calls[1]?.env.GH_TOKEN).toBe("selected-token");
+      expect(calls[1]?.env.GH_CONFIG_DIR).toBeUndefined();
     } finally {
-      if (previousToken === undefined) delete process.env.GITHUB_TOKEN;
-      else process.env.GITHUB_TOKEN = previousToken;
+      for (const [key, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
     }
   });
 
@@ -60,12 +76,38 @@ describe("GitHubAuthResolver", () => {
     );
   });
 
-  it("leaves repos without a selection on the existing host auth path", async () => {
+  it("does not produce GitHub credentials for repos without a selection", async () => {
     const unselected = { ...repo, githubUser: undefined };
     const resolver = new GitHubAuthResolver([
       unselected,
     ]);
 
     expect(await resolver.environmentForRepo(unselected)).toBeUndefined();
+  });
+
+  it("fails closed when a GitHub repository is missing its configured identity", async () => {
+    const resolver = new GitHubAuthResolver([{
+      ...repo,
+      githubUser: undefined,
+    }]);
+
+    await expect(
+      resolver.environmentForRepoRef("GrowthX-Club/gx-client-next"),
+    ).rejects.toThrow("must configure githubUser");
+    await expect(
+      resolver.environmentForRepoRef("GrowthX-Club/other-repo"),
+    ).rejects.toThrow("No GitHub identity is configured");
+  });
+
+  it("rejects a selected account that lacks an exact repository mapping", async () => {
+    const resolver = new GitHubAuthResolver([{
+      ...repo,
+      githubRepo: undefined,
+    }]);
+
+    await expect(resolver.environmentForRepo({
+      ...repo,
+      githubRepo: undefined,
+    })).rejects.toThrow("must configure githubRepo with githubUser");
   });
 });

--- a/src/github/auth.ts
+++ b/src/github/auth.ts
@@ -1,4 +1,7 @@
 import type { RepoConfig } from "../config.ts";
+import { chmodSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 const GITHUB_USER_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,38}$/;
 
@@ -19,6 +22,7 @@ export type GitHubCommandRunner = (
  */
 export class GitHubAuthResolver {
   private readonly reposByGitHubRef: Map<string, RepoConfig>;
+  private readonly reposByName: Map<string, RepoConfig>;
   private readonly verifiedTokens = new Map<string, string>();
   private readonly runCommand: GitHubCommandRunner;
 
@@ -31,23 +35,31 @@ export class GitHubAuthResolver {
         .filter((repo) => repo.githubRepo)
         .map((repo) => [normalizeRepoRef(repo.githubRepo!), repo]),
     );
+    this.reposByName = new Map(repos.map((repo) => [repo.name, repo]));
     this.runCommand = runCommand;
   }
 
   async environmentForRepoName(
     repoName: string,
   ): Promise<Record<string, string> | undefined> {
-    const repo = [...this.reposByGitHubRef.values()].find(
-      (candidate) => candidate.name === repoName,
-    );
+    const repo = this.reposByName.get(repoName);
     return repo ? this.environmentForRepo(repo) : undefined;
   }
 
   async environmentForRepoRef(
     repoRef: string,
-  ): Promise<Record<string, string> | undefined> {
+  ): Promise<Record<string, string>> {
     const repo = this.reposByGitHubRef.get(normalizeRepoRef(repoRef));
-    return repo ? this.environmentForRepo(repo) : undefined;
+    if (!repo) {
+      throw new Error(`No GitHub identity is configured for repository ${repoRef}`);
+    }
+    const environment = await this.environmentForRepo(repo);
+    if (!environment) {
+      throw new Error(
+        `Repository ${repo.name} must configure githubUser for GitHub operations`,
+      );
+    }
+    return environment;
   }
 
   async environmentForRepo(
@@ -55,6 +67,11 @@ export class GitHubAuthResolver {
   ): Promise<Record<string, string> | undefined> {
     const configuredUser = repo.githubUser?.trim();
     if (!configuredUser) return undefined;
+    if (!repo.githubRepo?.trim()) {
+      throw new Error(
+        `Repository ${repo.name} must configure githubRepo with githubUser for GitHub operations`,
+      );
+    }
     if (!GITHUB_USER_PATTERN.test(configuredUser)) {
       throw new Error(
         `Invalid githubUser "${configuredUser}" for repo ${repo.name}`,
@@ -62,11 +79,13 @@ export class GitHubAuthResolver {
     }
 
     const token = await this.tokenForUser(configuredUser, repo.name);
-    // GH_TOKEN is intentionally explicit for this child process. Remove
-    // inherited GITHUB_TOKEN at the call site so it cannot override it.
+    // GH_TOKEN is intentionally explicit for this child process. An empty,
+    // Junior-owned gh config prevents a selected token from falling back to
+    // whichever account happens to be active in the host's GH_CONFIG_DIR.
     return {
       GH_TOKEN: token,
       GH_PROMPT_DISABLED: "1",
+      GH_CONFIG_DIR: isolatedGitHubConfigDir(),
     };
   }
 
@@ -109,13 +128,34 @@ export function normalizeRepoRef(value: string): string {
   return value.trim().replace(/\.git$/i, "").toLowerCase();
 }
 
-export function cleanGitHubEnvironment(): Record<string, string> {
+export function cleanGitHubEnvironment(options: {
+  isolatedConfig?: boolean;
+} = {}): Record<string, string> {
   const env = { ...(process.env as Record<string, string>) };
   delete env.GH_TOKEN;
   delete env.GITHUB_TOKEN;
   delete env.GH_ENTERPRISE_TOKEN;
+  delete env.GITHUB_RECONCILE_TOKEN;
+  delete env.GH_CONFIG_DIR;
+  delete env.GH_HOST;
+  delete env.GH_REPO;
+  if (options.isolatedConfig) {
+    env.GH_CONFIG_DIR = isolatedGitHubConfigDir();
+  }
   env.GH_PROMPT_DISABLED = "1";
   return env;
+}
+
+/**
+ * Keep every gh child that already has an explicitly verified GH_TOKEN away
+ * from the host-wide gh account database. The directory contains no tokens;
+ * its only purpose is to make ambient account selection impossible.
+ */
+function isolatedGitHubConfigDir(): string {
+  const directory = join(tmpdir(), `junior-gh-isolated-${process.pid}`);
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  chmodSync(directory, 0o700);
+  return directory;
 }
 
 async function runGitHubCommand(

--- a/src/github/client.test.ts
+++ b/src/github/client.test.ts
@@ -211,12 +211,12 @@ describe("createGitHubClient", () => {
     expect(map.get("PR_missing")?.ok).toBe(false);
   });
 
-  it("passes CLI GraphQL arrays as repeated typed fields", async () => {
-    let cliArgs: string[] = [];
+  it("does not use ambient gh auth for CLI GraphQL calls without a repository", async () => {
+    let called = false;
     const client = createGitHubClient({
       useCli: true,
-      runCli: async (args) => {
-        cliArgs = args;
+      runCli: async (_args) => {
+        called = true;
         return {
           ok: true,
           status: 200,
@@ -226,11 +226,13 @@ describe("createGitHubClient", () => {
       },
     });
 
-    await client.fetchPullRequestsByNodeIds(["PR_1", "PR_2"]);
+    const result = await client.fetchPullRequestsByNodeIds(["PR_1", "PR_2"]);
 
-    expect(cliArgs).toContain("ids[]=PR_1");
-    expect(cliArgs).toContain("ids[]=PR_2");
-    expect(cliArgs).not.toContain('ids=["PR_1","PR_2"]');
+    expect(called).toBe(false);
+    expect(result.get("PR_1")).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("exact configured repository identity"),
+    });
   });
 
   it("passes the configured repo identity to the CLI GraphQL fallback", async () => {
@@ -262,5 +264,26 @@ describe("createGitHubClient", () => {
 
     expect(cliEnv?.GH_TOKEN).toBe("selected-token");
     expect(cliEnv?.GITHUB_TOKEN).toBeUndefined();
+    expect(cliEnv?.GH_CONFIG_DIR).toContain("junior-gh-isolated");
+  });
+
+  it("fails closed for a CLI fallback whose repository is not configured", async () => {
+    let called = false;
+    const client = createGitHubClient({
+      useCli: true,
+      githubAuth: new GitHubAuthResolver([]),
+      runCli: async () => {
+        called = true;
+        return { ok: true, status: 200, body: "{}", headers: {} };
+      },
+    });
+
+    const result = await client.fetchPullRequest("GrowthX-Club", "missing", 1);
+
+    expect(called).toBe(false);
+    expect(result).toMatchObject({
+      ok: false,
+      error: expect.stringContaining("No GitHub identity is configured"),
+    });
   });
 });

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -138,16 +138,31 @@ export function createGitHubClient(options: GitHubClientOptions = {}): GitHubCli
       const repoRef = typeof variables.owner === "string" && typeof variables.repo === "string"
         ? `${variables.owner}/${variables.repo}`
         : undefined;
-      const selectedEnv = repoRef && options.githubAuth
-        ? await options.githubAuth.environmentForRepoRef(repoRef)
-        : undefined;
+      if (!repoRef) {
+        return githubIdentityFailure(
+          "GitHub CLI fallback requires an exact configured repository identity",
+        );
+      }
+      if (!options.githubAuth) {
+        return githubIdentityFailure(
+          "GitHub CLI fallback requires a GitHub identity resolver",
+        );
+      }
+      let selectedEnv: Record<string, string>;
+      try {
+        selectedEnv = await options.githubAuth.environmentForRepoRef(repoRef);
+      } catch (error) {
+        return githubIdentityFailure(
+          error instanceof Error ? error.message : String(error),
+        );
+      }
       const result = await runCli([
         "api",
         "graphql",
         "-f",
         `query=${query}`,
         ...serializeCliVariables(variables),
-      ], selectedEnv ? { ...cleanGitHubEnvironment(), ...selectedEnv } : undefined);
+      ], { ...cleanGitHubEnvironment(), ...selectedEnv });
       if (!result.ok) {
         return {
           ok: false,
@@ -411,6 +426,16 @@ export function createGitHubClient(options: GitHubClientOptions = {}): GitHubCli
       };
     },
   };
+}
+
+function githubIdentityFailure(error: string): {
+  ok: false;
+  error: string;
+  status: number;
+  headers: Record<string, string>;
+  body: string;
+} {
+  return { ok: false, error, status: 0, headers: {}, body: "" };
 }
 
 function serializeCliVariables(

--- a/src/github/review-comments.test.ts
+++ b/src/github/review-comments.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "bun:test";
 import {
+  githubEnvironmentForEndpoint,
   postGitHubReview,
   readGitHubReviewState,
+  setGitHubAuthResolver,
   type GitHubApiRequest,
   type GitHubApiRunner,
   type GitHubReviewInput,
 } from "./review-comments.ts";
+import { GitHubAuthResolver } from "./auth.ts";
 
 const SHA = "a".repeat(40);
 
@@ -332,5 +335,39 @@ describe("readGitHubReviewState", () => {
       { ...target, reviewId: -1 },
       never,
     )).resolves.toEqual({ ok: false, reason: "reviewId must be a positive integer" });
+  });
+});
+
+describe("GitHub review API identity", () => {
+  it("requires an exact configured repository identity and isolates gh config", async () => {
+    setGitHubAuthResolver(undefined);
+    await expect(
+      githubEnvironmentForEndpoint("repos/GrowthX-Club/gx-backend/pulls/123"),
+    ).rejects.toThrow("configured identity resolver");
+
+    const resolver = new GitHubAuthResolver([{
+      name: "gx-backend",
+      path: "/tmp/gx-backend",
+      defaultBase: "origin/main",
+      githubRepo: "GrowthX-Club/gx-backend",
+      githubUser: "gxt-admin",
+    }], async (args) => args[0] === "auth"
+      ? { status: 0, stdout: "selected-token", stderr: "" }
+      : { status: 0, stdout: "gxt-admin", stderr: "" });
+    setGitHubAuthResolver(resolver);
+    try {
+      const env = await githubEnvironmentForEndpoint(
+        "repos/growthx-club/gx-backend/pulls/123",
+      );
+      expect(env.GH_TOKEN).toBe("selected-token");
+      expect(env.GH_CONFIG_DIR).toContain("junior-gh-isolated");
+      expect(env.GITHUB_TOKEN).toBeUndefined();
+
+      await expect(
+        githubEnvironmentForEndpoint("repos/GrowthX-Club/other/pulls/123"),
+      ).rejects.toThrow("No GitHub identity is configured");
+    } finally {
+      setGitHubAuthResolver(undefined);
+    }
   });
 });

--- a/src/github/review-comments.ts
+++ b/src/github/review-comments.ts
@@ -592,11 +592,24 @@ async function runGitHubApi(
   }
   if (request.paginate) args.push("--paginate", "--slurp");
 
+  let env: Record<string, string>;
+  try {
+    env = await githubEnvironmentForEndpoint(request.endpoint);
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    pipelineLog("warn", "github.api.rejected", {
+      method: request.method,
+      endpoint: request.endpoint,
+      reason,
+    });
+    return { ok: false, status: 0, stdout: "", stderr: reason };
+  }
+
   const proc = Bun.spawn(args, {
     stdin: request.body === undefined ? "ignore" : "pipe",
     stdout: "pipe",
     stderr: "pipe",
-    env: await githubEnvironmentForEndpoint(request.endpoint),
+    env,
   });
   if (request.body !== undefined && proc.stdin) {
     proc.stdin.write(JSON.stringify(request.body));
@@ -619,17 +632,17 @@ async function runGitHubApi(
   return result;
 }
 
-async function githubEnvironmentForEndpoint(
+export async function githubEnvironmentForEndpoint(
   endpoint: string,
 ): Promise<Record<string, string>> {
   const match = endpoint.match(/^repos\/([^/]+\/[^/]+)/i);
-  if (!githubAuthResolver || !match) {
-    return { ...(process.env as Record<string, string>), GH_PROMPT_DISABLED: "1" };
+  if (!match) {
+    throw new Error("GitHub operation requires an exact repository endpoint");
+  }
+  if (!githubAuthResolver) {
+    throw new Error("GitHub operation requires a configured identity resolver");
   }
   const selected = await githubAuthResolver.environmentForRepoRef(match[1]);
-  if (!selected) {
-    return { ...(process.env as Record<string, string>), GH_PROMPT_DISABLED: "1" };
-  }
   return { ...cleanGitHubEnvironment(), ...selected };
 }
 

--- a/src/lifecycle/dev-server.ts
+++ b/src/lifecycle/dev-server.ts
@@ -168,7 +168,7 @@ export class DevServerManager {
     log.info("dev-server", `spawn repo=${repoName} cmd=${cmdParts.join(" ")} cwd=${worktreePath}`);
     const proc = Bun.spawn(cmdParts, {
       cwd: worktreePath,
-      env: githubEnv ? { ...cleanGitHubEnvironment(), ...githubEnv } : undefined,
+      env: { ...cleanGitHubEnvironment({ isolatedConfig: true }), ...githubEnv },
       stdout: "pipe",
       stderr: "pipe",
       detached: true,
@@ -462,7 +462,7 @@ function sleep(ms: number): Promise<void> {
 async function runGit(args: string[], cwd: string, githubEnv?: Record<string, string>): Promise<string> {
   const proc = Bun.spawn(["git", ...args], {
     cwd,
-    env: githubEnv ? { ...cleanGitHubEnvironment(), ...githubEnv } : undefined,
+    env: { ...cleanGitHubEnvironment({ isolatedConfig: true }), ...githubEnv },
     stdout: "pipe",
     stderr: "pipe",
   });

--- a/src/runners/runtime.test.ts
+++ b/src/runners/runtime.test.ts
@@ -193,21 +193,50 @@ describe("runner runtime", () => {
   });
 
   it("uses the repo-selected GitHub token and removes inherited overrides", () => {
-    const previous = process.env.GITHUB_TOKEN;
+    const previous = {
+      GH_TOKEN: process.env.GH_TOKEN,
+      GITHUB_TOKEN: process.env.GITHUB_TOKEN,
+      GH_ENTERPRISE_TOKEN: process.env.GH_ENTERPRISE_TOKEN,
+      GH_CONFIG_DIR: process.env.GH_CONFIG_DIR,
+    };
+    process.env.GH_TOKEN = "wrong-global-token";
     process.env.GITHUB_TOKEN = "wrong-account-token";
+    process.env.GH_ENTERPRISE_TOKEN = "wrong-enterprise-token";
+    process.env.GH_CONFIG_DIR = "/tmp/wrong-gh-config";
     try {
       const env = buildRunnerEnv(
         makeSession({ activeAgentName: "review" }),
         "xoxb-test",
         undefined,
-        { GH_TOKEN: "selected-account-token", GH_PROMPT_DISABLED: "1" },
+        {
+          GH_TOKEN: "selected-account-token",
+          GH_PROMPT_DISABLED: "1",
+          GH_CONFIG_DIR: "/tmp/junior-gh-isolated",
+        },
       );
       expect(env.GH_TOKEN).toBe("selected-account-token");
-      expect(env.GITHUB_TOKEN).toBeUndefined();
+      expect(env.GITHUB_TOKEN).toBe("");
+      expect(env.GH_ENTERPRISE_TOKEN).toBe("");
+      expect(env.GH_CONFIG_DIR).toBe("/tmp/junior-gh-isolated");
       expect(env.GH_PROMPT_DISABLED).toBe("1");
     } finally {
-      if (previous === undefined) delete process.env.GITHUB_TOKEN;
-      else process.env.GITHUB_TOKEN = previous;
+      for (const [key, value] of Object.entries(previous)) {
+        if (value === undefined) delete process.env[key];
+        else process.env[key] = value;
+      }
+    }
+  });
+
+  it("removes ambient GitHub credentials when no repository identity was selected", () => {
+    const previous = process.env.GH_TOKEN;
+    process.env.GH_TOKEN = "wrong-global-token";
+    try {
+      const env = buildRunnerEnv(makeSession(), "xoxb-test");
+      expect(env.GH_TOKEN).toBe("");
+      expect(env.GH_CONFIG_DIR).toContain("junior-gh-isolated");
+    } finally {
+      if (previous === undefined) delete process.env.GH_TOKEN;
+      else process.env.GH_TOKEN = previous;
     }
   });
 

--- a/src/runners/runtime.ts
+++ b/src/runners/runtime.ts
@@ -1,5 +1,6 @@
 import { mkdirSync, realpathSync } from "node:fs";
 import { resolve } from "node:path";
+import { cleanGitHubEnvironment } from "../github/auth.ts";
 import type { AgentIdentity, RunnerProvider, ThreadSession } from "../session/types.ts";
 
 export interface RunnerRuntimeOptions {
@@ -170,7 +171,7 @@ export function buildRunnerEnv(
   githubAuthEnv?: Record<string, string>,
 ): Record<string, string> {
   const env: Record<string, string> = {
-    ...(process.env as Record<string, string>),
+    ...cleanGitHubEnvironment({ isolatedConfig: true }),
     JUNIOR_SPAWNED: "1",
     SLACK_CHANNEL: session.channel,
     SLACK_THREAD_TS: session.threadId,
@@ -179,9 +180,14 @@ export function buildRunnerEnv(
   };
   if (githubAuthEnv) {
     Object.assign(env, githubAuthEnv);
-    delete env.GITHUB_TOKEN;
-    delete env.GH_ENTERPRISE_TOKEN;
   }
+  // Empty sentinels prevent Bun-launched providers from reloading credentials
+  // from a target repository's dotenv file. A verified GH_TOKEN above is the
+  // sole exception.
+  if (!githubAuthEnv?.GH_TOKEN) env.GH_TOKEN = "";
+  env.GITHUB_TOKEN = "";
+  env.GH_ENTERPRISE_TOKEN = "";
+  env.GITHUB_RECONCILE_TOKEN = "";
   // MCP_CONTEXT_SECRET authenticates the agent identity embedded in MCP URLs.
   // A child that receives it could forge a different agent's capability token.
   delete env.MCP_CONTEXT_SECRET;

--- a/src/worktree/manager.ts
+++ b/src/worktree/manager.ts
@@ -1,5 +1,5 @@
 import type { RepoConfig } from "../config.ts";
-import { GitHubAuthResolver } from "../github/auth.ts";
+import { cleanGitHubEnvironment, GitHubAuthResolver } from "../github/auth.ts";
 import { statfs } from "node:fs/promises";
 import {
   closeSync,
@@ -601,13 +601,10 @@ export class WorktreeManager {
   private commandEnvironment(
     githubEnv?: Record<string, string>,
   ): Record<string, string> {
-    const env = { ...(process.env as Record<string, string>), ...githubEnv };
-    if (githubEnv) {
-      // An inherited GITHUB_TOKEN would take precedence over the selected
-      // account in some GitHub tooling. The repo-scoped GH_TOKEN is authoritative.
-      delete env.GITHUB_TOKEN;
-      delete env.GH_ENTERPRISE_TOKEN;
-    }
+    const env = {
+      ...cleanGitHubEnvironment({ isolatedConfig: true }),
+      ...githubEnv,
+    };
     // Git's prompt paths can outlive a child process (credential helpers and
     // SSH read /dev/tty directly), so every inline Git command and delegated
     // setup script receives a fail-fast, noninteractive transport contract.

--- a/src/worktree/prune.ts
+++ b/src/worktree/prune.ts
@@ -169,7 +169,7 @@ async function canonicalPath(path: string): Promise<string> {
 async function git(cwd: string, args: string[], githubEnv?: Record<string, string>): Promise<string> {
   const proc = Bun.spawn(["git", ...args], {
     cwd,
-    env: githubEnv ? { ...cleanGitHubEnvironment(), ...githubEnv } : undefined,
+    env: { ...cleanGitHubEnvironment({ isolatedConfig: true }), ...githubEnv },
     stdout: "pipe",
     stderr: "pipe",
   });
@@ -185,7 +185,7 @@ async function git(cwd: string, args: string[], githubEnv?: Record<string, strin
 async function gitExitCode(cwd: string, args: string[], githubEnv?: Record<string, string>): Promise<number> {
   const proc = Bun.spawn(["git", ...args], {
     cwd,
-    env: githubEnv ? { ...cleanGitHubEnvironment(), ...githubEnv } : undefined,
+    env: { ...cleanGitHubEnvironment({ isolatedConfig: true }), ...githubEnv },
     stdout: "ignore",
     stderr: "ignore",
   });


### PR DESCRIPTION
## Summary
- bind every `gh` operation to an exact configured repo and verified `githubUser`
- isolate `GH_CONFIG_DIR` and remove inherited GitHub credentials from runners, setup, dev-server, and prune children
- preserve the explicit token-based read-only HTTP reconciler

## Verification
- `bun run typecheck`
- focused: `bun test src/github/auth.test.ts src/github/client.test.ts src/github/review-comments.test.ts src/runners/runtime.test.ts src/worktree/manager.test.ts` (67 pass)
- `bun run build`
- full `bun test` has one unrelated baseline failure in `src/codex-app-server/config.test.ts` (unchanged by this PR)