### PR TITLE
fix(memory): link pre-recall feedback to turns

### DIFF
--- a/docs/code_index/pre-recall.md
+++ b/docs/code_index/pre-recall.md
@@ -25,6 +25,9 @@ default hot path; bounded LLM synthesis is optional through
 | `MemoryStore.markClaimsUsed(ids, now)` | `src/memory/store.ts`, `src/memory/sqlite.ts` | Deferred `last_used_at` bump for the claims that actually reached the prompt. |
 | `pre_recall_observation` / `pre_recall_feedback` | `src/memory/sqlite.ts` | Durable per-turn audit trail: every injected recall persists all candidate and selected claim ids with its Slack thread, while `memory_feedback(pre_recall_id, useful)` records a linked post-turn judgment and updates only selected claims. |
 
+Observations and linked feedback are retained for 90 days. The production health
+interval deletes at most 500 expired observations (and their feedback) per run.
+
 ## Flow
 
 ```

--- a/docs/code_index/pre-recall.md
+++ b/docs/code_index/pre-recall.md
@@ -23,6 +23,7 @@ default hot path; bounded LLM synthesis is optional through
 | `runPreRecallExited` / `runPreRecallProcess` / `readBoundedTextFile` | `src/memory/pre-recall.ts` | Timeout + process-tree SIGINT/SIGKILL guard shared by the claude/opencode/codex runners. Both provider pipes are drained immediately; stdout and stderr retain bounded tails, and oversized stdout/Codex output files are rejected. |
 | `recallMemory({ recordUsage })` | `src/mcp/slack-server.ts` | Retrieval. Pre-recall passes `false`; the `memory_recall` MCP tool keeps the default `true`. Each claim carries fused `score`, raw `cosine`, `lexicalScore`, and expanded parent-source context when available. |
 | `MemoryStore.markClaimsUsed(ids, now)` | `src/memory/store.ts`, `src/memory/sqlite.ts` | Deferred `last_used_at` bump for the claims that actually reached the prompt. |
+| `pre_recall_observation` / `pre_recall_feedback` | `src/memory/sqlite.ts` | Durable per-turn audit trail: every injected recall persists all candidate and selected claim ids with its Slack thread, while `memory_feedback(pre_recall_id, useful)` records a linked post-turn judgment and updates only selected claims. |
 
 ## Flow
 

--- a/docs/features/pre-recall-synthesis.md
+++ b/docs/features/pre-recall-synthesis.md
@@ -122,6 +122,11 @@ whether the claim was useful.
 That is wrong today and gets worse under this design, because synthesis exists
 precisely to discard most candidates. Filtered-out spam would be marked fresh on
 every turn it is retrieved, and `archiveStaleClaims` ("stale **and** low-value")
+only acts on genuinely surfaced claims. Each injected block carries a durable
+feedback reference: candidate and selected claim IDs are persisted, and the
+agent records a linked helpful/unhelpful judgment with `memory_feedback` after
+the turn. These records are retained for 90 days; production cleanup deletes a
+bounded batch of 500 expired observations and their feedback per interval.
 would never fade it. The claims that most need to decay are the ones a filter
 keeps rejecting.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,6 +95,8 @@ const permalinkCache = new SlackPermalinkCache({
 const memoryStore = createMemoryStore(config.memory.sqlitePath, {
   dedupThreshold: config.memory.dedupThreshold,
 });
+const PRE_RECALL_FEEDBACK_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
+const PRE_RECALL_FEEDBACK_CLEANUP_LIMIT = 500;
 const profileStore = createProfileStore();
 const memoryIngestor = new MemoryIngestor(memoryStore);
 const runbookCatalogStore = new CatalogStore(
@@ -641,6 +643,10 @@ void pipelineBoot;
 
 // Periodic health checks
 setInterval(() => {
+  memoryStore.deletePreRecallObservationsOlderThan(
+    Date.now() - PRE_RECALL_FEEDBACK_RETENTION_MS,
+    PRE_RECALL_FEEDBACK_CLEANUP_LIMIT,
+  ).catch((err) => log.warn("cleanup", `pre-recall feedback cleanup failed: ${String(err)}`));
   checkOrphanedSessions(store).then((orphaned) => {
     if (orphaned.length > 0) {
       log.warn("health", `Found ${orphaned.length} orphaned sessions: ${orphaned.join(", ")}`);

--- a/src/mcp/slack-server.ts
+++ b/src/mcp/slack-server.ts
@@ -1653,18 +1653,26 @@ export function registerTools(server: McpServer, runContext: SlackMcpRunContext 
       inputSchema: {
         claim_ids: z
           .array(z.string().min(1).max(200))
-          .min(1)
           .max(50)
-          .describe("Claim ids returned by memory_recall that share this judgment"),
+          .optional()
+          .describe("Claim ids returned by memory_recall, or a subset selected by pre_recall_id"),
+        pre_recall_id: z.string().min(1).optional().describe("Feedback reference emitted by automatic pre-recall"),
         useful: z
           .boolean()
           .describe("True when these claims materially helped or were correct; false otherwise"),
       },
     },
-    async ({ claim_ids, useful }) => {
+    async ({ claim_ids, pre_recall_id, useful }) => {
       return withMemoryStore(async (memory) => {
+        if (!pre_recall_id && (!claim_ids || claim_ids.length === 0)) {
+          throw new Error("memory_feedback: claim_ids or pre_recall_id is required");
+        }
+        if (pre_recall_id) {
+          const updated = await memory.recordPreRecallFeedback(pre_recall_id, useful, claim_ids);
+          return { content: [{ type: "text" as const, text: JSON.stringify({ useful, updated, preRecallId: pre_recall_id }, null, 2) }] };
+        }
         const result = await recordMemoryFeedback(
-          { claimIds: claim_ids, useful },
+          { claimIds: claim_ids!, useful },
           { store: memory },
         );
         return { content: [{ type: "text" as const, text: JSON.stringify(result, null, 2) }] };

--- a/src/memory/pre-recall.ts
+++ b/src/memory/pre-recall.ts
@@ -146,6 +146,7 @@ Return {"notes": [], "used": []} when nothing applies. That is the common case a
 
 // ── Public types ─────────────────────────────────────────────────────────────
 export interface PreRecallOptions {
+  threadId?: string | null;
   /**
    * Session target repo (RepoConfig.name). Scopes recall so another repo's
    * conventions or operational data can't inject into this session's prompt.
@@ -307,8 +308,16 @@ export function createPreRecall(
       if (notes.length === 0) return null;
 
       claimCount = notes.length;
+      const observationId = crypto.randomUUID();
+      await memDeps.store.appendPreRecallObservation({
+        id: observationId,
+        threadId: options?.threadId ?? null,
+        candidateIds: candidates.map((candidate) => candidate.id),
+        selectedIds: usedIds,
+        createdAt: Date.now(),
+      });
       await recordClaimUsage(memDeps, usedIds);
-      return formatPreRecallBlock(notes, { verbatim });
+      return formatPreRecallBlock(notes, { verbatim, observationId, selectedIds: usedIds });
     } catch (err) {
       failure = err instanceof Error ? err.message : String(err);
       _log.warn("pre-recall", `fail err=${failure}`);
@@ -581,7 +590,7 @@ export function parseSynthesisResult(
  */
 export function formatPreRecallBlock(
   notes: string[],
-  options?: { verbatim?: boolean },
+  options?: { verbatim?: boolean; observationId?: string; selectedIds?: string[] },
 ): string {
   const header = options?.verbatim
     ? "Claim text recalled from Junior's memory, unedited (long claims end in …). Use as context."
@@ -591,6 +600,11 @@ export function formatPreRecallBlock(
     header,
     "",
     notes.map((note) => `- ${note}`).join("\n"),
+    ...(options?.observationId ? [
+      `<pre-recall-feedback reference="${options.observationId}" claim-ids="${options.selectedIds?.join(",") ?? ""}">`,
+      "After the turn, call memory_feedback with this pre_recall_id and useful true/false. Omit claim_ids to label every selected claim.",
+      "</pre-recall-feedback>",
+    ] : []),
     "</pre-recall>",
   ].join("\n");
 }

--- a/src/memory/sqlite.test.ts
+++ b/src/memory/sqlite.test.ts
@@ -20,6 +20,34 @@ describe("queryHasExactLexicalAnchor", () => {
       "The overnight thing has gone quiet and I cannot tell whether patience is safer",
     )).toBe(false);
   });
+  it("migrates, persists, authorizes, and bounds pre-recall feedback retention", async () => {
+    const root = mkdtempSync(join(tmpdir(), "junior-pre-recall-ledger-"));
+    const store = new SqliteMemoryStore(join(root, "memory.db"));
+    try {
+    const raw = (store as unknown as { db: Database }).db;
+    expect(raw.query<{ name: string }, []>("SELECT name FROM sqlite_master WHERE name = 'pre_recall_observation'").get()?.name).toBe("pre_recall_observation");
+    for (const id of ["selected", "candidate-only"]) {
+      await store.upsertClaim({ id, kind: "lesson", text: id, createdAt: 1, skipDedup: true });
+    }
+    await store.appendPreRecallObservation({
+      id: "obs-old", threadId: "thread-1", candidateIds: ["selected", "candidate-only"], selectedIds: ["selected"], createdAt: 0,
+    });
+    await expect(store.recordPreRecallFeedback("obs-old", true)).resolves.toEqual([
+      { id: "selected", helpfulCount: 1, unhelpfulCount: 0 },
+    ]);
+    await expect(store.recordPreRecallFeedback("obs-old", false, ["candidate-only"])).rejects.toThrow("no selected claims");
+    expect(raw.query<{ thread_id: string; candidate_ids_json: string; selected_ids_json: string }, []>("SELECT thread_id, candidate_ids_json, selected_ids_json FROM pre_recall_observation WHERE id = 'obs-old'").get()).toEqual({
+      thread_id: "thread-1", candidate_ids_json: '["selected","candidate-only"]', selected_ids_json: '["selected"]',
+    });
+    await store.appendPreRecallObservation({ id: "obs-new", threadId: null, candidateIds: ["selected"], selectedIds: ["selected"], createdAt: 90 * 24 * 60 * 60 * 1000 });
+    expect(await store.deletePreRecallObservationsOlderThan(90 * 24 * 60 * 60 * 1000, 1)).toBe(1);
+    expect(raw.query<{ count: number }, []>("SELECT count(*) AS count FROM pre_recall_feedback").get()?.count).toBe(0);
+    expect(raw.query<{ count: number }, []>("SELECT count(*) AS count FROM pre_recall_observation").get()?.count).toBe(1);
+    } finally {
+      store.close();
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
 });
 
 describe("SqliteMemoryStore", () => {

--- a/src/memory/sqlite.ts
+++ b/src/memory/sqlite.ts
@@ -22,6 +22,7 @@ import type {
   MemoryFactInput,
   MemoryLessonInput,
   MemorySourceRecord,
+  PreRecallObservation,
   RecallLogInput,
   SearchableMemoryKind,
   SourceRecordQueryOptions,
@@ -1055,6 +1056,25 @@ export class SqliteMemoryStore implements MemoryStore {
     return txn.immediate();
   }
 
+  async appendPreRecallObservation(observation: PreRecallObservation): Promise<void> {
+    this.db.query(`INSERT INTO pre_recall_observation
+      (id, thread_id, candidate_ids_json, selected_ids_json, created_at) VALUES (?, ?, ?, ?, ?)`)
+      .run(observation.id, observation.threadId, JSON.stringify(unique(observation.candidateIds)), JSON.stringify(unique(observation.selectedIds)), observation.createdAt);
+  }
+
+  async recordPreRecallFeedback(observationId: string, useful: boolean, claimIds?: string[]): Promise<ClaimFeedbackResult[]> {
+    const row = this.db.query<{ selected_ids_json: string }, [string]>("SELECT selected_ids_json FROM pre_recall_observation WHERE id = ?").get(observationId);
+    if (!row) throw new Error("memory_feedback: unknown pre-recall reference");
+    let selected: string[];
+    try { selected = JSON.parse(row.selected_ids_json); } catch { throw new Error("memory_feedback: invalid pre-recall record"); }
+    const ids = unique((claimIds?.length ? claimIds : selected).filter((id) => selected.includes(id)));
+    if (ids.length === 0) throw new Error("memory_feedback: no selected claims for pre-recall reference");
+    const updated = await this.recordClaimFeedback(ids, useful);
+    this.db.query(`INSERT INTO pre_recall_feedback (id, observation_id, claim_ids_json, useful, created_at) VALUES (?, ?, ?, ?, ?)`)
+      .run(crypto.randomUUID(), observationId, JSON.stringify(ids), useful ? 1 : 0, Date.now());
+    return updated;
+  }
+
   // --- memory v3: consolidation source-record bookkeeping -------------------
 
   /**
@@ -1480,6 +1500,8 @@ export class SqliteMemoryStore implements MemoryStore {
     this.db.run(`CREATE TABLE IF NOT EXISTS ingestion_correction (id INTEGER PRIMARY KEY AUTOINCREMENT, event_id TEXT NOT NULL, field TEXT NOT NULL, incorrect_value TEXT, correct_value TEXT, corrected_by TEXT NOT NULL, created_at INTEGER NOT NULL)`);
     this.db.run(`CREATE TABLE IF NOT EXISTS consolidation_decision (id TEXT PRIMARY KEY, event_id TEXT NOT NULL, action TEXT NOT NULL, reason TEXT NOT NULL, source_ids_json TEXT NOT NULL, extractor TEXT NOT NULL, created_at INTEGER NOT NULL)`);
     this.db.run(`CREATE TABLE IF NOT EXISTS recall_log (id INTEGER PRIMARY KEY AUTOINCREMENT, query TEXT, tags_json TEXT, entities_json TEXT, kinds_json TEXT, caller_intent TEXT, returned_ids_json TEXT NOT NULL, result_count INTEGER NOT NULL, created_at INTEGER NOT NULL)`);
+    this.db.run(`CREATE TABLE IF NOT EXISTS pre_recall_observation (id TEXT PRIMARY KEY, thread_id TEXT, candidate_ids_json TEXT NOT NULL, selected_ids_json TEXT NOT NULL, created_at INTEGER NOT NULL)`);
+    this.db.run(`CREATE TABLE IF NOT EXISTS pre_recall_feedback (id TEXT PRIMARY KEY, observation_id TEXT NOT NULL, claim_ids_json TEXT NOT NULL, useful INTEGER NOT NULL, created_at INTEGER NOT NULL, FOREIGN KEY (observation_id) REFERENCES pre_recall_observation(id))`);
     // memory v3: semantic claim store (text + embedding co-located) — mirrors the lesson/memory_node relationship.
     this.db.run(`CREATE TABLE IF NOT EXISTS claim (id TEXT PRIMARY KEY, kind TEXT NOT NULL CHECK (kind IN ('lesson', 'fact', 'preference', 'decision', 'situation-claim')), text TEXT NOT NULL, retrieval_text TEXT, embedding BLOB, embed_model TEXT, dim INTEGER, repo TEXT, tags TEXT, source_episode TEXT, source_path TEXT, source_heading TEXT, source_text TEXT, helpful_count INTEGER DEFAULT 0, unhelpful_count INTEGER DEFAULT 0, weight REAL DEFAULT 1.0, created_at INTEGER, last_used_at INTEGER, active INTEGER DEFAULT 1, FOREIGN KEY (id) REFERENCES memory_node(id))`);
     this.db.run(`CREATE TABLE IF NOT EXISTS claim_embedding (claim_id TEXT NOT NULL, variant INTEGER NOT NULL, retrieval_text TEXT NOT NULL, embedding BLOB NOT NULL, embed_model TEXT, dim INTEGER NOT NULL, PRIMARY KEY (claim_id, variant), FOREIGN KEY (claim_id) REFERENCES claim(id))`);

--- a/src/memory/sqlite.ts
+++ b/src/memory/sqlite.ts
@@ -1075,6 +1075,20 @@ export class SqliteMemoryStore implements MemoryStore {
     return updated;
   }
 
+  async deletePreRecallObservationsOlderThan(before: number, limit: number): Promise<number> {
+    const ids = this.db.query<{ id: string }, [number, number]>(
+      "SELECT id FROM pre_recall_observation WHERE created_at < ? ORDER BY created_at LIMIT ?",
+    ).all(before, limit).map((row) => row.id);
+    if (ids.length === 0) return 0;
+    const placeholders = ids.map(() => "?").join(",");
+    const txn = this.db.transaction(() => {
+      this.db.query(`DELETE FROM pre_recall_feedback WHERE observation_id IN (${placeholders})`).run(...ids);
+      this.db.query(`DELETE FROM pre_recall_observation WHERE id IN (${placeholders})`).run(...ids);
+    });
+    txn.immediate();
+    return ids.length;
+  }
+
   // --- memory v3: consolidation source-record bookkeeping -------------------
 
   /**

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -16,6 +16,7 @@ import type {
   MemoryLessonInput,
   MemorySourceRecord,
   RecallLogInput,
+  PreRecallObservation,
   SourceRecordQueryOptions,
   UnconsolidatedSourceRecordOptions,
 } from "./types.ts";
@@ -80,6 +81,8 @@ export interface MemoryStore {
   markClaimsUsed(ids: string[], now: number): Promise<void>;
   /** Increment the usefulness counter for claims an agent explicitly judged. */
   recordClaimFeedback(ids: string[], useful: boolean): Promise<ClaimFeedbackResult[]>;
+  appendPreRecallObservation(observation: PreRecallObservation): Promise<void>;
+  recordPreRecallFeedback(observationId: string, useful: boolean, claimIds?: string[]): Promise<ClaimFeedbackResult[]>;
   /**
    * Decay: ARCHIVE (set `active = 0`, never delete — keep provenance) claims that
    * are BOTH stale AND low-value. Batch/offline only, never a hot-path TTL.

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -83,6 +83,7 @@ export interface MemoryStore {
   recordClaimFeedback(ids: string[], useful: boolean): Promise<ClaimFeedbackResult[]>;
   appendPreRecallObservation(observation: PreRecallObservation): Promise<void>;
   recordPreRecallFeedback(observationId: string, useful: boolean, claimIds?: string[]): Promise<ClaimFeedbackResult[]>;
+  deletePreRecallObservationsOlderThan(before: number, limit: number): Promise<number>;
   /**
    * Decay: ARCHIVE (set `active = 0`, never delete — keep provenance) claims that
    * are BOTH stale AND low-value. Batch/offline only, never a hot-path TTL.

--- a/src/memory/types.ts
+++ b/src/memory/types.ts
@@ -184,6 +184,14 @@ export interface ClaimFeedbackResult {
   unhelpfulCount: number;
 }
 
+export interface PreRecallObservation {
+  id: string;
+  threadId: string | null;
+  candidateIds: string[];
+  selectedIds: string[];
+  createdAt: number;
+}
+
 export interface CollapseDuplicateClaimsOptions {
   /** The claim that keeps its row and absorbs the duplicates' counters. */
   survivorId: string;

--- a/src/session/manager.ts
+++ b/src/session/manager.ts
@@ -2365,6 +2365,7 @@ export class SessionManager {
         // Scope recall to the session's repo so another repo's conventions
         // can't inject into this session's prompt.
         const preRecallBlock = await this.preRecall(rawMessage, {
+          threadId: session.threadId,
           repo: session.targetRepo,
           agent: agentName,
           // Agent identity is trusted routing context, not a keyword guessed


### PR DESCRIPTION
## Summary
- persist pre-recall candidate and selected claim IDs per injected turn
- include a durable feedback reference and selected IDs in automatic pre-recall context
- link helpful/unhelpful feedback to that reference and constrain it to selected claims

## Verification
- `bun run typecheck`
- `bun test src/memory/pre-recall.test.ts src/mcp/slack-server.test.ts src/memory/sqlite.test.ts` (126 passed; one existing private overlay fixture failure)
- `git diff --check`

Fixes audit finding F16.