### PR TITLE
feat: support multiple MongoDB MCP connections

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -124,7 +124,11 @@ MCP_PORT=3456
 # Generate a stable value once with: openssl rand -hex 32
 # MCP_CONTEXT_SECRET=
 
-# MongoDB MCP server. Use read-only credentials.
+# MongoDB MCP server. Use read-only credentials. Named targets are exposed as
+# a required selector to the agent; keep real URIs in local .env or a secret
+# manager.
+# MDB_MCP_CONNECTIONS={"prod":"mongodb+srv://<readonly-user>:<password>@<prod-cluster>/gx-prod-database","dev":"mongodb+srv://<readonly-user>:<password>@<dev-cluster>/GX-debug"}
+# Legacy single-connection fallback:
 MDB_MCP_CONNECTION_STRING=mongodb+srv://<readonly-user>:<password>@<cluster>/<database>?retryWrites=true&w=majority
 MONGODB_MCP_PROXY_IDLE_TTL_MS=600000
 MONGODB_MCP_PROXY_REQUEST_TIMEOUT_MS=120000

--- a/docs/code_index/mcp-server.md
+++ b/docs/code_index/mcp-server.md
@@ -12,8 +12,8 @@ operations using the bot token and signed run context.
 |---|---|---|
 | `startMcpServer(deps)` | `slack-server.ts` | Starts HTTP server on `MCP_PORT` (default 3456), binding `127.0.0.1` and best-effort `::1`. Optional dependencies wire stores and pipeline services. |
 | `registerTools(server)` (internal) | `slack-server.ts` | Registers Slack, worktree, and agent-registry tools on a fresh `McpServer` per request. |
-| `handleMongoMcpRequest(req, res)` | `mongodb-proxy.ts` | Serves `/mcp/mongodb` as a stateless HTTP MCP proxy to one shared read-only MongoDB stdio backend; hides upstream connection selection, injects the environment-backed `preconfigured` ID, and requires explicit `find.limit` values from 1–100. |
-| `closeMongoMcpBackend()` | `mongodb-proxy.ts` | Closes the shared backend immediately; also used by the idle TTL. |
+| `handleMongoMcpRequest(req, res)` | `mongodb-proxy.ts` | Serves `/mcp/mongodb` as a stateless HTTP MCP proxy to named read-only MongoDB stdio backends; adds a required configured-connection selector, injects each backend's upstream `preconfigured` ID, and requires explicit `find.limit` values from 1–100. |
+| `closeMongoMcpBackend()` | `mongodb-proxy.ts` | Closes all configured Mongo backends immediately; also used by the idle TTL. |
 | `handleMixpanelMcpRequest(req, res)` | `mixpanel-proxy.ts` | Serves `/mcp/mixpanel` as one signed read-only MCP surface over all configured Mixpanel regions. |
 | `createMixpanelProxyServer(...)` | `mixpanel-proxy.ts` | Unions safe upstream tools, adds the required `region` selector, strips it before forwarding, and rejects write tools. |
 | `closeMixpanelMcpBackends()` | `mixpanel-proxy.ts` | Closes the shared per-region HTTP clients immediately; also used by the idle TTL. |

--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -115,14 +115,19 @@ Status pill updates that agents post mid-run go through `slack_send_message` wit
   approval, disable its stored actions, and remove its buttons; a delayed Slack
   decision cannot outlive the provider process that requested it. An ordinary
   approval timeout/default deny performs the same idempotent cleanup.
