### PR TITLE
fix: publish typed pipeline outcome schema

### DIFF
--- a/docs/code_index/mcp-server.md
+++ b/docs/code_index/mcp-server.md
@@ -40,7 +40,7 @@ operations using the bot token and signed run context.
 | `runbook_select` | Runbooks + Memory v3 | `request` | Select reviewed runbook; on miss perform procedure-memory recall |
 | `promotion_record` / `runbook_propose` | Runbook promotion + authoring | promotion evidence plus optional authoritative `request`; proposal `fingerprint` | Promotion retains normalized request intent (with legacy runbook-name fallback), so proposals produce usable names/descriptions and dry-run PR content. |
 | `github_read_pr_review_state` / `github_post_review` | Fixed GitHub API surface | review-specific | inline comments |
-| `pipeline_*` | Durable pipeline store | tool-specific | artifact/check fields |
+| `pipeline_*` | Durable pipeline store | tool-specific | artifact/check fields; `pipeline_report_outcome` publishes the typed `AgentOutcome` action/status enums and nested blocker/check schemas |
 | `whatsapp_*` | Read-only archive | tool-specific | time/group filters |
 
 ### Configuration
@@ -81,6 +81,15 @@ authoritative request replaces that fallback for the same fingerprint.
 candidate and therefore receives a non-empty `normalizedIntent` for filename,
 description, routing examples, and proposal content. The evidence schema keeps
 `request` optional for backward compatibility.
+
+### Pipeline outcome contract
+
+`pipeline_report_outcome` publishes the same structural contract enforced by
+`src/pipelines/outcomes.ts`: action and status enums, allowed blocker kinds,
+check status enums, and nested `wait` / `nextAssignment` fields. Keep this
+schema aligned with the parser so provider tool metadata cannot invite values
+such as `status: "completed"` or string blockers that runtime validation will
+reject.
 
 ## Dependencies
 

