### PR TITLE
fix: preserve authoritative promotion request intent

### DIFF
--- a/docs/code_index/mcp-server.md
+++ b/docs/code_index/mcp-server.md
@@ -38,6 +38,7 @@ operations using the bot token and signed run context.
 | `agent_dispatch` | Junior internal | agent, prompt, thread context | repo refs; automatic repo-less isolation for Mongo-read agents with no repo, optional explicit `workspace_mode`; synthetic user/timestamp |
 | `memory_recall` / `memory_add` / `memory_consolidate` | Memory v3 | tool-specific | filters/options; `fact_kinds` exposes procedure/routing/curated-fact subtypes |
 | `runbook_select` | Runbooks + Memory v3 | `request` | Select reviewed runbook; on miss perform procedure-memory recall |
+| `promotion_record` / `runbook_propose` | Runbook promotion + authoring | promotion evidence plus optional authoritative `request`; proposal `fingerprint` | Promotion retains normalized request intent (with legacy runbook-name fallback), so proposals produce usable names/descriptions and dry-run PR content. |
 | `github_read_pr_review_state` / `github_post_review` | Fixed GitHub API surface | review-specific | inline comments |
 | `pipeline_*` | Durable pipeline store | tool-specific | artifact/check fields |
 | `whatsapp_*` | Read-only archive | tool-specific | time/group filters |
@@ -68,6 +69,16 @@ Called by lead/intake to create a per-thread worktree for a repo and persist its
 ### Agent registry tools
 
 `agent_search` scans `.claude/agents` and `agents-org` from disk and annotates each result with whether `AGENT_IDENTITIES` currently makes it dispatchable. `reload_agent_registry` reruns `loadOverlayIdentities("agents-org")`, which lets newly added private workers become dispatchable without a full process restart. Existing identities are not overwritten; prompts are already resolved from disk per turn.
+
+### Promotion intent continuity
+
+`promotion_record` accepts an authoritative operator request either at the
+top level or inside the evidence object. It normalizes that request before
+creating/updating the in-memory promotion candidate; legacy evidence without a
+request falls back to its runbook name. `runbook_propose` consumes the same
+candidate and therefore receives a non-empty `normalizedIntent` for filename,
+description, routing examples, and proposal content. The evidence schema keeps
+`request` optional for backward compatibility.
 
 ## Dependencies
 

--- a/docs/code_index/mcp-server.md
+++ b/docs/code_index/mcp-server.md
@@ -75,7 +75,9 @@ Called by lead/intake to create a per-thread worktree for a repo and persist its
 `promotion_record` accepts an authoritative operator request either at the
 top level or inside the evidence object. It normalizes that request before
 creating/updating the in-memory promotion candidate; legacy evidence without a
-request falls back to its runbook name. `runbook_propose` consumes the same
+request falls back to its runbook name and is marked non-authoritative. A later
+authoritative request replaces that fallback for the same fingerprint.
+`runbook_propose` consumes the same
 candidate and therefore receives a non-empty `normalizedIntent` for filename,
 description, routing examples, and proposal content. The evidence schema keeps
 `request` optional for backward compatibility.

