### PR TITLE
Fix GitHub authentication for worktree setup

### DIFF
--- a/docs/code_index/worktree-manager.md
+++ b/docs/code_index/worktree-manager.md
@@ -54,7 +54,12 @@ keeps stdout/stderr open. Git commands default to 30 seconds
 (`WORKTREE_GIT_TIMEOUT_MS`), setup scripts to 15 minutes
 (`WORKTREE_SETUP_TIMEOUT_MS`), and the force-kill grace is 1 second
 (`WORKTREE_TERMINATION_GRACE_MS`). The command environment disables terminal
-prompts, requires batch-mode SSH, and injects an empty Git credential helper.
+prompts, requires batch-mode SSH, and suppresses inherited Git credential
+helpers. When a repo has a verified `GH_TOKEN`, Junior creates a temporary
+0700 askpass helper that supplies GitHub's `x-access-token` username and that
+token for HTTPS authentication; the helper directory is removed after the
+bounded process exits. Without a verified token, Git uses a host-valid false
+askpass executable so private-repo auth fails fast rather than prompting.
 
 Before delegated setup, Junior requires 2 GiB of free space by default (`WORKTREE_SETUP_MIN_FREE_BYTES` overrides it). A script failure after `git worktree add` triggers rollback of the registered worktree and its branch; the surfaced stdout/stderr tails are capped independently.
 

--- a/docs/features/worktree-manager.md
+++ b/docs/features/worktree-manager.md
@@ -76,8 +76,13 @@ The bug-pipeline + dev-server fields are optional. Repos that only need the `!re
   force-kills it after `WORKTREE_TERMINATION_GRACE_MS` (1 second default), and
   cancels pipe readers so a grandchild holding stdout/stderr cannot keep the
   Slack turn alive. These processes are always noninteractive:
-  `GIT_TERMINAL_PROMPT=0`, batch-mode SSH, and an injected empty credential
-  helper prevent credential prompts from becoming hangs.
+  `GIT_TERMINAL_PROMPT=0`, batch-mode SSH, and suppressed inherited credential
+  helpers prevent credential prompts from becoming hangs. For a repo with a
+  verified `GH_TOKEN`, Junior supplies GitHub HTTPS credentials through a
+  temporary 0700 askpass helper (`x-access-token` plus the token), then removes
+  the helper after the bounded process exits. `GH_TOKEN` alone is not consumed
+  by Git's HTTPS transport. Repos without a verified token use a host-valid
+  false askpass executable and fail fast.
 - `removeWorktree(repoName, threadId) → Promise<void>` — reads the actual current branch via `git -C <wt> branch --show-current` before deletion (so cleanup works for `branchOverride` callers), force-removes the worktree, and `git branch -D`s the branch. It then verifies both the Git worktree registry and filesystem path are gone; a non-atomic leftover raises an incomplete-cleanup error with the path for preservation review. Branch lookup and deletion remain non-fatal for missing/detached state.
 - `worktreeExists(repoName, threadId) → Promise<boolean>` and `isWorktreeDirty(worktreePath) → Promise<boolean>` — used by cleanup.
 - `getWorktreePath(repoName, threadId) → string` and `getBranchName(threadId) → string` — pure helpers (no I/O).

--- a/src/worktree/manager.test.ts
+++ b/src/worktree/manager.test.ts
@@ -306,12 +306,15 @@ describe("WorktreeManager.createWorktree", () => {
 
   it("passes the selected GitHub account token to delegated setup", async () => {
     const authMarker = join(repoRoot, "github-auth-marker.txt");
+    const askpassMarker = join(repoRoot, "github-askpass-marker.txt");
     const authSetup = join(repoRoot, "github-auth-setup.sh");
     writeFileSync(
       authSetup,
       `#!/usr/bin/env bash
 set -e
 printf '%s' "\${GH_TOKEN:-}" > "${authMarker}"
