### PR TITLE
fix(slack): pin and verify deployment identity

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -60,6 +60,7 @@ surfaces have dedicated indexes:
 - [Pipelines](code_index/pipelines.md)
 - [Pre-recall](code_index/pre-recall.md)
 - [Project setup and boot](code_index/project-setup.md)
+- [Slack deployment identity](code_index/slack-deployment-identity.md)
 - [Runner providers](code_index/runner-providers.md)
 - [Support router](code_index/support-router.md)
 - [Task routes](code_index/task-routes.md)

--- a/docs/code_index/project-setup.md
+++ b/docs/code_index/project-setup.md
@@ -11,6 +11,8 @@ Entry point, configuration, logging, persona loading, and boot sequence. The pro
 | `loadConfig()` | `config.ts` | Reads env vars, validates, returns typed `Config` |
 | `log.info / log.warn / log.error` | `logger.ts` | Structured log to stdout + daily file `logs/YYYY-MM-DD.log` |
 | `loadPersona()` | `persona.ts` | Reads `identity/junior/IDENTITY.md` + `SOUL.md` from the submodule; cached |
+| `fetchSlackDeploymentIdentity()` | `slack/deployment-identity.ts` | Calls `auth.test`, `users.info`, and paginated `conversations.list` to resolve the token's deployment identity and joined channels |
+| `compareSlackDeploymentIdentity()` | `slack/deployment-identity.ts` | Fails closed on configured/persisted user, bot, team, visible-name, or channel-membership mismatch |
 
 ### Types
 

--- a/docs/code_index/slack-deployment-identity.md
+++ b/docs/code_index/slack-deployment-identity.md
@@ -1,0 +1,23 @@
+# Slack Deployment Identity
+
+Junior treats the Slack token's deployment identity as separate from agent
+persona identities (`Junior`, `Reviewer`, and overlay workers).
+
+`src/slack/deployment-identity.ts` resolves the token with `auth.test`, obtains
+the visible app/user name via `users.info`, and paginates public/private
+conversations to collect channels where the token is a member. Startup compares
+that result against `SLACK_EXPECTED_*` values or the mode-0600 persisted pin at
+`SLACK_DEPLOYMENT_IDENTITY_PATH`. A mismatch, missing pin, failed API call, or
+missing expected channel stops event-handler registration and exits non-zero.
+
+Use the explicit setup/doctor commands after authenticating the intended bot:
+
+```sh
+SLACK_BOT_TOKEN=xoxb-... bun run slack:identity:setup
+SLACK_BOT_TOKEN=xoxb-... bun run slack:identity:doctor
+```
+
+`SLACK_EXPECTED_CHANNEL_IDS` can constrain setup/doctor to the channels the
+deployment must join. Explicit environment pins override the persisted file,
+which makes a deployment swap visible instead of silently adopting the new
+token.

--- a/docs/code_index/slack-deployment-identity.md
+++ b/docs/code_index/slack-deployment-identity.md
@@ -9,6 +9,9 @@ conversations to collect channels where the token is a member. Startup compares
 that result against `SLACK_EXPECTED_*` values or the mode-0600 persisted pin at
 `SLACK_DEPLOYMENT_IDENTITY_PATH`. A mismatch, missing pin, failed API call, or
 missing expected channel stops event-handler registration and exits non-zero.
+The persisted pin must be a regular mode-0600 file; startup and doctor reject
+permissive or symlinked pins. The explicit setup command atomically rewrites a
+mode-0600 pin when repairing one.
 
 Use the explicit setup/doctor commands after authenticating the intended bot:
 

--- a/docs/features/project-setup.md
+++ b/docs/features/project-setup.md
@@ -32,8 +32,20 @@ The bot needs environment configuration (Slack tokens, repo paths, timeouts) and
 6. Register the App Home tab and graceful-shutdown hooks.
 7. Start two `setInterval` loops: orphan check (60s) and stale-session cleanup (`SESSION_CLEANUP_INTERVAL_MS`).
 8. Async bootstrap: `loadOverlayIdentities("agents-org")` merges private agent identities from frontmatter (`username`, `iconEmoji`) into `AGENT_IDENTITIES`; `devServerManager.bootstrap()` prepares dev-server worktrees. Both are non-fatal.
