### PR TITLE
fix(worktree): verify removal postconditions

### DIFF
--- a/docs/code_index/worktree-manager.md
+++ b/docs/code_index/worktree-manager.md
@@ -10,7 +10,7 @@ Creates, removes, and inspects git worktrees in target repos for per-thread code
 |---|---|---|
 | `WorktreeManager(repos, options?)` | `manager.ts` | Constructor — keeps `RepoConfig[]`; options support deterministic disk-headroom tests and an injectable repo-scoped GitHub auth resolver. |
 | `createWorktree(repoName, threadId, baseRef?, branchOverride?)` | `manager.ts` | Creates worktree. `baseRef` defaults to `repo.defaultBase`. `branchOverride` defaults to `slack/<threadId>`. Returns absolute path. |
-| `removeWorktree(repoName, threadId)` | `manager.ts` | `git worktree remove --force` + `git branch -D` (queries actual branch name from the worktree first to handle `branchOverride`) |
+| `removeWorktree(repoName, threadId)` | `manager.ts` | `git worktree remove --force` + `git branch -D`, then verifies both registry absence and filesystem absence (queries actual branch name first to handle `branchOverride`) |
 | `worktreeExists(repoName, threadId)` | `manager.ts` | Filesystem check via `node:fs/promises.stat` |
 | `isWorktreeDirty(worktreePath)` | `manager.ts` | `git status --porcelain` |
 | `getWorktreeStatus(worktreePath, repoName?)` | `manager.ts` | Reports tracked/untracked changes, unpushed commits, and ignored dotenv paths (path names only; contents are never read). |
@@ -81,7 +81,7 @@ Durable pipeline assignments use a stricter path: `pipeline-routing.ts` resolves
 
 ### Dirty-check before remove
 
-Callers should `isWorktreeDirty(path)` before `removeWorktree` so uncommitted work isn't silently destroyed. The cleanup pass in `lifecycle/cleanup.ts` skips busy/draining and deletes only stale idle sessions; worktree removal itself is not currently automatic on cleanup (worktrees outlive the session row).
+Callers should `isWorktreeDirty(path)` before `removeWorktree` so uncommitted work isn't silently destroyed. Removal also verifies that Git's registry entry and the filesystem path are both gone; a leftover (for example, an ignored dotenv file) raises an incomplete-cleanup error for preservation review. The cleanup pass in `lifecycle/cleanup.ts` skips busy/draining and deletes only stale idle sessions; worktree removal itself is not currently automatic on cleanup (worktrees outlive the session row).
 
 ## Dependencies
 

