### PR TITLE
fix(github): bound CLI output and pagination

### DIFF
--- a/docs/code_index/github-reconciliation.md
+++ b/docs/code_index/github-reconciliation.md
@@ -16,6 +16,7 @@ webhook to keep pipeline state correct.
 | Review comments | `src/github/review-comments.ts` | Scopes comments to an exact head SHA and avoids duplicate writes. |
 | Types | `src/github/types.ts` | GitHub resource, review, and reconciliation contracts. |
 | Repo-scoped auth | `src/github/auth.ts`, `src/config.ts` | Resolves each configured `RepoConfig.githubUser` with `gh auth token --user`, verifies the account with `gh api user`, and injects only that token plus an isolated `GH_CONFIG_DIR` into repo-scoped `gh` children. Unknown repo mappings and repos without `githubUser` are rejected before `gh` runs. |
+| Bounded CLI transport | `src/github/cli.ts` | Concurrently drains `gh` stdout/stderr with 512 KiB response and 64 KiB diagnostic caps, hard timeout, and process-group cleanup. |
 
 ## Configuration
 
@@ -35,6 +36,11 @@ than using the host's active `gh` account. The normal HTTP reconciler remains
 available with its explicit `GITHUB_RECONCILE_TOKEN`; it does not use `gh`.
 Runner environments use empty token sentinels plus an isolated config directory
 unless the selected target repo supplied a verified auth environment.
+
+The review-state reader no longer delegates unbounded pagination to `gh`.
+It requests up to ten `per_page=100` pages sequentially, rejects a response
+that exceeds 512 KiB in aggregate, and preserves the existing slurped-array
+parser contract for callers.
 
 When a reconcile pass observes an `OPEN`/`CLOSED` to `MERGED` transition,
 Junior starts `worktree-prune` with structured trigger context containing the

--- a/src/github/auth.ts
+++ b/src/github/auth.ts
@@ -2,6 +2,7 @@ import type { RepoConfig } from "../config.ts";
 import { chmodSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { runBoundedGitHubCommand } from "./cli.ts";
 
 const GITHUB_USER_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]{0,38}$/;
 