+printf '%s\\n' "$($GIT_ASKPASS 'Username for https://github.com:')" > "${askpassMarker}"
+printf '%s\\n' "$($GIT_ASKPASS 'Password for https://github.com:')" >> "${askpassMarker}"
 BRANCH="$1"
 shift
 while [[ $# -gt 0 ]]; do
@@ -348,8 +351,10 @@ git worktree add "$TARGET" -b "$BRANCH" "$BASE"
     );
 
     expect(await Bun.file(authMarker).text()).toBe("selected-token");
+    expect(await Bun.file(askpassMarker).text()).toBe("x-access-token\nselected-token\n");
     await wm.removeWorktree("selected-auth-flow", "selected-auth-thread");
     rmSync(authMarker, { force: true });
+    rmSync(askpassMarker, { force: true });
     rmSync(authSetup, { force: true });
   });
 

--- a/src/worktree/manager.ts
+++ b/src/worktree/manager.ts
@@ -3,13 +3,18 @@ import { cleanGitHubEnvironment, GitHubAuthResolver } from "../github/auth.ts";
 import { statfs } from "node:fs/promises";
 import {
   closeSync,
+  chmodSync,
   existsSync,
+  mkdtempSync,
   mkdirSync,
   openSync,
+  rmSync,
   unlinkSync,
+  writeFileSync,
   writeSync,
 } from "node:fs";
-import { basename, join } from "node:path";
+import { basename, delimiter, join } from "node:path";
+import { tmpdir } from "node:os";
 import { terminateProcessTree } from "../lifecycle/process-tree.ts";
 import { ignoredDotenvPaths } from "./safety.ts";
 
@@ -22,6 +27,17 @@ const DEFAULT_TERMINATION_GRACE_MS = 1_000;
 const MAX_COMMAND_STREAM_CHARS = 110;
 const MAX_GIT_STREAM_CHARS = 64 * 1024;
 const SETUP_LOG_DIR = join(import.meta.dir, "..", "..", "logs", "worktree-setup");
