### PR TITLE
fix(usage): aggregate SQLite spend in SQL

### DIFF
--- a/docs/code_index/usage-store.md
+++ b/docs/code_index/usage-store.md
@@ -1,0 +1,21 @@
+# Code Index: Usage Store
+
+Usage persistence and spend aggregation used by the dashboard and health
+routes.
+
+## Code Index
+
+| Symbol | File | Purpose |
+|---|---|---|
+| `UsageStore` | `src/usage/store/interface.ts` | Provider-neutral add/get/list/group/count/thread-summary/retention contract. |
+| `InMemoryUsageStore.groupBy` | `src/usage/store/memory.ts` | Reference aggregate behavior for tests and development. |
+| `SqliteUsageStore.groupBy` | `src/usage/store/sqlite.ts` | Uses SQL `COUNT`, `SUM`, and `GROUP BY` over the bounded time window; only aggregate rows cross into JavaScript. |
+| `groupUsageEvents` | `src/usage/store/aggregate.ts` | In-memory grouping semantics, including null labels, missing-usage turns, and locale-sorted buckets. |
+
+`SqliteUsageStore.groupBy` keeps the response shape identical to the in-memory
+provider. Group labels are allowlisted expressions for day, session, agent,
+provider, workflow, and pipeline. Day grouping builds bounded SQL `CASE`
+segments from the JavaScript runtime's historical timezone offsets, so DST
+transitions are applied per event range rather than using today's offset.
+Totals and buckets are aggregate queries, so a large usage table is not
+materialized by the spend endpoint.

--- a/src/usage/store/sqlite.test.ts
+++ b/src/usage/store/sqlite.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { normalizeRunnerUsage, type NormalizedUsage } from "../normalize.ts";
 import { SqliteUsageStore } from "./sqlite.ts";