@@ -162,17 +163,17 @@ async function runGitHubCommand(
   args: string[],
   env: Record<string, string>,
 ): Promise<GitHubCommandResult> {
-  const proc = Bun.spawn(["gh", ...args], {
-    env,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  const [stdout, stderr, status] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ]);
-  return { status, stdout, stderr };
+  const result = await runBoundedGitHubCommand(args, { env });
+  if (result.timedOut || result.outputExceeded) {
+    return {
+      status: -1,
+      stdout: result.stdout,
+      stderr: result.timedOut
+        ? "gh command timed out"
+        : "gh command exceeded output limit",
+    };
+  }
+  return { status: result.status ?? -1, stdout: result.stdout, stderr: result.stderr };
 }
 
 function commandError(result: GitHubCommandResult): string {

--- a/src/github/cli.test.ts
+++ b/src/github/cli.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "bun:test";
+import { runBoundedGitHubCommand } from "./cli.ts";
+
+const bunProgram = process.execPath;
+
+describe("runBoundedGitHubCommand", () => {
+  it("drains a large response incrementally and terminates once it crosses the cap", async () => {
+    const result = await runBoundedGitHubCommand([
+      "-e",
+      "process.stdout.write('x'.repeat(200000)); setInterval(() => {}, 1000)",
+    ], {
+      env: process.env as Record<string, string>,
+      program: bunProgram,
+      maxResponseBytes: 1024,
+      timeoutMs: 2_000,
+    });
+
+    expect(result.outputExceeded).toBe(true);
+    expect(result.timedOut).toBe(false);
+    expect(new TextEncoder().encode(result.stdout).byteLength).toBeLessThanOrEqual(1024);
+  });
+
+  it("bounds stderr separately and cleans up a stalled command", async () => {
+    const result = await runBoundedGitHubCommand([
+      "-e",
+      "process.stderr.write('e'.repeat(200000)); setInterval(() => {}, 1000)",
+    ], {
+      env: process.env as Record<string, string>,
+      program: bunProgram,
+      maxErrorBytes: 1024,
+      timeoutMs: 2_000,
+    });
+
+    expect(result.outputExceeded).toBe(true);
+    expect(new TextEncoder().encode(result.stderr).byteLength).toBeLessThanOrEqual(1024);
+  });
+
+  it("terminates a command that does not finish before its deadline", async () => {
+    const result = await runBoundedGitHubCommand([
+      "-e",
+      "setInterval(() => {}, 1000)",
+    ], {
+      env: process.env as Record<string, string>,
+      program: bunProgram,
+      timeoutMs: 25,
+    });
+
+    expect(result.timedOut).toBe(true);
+    expect(result.outputExceeded).toBe(false);
+  });
+});

--- a/src/github/cli.ts
+++ b/src/github/cli.ts
@@ -1,0 +1,157 @@
+import { terminateProcessTree } from "../lifecycle/process-tree.ts";
+
+export const MAX_GITHUB_RESPONSE_BYTES = 512 * 1024;
+export const MAX_GITHUB_ERROR_BYTES = 64 * 1024;
+export const DEFAULT_GITHUB_COMMAND_TIMEOUT_MS = 30_000;
+
+export interface BoundedGitHubCommandResult {
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+  outputExceeded: boolean;
+}
+
+export interface BoundedGitHubCommandOptions {
+  env: Record<string, string>;
+  input?: string;
+  timeoutMs?: number;
+  maxResponseBytes?: number;
+  maxErrorBytes?: number;
+  /** Test-only override; production always invokes `gh`. */
+  program?: string;
+}
+
+/**
+ * Execute a gh command without allowing a verbose response, blocked pipe, or
+ * surviving descendant to consume Junior indefinitely. Successful stdout is
+ * retained only up to its response cap; stderr keeps a bounded diagnostic tail.
+ */
+export async function runBoundedGitHubCommand(
+  args: string[],
+  options: BoundedGitHubCommandOptions,
+): Promise<BoundedGitHubCommandResult> {
+  const responseLimit = options.maxResponseBytes ?? MAX_GITHUB_RESPONSE_BYTES;
+  const errorLimit = options.maxErrorBytes ?? MAX_GITHUB_ERROR_BYTES;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_GITHUB_COMMAND_TIMEOUT_MS;
+  const proc = Bun.spawn([options.program ?? "gh", ...args], {
+    env: options.env,
+    stdin: options.input === undefined ? "ignore" : "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+    detached: true,
+  });
+  if (options.input !== undefined && proc.stdin) {
+    proc.stdin.write(options.input);
+    proc.stdin.end();
+  }
+
+  let resolveLimit: (() => void) | undefined;
+  const outputLimit = new Promise<"output_limit">((resolve) => {
+    resolveLimit = () => resolve("output_limit");
+  });
+  const stdout = drain(proc.stdout, responseLimit, "prefix", () => resolveLimit?.());
+  const stderr = drain(proc.stderr, errorLimit, "tail", () => resolveLimit?.());
+  const completed = Promise.all([proc.exited, stdout.done, stderr.done]);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<"timeout">((resolve) => {
+    timer = setTimeout(() => resolve("timeout"), timeoutMs);
+  });
+
+  try {
+    const outcome = await Promise.race([completed, outputLimit, timeout]);
+    if (outcome === "timeout" || outcome === "output_limit") {
+      await terminateProcessTree(proc.pid, {
+        signal: "SIGTERM",
+        forceAfterMs: 1_000,
+        waitAfterForceMs: 1_000,
+      });
+      stdout.cancel();
+      stderr.cancel();
+      return {
+        status: null,
+        stdout: stdout.text(),
+        stderr: stderr.text(),
+        timedOut: outcome === "timeout",
+        outputExceeded: outcome === "output_limit",
+      };
+    }
+    return {
+      status: outcome[0],
+      stdout: stdout.text(),
+      stderr: stderr.text(),
+      timedOut: false,
+      outputExceeded: false,
+    };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function drain(
+  stream: ReadableStream<Uint8Array>,
+  maxBytes: number,
+  mode: "prefix" | "tail",
+  onLimit: () => void,
+): { done: Promise<void>; text: () => string; cancel: () => void } {
+  const reader = stream.getReader();
+  let bytes = 0;
+  let chunks: Uint8Array[] = [];
+  let exceeded = false;
+  const append = (chunk: Uint8Array): void => {
+    if (exceeded) return;
+    const remaining = maxBytes - bytes;
+    if (remaining <= 0) {
+      exceeded = true;
+      onLimit();
+      return;
+    }
+    const accepted = chunk.byteLength > remaining ? chunk.subarray(0, remaining) : chunk;
+    if (mode === "prefix") {
+      chunks.push(accepted.slice());
+    } else {
+      chunks = [joinBytes(chunks, accepted, maxBytes)].filter((value) => value.byteLength > 0);
+    }
+    bytes += accepted.byteLength;
+    if (accepted.byteLength !== chunk.byteLength) {
+      exceeded = true;
+      onLimit();
+    }
+  };
+  const done = (async () => {
+    try {
+      while (true) {
+        const next = await reader.read();
+        if (next.done) break;
+        append(next.value);
+        if (exceeded) break;
+      }
+    } catch {
+      // Cancellation after a limit or timeout retains the bounded partial text.
+    }
+  })();
+  return {
+    done,
+    text: () => new TextDecoder().decode(joinBytes(chunks)),
+    cancel: () => { void reader.cancel().catch(() => undefined); },
+  };
+}
+
+function joinBytes(
+  chunks: Uint8Array[],
+  extra?: Uint8Array,
+  tailLimit?: number,
+): Uint8Array {
+  const size = chunks.reduce((total, chunk) => total + chunk.byteLength, 0) +
+    (extra?.byteLength ?? 0);
+  const all = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    all.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  if (extra) all.set(extra, offset);
+  return tailLimit !== undefined && all.byteLength > tailLimit
+    ? all.subarray(all.byteLength - tailLimit)
+    : all;
+}

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -24,6 +24,7 @@ import type {
   PrSnapshot,
 } from "./types.ts";
 import { cleanGitHubEnvironment, type GitHubAuthResolver } from "./auth.ts";
+import { runBoundedGitHubCommand } from "./cli.ts";
 
 const DEFAULT_API_URL = "https://api.github.com/graphql";
 const DEFAULT_TIMEOUT_MS = 20_000;
@@ -103,20 +104,21 @@ export function createGitHubClient(options: GitHubClientOptions = {}): GitHubCli
   const runCli =
     options.runCli ??
     (async (args: string[], env?: Record<string, string>) => {
-      const proc = Bun.spawn(["gh", ...args], {
-        env,
-        stdout: "pipe",
-        stderr: "pipe",
+      const result = await runBoundedGitHubCommand(args, {
+        env: env ?? (process.env as Record<string, string>),
+        timeoutMs,
       });
-      const [stdout, stderr] = await Promise.all([
-        new Response(proc.stdout).text(),
-        new Response(proc.stderr).text(),
-      ]);
-      const status = await proc.exited;
+      const status = result.status ?? -1;
       return {
-        ok: status === 0,
+        ok: status === 0 && !result.timedOut && !result.outputExceeded,
         status: status === 0 ? 200 : status,
-        body: status === 0 ? stdout : stderr || stdout,
+        body: result.timedOut
+          ? "gh api graphql timed out"
+          : result.outputExceeded
+          ? "gh api graphql exceeded output limit"
+          : status === 0
+          ? result.stdout
+          : result.stderr || result.stdout,
         headers: {},
       };
     });

--- a/src/github/review-comments.test.ts
+++ b/src/github/review-comments.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+  collectPaginatedGitHubApi,
   githubEnvironmentForEndpoint,
   postGitHubReview,
   readGitHubReviewState,
@@ -369,5 +370,72 @@ describe("GitHub review API identity", () => {
     } finally {
       setGitHubAuthResolver(undefined);
     }
+  });
+});
+
+describe("bounded GitHub review pagination", () => {
+  it("preserves per_page and appends page numbers, stopping at a short page", async () => {
+    const endpoints: string[] = [];
+    const result = await collectPaginatedGitHubApi(
+      "repos/GrowthX-Club/gx-backend/pulls/123/reviews?per_page=100",
+      async (endpoint) => {
+        endpoints.push(endpoint);
+        const page = endpoints.length === 1
+          ? Array.from({ length: 100 }, (_, id) => ({ id }))
+          : [{ id: 101 }];
+        return { ok: true, status: 0, stdout: JSON.stringify(page), stderr: "" };
+      },
+    );
+
+    expect(endpoints).toEqual([
+      "repos/GrowthX-Club/gx-backend/pulls/123/reviews?per_page=100&page=1",
+      "repos/GrowthX-Club/gx-backend/pulls/123/reviews?per_page=100&page=2",
+    ]);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error(result.stderr);
+    expect(JSON.parse(result.stdout)).toHaveLength(2);
+  });
+
+  it("stops after ten full pages rather than requesting an unbounded eleventh page", async () => {
+    const endpoints: string[] = [];
+    const result = await collectPaginatedGitHubApi(
+      "repos/GrowthX-Club/gx-backend/pulls/123/comments?per_page=100",
+      async (endpoint) => {
+        endpoints.push(endpoint);
+        return {
+          ok: true,
+          status: 0,
+          stdout: JSON.stringify(Array.from({ length: 100 }, (_, id) => ({ id }))),
+          stderr: "",
+        };
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(endpoints).toHaveLength(10);
+    expect(endpoints.at(-1)).toEndWith("page=10");
+  });
+
+  it("rejects aggregate pagination output below the individual command cap", async () => {
+    const endpoints: string[] = [];
+    const page = Array.from({ length: 100 }, (_, id) => ({ id, body: "x".repeat(40) }));
+    const individualBytes = new TextEncoder().encode(JSON.stringify(page)).byteLength;
+    const result = await collectPaginatedGitHubApi(
+      "repos/GrowthX-Club/gx-backend/pulls/123/comments?per_page=100",
+      async (endpoint) => {
+        endpoints.push(endpoint);
+        return { ok: true, status: 0, stdout: JSON.stringify(page), stderr: "" };
+      },
+      { maxResponseBytes: individualBytes + 4 },
+    );
+
+    expect(individualBytes).toBeLessThan(512 * 1024);
+    expect(result).toEqual({
+      ok: false,
+      status: -1,
+      stdout: "",
+      stderr: "gh api paginated response exceeded output limit",
+    });
+    expect(endpoints).toHaveLength(2);
   });
 });

--- a/src/github/review-comments.ts
+++ b/src/github/review-comments.ts
@@ -652,13 +652,26 @@ async function runPaginatedGitHubApi(
   args: string[],
   env: Record<string, string>,
 ): Promise<GitHubApiResult> {
+  return collectPaginatedGitHubApi(
+    args[1]!,
+    (endpoint) => runGitHubApiCommand([args[0]!, endpoint], env),
+  );
+}
+
+export async function collectPaginatedGitHubApi(
+  endpoint: string,
+  runPage: (endpoint: string) => Promise<GitHubApiResult>,
+  limits: {
+    maxPages?: number;
+    maxResponseBytes?: number;
+  } = {},
+): Promise<GitHubApiResult> {
+  const maxPages = limits.maxPages ?? MAX_GITHUB_PAGES;
+  const maxResponseBytes = limits.maxResponseBytes ?? MAX_GITHUB_PAGINATED_RESPONSE_BYTES;
   const pages: unknown[] = [];
   let responseBytes = 2; // JSON outer-array delimiters.
-  for (let page = 1; page <= MAX_GITHUB_PAGES; page += 1) {
-    const result = await runGitHubApiCommand(
-      [args[0]!, appendPage(args[1]!, page)],
-      env,
-    );
+  for (let page = 1; page <= maxPages; page += 1) {
+    const result = await runPage(appendPage(endpoint, page));
     if (!result.ok) return result;
     let parsed: unknown;
     try {
@@ -670,7 +683,7 @@ async function runPaginatedGitHubApi(
       return { ...result, ok: false, stderr: "expected an array from gh api pagination" };
     }
     const pageBytes = new TextEncoder().encode(JSON.stringify(parsed)).byteLength;
-    if (responseBytes + pageBytes > MAX_GITHUB_PAGINATED_RESPONSE_BYTES) {
+    if (responseBytes + pageBytes > maxResponseBytes) {
       return {
         ok: false,
         status: -1,

--- a/src/github/review-comments.ts
+++ b/src/github/review-comments.ts
@@ -4,6 +4,7 @@ import {
   cleanGitHubEnvironment,
   type GitHubAuthResolver,
 } from "./auth.ts";
+import { runBoundedGitHubCommand } from "./cli.ts";
 import type { SlackMcpRunContext } from "../mcp/context.ts";
 import { pipelineLog } from "../pipelines/logging.ts";
 
@@ -26,6 +27,8 @@ export function setGitHubAuthResolver(
 }
 
 const MAX_READ_REVIEW_ITEMS = 100;
+const MAX_GITHUB_PAGES = 10;
+const MAX_GITHUB_PAGINATED_RESPONSE_BYTES = 512 * 1024;
 
 export interface GitHubInlineReviewComment {
   path: string;
@@ -586,11 +589,10 @@ async function runGitHubApi(
     paginate: request.paginate ?? false,
     has_body: request.body !== undefined,
   });
-  const args = ["gh", "api", request.endpoint];
+  const args = ["api", request.endpoint];
   if (request.method !== "GET") {
     args.push("--method", request.method, "--input", "-");
   }
-  if (request.paginate) args.push("--paginate", "--slurp");
 
   let env: Record<string, string>;
   try {
@@ -605,31 +607,86 @@ async function runGitHubApi(
     return { ok: false, status: 0, stdout: "", stderr: reason };
   }
 
-  const proc = Bun.spawn(args, {
-    stdin: request.body === undefined ? "ignore" : "pipe",
-    stdout: "pipe",
-    stderr: "pipe",
-    env,
-  });
-  if (request.body !== undefined && proc.stdin) {
-    proc.stdin.write(JSON.stringify(request.body));
-    proc.stdin.end();
-  }
-  const [stdout, stderr, status] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ]);
-  const result = { ok: status === 0, status, stdout, stderr };
+  const result = request.paginate
+    ? await runPaginatedGitHubApi(args, env)
+    : await runGitHubApiCommand(args, env, request.body);
   pipelineLog(result.ok ? "info" : "warn", "github.api.completed", {
     method: request.method,
     endpoint: request.endpoint,
-    status,
-    http_status: extractHttpStatus(stderr || stdout),
+    status: result.status,
+    http_status: extractHttpStatus(result.stderr || result.stdout),
     ok: result.ok,
     duration_ms: Math.round(performance.now() - startedAt),
   });
   return result;
+}
+
+async function runGitHubApiCommand(
+  args: string[],
+  env: Record<string, string>,
+  body?: unknown,
+): Promise<GitHubApiResult> {
+  const result = await runBoundedGitHubCommand(args, {
+    env,
+    input: body === undefined ? undefined : JSON.stringify(body),
+  });
+  return {
+    ok: result.status === 0 && !result.timedOut && !result.outputExceeded,
+    status: result.status ?? -1,
+    stdout: result.stdout,
+    stderr: result.timedOut
+      ? "gh api timed out"
+      : result.outputExceeded
+      ? "gh api exceeded output limit"
+      : result.stderr,
+  };
+}
+
+/**
+ * `gh api --paginate --slurp` buffers every remote page in one process. Read
+ * review state only needs a bounded history, so fetch fixed pages one at a
+ * time and stop at the first short page. The returned outer array preserves
+ * the old --slurp parsing contract.
+ */
+async function runPaginatedGitHubApi(
+  args: string[],
+  env: Record<string, string>,
+): Promise<GitHubApiResult> {
+  const pages: unknown[] = [];
+  let responseBytes = 2; // JSON outer-array delimiters.
+  for (let page = 1; page <= MAX_GITHUB_PAGES; page += 1) {
+    const result = await runGitHubApiCommand(
+      [args[0]!, appendPage(args[1]!, page)],
+      env,
+    );
+    if (!result.ok) return result;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(result.stdout);
+    } catch {
+      return { ...result, ok: false, stderr: "invalid JSON from gh api pagination" };
+    }
+    if (!Array.isArray(parsed)) {
+      return { ...result, ok: false, stderr: "expected an array from gh api pagination" };
+    }
+    const pageBytes = new TextEncoder().encode(JSON.stringify(parsed)).byteLength;
+    if (responseBytes + pageBytes > MAX_GITHUB_PAGINATED_RESPONSE_BYTES) {
+      return {
+        ok: false,
+        status: -1,
+        stdout: "",
+        stderr: "gh api paginated response exceeded output limit",
+      };
+    }
+    responseBytes += pageBytes;
+    pages.push(parsed);
+    if (parsed.length < 100) break;
+  }
+  return { ok: true, status: 0, stdout: JSON.stringify(pages), stderr: "" };
+}
+
+function appendPage(endpoint: string, page: number): string {
+  return `${endpoint}${endpoint.includes("?") ? "&" : "?"}page=${page}`;
 }
 
 export async function githubEnvironmentForEndpoint(


### PR DESCRIPTION
## Summary
- add a shared, process-group-aware bounded `gh` CLI runner
- cap stdout/stderr and terminate oversized or timed-out commands
- replace review `--paginate --slurp` with bounded sequential page requests

## Verification
- `bun run typecheck`
- `bun test src/github/cli.test.ts src/github/auth.test.ts src/github/client.test.ts src/github/review-comments.test.ts` (30 pass)
- `bun run build`
- full `bun test` exposes pre-existing unrelated runbook fixture/manifest failures on current main