-- MongoDB MCP uses `MDB_MCP_CONNECTION_STRING` from the process environment.
-  `.env.example` includes a placeholder; real values belong only in local
-  `.env` or secret managers. Junior exposes a shared read-only HTTP proxy at
-  `/mcp/mongodb`, backed by one wrapped `mongodb-mcp-server@2.1.0 --readOnly`
-  stdio child. Mongo MCP v2 registers the environment connection as
-  `preconfigured`; the proxy removes `connectionId` from exposed schemas and
-  injects that ID itself so agents cannot select or guess connections. Runner adapters inject that proxy only when the active agent
-  declares `permissions.mcp: mongodb` or lists `mcp__mongodb__*` tools.
+- MongoDB MCP uses named read-only connections from `MDB_MCP_CONNECTIONS`, a
+  JSON object mapping stable IDs such as `dev` and `prod` to connection
+  strings. `.env.example` includes a placeholder; real values belong only in
+  local `.env` or secret managers. Junior exposes a shared read-only HTTP
+  proxy at `/mcp/mongodb`, backed by one wrapped
+  `mongodb-mcp-server@2.1.0 --readOnly` stdio child per configured target.
+  The proxy unions the safe tool schemas and adds a required `connection`
+  selector, then injects the upstream `preconfigured` ID into the selected
+  backend. Agents cannot supply raw connection strings or select arbitrary
+  upstream IDs. The legacy `MDB_MCP_CONNECTION_STRING` remains supported as a
+  single `preconfigured` target. Runner adapters inject that proxy only when
+  the active agent declares `permissions.mcp: mongodb` or lists
+  `mcp__mongodb__*` tools.
   Disable with `OPENCODE_MONGODB_MCP_ENABLED=false` /
   `CODEX_MONGODB_MCP_ENABLED=false`.
   The proxy requires every `find` call to provide an explicit integer