+const GIT_ASKPASS_TOKEN_ENV = "JUNIOR_GIT_ASKPASS_TOKEN";
+const GIT_ASKPASS_SCRIPT = `#!/bin/sh
+case "$1" in
+  *[Pp][Aa][Ss][Ss][Ww][Oo][Rr][Dd]*)
+    printf '%s\\n' "\${${GIT_ASKPASS_TOKEN_ENV}:-}"
+    ;;
+  *)
+    printf '%s\\n' "x-access-token"
+    ;;
+esac
+`;
 
 export interface WorktreeManagerOptions {
   setupMinFreeBytes?: number;
@@ -538,21 +554,22 @@ export class WorktreeManager {
     maxStreamChars: number,
     logFd: number | null = null,
   ): Promise<{ exitCode: number | null; stdout: string; stderr: string; timedOut: boolean }> {
-    const proc = Bun.spawn(args, {
-      cwd,
-      env: this.commandEnvironment(githubEnv),
-      stdout: "pipe",
-      stderr: "pipe",
-      detached: true,
-    });
-    const stdout = this.startOutputDrain(proc.stdout, "stdout", maxStreamChars, logFd);
-    const stderr = this.startOutputDrain(proc.stderr, "stderr", maxStreamChars, logFd);
-    const completed = Promise.all([proc.exited, stdout.done, stderr.done]);
+    const commandEnvironment = this.commandEnvironment(githubEnv);
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timeout = new Promise<"timeout">((resolve) => {
       timer = setTimeout(() => resolve("timeout"), timeoutMs);
     });
     try {
+      const proc = Bun.spawn(args, {
+        cwd,
+        env: commandEnvironment.env,
+        stdout: "pipe",
+        stderr: "pipe",
+        detached: true,
+      });
+      const stdout = this.startOutputDrain(proc.stdout, "stdout", maxStreamChars, logFd);
+      const stderr = this.startOutputDrain(proc.stderr, "stderr", maxStreamChars, logFd);
+      const completed = Promise.all([proc.exited, stdout.done, stderr.done]);
       const outcome = await Promise.race([completed, timeout]);
       if (outcome === "timeout") {
         await terminateProcessTree(proc.pid, {
@@ -572,6 +589,7 @@ export class WorktreeManager {
       };
     } finally {
       clearTimeout(timer);
+      commandEnvironment.cleanup();
     }
   }
 
@@ -621,7 +639,7 @@ export class WorktreeManager {
 
   private commandEnvironment(
     githubEnv?: Record<string, string>,
-  ): Record<string, string> {
+  ): { env: Record<string, string>; cleanup: () => void } {
     const env = {
       ...cleanGitHubEnvironment({ isolatedConfig: true }),
       ...githubEnv,
@@ -631,16 +649,25 @@ export class WorktreeManager {
     // setup script receives a fail-fast, noninteractive transport contract.
     // The injected empty credential.helper resets any inherited helper list.
     const configuredSsh = env.GIT_SSH_COMMAND?.trim() || "ssh";
-    return {
+    const askpass = githubEnv?.GH_TOKEN
+      ? createGitAskpass()
+      : null;
+    const falseExecutable = resolveFalseExecutable();
+    const commandEnv: Record<string, string> = {
       ...env,
       GIT_TERMINAL_PROMPT: "0",
-      GIT_ASKPASS: "/bin/false",
-      SSH_ASKPASS: "/bin/false",
+      GIT_ASKPASS: askpass?.path ?? falseExecutable,
+      SSH_ASKPASS: falseExecutable,
       GCM_INTERACTIVE: "Never",
       GIT_SSH_COMMAND: `${configuredSsh} -oBatchMode=yes -oNumberOfPasswordPrompts=0 -oConnectTimeout=10`,
       GIT_CONFIG_COUNT: "1",
       GIT_CONFIG_KEY_0: "credential.helper",
       GIT_CONFIG_VALUE_0: "",
+    };
+    if (askpass) commandEnv[GIT_ASKPASS_TOKEN_ENV] = githubEnv!.GH_TOKEN!;
+    return {
+      env: commandEnv,
+      cleanup: () => askpass?.cleanup(),
     };
   }
 
@@ -652,4 +679,30 @@ export class WorktreeManager {
     const candidate = override ?? Number(process.env[envName] ?? fallback);
     return Number.isFinite(candidate) && candidate > 0 ? candidate : fallback;
   }
+}
+
+function createGitAskpass(): { path: string; cleanup: () => void } {
+  const directory = mkdtempSync(join(tmpdir(), "junior-git-askpass-"));
+  chmodSync(directory, 0o700);
+  const path = join(directory, "askpass.sh");
+  writeFileSync(path, GIT_ASKPASS_SCRIPT, { mode: 0o700 });
+  chmodSync(path, 0o700);
+  return {
+    path,
+    cleanup: () => rmSync(directory, { recursive: true, force: true }),
+  };
+}
+
+function resolveFalseExecutable(): string {
+  const candidates = ["/usr/bin/false", "/bin/false"];
+  for (const candidate of candidates) {
+    if (existsSync(candidate)) return candidate;
+  }
+  const executable = process.platform === "win32" ? "false.exe" : "false";
+  for (const directory of (process.env.PATH ?? "").split(delimiter)) {
+    if (!directory) continue;
+    const candidate = join(directory, executable);
+    if (existsSync(candidate)) return candidate;
+  }
+  return executable;
 }


### PR DESCRIPTION
## Summary\n\n- Provide a temporary, permission-locked Git askpass helper when a repo has a verified GitHub token.\n- Preserve fail-fast noninteractive behavior for repos without a token.\n- Clean up the helper after inline Git or delegated setup commands finish.\n- Document and test selected-account HTTPS authentication.\n\n## Verification\n\n- bun run typecheck\n- bun test src/worktree/manager.test.ts src/worktree/prune.test.ts src/lifecycle/dev-server.test.ts (48 passed)\n\n## Scope\n\nThe pre-existing dirty agents-org submodule was not included.