### PR TITLE
fix(mongodb): reject implicit partial find results

### DIFF
--- a/docs/code_index/mcp-server.md
+++ b/docs/code_index/mcp-server.md
@@ -12,7 +12,7 @@ operations using the bot token and signed run context.
 |---|---|---|
 | `startMcpServer(deps)` | `slack-server.ts` | Starts HTTP server on `MCP_PORT` (default 3456), binding `127.0.0.1` and best-effort `::1`. Optional dependencies wire stores and pipeline services. |
 | `registerTools(server)` (internal) | `slack-server.ts` | Registers Slack, worktree, and agent-registry tools on a fresh `McpServer` per request. |
-| `handleMongoMcpRequest(req, res)` | `mongodb-proxy.ts` | Serves `/mcp/mongodb` as a stateless HTTP MCP proxy to one shared read-only MongoDB stdio backend; hides upstream connection selection and injects the environment-backed `preconfigured` ID. |
+| `handleMongoMcpRequest(req, res)` | `mongodb-proxy.ts` | Serves `/mcp/mongodb` as a stateless HTTP MCP proxy to one shared read-only MongoDB stdio backend; hides upstream connection selection, injects the environment-backed `preconfigured` ID, and requires explicit `find.limit` values from 1–100. |
 | `closeMongoMcpBackend()` | `mongodb-proxy.ts` | Closes the shared backend immediately; also used by the idle TTL. |
 | `handleMixpanelMcpRequest(req, res)` | `mixpanel-proxy.ts` | Serves `/mcp/mixpanel` as one signed read-only MCP surface over all configured Mixpanel regions. |
 | `createMixpanelProxyServer(...)` | `mixpanel-proxy.ts` | Unions safe upstream tools, adds the required `region` selector, strips it before forwarding, and rejects write tools. |

--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -125,6 +125,11 @@ Status pill updates that agents post mid-run go through `slack_send_message` wit
   declares `permissions.mcp: mongodb` or lists `mcp__mongodb__*` tools.
   Disable with `OPENCODE_MONGODB_MCP_ENABLED=false` /
   `CODEX_MONGODB_MCP_ENABLED=false`.
+  The proxy requires every `find` call to provide an explicit integer
+  `limit` from 1 through 100 and rejects unbounded/over-cap requests before
+  contacting MongoDB. This makes capped results explicit rather than silently
+  presenting a partial dataset; complete exports must use a separately
+  approved schema-preserving export workflow.
 
 ### Agent registry tools
 

--- a/src/mcp/mongodb-proxy.test.ts
+++ b/src/mcp/mongodb-proxy.test.ts
@@ -31,6 +31,7 @@ describe("MongoDB MCP read-only proxy", () => {
                     type: "object",
                     additionalProperties: true,
                   },
+                  limit: { type: "integer" },
                 },
                 required: ["connectionId", "database", "collection"],
               },
@@ -72,7 +73,7 @@ describe("MongoDB MCP read-only proxy", () => {
         },
       });
       expect(tools[0]?.inputSchema.properties).not.toHaveProperty("connectionId");
-      expect(tools[0]?.inputSchema.required).toEqual(["database", "collection"]);
+      expect(tools[0]?.inputSchema.required).toEqual(["database", "collection", "limit"]);
 
       const filter = {
         status: { $in: ["active", "trial"] },
@@ -84,6 +85,7 @@ describe("MongoDB MCP read-only proxy", () => {
           database: "app",
           collection: "members",
           filter,
+          limit: 50,
         },
       });
 