--- a/src/mcp/slack-server.test.ts
+++ b/src/mcp/slack-server.test.ts
@@ -94,7 +94,6 @@ describe("MCP promotion authoring", () => {
             completedAt: 2_000,
             intentFingerprint: fingerprint,
           },
-          request: "Transfer six months of membership",
         },
       });
       const recordedResult = recorded as unknown as {
@@ -104,8 +103,40 @@ describe("MCP promotion authoring", () => {
         recordedResult.content[0]!.text,
       ) as { candidate: { normalizedIntent: string } };
       expect(recordedPayload.candidate.normalizedIntent).toBe(
-        "transfer six months of membership",
+        "legacy placeholder",
       );
+
+      const upgraded = await client.callTool({
+        name: "promotion_record",
+        arguments: {
+          evidence: {
+            runId: "mcp-promotion-run-2",
+            runbookName: "legacy-placeholder",
+            contentDigest: "digest",
+            ownerAgent: "build",
+            risk: "production-write",
+            boundInputs: {},
+            status: "completed",
+            startedAt: 3_000,
+            completedAt: 4_000,
+            intentFingerprint: fingerprint,
+          },
+          request: "Transfer six months of membership",
+        },
+      });
+      const upgradedResult = upgraded as unknown as {
+        content: Array<{ text: string }>;
+      };
+      const upgradedPayload = JSON.parse(upgradedResult.content[0]!.text) as {
+        candidate: {
+          normalizedIntent: string;
+          normalizedIntentAuthoritative?: boolean;
+        };
+      };
+      expect(upgradedPayload.candidate).toMatchObject({
+        normalizedIntent: "transfer six months of membership",
+        normalizedIntentAuthoritative: true,
+      });
 
       const proposed = await client.callTool({
         name: "runbook_propose",

--- a/src/mcp/slack-server.test.ts
+++ b/src/mcp/slack-server.test.ts
@@ -18,6 +18,7 @@ import {
 import { createMemoryStore } from "../memory/factory.ts";
 import { HashingEmbeddingProvider } from "../memory/embedding/hashing.ts";
 import { createProfileStore } from "../memory/profiles/index.ts";
+import { clearCandidatesForTests } from "../runbooks/promotion.ts";
 
 describe("MCP Slack tool catalogue", () => {
   it("serializes every registered tool through tools/list", async () => {
@@ -60,6 +61,71 @@ describe("MCP Slack tool catalogue", () => {
         ]),
       });
     } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+});
+
+describe("MCP promotion authoring", () => {
+  it("carries the authoritative request from promotion_record into runbook_propose", async () => {
+    clearCandidatesForTests();
+    const server = new McpServer({ name: "slack-bot-promotion-test", version: "0.1.0" });
+    registerTools(server);
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    const client = new Client({ name: "slack-bot-promotion-client", version: "0.1.0" });
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    const fingerprint = `mcp-promotion-${Date.now()}`;
+    try {
+      const recorded = await client.callTool({
+        name: "promotion_record",
+        arguments: {
+          evidence: {
+            runId: "mcp-promotion-run",
+            runbookName: "legacy-placeholder",
+            contentDigest: "digest",
+            ownerAgent: "build",
+            risk: "production-write",
+            boundInputs: {},
+            status: "completed",
+            startedAt: 1_000,
+            completedAt: 2_000,
+            intentFingerprint: fingerprint,
+          },
+          request: "Transfer six months of membership",
+        },
+      });
+      const recordedResult = recorded as unknown as {
+        content: Array<{ text: string }>;
+      };
+      const recordedPayload = JSON.parse(
+        recordedResult.content[0]!.text,
+      ) as { candidate: { normalizedIntent: string } };
+      expect(recordedPayload.candidate.normalizedIntent).toBe(
+        "transfer six months of membership",
+      );
+
+      const proposed = await client.callTool({
+        name: "runbook_propose",
+        arguments: { fingerprint, dry_run: true },
+      });
+      const proposedResult = proposed as unknown as {
+        content: Array<{ text: string }>;
+      };
+      const proposalPayload = JSON.parse(
+        proposedResult.content[0]!.text,
+      ) as { rendered: { ok: boolean; filename?: string; content?: string } };
+      expect(proposalPayload.rendered.ok).toBe(true);
+      expect(proposalPayload.rendered.filename).toBe(
+        "transfer-six-months-of-membership.runbook.md",
+      );
+      expect(proposalPayload.rendered.content).toContain(
+        "transfer six months of membership",
+      );
+    } finally {
+      clearCandidatesForTests();
       await client.close();
       await server.close();
     }

--- a/src/mcp/slack-server.ts
+++ b/src/mcp/slack-server.ts
@@ -1385,7 +1385,13 @@ export function registerTools(server: McpServer, runContext: SlackMcpRunContext 
     async ({ evidence, request }) => {
       const authoritativeRequest =
         request?.trim() || evidence.request?.trim() || evidence.runbookName.trim();
-      promotionRecordExecution(evidence as RunbookRunEvidence, authoritativeRequest);
+      promotionRecordExecution(
+        evidence as RunbookRunEvidence,
+        authoritativeRequest,
+        {
+          authoritative: Boolean(request?.trim() || evidence.request?.trim()),
+        },
+      );
       const check = promotionCheckThreshold(evidence.intentFingerprint);
       return {
         content: [

--- a/src/mcp/slack-server.ts
+++ b/src/mcp/slack-server.ts
@@ -1377,11 +1377,15 @@ export function registerTools(server: McpServer, runContext: SlackMcpRunContext 
           startedAt: z.number(),
           completedAt: z.number().optional(),
           intentFingerprint: z.string(),
+          request: z.string().optional().describe("Authoritative operator request used to derive the promotion candidate intent"),
         }).describe("RunbookRunEvidence from a completed run"),
+        request: z.string().optional().describe("Authoritative operator request; overrides evidence.request when supplied"),
       },
     },
-    async ({ evidence }) => {
-      promotionRecordExecution(evidence as RunbookRunEvidence);
+    async ({ evidence, request }) => {
+      const authoritativeRequest =
+        request?.trim() || evidence.request?.trim() || evidence.runbookName.trim();
+      promotionRecordExecution(evidence as RunbookRunEvidence, authoritativeRequest);
       const check = promotionCheckThreshold(evidence.intentFingerprint);
       return {
         content: [

--- a/src/runbooks/evidence.ts
+++ b/src/runbooks/evidence.ts
@@ -20,6 +20,8 @@ export interface RunbookRunEvidence {
   startedAt: number;
   completedAt?: number;
   intentFingerprint: string;
+  /** Original operator request; retained so promotion authoring has intent. */
+  request?: string;
 }
 
 export function createRunEvidence(
@@ -38,6 +40,7 @@ export function createRunEvidence(
     status: "selected",
     startedAt,
     intentFingerprint: createIntentFingerprint(request, runbook),
+    request: request.trim(),
   };
 }
 

--- a/src/runbooks/promotion.ts
+++ b/src/runbooks/promotion.ts
@@ -13,10 +13,12 @@ const candidates = new Map<string, PromotionCandidate>();
 export function recordSuccessfulExecution(
   evidence: RunbookRunEvidence,
   request?: string,
+  options?: { authoritative?: boolean },
 ): void {
   const fp = evidence.intentFingerprint;
   const existing = candidates.get(fp);
   const normalizedText = request ? normalizeForFingerprint(request) : "";
+  const authoritative = options?.authoritative ?? Boolean(normalizedText);
 
   if (existing) {
     existing.occurrenceCount++;
@@ -26,7 +28,13 @@ export function recordSuccessfulExecution(
       existing.evidenceRefs.push(evidence.runId);
     }
     if (evidence.risk && !existing.risk) existing.risk = evidence.risk;
-    if (normalizedText && !existing.normalizedIntent) existing.normalizedIntent = normalizedText;
+    if (
+      normalizedText &&
+      (authoritative || !existing.normalizedIntent)
+    ) {
+      existing.normalizedIntent = normalizedText;
+      if (authoritative) existing.normalizedIntentAuthoritative = true;
+    }
     return;
   }
 
@@ -44,6 +52,7 @@ export function recordSuccessfulExecution(
       ? "runbook"
       : (classification.classification as PromotionCandidate["proposedKind"]),
     normalizedIntent: normalizedText,
+    normalizedIntentAuthoritative: authoritative,
     ownerAgent: evidence.ownerAgent,
     occurrenceCount: 1,
     successfulCount: evidence.status === "completed" ? 1 : 0,

--- a/src/runbooks/types.ts
+++ b/src/runbooks/types.ts
@@ -97,6 +97,8 @@ export interface PromotionCandidate {
   fingerprint: string;
   proposedKind: "runbook" | "agent-extension" | "new-agent" | "workflow";
   normalizedIntent: string;
+  /** Whether normalizedIntent came from an authoritative operator request. */
+  normalizedIntentAuthoritative?: boolean;
   ownerAgent: string;
   occurrenceCount: number;
   successfulCount: number;


### PR DESCRIPTION
## Summary
- accept authoritative request intent in promotion_record (top-level or evidence.request)
- retain request on RunbookRunEvidence and derive a legacy fallback from runbookName
- verify MCP promotion_record → runbook_propose renders usable normalized intent, filename, and content
- document schema/backward compatibility

## Verification
- `bun run typecheck`
- `bun test src/mcp/slack-server.test.ts -t "promotion authoring|serializes every registered tool"` (2 passed)

The broader runbook suite has pre-existing fixture-manifest failures on origin/main (`db-executioner` fixture rejected; 9 failures); those are unrelated to this change.