+import { InMemoryUsageStore } from "./memory.ts";
 import { USAGE_RETENTION_MS } from "../../lifecycle/cleanup.ts";
 
 function usage(overrides: Partial<NormalizedUsage> = {}): NormalizedUsage {
@@ -187,6 +188,62 @@ describe("SqliteUsageStore", () => {
       String(local.getDate()).padStart(2, "0"),
     ].join("-");
     expect(result.buckets.map((bucket) => bucket.key)).toEqual([expected]);
+  });
+
+  it("keeps historical winter and summer day boundaries aligned with JavaScript DST", async () => {
+    const previousTz = process.env.TZ;
+    process.env.TZ = "America/New_York";
+    try {
+      const winter = new Date("2026-01-15T00:30:00-05:00").getTime();
+      const summer = new Date("2026-07-15T00:30:00-04:00").getTime();
+      await store.add(usage({ sourceId: "dst-winter", occurredAt: winter }));
+      await store.add(usage({ sourceId: "dst-summer", occurredAt: summer }));
+      const result = await store.groupBy({
+        from: winter - 1,
+        to: summer + 1,
+        groupBy: "day",
+      });
+      expect(result.buckets.map((bucket) => bucket.key)).toEqual(["2026-01-15", "2026-07-15"]);
+    } finally {
+      if (previousTz === undefined) delete process.env.TZ;
+      else process.env.TZ = previousTz;
+    }
+  });
+
+  it("matches the in-memory aggregate shape across null fallbacks and filters", async () => {
+    const events = [
+      usage({ sourceId: "group-a", threadId: null, agentName: null, provider: null, workflowName: null, workflowRunId: "workflow-1", pipelineRunId: null, inputTokens: null, outputTokens: null, costUsd: null, occurredAt: 1_700_000_100_000 }),
+      usage({ sourceId: "group-b", threadId: "thread-b", agentName: "review", provider: "claude", workflowName: "worklog", pipelineRunId: "run-1", inputTokens: 3, outputTokens: 4, costUsd: 0.25, occurredAt: 1_700_000_200_000 }),
+      usage({ sourceId: "outside", threadId: "outside", inputTokens: 99, occurredAt: 1_700_001_000_000 }),
+    ];
+    const memory = new InMemoryUsageStore();
+    for (const event of events) {
+      await store.add(event);
+      await memory.add(event);
+    }
+    for (const groupBy of ["session", "agent", "provider", "workflow", "pipeline"] as const) {
+      await expect(store.groupBy({ from: 1_700_000_000_000, to: 1_700_000_300_000, groupBy }))
+        .resolves.toEqual(await memory.groupBy({ from: 1_700_000_000_000, to: 1_700_000_300_000, groupBy }));
+    }
+  });
+
+  it("aggregates a large event set without materializing usage rows", async () => {
+    for (let i = 0; i < 2_000; i += 1) {
+      await store.add(usage({
+        sourceId: `large-${i}`,
+        threadId: `thread-${i % 10}`,
+        inputTokens: 1,
+        outputTokens: 2,
+        occurredAt: 1_700_000_000_000 + i,
+      }));
+    }
+    const result = await store.groupBy({
+      from: 1_700_000_000_000,
+      to: 1_700_000_010_000,
+      groupBy: "session",
+    });
+    expect(result.totals).toMatchObject({ turns: 2_000, inputTokens: 2_000, outputTokens: 4_000 });
+    expect(result.buckets).toHaveLength(10);
   });
 
   it("deletes rows older than the retention cutoff", async () => {

--- a/src/usage/store/sqlite.ts
+++ b/src/usage/store/sqlite.ts
@@ -3,7 +3,6 @@ import { mkdirSync } from "node:fs";
 import { dirname } from "node:path";
 import { mergeUsage } from "../merge.ts";
 import type { NormalizedUsage, UsageEvent, UsageSourceKind } from "../normalize.ts";
-import { groupUsageEvents } from "./aggregate.ts";
 import type { UsageBucket, UsageGroupBy, UsageGroupResult, UsageStore } from "./interface.ts";
 
 type UsageRow = {
@@ -167,8 +166,63 @@ export class SqliteUsageStore implements UsageStore {
     to: number;
     groupBy: UsageGroupBy;
   }): Promise<UsageGroupResult> {
-    const events = await this.list({ from: input.from, to: input.to });
-    return groupUsageEvents(events, input.groupBy);
+    const group = usageGroupExpression(input.groupBy, input.from, input.to);
+    const totals = this.db.query<{
+      turns: number;
+      inputTokens: number;
+      outputTokens: number;
+      costUsd: number;
+      missingUsageTurns: number;
+    }, [number, number]>(
+      `SELECT COUNT(*) AS turns,
+              COALESCE(SUM(input_tokens), 0) AS inputTokens,
+              COALESCE(SUM(output_tokens), 0) AS outputTokens,
+              COALESCE(SUM(cost_usd), 0) AS costUsd,
+              COALESCE(SUM(CASE WHEN input_tokens IS NULL
+                           AND output_tokens IS NULL
+                           AND cache_read_tokens IS NULL
+                           AND cache_write_tokens IS NULL
+                           AND cost_usd IS NULL
+                       THEN 1 ELSE 0 END), 0) AS missingUsageTurns
+       FROM usage_events
+       WHERE occurred_at >= ? AND occurred_at <= ?`,
+    ).get(input.from, input.to) ?? {
+      turns: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      costUsd: 0,
+      missingUsageTurns: 0,
+    };
+    const rows = this.db.query<{
+      key: string;
+      turns: number;
+      inputTokens: number;
+      outputTokens: number;
+      costUsd: number;
+    }, number[]>(
+      `SELECT ${group.sql} AS key,
+              COUNT(*) AS turns,
+              COALESCE(SUM(input_tokens), 0) AS inputTokens,
+              COALESCE(SUM(output_tokens), 0) AS outputTokens,
+              COALESCE(SUM(cost_usd), 0) AS costUsd
+       FROM usage_events
+       WHERE occurred_at >= ? AND occurred_at <= ?
+       GROUP BY ${group.sql}`,
+    ).all(...group.params, input.from, input.to, ...group.params);
+    return {
+      totals: { ...totals, costEstimatedUsd: 0 },
+      buckets: rows
+        .map((row) => ({
+          key: row.key,
+          label: row.key,
+          turns: row.turns,
+          inputTokens: row.inputTokens,
+          outputTokens: row.outputTokens,
+          costUsd: row.costUsd,
+          costEstimatedUsd: 0,
+        }))
+        .sort((a, b) => a.key.localeCompare(b.key)),
+    };
   }
 
   async count(filter: {
@@ -307,6 +361,71 @@ export class SqliteUsageStore implements UsageStore {
         ON usage_events (workflow_name, occurred_at)
     `);
   }
+}
+
+function usageGroupExpression(
+  groupBy: UsageGroupBy,
+  from: number,
+  to: number,
+): { sql: string; params: number[] } {
+  switch (groupBy) {
+    case "day": return localDaySqlExpression(from, to);
+    case "session": return { sql: "COALESCE(thread_id, 'unknown')", params: [] };
+    case "agent": return { sql: "COALESCE(agent_name, 'unknown')", params: [] };
+    case "provider": return { sql: "COALESCE(provider, 'unknown')", params: [] };
+    case "workflow": return { sql: "COALESCE(workflow_name, workflow_run_id, 'unknown')", params: [] };
+    case "pipeline": return { sql: "COALESCE(pipeline_run_id, 'unknown')", params: [] };
+  }
+}
+
+function localDaySqlExpression(from: number, to: number): { sql: string; params: number[] } {
+  const segments = timezoneSegments(from, to);
+  const params: number[] = [];
+  const cases = segments.map((segment) => {
+    params.push(segment.from, segment.toExclusive);
+    return `WHEN occurred_at >= ? AND occurred_at < ? THEN strftime('%Y-%m-%d', occurred_at / 1000, 'unixepoch', ${timezoneModifier(segment.offsetMinutes)})`;
+  });
+  return {
+    sql: `(CASE ${cases.join(" ")} ELSE strftime('%Y-%m-%d', occurred_at / 1000, 'unixepoch') END)`,
+    params,
+  };
+}
+
+type TimezoneSegment = { from: number; toExclusive: number; offsetMinutes: number };
+
+function timezoneSegments(from: number, to: number): TimezoneSegment[] {
+  const end = to + 1;
+  const segments: TimezoneSegment[] = [];
+  let cursor = from;
+  while (cursor < end) {
+    const offset = new Date(cursor).getTimezoneOffset();
+    let probe = Math.min(cursor + 24 * 60 * 60 * 1000, end);
+    while (probe < end && new Date(probe).getTimezoneOffset() === offset) {
+      probe = Math.min(probe + 24 * 60 * 60 * 1000, end);
+    }
+    let transition = probe;
+    if (probe < end) {
+      let low = cursor;
+      let high = probe;
+      while (high - low > 1) {
+        const middle = Math.floor((low + high) / 2);
+        if (new Date(middle).getTimezoneOffset() === offset) low = middle;
+        else high = middle;
+      }
+      transition = high;
+    }
+    segments.push({ from: cursor, toExclusive: transition, offsetMinutes: offset });
+    cursor = transition;
+  }
+  return segments;
+}
+
+function timezoneModifier(offsetMinutes: number): string {
+  const eastMinutes = -offsetMinutes;
+  const sign = eastMinutes >= 0 ? "+" : "-";
+  const absolute = Math.abs(eastMinutes);
+  const hours = `'${sign}${Math.floor(absolute / 60)} hours'`;
+  return absolute % 60 ? `${hours}, '${sign}${absolute % 60} minutes'` : hours;
 }
 
 function usageWhere(filter: {


### PR DESCRIPTION
## Summary
- replace SQLite `groupBy` fetch-all + JS reduction with SQL COUNT/SUM/GROUP BY aggregates
- preserve in-memory response shape, null fallback labels, missing-usage counts, bucket ordering, and host-local day semantics
- build bounded SQL CASE segments from historical JavaScript timezone offsets so winter/summer DST boundaries remain correct without materializing rows
- add SQLite/in-memory parity, 2,000-row scale, and America/New_York winter/summer regression coverage
- document the provider boundary and aggregate query behavior

## Verification
- `bun run typecheck`
- `bun test src/usage/store/sqlite.test.ts src/http/routes/spend.test.ts` (13 pass)

Fixes audit finding F22.