@@ -95,8 +97,61 @@ describe("MongoDB MCP read-only proxy", () => {
           database: "app",
           collection: "members",
           filter,
+          limit: 50,
         },
       }]);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it("rejects unbounded and over-cap finds before touching the backend", async () => {
+    let called = false;
+    const server = createMongoProxyServer(RUN_CONTEXT, async () => ({
+      client: {
+        async listTools() { return { tools: [] }; },
+        async callTool() { called = true; return { content: [{ type: "text" as const, text: "unexpected" }] }; },
+      } as never,
+    }));
+    const client = new Client({ name: "mongo-proxy-test", version: "0.1.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    try {
+      for (const limit of [undefined, 101, 0]) {
+        const result = await client.callTool({
+          name: "find",
+          arguments: { database: "app", collection: "members", ...(limit === undefined ? {} : { limit }) },
+        });
+        expect(result.isError).toBe(true);
+      }
+      expect(called).toBe(false);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it("requires a signed run context before any bounded find", async () => {
+    let called = false;
+    const server = createMongoProxyServer(null, async () => ({
+      client: {
+        async listTools() { return { tools: [] }; },
+        async callTool() { called = true; return { content: [{ type: "text" as const, text: "unexpected" }] }; },
+      } as never,
+    }));
+    const client = new Client({ name: "mongo-proxy-test", version: "0.1.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+    try {
+      const result = await client.callTool({
+        name: "find",
+        arguments: { database: "app", collection: "members", limit: 10 },
+      });
+      expect(result.isError).toBe(true);
+      expect(called).toBe(false);
     } finally {
       await client.close();
       await server.close();

--- a/src/mcp/mongodb-proxy.test.ts
+++ b/src/mcp/mongodb-proxy.test.ts
@@ -31,7 +31,13 @@ describe("MongoDB MCP read-only proxy", () => {
                     type: "object",
                     additionalProperties: true,
                   },
-                  limit: { type: "integer" },
+                  limit: {
+                    type: "number",
+                    minimum: 0,
+                    maximum: 1000,
+                    description: "Upstream page size",
+                    "x-upstream": "preserved",
+                  },
                 },
                 required: ["connectionId", "database", "collection"],
               },
@@ -73,6 +79,13 @@ describe("MongoDB MCP read-only proxy", () => {
         },
       });
       expect(tools[0]?.inputSchema.properties).not.toHaveProperty("connectionId");
+      expect(tools[0]?.inputSchema.properties?.limit).toEqual({
+        type: "integer",
+        minimum: 1,
+        maximum: 100,
+        description: "Upstream page size. Must be between 1 and 100.",
+        "x-upstream": "preserved",
+      });
       expect(tools[0]?.inputSchema.required).toEqual(["database", "collection", "limit"]);
 
       const filter = {

--- a/src/mcp/mongodb-proxy.ts
+++ b/src/mcp/mongodb-proxy.ts
@@ -16,6 +16,7 @@ const MONGODB_PROXY_IDLE_TTL_MS = Number(process.env.MONGODB_MCP_PROXY_IDLE_TTL_
 const MONGODB_PROXY_REQUEST_TIMEOUT_MS = Number(process.env.MONGODB_MCP_PROXY_REQUEST_TIMEOUT_MS ?? "120000");
 const MONGODB_PRECONFIGURED_CONNECTION_ID = "preconfigured";
 const MONGODB_MCP_PACKAGE = "mongodb-mcp-server@2.1.0";
+export const MONGODB_FIND_MAX_LIMIT = 100;
 const MONGODB_TOOL_NAMES = [
   "aggregate",
   "collection-schema",
@@ -87,6 +88,8 @@ export function createMongoProxyServer(
     }
 
     try {
+      const validation = validateMongoToolArguments(name, args ?? {});
+      if (validation) return mongoProxyError(validation);
       const { client } = await backendProvider();
       armIdleTimer();
       return await client.callTool(
@@ -113,17 +116,37 @@ export function createMongoProxyServer(
   return server;
 }
 
-function hideMongoConnectionId<T extends { inputSchema: Record<string, unknown> }>(
+function hideMongoConnectionId<T extends { name: string; description?: string; inputSchema: Record<string, unknown> }>(
   tool: T,
 ): T {
   const schema = tool.inputSchema;
-  const properties = schema.properties && typeof schema.properties === "object"
+  let properties = schema.properties && typeof schema.properties === "object"
     ? { ...(schema.properties as Record<string, unknown>) }
     : undefined;
   if (properties) delete properties.connectionId;
   const required = Array.isArray(schema.required)
     ? schema.required.filter((name) => name !== "connectionId")
     : schema.required;
+  if (tool.name === "find") {
+    properties ??= {};
+    properties.limit ??= {
+      type: "integer",
+      minimum: 1,
+      maximum: MONGODB_FIND_MAX_LIMIT,
+      description: "Required bounded page size; results never exceed 100 documents.",
+    };
+    const findRequired = Array.isArray(required) ? [...required] : [];
+    if (!findRequired.includes("limit")) findRequired.push("limit");
+    return {
+      ...tool,
+      description: `${tool.description ?? ""} Results are bounded to an explicit limit of 100 or fewer; use a separate export workflow for complete datasets.`,
+      inputSchema: {
+        ...schema,
+        properties,
+        required: findRequired,
+      },
+    };
+  }
   return {
     ...tool,
     inputSchema: {
@@ -132,6 +155,18 @@ function hideMongoConnectionId<T extends { inputSchema: Record<string, unknown> 
       ...(required ? { required } : {}),
     },
   };
+}
+
+function validateMongoToolArguments(
+  name: string,
+  args: Record<string, unknown>,
+): string | null {
+  if (name !== "find") return null;
+  const limit = args.limit;
+  if (!Number.isInteger(limit) || (limit as number) < 1 || (limit as number) > MONGODB_FIND_MAX_LIMIT) {
+    return `find requires an explicit integer limit from 1 to ${MONGODB_FIND_MAX_LIMIT}; broad or capped partial results are refused. Use an approved export workflow for complete datasets.`;
+  }
+  return null;
 }
 
 export async function closeMongoMcpBackend(): Promise<void> {

--- a/src/mcp/mongodb-proxy.ts
+++ b/src/mcp/mongodb-proxy.ts
@@ -129,11 +129,23 @@ function hideMongoConnectionId<T extends { name: string; description?: string; i
     : schema.required;
   if (tool.name === "find") {
     properties ??= {};
-    properties.limit ??= {
+    const upstreamLimit = properties.limit && typeof properties.limit === "object"
+      ? properties.limit as Record<string, unknown>
+      : {};
+    const upstreamMinimum = typeof upstreamLimit.minimum === "number"
+      ? upstreamLimit.minimum
+      : 1;
+    const upstreamMaximum = typeof upstreamLimit.maximum === "number"
+      ? upstreamLimit.maximum
+      : MONGODB_FIND_MAX_LIMIT;
+    properties.limit = {
+      ...upstreamLimit,
       type: "integer",
-      minimum: 1,
-      maximum: MONGODB_FIND_MAX_LIMIT,
-      description: "Required bounded page size; results never exceed 100 documents.",
+      minimum: Math.max(1, upstreamMinimum),
+      maximum: Math.min(MONGODB_FIND_MAX_LIMIT, upstreamMaximum),
+      description: typeof upstreamLimit.description === "string"
+        ? `${upstreamLimit.description}. Must be between 1 and ${MONGODB_FIND_MAX_LIMIT}.`
+        : `Required bounded page size; results never exceed ${MONGODB_FIND_MAX_LIMIT} documents.`,
     };
     const findRequired = Array.isArray(required) ? [...required] : [];
     if (!findRequired.includes("limit")) findRequired.push("limit");


### PR DESCRIPTION
## Summary
- require MongoDB `find` calls to provide an explicit integer `limit` from 1 through 100
- reject unbounded and over-cap finds before contacting the backend, with explicit partial-result/export guidance
- expose the bounded limit in the mirrored MCP schema while preserving upstream tool arguments and connection-ID isolation
- add signed-context, cap, schema, and backend-auth tests
- revalidate upstream `mongodb-mcp-server@2.1.0` package metadata/CLI and document the boundary

## Verification
- `bun run typecheck`
- `bun test src/mcp/mongodb-proxy.test.ts` (5 passed)
- `bun run build`
- `npx -y mongodb-mcp-server@2.1.0 --help`

Closes audit finding F25 from `docs/audits/2026-08-23-memory-lessons-compliance.md`.