--- a/docs/features/worktree-manager.md
+++ b/docs/features/worktree-manager.md
@@ -78,7 +78,7 @@ The bug-pipeline + dev-server fields are optional. Repos that only need the `!re
   Slack turn alive. These processes are always noninteractive:
   `GIT_TERMINAL_PROMPT=0`, batch-mode SSH, and an injected empty credential
   helper prevent credential prompts from becoming hangs.
-- `removeWorktree(repoName, threadId) → Promise<void>` — reads the actual current branch via `git -C <wt> branch --show-current` before deletion (so cleanup works for `branchOverride` callers), force-removes the worktree, and `git branch -D`s the branch. Both lookup and delete are wrapped in try/catch so missing/detached state is non-fatal.
+- `removeWorktree(repoName, threadId) → Promise<void>` — reads the actual current branch via `git -C <wt> branch --show-current` before deletion (so cleanup works for `branchOverride` callers), force-removes the worktree, and `git branch -D`s the branch. It then verifies both the Git worktree registry and filesystem path are gone; a non-atomic leftover raises an incomplete-cleanup error with the path for preservation review. Branch lookup and deletion remain non-fatal for missing/detached state.
 - `worktreeExists(repoName, threadId) → Promise<boolean>` and `isWorktreeDirty(worktreePath) → Promise<boolean>` — used by cleanup.
 - `getWorktreePath(repoName, threadId) → string` and `getBranchName(threadId) → string` — pure helpers (no I/O).
 

--- a/src/worktree/manager.test.ts
+++ b/src/worktree/manager.test.ts
@@ -659,6 +659,34 @@ git worktree add "$TARGET" -b "$BRANCH" "$BASE"
     expect(listed).toBe("");
   });
 
+  it("surfaces a non-atomic ignored leftover after git removes the worktree registry entry", async () => {
+    const wm = new WorktreeManager([{
+      name: "non-atomic-remove",
+      path: repoRoot,
+      defaultBase: "origin/main",
+    }]);
+    const threadId = "non-atomic-remove-thread";
+    const wtPath = await wm.createWorktree("non-atomic-remove", threadId);
+    const originalRunGit = (wm as unknown as {
+      runGit: (args: string[], cwd: string, env?: Record<string, string>) => Promise<string>;
+    }).runGit.bind(wm);
+    (wm as unknown as {
+      runGit: (args: string[], cwd: string, env?: Record<string, string>) => Promise<string>;
+    }).runGit = async (args, cwd, env) => {
+      const output = await originalRunGit(args, cwd, env);
+      if (args[0] === "worktree" && args[1] === "remove") {
+        mkdirSync(wtPath);
+        writeFileSync(join(wtPath, ".env.local"), "SECRET=must-not-be-logged\n");
+      }
+      return output;
+    };
+
+    await expect(wm.removeWorktree("non-atomic-remove", threadId))
+      .rejects.toThrow(new RegExp(`worktree removal incomplete: filesystem path remains: ${wtPath}`));
+    expect(existsSync(wtPath)).toBe(true);
+    rmSync(wtPath, { recursive: true, force: true });
+  });
+
   it("delegates branchOverride to the setup script", async () => {
     const repos: RepoConfig[] = [
       {

--- a/src/worktree/manager.ts
+++ b/src/worktree/manager.ts
@@ -3,6 +3,7 @@ import { cleanGitHubEnvironment, GitHubAuthResolver } from "../github/auth.ts";
 import { statfs } from "node:fs/promises";
 import {
   closeSync,
+  existsSync,
   mkdirSync,
   openSync,
   unlinkSync,
@@ -198,6 +199,26 @@ export class WorktreeManager {
       await this.runGit(["branch", "-D", branchName], repo.path);
     } catch {
       // branch may not exist — non-fatal
+    }
+
+    // `git worktree remove` is not atomic with respect to the filesystem: an
+    // ignored leftover can survive even after the registry entry is gone.
+    // Verify both postconditions before reporting success so callers can
+    // preserve and review partial cleanup instead of losing the path.
+    const registry = await this.runGit(
+      ["worktree", "list", "--porcelain"],
+      repo.path,
+    );
+    const registryContainsPath = registry.split(/\r?\n\r?\n+/).some((record) =>
+      record.split(/\r?\n/).some((line) => line === `worktree ${worktreePath}`),
+    );
+    const pathRemains = existsSync(worktreePath);
+    if (registryContainsPath || pathRemains) {
+      const remaining = [
+        registryContainsPath ? "git registry entry remains" : null,
+        pathRemains ? "filesystem path remains" : null,
+      ].filter((reason): reason is string => reason !== null).join("; ");
+      throw new Error(`worktree removal incomplete: ${remaining}: ${worktreePath}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- verify `git worktree list --porcelain` no longer contains the removed worktree
- verify the worktree filesystem path is absent before reporting success
- surface incomplete cleanup with path-only diagnostics when either postcondition fails
- add a non-atomic ignored-leftover regression and document the contract

## Verification
- `bun run typecheck`
- `bun test src/worktree/manager.test.ts src/worktree/prune.test.ts src/slack/action-buttons.test.ts` (35 pass)

F15 from the memory-lessons audit. Includes the already-merged F07/F08 baseline.