-9. `app.start()`, resolve bot identity via `auth.test`, register event handlers (every message goes through `supportRouter.handleMessage`).
+9. `app.start()`, validate the Slack deployment identity via `auth.test`, `users.info`, and joined-channel pagination against the configured/persisted pin, then register event handlers (every message goes through `supportRouter.handleMessage`). A mismatch fails closed.
 10. If `config.http.enabled`, dynamic-import `./http/server.ts` and start the localhost dashboard. Failure is non-fatal — logged so the bot keeps running.
+
+Before first start, pin the intended Slack deployment token and verify it on
+subsequent deploys:
+
+```bash
+SLACK_BOT_TOKEN=xoxb-... bun run slack:identity:setup
+SLACK_BOT_TOKEN=xoxb-... bun run slack:identity:doctor
+```
+
+Startup refuses to register Slack event handlers when the live token differs
+from the configured or persisted user, visible name, workspace, or required
+channel membership.
 
 ## Private Org Overlay
 
@@ -133,6 +145,12 @@ interface Config {
 | `SLACK_BOT_TOKEN` | yes | — | |
 | `SLACK_APP_TOKEN` | yes | — | Socket Mode `xapp-...` |
 | `SLACK_SIGNING_SECRET` | no | `""` | only needed if you ever switch to Events API |
+| `SLACK_DEPLOYMENT_IDENTITY_PATH` | no | `data/slack-deployment-identity.json` | Persisted expected Slack token identity used by startup and doctor |
+| `SLACK_EXPECTED_USER_ID` | no | unset | Explicit expected `auth.test.user_id`; overrides the persisted pin |
+| `SLACK_EXPECTED_BOT_ID` | no | unset | Optional expected `auth.test.bot_id` |
+| `SLACK_EXPECTED_TEAM_ID` | no | unset | Optional expected workspace/team ID |
+| `SLACK_EXPECTED_VISIBLE_NAME` | no | unset | Optional exact `users.info` display/visible name |
+| `SLACK_EXPECTED_CHANNEL_IDS` | no | unset | Comma-separated channels the deployment must be joined to |
 | `RUNNER_PROVIDER` | no | `opencode` | `opencode` \| `opencode-sdk` \| `codex-app-server` \| `claude` |
 | `CLAUDE_MAX_TURNS` | no | `100` | Max turns per `claude -p` / `claude -p --resume` invocation |
 | `CLAUDE_TIMEOUT_MS` | no | `300000` | |

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "slack:archive:import": "bun run src/slack/archive-cli.ts import",
     "slack:archive:embed": "bun run src/slack/archive-cli.ts embed",
     "slack:archive:index": "bun run src/slack/archive-cli.ts index",
+    "slack:identity:setup": "bun run src/slack/identity-cli.ts setup",
+    "slack:identity:doctor": "bun run src/slack/identity-cli.ts doctor",
     "migrate:prune-routing-logs": "bun run src/memory/migrations/2026-06-13-prune-routing-decision-logs.ts"
   },
   "dependencies": {

--- a/src/config.ts
+++ b/src/config.ts
@@ -60,6 +60,13 @@ export interface Config {
     botToken: string;
     appToken: string;
     signingSecret: string;
+    /** Pinned Slack deployment identity; startup fails closed on mismatch. */
+    deploymentIdentityPath?: string;
+    expectedUserId?: string | null;
+    expectedBotId?: string | null;
+    expectedTeamId?: string | null;
+    expectedVisibleName?: string | null;
+    expectedChannelIds?: string[];
   };
   claude: {
     maxTurns: number;
@@ -303,6 +310,18 @@ export function loadConfig(): Config {
       botToken: required("SLACK_BOT_TOKEN"),
       appToken: required("SLACK_APP_TOKEN"),
       signingSecret: optional("SLACK_SIGNING_SECRET", ""),
+      deploymentIdentityPath: optional(
+        "SLACK_DEPLOYMENT_IDENTITY_PATH",
+        "data/slack-deployment-identity.json",
+      ),
+      expectedUserId: process.env.SLACK_EXPECTED_USER_ID ?? null,
+      expectedBotId: process.env.SLACK_EXPECTED_BOT_ID ?? null,
+      expectedTeamId: process.env.SLACK_EXPECTED_TEAM_ID ?? null,
+      expectedVisibleName: process.env.SLACK_EXPECTED_VISIBLE_NAME ?? null,
+      expectedChannelIds: (process.env.SLACK_EXPECTED_CHANNEL_IDS ?? "")
+        .split(",")
+        .map((id) => id.trim())
+        .filter(Boolean),
     },
     claude: {
       maxTurns: Number(optional("CLAUDE_MAX_TURNS", "100")),

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,12 @@ import {
   bootstrapRunbookRuntime,
   resolveGitCommitSha,
 } from "./runbooks/runtime.ts";
+import {
+  compareSlackDeploymentIdentity,
+  expectedSlackDeploymentIdentity,
+  fetchSlackDeploymentIdentity,
+  loadExpectedSlackDeploymentIdentity,
+} from "./slack/deployment-identity.ts";
 
 const config = loadConfig();
 const app = createSlackApp(config);
@@ -805,23 +811,28 @@ setInterval(() => {
 
   await app.start();
 
-  // Resolve bot identity before registering event handlers
+  // Resolve and pin deployment identity before registering event handlers.
   let selfBotId: string | undefined;
   let slackWorkspaceOrigin: string | undefined;
   try {
-    const auth = await app.client.auth.test();
-    if (auth.url) slackWorkspaceOrigin = auth.url;
-    if (auth.user_id) {
-      sessionManager.botUserId = auth.user_id;
-      log.info("boot", `Bot user ID: ${auth.user_id}`);
+    const persisted = loadExpectedSlackDeploymentIdentity(config.slack.deploymentIdentityPath);
+    const expected = expectedSlackDeploymentIdentity(config.slack, persisted);
+    const identity = await fetchSlackDeploymentIdentity(app.client);
+    const check = compareSlackDeploymentIdentity(identity, expected);
+    if (check.errors.length > 0) {
+      throw new Error(`Slack deployment identity validation failed: ${check.errors.join("; ")}`);
     }
-    if (auth.bot_id) {
-      selfBotId = auth.bot_id;
-      sessionManager.selfBotId = auth.bot_id;
-      log.info("boot", `Bot ID: ${auth.bot_id}`);
-    }
+    sessionManager.botUserId = identity.userId;
+    sessionManager.selfBotId = identity.botId ?? undefined;
+    selfBotId = identity.botId ?? undefined;
+    log.info("boot", `Slack deployment verified: user=${identity.userId} name=${JSON.stringify(identity.visibleName)} joined=${identity.joinedChannelIds.length}`);
+    // Preserve the workspace URL used by cross-workspace permalink guards.
+    slackWorkspaceOrigin = identity.workspaceUrl ?? undefined;
   } catch (err) {
-    log.warn("boot", `Failed to resolve bot identity: ${err}`);
+    log.error("boot", `${err instanceof Error ? err.message : String(err)}`);
+    await app.stop().catch(() => undefined);
+    process.exitCode = 1;
+    return;
   }
 
   registerEventHandlers(app, async (event) => {

--- a/src/slack/deployment-identity.test.ts
+++ b/src/slack/deployment-identity.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, readFileSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  compareSlackDeploymentIdentity,
+  expectedSlackDeploymentIdentity,
+  fetchSlackDeploymentIdentity,
+  loadExpectedSlackDeploymentIdentity,
+  persistExpectedSlackDeploymentIdentity,
+} from "./deployment-identity.ts";
+
+describe("Slack deployment identity", () => {
+  it("authenticates the token, resolves visible name, and paginates joined channels", async () => {
+    const calls: string[] = [];
+    const client = {
+      auth: { test: async () => ({ user_id: "Ubot", bot_id: "Bbot", team_id: "Tteam" }) },
+      users: {
+        info: async ({ user }: { user: string }) => {
+          calls.push(`user:${user}`);
+          return { user: { profile: { display_name: "Junior" }, real_name: "Junior Bot" } };
+        },
+      },
+      conversations: {
+        list: async ({ cursor }: { cursor?: string }) => {
+          calls.push(`channels:${cursor ?? ""}`);
+          return cursor
+            ? { channels: [{ id: "C-private", is_member: true }], response_metadata: { next_cursor: "" } }
+            : { channels: [{ id: "C-public", is_member: true }, { id: "C-other", is_member: false }], response_metadata: { next_cursor: "next" } };
+        },
+      },
+    };
+
+    await expect(fetchSlackDeploymentIdentity(client)).resolves.toEqual({
+      userId: "Ubot",
+      botId: "Bbot",
+      teamId: "Tteam",
+      workspaceUrl: null,
+      visibleName: "Junior",
+      joinedChannelIds: ["C-private", "C-public"],
+    });
+    expect(calls).toEqual(["user:Ubot", "channels:", "channels:next"]);
+  });
+
+  it("fails closed on identity, visible-name, and joined-channel mismatches", () => {
+    const check = compareSlackDeploymentIdentity(
+      {
+        userId: "Uactual",
+        botId: "Bactual",
+        teamId: "Tactual",
+        workspaceUrl: null,
+        visibleName: "Other App",
+        joinedChannelIds: ["C-safe"],
+      },
+      {
+        userId: "Uexpected",
+        botId: "Bexpected",
+        teamId: "Texpected",
+        visibleName: "Junior",
+        joinedChannelIds: ["C-required"],
+      },
+    );
+    expect(check.errors).toHaveLength(5);
+    expect(check.errors.join("; ")).toContain("user_id mismatch");
+    expect(check.errors.join("; ")).toContain("not joined");
+  });
+
+  it("merges explicit config over persisted identity and persists mode-0600 JSON", () => {
+    const dir = mkdtempSync(join(tmpdir(), "junior-slack-identity-"));
+    const path = join(dir, "identity.json");
+    persistExpectedSlackDeploymentIdentity(
+      { userId: "Uold", visibleName: "Old", joinedChannelIds: ["C1"] },
+      path,
+    );
+    const persisted = loadExpectedSlackDeploymentIdentity(path);
+    expect(persisted?.userId).toBe("Uold");
+    const merged = expectedSlackDeploymentIdentity(
+      { expectedUserId: "Unew", expectedVisibleName: "New", expectedChannelIds: ["C2"] },
+      persisted,
+    );
+    expect(merged).toEqual({ userId: "Unew", visibleName: "New", joinedChannelIds: ["C2"] });
+    expect(JSON.parse(readFileSync(path, "utf8")).userId).toBe("Uold");
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+  });
+});

--- a/src/slack/deployment-identity.test.ts
+++ b/src/slack/deployment-identity.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { mkdtempSync, readFileSync, statSync } from "node:fs";
+import { chmodSync, mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
@@ -81,5 +81,13 @@ describe("Slack deployment identity", () => {
     expect(merged).toEqual({ userId: "Unew", visibleName: "New", joinedChannelIds: ["C2"] });
     expect(JSON.parse(readFileSync(path, "utf8")).userId).toBe("Uold");
     expect(statSync(path).mode & 0o777).toBe(0o600);
+  });
+
+  it.each([0o644, 0o666])("rejects an existing insecure mode %o pin", (mode) => {
+    const dir = mkdtempSync(join(tmpdir(), "junior-slack-insecure-"));
+    const path = join(dir, "identity.json");
+    writeFileSync(path, JSON.stringify({ userId: "Ubot" }), { mode: 0o600 });
+    chmodSync(path, mode);
+    expect(() => loadExpectedSlackDeploymentIdentity(path)).toThrow(/mode-0600/);
   });
 });

--- a/src/slack/deployment-identity.ts
+++ b/src/slack/deployment-identity.ts
@@ -1,0 +1,187 @@
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import type { WebClient } from "@slack/web-api";
+
+export interface SlackDeploymentIdentity {
+  userId: string;
+  botId: string | null;
+  teamId: string | null;
+  workspaceUrl: string | null;
+  visibleName: string;
+  joinedChannelIds: string[];
+}
+
+export interface ExpectedSlackDeploymentIdentity {
+  userId: string;
+  botId?: string | null;
+  teamId?: string | null;
+  visibleName?: string;
+  joinedChannelIds?: string[];
+}
+
+export interface SlackIdentityClient {
+  auth: { test(): Promise<Record<string, unknown>> };
+  users: { info(args: { user: string }): Promise<Record<string, unknown>> };
+  conversations: {
+    list(args: { types: string; limit: number; cursor?: string }): Promise<Record<string, unknown>>;
+  };
+}
+
+export interface SlackIdentityCheck {
+  identity: SlackDeploymentIdentity;
+  errors: string[];
+}
+
+export interface SlackIdentityConfig {
+  expectedUserId?: string | null;
+  expectedBotId?: string | null;
+  expectedTeamId?: string | null;
+  expectedVisibleName?: string | null;
+  expectedChannelIds?: string[];
+}
+
+export const DEFAULT_SLACK_IDENTITY_PATH = "data/slack-deployment-identity.json";
+
+export function expectedSlackDeploymentIdentity(
+  config: SlackIdentityConfig,
+  persisted: ExpectedSlackDeploymentIdentity | null,
+): ExpectedSlackDeploymentIdentity | null {
+  const configured = config.expectedUserId?.trim() ? {
+    userId: config.expectedUserId.trim(),
+    ...(config.expectedBotId ? { botId: config.expectedBotId } : {}),
+    ...(config.expectedTeamId ? { teamId: config.expectedTeamId } : {}),
+    ...(config.expectedVisibleName ? { visibleName: config.expectedVisibleName } : {}),
+    ...(config.expectedChannelIds?.length ? { joinedChannelIds: config.expectedChannelIds } : {}),
+  } : null;
+  return configured ?? persisted;
+}
+
+export async function fetchSlackDeploymentIdentity(
+  client: SlackIdentityClient | WebClient,
+): Promise<SlackDeploymentIdentity> {
+  const auth = await client.auth.test();
+  if (auth.ok === false) {
+    throw new Error(`Slack auth.test failed: ${stringField(auth, "error") ?? "unknown error"}`);
+  }
+  const userId = stringField(auth, "user_id");
+  if (!userId) throw new Error("Slack auth.test did not return user_id");
+
+  const userResult = await client.users.info({ user: userId });
+  if (userResult.ok === false) {
+    throw new Error(`Slack users.info(${userId}) failed: ${stringField(userResult, "error") ?? "unknown error"}`);
+  }
+  const user = recordField(userResult, "user");
+  const profile = user ? recordField(user, "profile") : null;
+  const visibleName =
+    stringField(profile, "display_name")?.trim() ||
+    stringField(profile, "real_name")?.trim() ||
+    stringField(user, "real_name")?.trim() ||
+    stringField(user, "name")?.trim();
+  if (!visibleName) throw new Error(`Slack users.info(${userId}) has no visible name`);
+
+  const joinedChannelIds = new Set<string>();
+  let cursor: string | undefined;
+  do {
+    const result = await client.conversations.list({
+      types: "public_channel,private_channel",
+      limit: 200,
+      ...(cursor ? { cursor } : {}),
+    });
+    if (result.ok === false) {
+      throw new Error(`Slack conversations.list failed: ${stringField(result, "error") ?? "unknown error"}`);
+    }
+    const channels = Array.isArray(result.channels) ? result.channels : [];
+    for (const value of channels) {
+      const channel = asRecord(value);
+      if (channel?.is_member === true && typeof channel.id === "string") {
+        joinedChannelIds.add(channel.id);
+      }
+    }
+    const metadata = asRecord(result.response_metadata);
+    cursor = stringField(metadata, "next_cursor")?.trim() || undefined;
+  } while (cursor);
+
+  return {
+    userId,
+    botId: stringField(auth, "bot_id"),
+    teamId: stringField(auth, "team_id"),
+    workspaceUrl: stringField(auth, "url"),
+    visibleName,
+    joinedChannelIds: [...joinedChannelIds].sort(),
+  };
+}
+
+export function compareSlackDeploymentIdentity(
+  actual: SlackDeploymentIdentity,
+  expected: ExpectedSlackDeploymentIdentity | null,
+): SlackIdentityCheck {
+  const errors: string[] = [];
+  if (!expected) {
+    errors.push("no expected Slack deployment identity is pinned; run `bun run slack:identity:setup`");
+  } else {
+    if (actual.userId !== expected.userId) {
+      errors.push(`user_id mismatch (expected ${expected.userId}, got ${actual.userId})`);
+    }
+    if (expected.botId !== undefined && actual.botId !== expected.botId) {
+      errors.push(`bot_id mismatch (expected ${expected.botId ?? "none"}, got ${actual.botId ?? "none"})`);
+    }
+    if (expected.teamId !== undefined && actual.teamId !== expected.teamId) {
+      errors.push(`team_id mismatch (expected ${expected.teamId ?? "none"}, got ${actual.teamId ?? "none"})`);
+    }
+    if (expected.visibleName !== undefined && actual.visibleName !== expected.visibleName) {
+      errors.push(`visible name mismatch (expected ${JSON.stringify(expected.visibleName)}, got ${JSON.stringify(actual.visibleName)})`);
+    }
+    for (const channelId of expected.joinedChannelIds ?? []) {
+      if (!actual.joinedChannelIds.includes(channelId)) {
+        errors.push(`bot is not joined to expected channel ${channelId}`);
+      }
+    }
+  }
+  return { identity: actual, errors };
+}
+
+export function loadExpectedSlackDeploymentIdentity(
+  path = DEFAULT_SLACK_IDENTITY_PATH,
+): ExpectedSlackDeploymentIdentity | null {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(resolve(path), "utf8"));
+    const record = asRecord(parsed);
+    if (!record || typeof record.userId !== "string" || !record.userId.trim()) {
+      throw new Error("expected identity must contain a non-empty userId");
+    }
+    return {
+      userId: record.userId,
+      ...(typeof record.botId === "string" || record.botId === null ? { botId: record.botId } : {}),
+      ...(typeof record.teamId === "string" || record.teamId === null ? { teamId: record.teamId } : {}),
+      ...(typeof record.visibleName === "string" ? { visibleName: record.visibleName } : {}),
+      ...(Array.isArray(record.joinedChannelIds)
+        ? { joinedChannelIds: record.joinedChannelIds.filter((id): id is string => typeof id === "string") }
+        : {}),
+    };
+  } catch (error) {
+    if (error instanceof Error && "code" in error && (error as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw error;
+  }
+}
+
+export function persistExpectedSlackDeploymentIdentity(
+  identity: ExpectedSlackDeploymentIdentity,
+  path = DEFAULT_SLACK_IDENTITY_PATH,
+): void {
+  const target = resolve(path);
+  mkdirSync(dirname(target), { recursive: true, mode: 0o700 });
+  writeFileSync(target, `${JSON.stringify(identity, null, 2)}\n`, { mode: 0o600 });
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" ? value as Record<string, unknown> : null;
+}
+
+function recordField(value: unknown, key: string): Record<string, unknown> | null {
+  return asRecord(asRecord(value)?.[key]);
+}
+
+function stringField(value: unknown, key: string): string | null {
+  const candidate = asRecord(value)?.[key];
+  return typeof candidate === "string" && candidate ? candidate : null;
+}

--- a/src/slack/deployment-identity.ts
+++ b/src/slack/deployment-identity.ts
@@ -1,4 +1,11 @@
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname, resolve } from "node:path";
 import type { WebClient } from "@slack/web-api";
 
@@ -144,7 +151,12 @@ export function loadExpectedSlackDeploymentIdentity(
   path = DEFAULT_SLACK_IDENTITY_PATH,
 ): ExpectedSlackDeploymentIdentity | null {
   try {
-    const parsed: unknown = JSON.parse(readFileSync(resolve(path), "utf8"));
+    const target = resolve(path);
+    const file = lstatSync(target);
+    if (!file.isFile() || (file.mode & 0o777) !== 0o600) {
+      throw new Error(`expected Slack identity must be a regular mode-0600 file: ${target}`);
+    }
+    const parsed: unknown = JSON.parse(readFileSync(target, "utf8"));
     const record = asRecord(parsed);
     if (!record || typeof record.userId !== "string" || !record.userId.trim()) {
       throw new Error("expected identity must contain a non-empty userId");
@@ -170,7 +182,10 @@ export function persistExpectedSlackDeploymentIdentity(
 ): void {
   const target = resolve(path);
   mkdirSync(dirname(target), { recursive: true, mode: 0o700 });
-  writeFileSync(target, `${JSON.stringify(identity, null, 2)}\n`, { mode: 0o600 });
+  const temporary = `${target}.${process.pid}.tmp`;
+  writeFileSync(temporary, `${JSON.stringify(identity, null, 2)}\n`, { mode: 0o600 });
+  chmodSync(temporary, 0o600);
+  renameSync(temporary, target);
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {

--- a/src/slack/identity-cli.ts
+++ b/src/slack/identity-cli.ts
@@ -1,0 +1,54 @@
+import { WebClient } from "@slack/web-api";
+import {
+  compareSlackDeploymentIdentity,
+  expectedSlackDeploymentIdentity,
+  fetchSlackDeploymentIdentity,
+  loadExpectedSlackDeploymentIdentity,
+  persistExpectedSlackDeploymentIdentity,
+  type ExpectedSlackDeploymentIdentity,
+} from "./deployment-identity.ts";
+
+const token = process.env.SLACK_BOT_TOKEN;
+if (!token) throw new Error("SLACK_BOT_TOKEN is required");
+
+const path = process.env.SLACK_DEPLOYMENT_IDENTITY_PATH ?? "data/slack-deployment-identity.json";
+const command = process.argv[2] ?? "doctor";
+const client = new WebClient(token);
+const identity = await fetchSlackDeploymentIdentity(client);
+
+if (command === "setup") {
+  const configuredChannels = (process.env.SLACK_EXPECTED_CHANNEL_IDS ?? "")
+    .split(",")
+    .map((id) => id.trim())
+    .filter(Boolean);
+  const expected: ExpectedSlackDeploymentIdentity = {
+    ...identity,
+    ...(configuredChannels.length ? { joinedChannelIds: configuredChannels } : { joinedChannelIds: [] }),
+  };
+  const check = compareSlackDeploymentIdentity(identity, expected);
+  if (check.errors.length > 0) throw new Error(check.errors.join("; "));
+  persistExpectedSlackDeploymentIdentity(expected, path);
+  console.log(`Pinned Slack deployment identity at ${path}`);
+  console.log(JSON.stringify(expected, null, 2));
+} else if (command === "doctor") {
+  const expected = expectedSlackDeploymentIdentity(
+    {
+      expectedUserId: process.env.SLACK_EXPECTED_USER_ID,
+      expectedBotId: process.env.SLACK_EXPECTED_BOT_ID,
+      expectedTeamId: process.env.SLACK_EXPECTED_TEAM_ID,
+      expectedVisibleName: process.env.SLACK_EXPECTED_VISIBLE_NAME,
+      expectedChannelIds: (process.env.SLACK_EXPECTED_CHANNEL_IDS ?? "")
+        .split(",").map((id) => id.trim()).filter(Boolean),
+    },
+    loadExpectedSlackDeploymentIdentity(path),
+  );
+  const check = compareSlackDeploymentIdentity(identity, expected);
+  if (check.errors.length > 0) {
+    console.error(check.errors.join("\n"));
+    process.exitCode = 1;
+  } else {
+    console.log(`Slack deployment identity is valid: ${identity.userId} ${identity.visibleName}`);
+  }
+} else {
+  throw new Error(`Unknown command ${command}; expected setup or doctor`);
+}


### PR DESCRIPTION
## Summary
- add Slack deployment identity resolution via `auth.test`, `users.info`, and paginated joined-channel enumeration
- compare live identity against explicit `SLACK_EXPECTED_*` pins or a mode-0600 persisted identity file
- fail closed before event-handler registration when identity/channel validation fails
- add `slack:identity:setup` and `slack:identity:doctor` commands
- document configuration, setup, doctor, and boot behavior

## Verification
- `bun run typecheck`
- `bun test src/slack/deployment-identity.test.ts src/config.test.ts`
- `bun run build`

Closes audit finding F18 from `docs/audits/2026-08-23-memory-lessons-compliance.md`.