--- a/src/claude/policy.ts
+++ b/src/claude/policy.ts
@@ -67,6 +67,7 @@ export const DIRECT_DATABASE_ACCESS_DISALLOWED = [
   "Bash(*mongodb+srv://*)",
   "Bash(*mongodb://*)",
   "Bash(*DB_STRING*)",
+  "Bash(*MDB_MCP_CONNECTIONS*)",
   "Bash(*MDB_MCP_CONNECTION_STRING*)",
   "Bash(*.env*)",
   "Read(**/.env)",

--- a/src/mcp/mongodb-proxy.test.ts
+++ b/src/mcp/mongodb-proxy.test.ts
@@ -1,8 +1,11 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import type { SlackMcpRunContext } from "./context.ts";
-import { createMongoProxyServer } from "./mongodb-proxy.ts";
+import {
+  configuredMongoConnections,
+  createMongoProxyServer,
+} from "./mongodb-proxy.ts";
 
 const RUN_CONTEXT: SlackMcpRunContext = {
   agent: "thinker",
@@ -10,6 +13,12 @@ const RUN_CONTEXT: SlackMcpRunContext = {
   threadId: "thread-1",
   signed: true,
 };
+
+const originalConnections = process.env.MDB_MCP_CONNECTIONS;
+afterEach(() => {
+  if (originalConnections === undefined) delete process.env.MDB_MCP_CONNECTIONS;
+  else process.env.MDB_MCP_CONNECTIONS = originalConnections;
+});
 
 describe("MongoDB MCP read-only proxy", () => {
   it("mirrors backend schemas and forwards nested filter arguments", async () => {
@@ -59,6 +68,7 @@ describe("MongoDB MCP read-only proxy", () => {
     const server = createMongoProxyServer(
       RUN_CONTEXT,
       async () => ({ client: backendClient as never }),
+      ["preconfigured"],
     );
     const client = new Client({ name: "mongo-proxy-test", version: "0.1.0" });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
@@ -71,6 +81,7 @@ describe("MongoDB MCP read-only proxy", () => {
       expect(tools.map((tool) => tool.name)).toEqual(["find"]);
       expect(tools[0]?.inputSchema).toMatchObject({
         properties: {
+          connection: { type: "string", enum: ["preconfigured"] },
           database: { type: "string" },
           filter: {
             type: "object",
@@ -86,7 +97,7 @@ describe("MongoDB MCP read-only proxy", () => {
         description: "Upstream page size. Must be between 1 and 100.",
         "x-upstream": "preserved",
       });
-      expect(tools[0]?.inputSchema.required).toEqual(["database", "collection", "limit"]);
+      expect(tools[0]?.inputSchema.required).toEqual(["connection", "database", "collection", "limit"]);
 
       const filter = {
         status: { $in: ["active", "trial"] },
@@ -95,6 +106,7 @@ describe("MongoDB MCP read-only proxy", () => {
       const result = await client.callTool({
         name: "find",
         arguments: {
+          connection: "preconfigured",
           database: "app",
           collection: "members",
           filter,
@@ -126,7 +138,7 @@ describe("MongoDB MCP read-only proxy", () => {
         async listTools() { return { tools: [] }; },
         async callTool() { called = true; return { content: [{ type: "text" as const, text: "unexpected" }] }; },
       } as never,
-    }));
+    }), ["preconfigured"]);
     const client = new Client({ name: "mongo-proxy-test", version: "0.1.0" });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     await server.connect(serverTransport);
@@ -135,7 +147,12 @@ describe("MongoDB MCP read-only proxy", () => {
       for (const limit of [undefined, 101, 0]) {
         const result = await client.callTool({
           name: "find",
-          arguments: { database: "app", collection: "members", ...(limit === undefined ? {} : { limit }) },
+          arguments: {
+            connection: "preconfigured",
+            database: "app",
+            collection: "members",
+            ...(limit === undefined ? {} : { limit }),
+          },
         });
         expect(result.isError).toBe(true);
       }
@@ -153,7 +170,7 @@ describe("MongoDB MCP read-only proxy", () => {
         async listTools() { return { tools: [] }; },
         async callTool() { called = true; return { content: [{ type: "text" as const, text: "unexpected" }] }; },
       } as never,
-    }));
+    }), ["preconfigured"]);
     const client = new Client({ name: "mongo-proxy-test", version: "0.1.0" });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     await server.connect(serverTransport);
@@ -183,7 +200,7 @@ describe("MongoDB MCP read-only proxy", () => {
           return { content: [{ type: "text" as const, text: "ok" }] };
         },
       } as never,
-    }));
+    }), ["preconfigured"]);
     const client = new Client({ name: "mongo-proxy-test", version: "0.1.0" });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
     await server.connect(serverTransport);
@@ -192,7 +209,7 @@ describe("MongoDB MCP read-only proxy", () => {
     try {
       await client.callTool({
         name: "list-databases",
-        arguments: { connectionId: "growthx-prod" },
+        arguments: { connection: "preconfigured", connectionId: "growthx-prod" },
       });
       expect(calls).toEqual([{
         name: "list-databases",
@@ -223,6 +240,7 @@ describe("MongoDB MCP read-only proxy", () => {
     const server = createMongoProxyServer(
       RUN_CONTEXT,
       async () => ({ client: backendClient as never }),
+      ["preconfigured"],
     );
     const client = new Client({ name: "mongo-proxy-test", version: "0.1.0" });
     const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
@@ -242,5 +260,67 @@ describe("MongoDB MCP read-only proxy", () => {
       await client.close();
       await server.close();
     }
+  });
+
+  it("routes calls through the selected named connection", async () => {
+    const calls: Array<{ connectionId: string; request: unknown }> = [];
+    const server = createMongoProxyServer(
+      RUN_CONTEXT,
+      async (connectionId) => ({
+        client: {
+          async listTools() {
+            return {
+              tools: [{
+                name: "list-databases",
+                inputSchema: { type: "object" as const },
+              }],
+            };
+          },
+          async callTool(request: unknown) {
+            calls.push({ connectionId, request });
+            return { content: [{ type: "text" as const, text: connectionId }] };
+          },
+        } as never,
+      }),
+      ["dev", "prod"],
+    );
+    const client = new Client({ name: "mongo-proxy-test", version: "0.1.0" });
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    await client.connect(clientTransport);
+
+    try {
+      const { tools } = await client.listTools();
+      expect(tools[0]?.inputSchema).toMatchObject({
+        properties: { connection: { type: "string", enum: ["dev", "prod"] } },
+        required: ["connection"],
+      });
+      const result = await client.callTool({
+        name: "list-databases",
+        arguments: { connection: "dev" },
+      });
+      expect(result.isError).not.toBe(true);
+      expect(calls).toEqual([{
+        connectionId: "dev",
+        request: {
+          name: "list-databases",
+          arguments: { connectionId: "preconfigured" },
+        },
+      }]);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  });
+
+  it("parses named connection URIs without exposing them", () => {
+    process.env.MDB_MCP_CONNECTIONS = JSON.stringify({
+      prod: "mongodb://prod.example/test",
+      dev: "mongodb://dev.example/GX-debug",
+    });
+    expect(configuredMongoConnections()).toEqual([
+      { id: "dev", connectionString: "mongodb://dev.example/GX-debug" },
+      { id: "prod", connectionString: "mongodb://prod.example/test" },
+    ]);
   });
 });

--- a/src/mcp/mongodb-proxy.ts
+++ b/src/mcp/mongodb-proxy.ts
@@ -17,6 +17,7 @@ const MONGODB_PROXY_REQUEST_TIMEOUT_MS = Number(process.env.MONGODB_MCP_PROXY_RE
 const MONGODB_PRECONFIGURED_CONNECTION_ID = "preconfigured";
 const MONGODB_MCP_PACKAGE = "mongodb-mcp-server@2.1.0";
 export const MONGODB_FIND_MAX_LIMIT = 100;
+const MONGODB_CONNECTION_ID_PATTERN = /^[a-z0-9]+(?:[-_][a-z0-9]+)*$/;
 const MONGODB_TOOL_NAMES = [
   "aggregate",
   "collection-schema",
@@ -26,15 +27,20 @@ const MONGODB_TOOL_NAMES = [
   "list-databases",
 ] as const;
 
+export interface MongoConnectionConfig {
+  id: string;
+  connectionString: string;
+}
+
 interface MongoBackend {
   client: Client;
   transport: StdioClientTransport;
 }
 
 type MongoBackendClient = Pick<Client, "callTool" | "listTools">;
-type MongoBackendProvider = () => Promise<{ client: MongoBackendClient }>;
+type MongoBackendProvider = (connectionId: string) => Promise<{ client: MongoBackendClient }>;
 
-let backend: Promise<MongoBackend> | null = null;
+const backends = new Map<string, Promise<MongoBackend>>();
 let idleTimer: ReturnType<typeof setTimeout> | null = null;
 
 export async function handleMongoMcpRequest(
@@ -61,6 +67,7 @@ export async function handleMongoMcpRequest(
 export function createMongoProxyServer(
   runContext: SlackMcpRunContext | null,
   backendProvider: MongoBackendProvider = getMongoBackend,
+  configuredConnections: string[] = configuredMongoConnectionIds(),
 ): Server {
   const server = new Server(
     { name: "mongodb", version: "0.1.0" },
@@ -68,18 +75,27 @@ export function createMongoProxyServer(
   );
 
   server.setRequestHandler(ListToolsRequestSchema, async () => {
-    const { client } = await backendProvider();
+    if (configuredConnections.length === 0) {
+      throw new Error("No MongoDB MCP connections are configured");
+    }
+    const byConnection = await Promise.all(configuredConnections.map(async (connectionId) => {
+      const { client } = await backendProvider(connectionId);
+      return { connectionId, tools: (await client.listTools()).tools };
+    }));
     armIdleTimer();
-    const { tools } = await client.listTools();
+    const union = new Map<string, (typeof byConnection)[number]["tools"][number]>();
+    for (const { tools } of byConnection) {
+      for (const tool of tools) {
+        if (isAllowedMongoTool(tool.name) && !union.has(tool.name)) union.set(tool.name, tool);
+      }
+    }
     return {
-      tools: tools
-        .filter((tool) => isAllowedMongoTool(tool.name))
-        .map(hideMongoConnectionId),
+      tools: [...union.values()].map((tool) => addConnectionToSchema(tool, configuredConnections)),
     };
   });
 
   server.setRequestHandler(CallToolRequestSchema, async (request) => {
-    const { name, arguments: args } = request.params;
+    const { name, arguments: rawArgs } = request.params;
     if (!isAllowedMongoTool(name)) {
       return mongoProxyError(`tool "${name}" is not available through the read-only proxy.`);
     }
@@ -88,9 +104,17 @@ export function createMongoProxyServer(
     }
 
     try {
+      const args = { ...(rawArgs ?? {}) };
+      const connectionId = args.connection;
+      delete args.connection;
+      if (typeof connectionId !== "string" || !configuredConnections.includes(connectionId)) {
+        return mongoProxyError(
+          `connection must be one of the configured connections: ${configuredConnections.join(", ") || "none"}.`,
+        );
+      }
       const validation = validateMongoToolArguments(name, args ?? {});
       if (validation) return mongoProxyError(validation);
-      const { client } = await backendProvider();
+      const { client } = await backendProvider(connectionId);
       armIdleTimer();
       return await client.callTool(
         {
@@ -184,12 +208,13 @@ function validateMongoToolArguments(
 export async function closeMongoMcpBackend(): Promise<void> {
   if (idleTimer) clearTimeout(idleTimer);
   idleTimer = null;
-  const current = backend;
-  backend = null;
-  if (!current) return;
-  const { client, transport } = await current.catch(() => ({ client: null, transport: null }));
-  await client?.close().catch(() => undefined);
-  await transport?.close().catch(() => undefined);
+  const active = [...backends.values()];
+  backends.clear();
+  await Promise.all(active.map(async (current) => {
+    const { client, transport } = await current.catch(() => ({ client: null, transport: null }));
+    await client?.close().catch(() => undefined);
+    await transport?.close().catch(() => undefined);
+  }));
 }
 
 function isAllowedMongoTool(name: string): name is typeof MONGODB_TOOL_NAMES[number] {
@@ -206,16 +231,60 @@ function mongoProxyError(message: string): CallToolResult {
   };
 }
 
-function getMongoBackend(): Promise<MongoBackend> {
-  if (!backend) backend = startMongoBackend();
-  armIdleTimer();
-  return backend;
+export function configuredMongoConnections(): MongoConnectionConfig[] {
+  const raw = process.env.MDB_MCP_CONNECTIONS?.trim();
+  if (!raw) {
+    const legacy = process.env.MDB_MCP_CONNECTION_STRING?.trim();
+    return legacy ? [{ id: "preconfigured", connectionString: legacy }] : [];
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error("MDB_MCP_CONNECTIONS must be a JSON object mapping connection IDs to MongoDB URIs");
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("MDB_MCP_CONNECTIONS must be a JSON object mapping connection IDs to MongoDB URIs");
+  }
+
+  const connections = Object.entries(parsed as Record<string, unknown>)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([id, value]) => {
+      if (!MONGODB_CONNECTION_ID_PATTERN.test(id)) {
+        throw new Error(`Invalid MongoDB MCP connection ID "${id}"`);
+      }
+      if (typeof value !== "string" || !value.trim()) {
+        throw new Error(`MongoDB MCP connection "${id}" must have a non-empty URI`);
+      }
+      return { id, connectionString: value.trim() };
+    });
+  if (connections.length === 0) {
+    throw new Error("MDB_MCP_CONNECTIONS must configure at least one connection");
+  }
+  return connections;
 }
 
-async function startMongoBackend(): Promise<MongoBackend> {
-  if (!process.env.MDB_MCP_CONNECTION_STRING?.trim()) {
-    throw new Error("MDB_MCP_CONNECTION_STRING is not configured");
+export function configuredMongoConnectionIds(): string[] {
+  return configuredMongoConnections().map(({ id }) => id);
+}
+
+function getMongoBackend(connectionId: string): Promise<MongoBackend> {
+  let current = backends.get(connectionId);
+  if (!current) {
+    const connection = configuredMongoConnections().find(({ id }) => id === connectionId);
+    if (!connection) throw new Error(`MongoDB MCP connection "${connectionId}" is not configured`);
+    current = startMongoBackend(connection).catch((err) => {
+      backends.delete(connectionId);
+      throw err;
+    });
+    backends.set(connectionId, current);
   }
+  armIdleTimer();
+  return current;
+}
+
+async function startMongoBackend(connection: MongoConnectionConfig): Promise<MongoBackend> {
   const transport = new StdioClientTransport({
     command: resolve(
       import.meta.dirname ?? ".",
@@ -224,7 +293,8 @@ async function startMongoBackend(): Promise<MongoBackend> {
     args: ["--", "npx", "-y", MONGODB_MCP_PACKAGE, "--readOnly"],
     env: {
       ...process.env,
-      MDB_MCP_CONNECTION_STRING: process.env.MDB_MCP_CONNECTION_STRING ?? "",
+      MDB_MCP_CONNECTIONS: "",
+      MDB_MCP_CONNECTION_STRING: connection.connectionString,
     },
     stderr: "pipe",
   });
@@ -232,17 +302,39 @@ async function startMongoBackend(): Promise<MongoBackend> {
     log.warn("mongodb-mcp", `backend error: ${err.message}`);
   };
   transport.onclose = () => {
-    backend = null;
-    log.info("mongodb-mcp", "backend closed");
+    backends.delete(connection.id);
+    log.info("mongodb-mcp", `${connection.id} backend closed`);
   };
 
   const client = new Client(
-    { name: "junior-mongodb-mcp-proxy", version: "0.1.0" },
+    { name: `junior-mongodb-${connection.id}-proxy`, version: "0.1.0" },
     { capabilities: {} },
   );
   await client.connect(transport);
-  log.info("mongodb-mcp", `backend started pid=${transport.pid ?? "unknown"}`);
+  log.info("mongodb-mcp", `${connection.id} backend started pid=${transport.pid ?? "unknown"}`);
   return { client, transport };
+}
+
+function addConnectionToSchema<T extends { name: string; description?: string; inputSchema: Record<string, unknown> }>(
+  tool: T,
+  connections: string[],
+): T {
+  const sanitized = hideMongoConnectionId(tool);
+  const schema = sanitized.inputSchema;
+  const properties = schema.properties && typeof schema.properties === "object"
+    ? { ...(schema.properties as Record<string, unknown>) }
+    : {};
+  properties.connection = {
+    type: "string",
+    enum: connections,
+    description: "Configured MongoDB connection for this request.",
+  };
+  const required = Array.isArray(schema.required) ? [...schema.required] : [];
+  if (!required.includes("connection")) required.unshift("connection");
+  return {
+    ...sanitized,
+    inputSchema: { ...schema, type: "object", properties, required },
+  };
 }
 
 function armIdleTimer(): void {

--- a/src/runners/runtime.ts
+++ b/src/runners/runtime.ts
@@ -18,6 +18,7 @@ export interface RunnerRuntime {
 }
 
 export const DATABASE_CREDENTIAL_ENV_KEYS = [
+  "MDB_MCP_CONNECTIONS",
   "MDB_MCP_CONNECTION_STRING",
   "DB_STRING",
   "MONGODB_URI",


### PR DESCRIPTION
## Summary
- mirror the Mixpanel multi-target proxy pattern for MongoDB
- route through named read-only backends with a required connection selector
- preserve the legacy single-connection fallback and scrub the new credential env

## Verification
- bun run typecheck
- bun test
- 2319 passing, 4 skipped, 0 failing

This is isolated from the unrelated worktree-auth commit on the previous branch.