--- a/src/mcp/slack-server.test.ts
+++ b/src/mcp/slack-server.test.ts
@@ -36,6 +36,40 @@ describe("MCP Slack tool catalogue", () => {
       const names = tools.map((tool) => tool.name);
 
       expect(names).toContain("pipeline_report_outcome");
+      const pipelineOutcome = tools.find((tool) => tool.name === "pipeline_report_outcome");
+      expect(pipelineOutcome?.inputSchema).toMatchObject({
+        properties: {
+          outcome: {
+            properties: {
+              action: {
+                enum: ["continue_self", "delegate", "handoff", "wait", "escalate", "complete"],
+              },
+              status: {
+                enum: ["progress", "succeeded", "expected_behavior", "not_reproduced", "blocked", "failed"],
+              },
+              blockers: {
+                items: {
+                  properties: {
+                    kind: {
+                      enum: [
+                        "missing_context",
+                        "missing_authority",
+                        "human_gate",
+                        "unsafe_mutation",
+                        "conflicting_evidence",
+                        "no_progress",
+                        "infra_failure",
+                      ],
+                    },
+                    detail: { type: "string" },
+                  },
+                  required: ["kind", "detail"],
+                },
+              },
+            },
+          },
+        },
+      });
       expect(names).toContain("runbook_select");
       expect(names).toContain("promotion_record");
       const memoryRecall = tools.find((tool) => tool.name === "memory_recall");

--- a/src/mcp/slack-server.ts
+++ b/src/mcp/slack-server.ts
@@ -163,6 +163,73 @@ let pipelineRuntime: PipelineToolRuntime | undefined;
 let catalogStore: CatalogStore | undefined;
 let slackArchiveApprovedChannelIds = new Set<string>();
 
+const pipelineOutcomeSchema = z.object({
+  assignmentId: z.string().min(1).describe("Exact signed assignment id being settled"),
+  expectedRunVersion: z.number().describe("Run state version read from pipeline_get_state"),
+  action: z.enum([
+    "continue_self",
+    "delegate",
+    "handoff",
+    "wait",
+    "escalate",
+    "complete",
+  ]),
+  status: z.enum([
+    "progress",
+    "succeeded",
+    "expected_behavior",
+    "not_reproduced",
+    "blocked",
+    "failed",
+  ]),
+  targetAgent: z.string().min(1).optional(),
+  reason: z.string().min(1),
+  evidenceRefs: z.array(z.string()).default([]),
+  artifactRefs: z.array(z.string()).default([]),
+  blockers: z.array(z.object({
+    kind: z.enum([
+      "missing_context",
+      "missing_authority",
+      "human_gate",
+      "unsafe_mutation",
+      "conflicting_evidence",
+      "no_progress",
+      "infra_failure",
+    ]),
+    detail: z.string().min(1),
+  })).default([]),
+  checks: z.array(z.object({
+    name: z.string().min(1),
+    status: z.enum(["passed", "failed", "skipped"]),
+    evidenceRef: z.string().optional(),
+  })).default([]),
+  confidence: z.number().optional(),
+  progressFingerprint: z.string().min(1),
+  wait: z.object({
+    conditionName: z.string().min(1),
+    wakeAt: z.number().optional(),
+    deadlineAt: z.number(),
+  }).optional(),
+  nextAssignment: z.object({
+    id: z.string().min(1).optional(),
+    parentAssignmentId: z.string().min(1).nullable().optional(),
+    targetAgent: z.string().min(1),
+    objective: z.string().min(1),
+    contextRefs: z.array(z.string()).default([]),
+    artifactRefs: z.array(z.string()).default([]),
+    acceptanceCriteria: z.array(z.string()).default([]),
+    mutationScope: z.array(z.string()).default([]),
+    dependsOn: z.array(z.string()).default([]),
+    attempt: z.number().default(1),
+    attemptId: z.string().min(1).nullable().optional(),
+    candidateRevisionDigest: z.string().min(1).nullable().optional(),
+    deadlineAt: z.number().nullable().optional(),
+    idempotencyKey: z.string().min(1),
+  }).optional(),
+}).describe(
+  "Typed AgentOutcome. For a successful review or build, use action=complete and status=succeeded. Blockers must be objects with an allowed kind and detail.",
+);
+
 /** Inject pipeline tool runtime (store + mode). Called from boot or tests. */
 export function setPipelineRuntime(runtime: PipelineToolRuntime | undefined): void {
   pipelineRuntime = runtime;
@@ -1812,9 +1879,7 @@ export function registerTools(server: McpServer, runContext: SlackMcpRunContext 
         "Settle the caller's exact signed assignment with continue_self|wait|escalate|complete. Use agent_dispatch for every agent-to-agent transition. " +
         "Runtime validates authority, state version, edges, and budgets; returns an explicit receipt.",
       inputSchema: {
-        outcome: z
-          .record(z.string(), z.unknown())
-          .describe("AgentOutcome object with assignmentId, expectedRunVersion, action, status, reason, evidenceRefs, artifactRefs, blockers, checks, progressFingerprint, plus wait when action=wait. For scheduled monitoring, wait includes wakeAt (next check) and deadlineAt (final stop); external-condition waits omit wakeAt."),
+        outcome: pipelineOutcomeSchema,
         to_phase: z.string().optional().describe("Optional phase advance"),
         idempotency_key: z.string().optional().describe("Duplicate-safe idempotency key"),
       },


### PR DESCRIPTION
## Summary
- expose the runtime AgentOutcome contract in `pipeline_report_outcome`
- constrain action/status/blocker/check/wait/next-assignment fields at the MCP boundary
- add a tools/list regression test and document the contract

This prevents provider payloads such as `status: "completed"` and string blockers from reaching runtime validation as apparently valid MCP inputs.

## Verification
- `bun run typecheck`
- `bun test src/mcp/slack-server.test.ts -t "serializes every registered tool"`
- `bun test src/pipelines/outcomes-handoffs.test.ts src/pipelines/settlement-recovery.test.ts src/pipelines/recovery.test.ts` (28 pass)

The full Slack/session suites still require the private `agents-org` submodule, which is unavailable in this checkout.