### PR TITLE
feat: add safe MCP worktree unregister

### DIFF
--- a/docs/code_index/mcp-server.md
+++ b/docs/code_index/mcp-server.md
@@ -32,6 +32,7 @@ operations using the bot token and signed run context.
 | `slack_search_users` | `users.list` (filtered) | `query` | — |
 | `slack_upload_file` | `files.getUploadURLExternal` + `completeUploadExternal` | `file_path`, `channel_id` | `thread_ts`, `comment` |
 | `register_worktree` | Junior internal | `thread_id`, `repo` | `branch` (branch-name override) |
+| `unregister_worktree` | Junior internal | `repo` | `discard_changes` (human-confirmed destructive override) |
 | `agent_search` | Junior internal | — | `query`, `include_public`, `include_private`, `limit` |
 | `reload_agent_registry` | Junior internal | — | — |
 | `slack_send_dm` | Slack Web API | `user_id`, `text` | identity fields |
@@ -65,6 +66,13 @@ Messages sent via `slack_send_message` carry Junior's `bot_id`. Optional `userna
 ### `register_worktree` tool
 
 Called by lead/intake to create a per-thread worktree for a repo and persist its path into `session.worktreePaths[repoName]`. Multi-repo bug-pipeline support — `worktreePaths` keys are repo names from `REPOS` config. Refetch-then-mutate guards against concurrent session writes.
+
+### `unregister_worktree` tool
+
+Bound to the signed current-thread context. Checks the registered path with
+`getWorktreeStatus`, refuses preservation-sensitive state unless
+`discard_changes` is explicitly true after human confirmation, removes the
+worktree/branch, and semantically mutates the session to drop only that repo.
 
 ### Agent registry tools
 

--- a/docs/code_index/worktree-manager.md
+++ b/docs/code_index/worktree-manager.md
@@ -10,7 +10,7 @@ Creates, removes, and inspects git worktrees in target repos for per-thread code
 |---|---|---|
 | `WorktreeManager(repos, options?)` | `manager.ts` | Constructor — keeps `RepoConfig[]`; options support deterministic disk-headroom tests and an injectable repo-scoped GitHub auth resolver. |
 | `createWorktree(repoName, threadId, baseRef?, branchOverride?)` | `manager.ts` | Creates worktree. `baseRef` defaults to `repo.defaultBase`. `branchOverride` defaults to `slack/<threadId>`. Returns absolute path. |
-| `removeWorktree(repoName, threadId)` | `manager.ts` | `git worktree remove --force` + `git branch -D`, then verifies both registry absence and filesystem absence (queries actual branch name first to handle `branchOverride`) |
+| `removeWorktree(repoName, threadId, { force? })` | `manager.ts` | `git worktree remove` (force by default; safe cleanup can omit `--force`) + `git branch -D`, then verifies both registry absence and filesystem absence (queries actual branch name first to handle `branchOverride`) |
 | `worktreeExists(repoName, threadId)` | `manager.ts` | Filesystem check via `node:fs/promises.stat` |
 | `isWorktreeDirty(worktreePath)` | `manager.ts` | `git status --porcelain` |
 | `getWorktreeStatus(worktreePath, repoName?)` | `manager.ts` | Reports tracked/untracked changes, unpushed commits, and ignored dotenv paths (path names only; contents are never read). |
@@ -86,9 +86,9 @@ Durable pipeline assignments use a stricter path: `pipeline-routing.ts` resolves
 
 ### Dirty-check before remove
 
-Callers should `isWorktreeDirty(path)` before `removeWorktree` so uncommitted work isn't silently destroyed. Removal also verifies that Git's registry entry and the filesystem path are both gone; a leftover (for example, an ignored dotenv file) raises an incomplete-cleanup error for preservation review. The cleanup pass in `lifecycle/cleanup.ts` skips busy/draining and deletes only stale idle sessions; worktree removal itself is not currently automatic on cleanup (worktrees outlive the session row).
+Callers should inspect preservation state before `removeWorktree` so uncommitted work isn't silently destroyed. The Slack cleanup action and signed MCP `unregister_worktree` tool use `getWorktreeStatus`; the MCP path requires an explicit human-confirmed `discard_changes` override to delete unsafe state. Removal also verifies that Git's registry entry and the filesystem path are both gone; a leftover (for example, an ignored dotenv file) raises an incomplete-cleanup error for preservation review. The cleanup pass in `lifecycle/cleanup.ts` skips busy/draining and deletes only stale idle sessions; worktree removal itself is not currently automatic on cleanup (worktrees outlive the session row).
 
 ## Dependencies
 
 - **Uses**: `config.RepoConfig`, `Bun.spawn` (git, optional setup script), `node:fs/promises` (stat)
-- **Used by**: `SessionManager.runRunnerWithAgent` (per-thread and durable pipeline provisioning), `DevServerManager.bootstrap` (shared dev-server worktree), MCP `register_worktree` tool (explicit/manual routing)
+- **Used by**: `SessionManager.runRunnerWithAgent` (per-thread and durable pipeline provisioning), `DevServerManager.bootstrap` (shared dev-server worktree), MCP `register_worktree` / `unregister_worktree` tools (explicit/manual lifecycle)

--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -53,6 +53,7 @@ Junior main process
 | `slack_search_users` | `users.list` | Find users by name, email, or title |
 | `slack_upload_file` | `files.getUploadURLExternal` | Upload files to channels/threads |
 | `register_worktree` | (internal) | Create a per-thread worktree in a routed repo and persist its path on the session |
+| `unregister_worktree` | (internal) | Safely prune one current-thread worktree and remove its session registration; destructive discard requires explicit confirmation |
 | `agent_search` | (internal) | Search public/private agent definitions and show dispatch registration state |
 | `reload_agent_registry` | (internal) | Reload private overlay agent identities so newly added workers become dispatchable |
 | `memory_recall` | (internal SQLite + profiles) | Recall v3 memory: keyed entity profiles (by `entity_refs`) + semantic claims (query embedded locally, cosine-ranked) |
@@ -66,6 +67,13 @@ Junior main process
 Slack tools require explicit `channel_id` and `thread_ts` parameters. The spawned Claude already knows its thread coordinates from the prompt preamble built by `buildPromptPreamble()`.
 
 `register_worktree` is wired to Junior's `SessionStore` and `WorktreeManager` (passed into `startMcpServer`). It's invoked by agents during intake — once per routed repo — and writes `session.worktreePaths[repo]`. The `branch` arg is a branch-name override (not a base ref); `createWorktree` keeps `branchOverride` distinct from `baseRef` so callers can name the branch without changing what it forks from. See [worktree-manager.md](./worktree-manager.md) and [session-management.md](./session-management.md).
+
+`unregister_worktree` is available only with signed run context and derives the
+thread ID from that context rather than accepting an agent-supplied thread. It
+uses the same preservation policy as the Slack cleanup action, removes the
+worktree and branch through `WorktreeManager`, and then uses the session store's
+semantic mutation API to unregister the selected repo without clobbering
+concurrent session updates.
 
 Status pill updates that agents post mid-run go through `slack_send_message` with a stable `username` / `icon_emoji` identity — the streaming layer keys pills per-agent off those fields. See [stream-to-slack.md](./stream-to-slack.md).
 

--- a/docs/features/worktree-manager.md
+++ b/docs/features/worktree-manager.md
@@ -83,11 +83,21 @@ The bug-pipeline + dev-server fields are optional. Repos that only need the `!re
   the helper after the bounded process exits. `GH_TOKEN` alone is not consumed
   by Git's HTTPS transport. Repos without a verified token use a host-valid
   false askpass executable and fail fast.
-- `removeWorktree(repoName, threadId) → Promise<void>` — reads the actual current branch via `git -C <wt> branch --show-current` before deletion (so cleanup works for `branchOverride` callers), force-removes the worktree, and `git branch -D`s the branch. It then verifies both the Git worktree registry and filesystem path are gone; a non-atomic leftover raises an incomplete-cleanup error with the path for preservation review. Branch lookup and deletion remain non-fatal for missing/detached state.
+- `removeWorktree(repoName, threadId, { force? }) → Promise<void>` — reads the actual current branch via `git -C <wt> branch --show-current` before deletion (so cleanup works for `branchOverride` callers), removes the worktree (forcefully by default; safe cleanup passes `force: false` so Git gets a final dirty-worktree guard), and `git branch -D`s the branch. It then verifies both the Git worktree registry and filesystem path are gone; a non-atomic leftover raises an incomplete-cleanup error with the path for preservation review. Branch lookup and deletion remain non-fatal for missing/detached state.
 - `worktreeExists(repoName, threadId) → Promise<boolean>` and `isWorktreeDirty(worktreePath) → Promise<boolean>` — used by cleanup.
 - `getWorktreePath(repoName, threadId) → string` and `getBranchName(threadId) → string` — pure helpers (no I/O).
 
 The MCP tool `mcp__slack-bot__register_worktree({ thread_id, repo, branch? })` (in `src/mcp/slack-server.ts`) wraps `createWorktree` for lead's intake and persists the resulting path into `session.worktreePaths[repo]` via the session store using the refetch-then-mutate pattern.
+
+The signed MCP tool `mcp__slack-bot__unregister_worktree({ repo, discard_changes? })`
+is the matching teardown path. It is bound to the authenticated current Slack
+thread, checks the registered worktree for tracked/untracked changes, ignored
+dotenv files, and unpushed commits, then calls `removeWorktree` and removes only
+that repo from the session's worktree fields. Preservation-sensitive state is
+refused by default. `discard_changes: true` is an explicit destructive override
+that agents may use only after a human confirms permanent deletion. The
+`worktree-mutate` capability exposes this tool to Junior without granting it to
+read-only workers.
 
 ## Deterministic prune script
 

--- a/src/claude/policy.test.ts
+++ b/src/claude/policy.test.ts
@@ -138,6 +138,15 @@ describe("mapClaudeRunPolicy", () => {
     expect(policy.addDirs).toEqual(["/repo"]);
   });
 
+  test("worktree-mutate capability exposes managed unregister", () => {
+    const session = sessionWith({ intent: "read-only", mcp: ["slack-bot"], tools: [] });
+    session.assignmentCapabilities = ["worktree-mutate"];
+
+    const policy = mapClaudeRunPolicy({ config, session, cwd: "/repo" });
+
+    expect(policy.allowedTools).toContain("mcp__slack-bot__unregister_worktree");
+  });
+
   test("denies provider-native fan-out for orchestrators too", () => {
     const session = createSession("t", "c");
     session.activeAgentName = "default";

--- a/src/claude/policy.ts
+++ b/src/claude/policy.ts
@@ -124,6 +124,9 @@ export function mapClaudeRunPolicy(options: {
     ...(subjectHasCapability(session, "pipeline-run-start")
       ? ["mcp__slack-bot__pipeline_start_run"]
       : []),
+    ...(subjectHasCapability(session, "worktree-mutate")
+      ? ["mcp__slack-bot__unregister_worktree"]
+      : []),
   ];
   const worktreeRoots = [
     session.worktreePath,

--- a/src/mcp/slack-server.test.ts
+++ b/src/mcp/slack-server.test.ts
@@ -13,6 +13,7 @@ import {
   registerTools,
   searchAgentDefinitions,
   sendSlackDirectMessage,
+  unregisterWorktree,
   type MemoryToolDeps,
 } from "./slack-server.ts";
 import { createMemoryStore } from "../memory/factory.ts";
@@ -79,6 +80,14 @@ describe("MCP Slack tool catalogue", () => {
         },
       });
       expect(names).toContain("memory_feedback");
+      const unregister = tools.find((tool) => tool.name === "unregister_worktree");
+      expect(unregister?.inputSchema).toMatchObject({
+        properties: {
+          repo: { type: "string" },
+          discard_changes: { type: "boolean" },
+        },
+        required: ["repo"],
+      });
       const dispatch = tools.find((tool) => tool.name === "agent_dispatch");
       expect(dispatch?.inputSchema).toMatchObject({
         properties: {
@@ -98,6 +107,127 @@ describe("MCP Slack tool catalogue", () => {
       await client.close();
       await server.close();
     }
+  });
+});
+
+describe("unregister_worktree", () => {
+  it("prunes a safe worktree and removes only that repo from session state", async () => {
+    const session = {
+      threadId: "thread-1",
+      targetRepo: "frontend",
+      worktreePath: "/worktrees/frontend",
+      worktreePaths: { frontend: "/worktrees/frontend", backend: "/worktrees/backend" },
+    } as any;
+    let removed: string | null = null;
+    let force: boolean | undefined;
+    const result = await unregisterWorktree({
+      threadId: "thread-1",
+      repoName: "frontend",
+      discardChanges: false,
+      store: {
+        get: async () => session,
+        mutateThread: async (_threadId: string, mutator: (value: any) => void) => {
+          await mutator(session);
+          return session;
+        },
+      } as any,
+      manager: {
+        getRepo: () => ({ name: "frontend" }),
+        getWorktreeStatus: async () => ({
+          tracked: [], untracked: [], ignoredDotenv: [], unpushedCommits: 0,
+        }),
+        removeWorktree: async (repo: string, _threadId: string, options?: { force?: boolean }) => {
+          removed = repo;
+          force = options?.force;
+        },
+      } as any,
+    });
+
+    expect(JSON.parse(result)).toMatchObject({ pruned: true, unregistered: true });
+    expect(String(removed)).toBe("frontend");
+    expect(force).toBe(false);
+    expect(session.worktreePaths).toEqual({ backend: "/worktrees/backend" });
+    expect(session.targetRepo).toBeNull();
+    expect(session.worktreePath).toBeNull();
+  });
+
+  it("refuses preservation-sensitive state unless discard is explicit", async () => {
+    let removed = false;
+    const result = await unregisterWorktree({
+      threadId: "thread-2",
+      repoName: "backend",
+      discardChanges: false,
+      store: {
+        get: async () => ({
+          threadId: "thread-2",
+          worktreePaths: { backend: "/worktrees/backend" },
+        }),
+      } as any,
+      manager: {
+        getRepo: () => ({ name: "backend" }),
+        getWorktreeStatus: async () => ({
+          tracked: ["apps/migrations/new.ts"],
+          untracked: [], ignoredDotenv: [], unpushedCommits: 0,
+        }),
+        removeWorktree: async () => { removed = true; },
+      } as any,
+    });
+
+    expect(result).toContain("Prune refused");
+    expect(result).toContain("discard_changes=true");
+    expect(removed).toBe(false);
+  });
+
+  it("requires a human confirmation callback for destructive discard", async () => {
+    let removed = false;
+    let force: boolean | undefined;
+    const base = {
+      threadId: "thread-3",
+      repoName: "backend",
+      discardChanges: true,
+      store: {
+        get: async () => ({
+          threadId: "thread-3",
+          worktreePaths: { backend: "/worktrees/backend" },
+        }),
+        mutateThread: async (_threadId: string, mutator: (value: any) => void) => {
+          const current = {
+            threadId: "thread-3",
+            worktreePaths: { backend: "/worktrees/backend" },
+          };
+          await mutator(current);
+          return current;
+        },
+      } as any,
+      manager: {
+        getRepo: () => ({ name: "backend" }),
+        getWorktreeStatus: async () => ({
+          tracked: ["apps/migrations/new.ts"],
+          untracked: [], ignoredDotenv: [], unpushedCommits: 0,
+        }),
+        removeWorktree: async (_repo: string, _threadId: string, options?: { force?: boolean }) => {
+          removed = true;
+          force = options?.force;
+        },
+      } as any,
+    };
+
+    expect(await unregisterWorktree(base)).toContain("requires an explicit human confirmation");
+    expect(removed).toBe(false);
+
+    expect(await unregisterWorktree({
+      ...base,
+      confirmDiscard: async () => false,
+    })).toContain("confirmation was not granted");
+    expect(removed).toBe(false);
+
+    const result = await unregisterWorktree({
+      ...base,
+      confirmDiscard: async () => true,
+    });
+    expect(JSON.parse(result)).toMatchObject({ pruned: true, unregistered: true });
+    expect(removed).toBe(true);
+    expect(force).toBe(true);
   });
 });
 

--- a/src/mcp/slack-server.ts
+++ b/src/mcp/slack-server.ts
@@ -46,6 +46,7 @@ import type { EmbeddingProviderKind } from "../memory/embedding/factory.ts";
 import type { SessionStore } from "../session/store/interface.ts";
 import type { SessionManager } from "../session/manager.ts";
 import type { WorktreeManager } from "../worktree/manager.ts";
+import { unsafeCleanupReason } from "../slack/action-buttons.ts";
 import {
   AGENT_IDENTITIES,
   dispatchableAgentsFor,
@@ -61,7 +62,10 @@ import { registerTaskRouteTools } from "../routes/tools.ts";
 import { handleMongoMcpRequest } from "./mongodb-proxy.ts";
 import { handleMixpanelMcpRequest } from "./mixpanel-proxy.ts";
 import { registerPendingApproval } from "./approval.ts";
-import { configureSlackApprovalBridge } from "./slack-approval-bridge.ts";
+import {
+  configureSlackApprovalBridge,
+  requestSlackApproval,
+} from "./slack-approval-bridge.ts";
 import { prepareSlackResponseWithActions, type SlackActionButtonSpec } from "../slack/formatting.ts";
 import { buildActionBlocks, splitActionMessageText } from "../slack/responder.ts";
 import type { SlackActionStore } from "../slack/action-store.ts";
@@ -233,6 +237,91 @@ const pipelineOutcomeSchema = z.object({
 /** Inject pipeline tool runtime (store + mode). Called from boot or tests. */
 export function setPipelineRuntime(runtime: PipelineToolRuntime | undefined): void {
   pipelineRuntime = runtime;
+}
+
+export async function unregisterWorktree(options: {
+  threadId: string;
+  repoName: string;
+  discardChanges: boolean;
+  store: SessionStore;
+  manager: WorktreeManager;
+  confirmDiscard?: (preservationRisk: string | null) => Promise<boolean>;
+}): Promise<string> {
+  const {
+    threadId,
+    repoName,
+    discardChanges,
+    store,
+    manager,
+    confirmDiscard,
+  } = options;
+  if (!manager.getRepo(repoName)) {
+    return `Error: unknown repo "${repoName}". Check REPOS config for valid names.`;
+  }
+
+  const session = await store.get(threadId);
+  if (!session) return `Error: no session found for thread ${threadId}.`;
+
+  const registeredPath = session.worktreePaths?.[repoName]
+    ?? (session.targetRepo === repoName ? session.worktreePath : null);
+  if (!registeredPath) {
+    return `Error: repo "${repoName}" has no registered worktree in this thread.`;
+  }
+
+  let preservationRisk: string | null = null;
+  try {
+    const status = await manager.getWorktreeStatus(registeredPath, repoName);
+    preservationRisk = unsafeCleanupReason(status);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return `Prune refused for ${repoName}: could not verify preservation state — ${message}`;
+  }
+
+  if (preservationRisk && !discardChanges) {
+    return `Prune refused for ${repoName}: ${preservationRisk}. Ask the human to confirm permanent discard, then retry with discard_changes=true.`;
+  }
+
+  if (discardChanges) {
+    if (!confirmDiscard) {
+      return `Prune refused for ${repoName}: discard_changes=true requires an explicit human confirmation.`;
+    }
+    let confirmed = false;
+    try {
+      confirmed = await confirmDiscard(preservationRisk);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      return `Prune refused for ${repoName}: human confirmation failed — ${message}`;
+    }
+    if (!confirmed) {
+      return `Prune refused for ${repoName}: human confirmation was not granted.`;
+    }
+  }
+
+  try {
+    await manager.removeWorktree(repoName, threadId, { force: discardChanges });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return `Error: worktree prune failed — ${message}`;
+  }
+
+  try {
+    await store.mutateThread(threadId, (current) => {
+      if (current.worktreePaths?.[repoName]) {
+        const nextPaths = { ...current.worktreePaths };
+        delete nextPaths[repoName];
+        current.worktreePaths = nextPaths;
+      }
+      if (current.targetRepo === repoName) {
+        current.worktreePath = null;
+        current.targetRepo = null;
+      }
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return `Error: worktree was pruned, but session unregister failed — ${message}`;
+  }
+
+  return JSON.stringify({ repo: repoName, path: registeredPath, pruned: true, unregistered: true });
 }
 
 export function registerTools(server: McpServer, runContext: SlackMcpRunContext | null = null) {
@@ -1039,6 +1128,53 @@ export function registerTools(server: McpServer, runContext: SlackMcpRunContext 
           },
         ],
       };
+    },
+  );
+
+  registerTool(
+    server,
+    "unregister_worktree",
+    {
+      description:
+        "Prune one managed worktree for the authenticated current Slack thread and unregister it from the session. " +
+        "Refuses local changes, ignored dotenv files, and unpushed commits by default. Set discard_changes only after a human explicitly confirms permanent deletion.",
+      inputSchema: {
+        repo: z.string().describe("Repo name as configured in REPOS"),
+        discard_changes: z.boolean().optional().default(false).describe(
+          "Permanently discard preservation-sensitive worktree state. Use only after explicit human confirmation.",
+        ),
+      },
+    },
+    async ({ repo: repoName, discard_changes }) => {
+      if (!runContext?.signed) {
+        return { content: [{ type: "text" as const, text: "Error: signed run context required" }] };
+      }
+      if (!sessionStore) {
+        return { content: [{ type: "text" as const, text: "Error: session store not available" }] };
+      }
+      if (!worktreeManager) {
+        return { content: [{ type: "text" as const, text: "Error: worktree manager not available" }] };
+      }
+
+      const result = await unregisterWorktree({
+        threadId: runContext.threadId,
+        repoName,
+        discardChanges: discard_changes,
+        store: sessionStore,
+        manager: worktreeManager,
+        confirmDiscard: (preservationRisk) => requestSlackApproval({
+          channel: runContext.channel,
+          threadTs: runContext.threadId,
+          agent: runContext.agent,
+          toolName: "unregister_worktree",
+          input: {
+            repo: repoName,
+            discard_changes: true,
+            preservation_risk: preservationRisk ?? "none detected; branch and worktree will still be permanently removed",
+          },
+        }),
+      });
+      return { content: [{ type: "text" as const, text: result }] };
     },
   );
 

--- a/src/runners/policy.test.ts
+++ b/src/runners/policy.test.ts
@@ -35,6 +35,23 @@ const codexConfig = {
 };
 
 describe("compileOpenCodePermission", () => {
+  it("exposes managed unregister only through worktree-mutate capability", () => {
+    const allowed = compileOpenCodePermission({
+      subject: {
+        assignmentCapabilities: ["worktree-mutate"],
+        agentPermissions: { intent: "read-only", mcp: ["slack-bot"], tools: [] },
+      },
+    }) as Record<string, string>;
+    const denied = compileOpenCodePermission({
+      subject: {
+        agentPermissions: { intent: "read-only", mcp: ["slack-bot"], tools: [] },
+      },
+    }) as Record<string, string>;
+
+    expect(allowed["mcp__slack-bot__unregister_worktree"]).toBe("allow");
+    expect(denied["mcp__slack-bot__unregister_worktree"]).not.toBe("allow");
+  });
+
   it("compiles a stateless skill's assignment capabilities without catalog identity", () => {
     const permission = compileOpenCodePermission({
       subject: {

--- a/src/runners/policy.ts
+++ b/src/runners/policy.ts
@@ -141,6 +141,9 @@ export function compileOpenCodePermission(options: {
     ...(subjectHasCapability(options.subject, "pipeline-run-start")
       ? { "mcp__slack-bot__pipeline_start_run": "allow" }
       : {}),
+    ...(subjectHasCapability(options.subject, "worktree-mutate")
+      ? { "mcp__slack-bot__unregister_worktree": "allow" }
+      : {}),
   };
   const declaredBashPatterns = (options.subject.agentPermissions?.tools ?? [])
     .map((tool) => /^Bash\((.+)\)$/.exec(tool)?.[1])

--- a/src/slack/action-buttons.ts
+++ b/src/slack/action-buttons.ts
@@ -225,7 +225,7 @@ export async function cleanupThreadWorktrees(
 
   const removed: string[] = [];
   for (const worktree of worktrees) {
-    await worktreeManager.removeWorktree(worktree.repo, session.threadId);
+    await worktreeManager.removeWorktree(worktree.repo, session.threadId, { force: false });
     removed.push(worktree.repo);
     if (session.worktreePaths?.[worktree.repo]) {
       delete session.worktreePaths[worktree.repo];

--- a/src/worktree/manager.ts
+++ b/src/worktree/manager.ts
@@ -180,7 +180,8 @@ export class WorktreeManager {
    */
   async removeWorktree(
     repoName: string,
-    threadId: string
+    threadId: string,
+    options: { force?: boolean } = {},
   ): Promise<void> {
     const repo = this.getRepo(repoName);
     if (!repo) {
@@ -204,9 +205,12 @@ export class WorktreeManager {
       // worktree path is gone or not a git checkout — proceed with default
     }
 
-    // Force-remove the worktree
+    // Safe callers can omit --force so Git gets a final chance to reject a
+    // worktree that became dirty after the caller's preservation check. The
+    // existing default remains forceful for explicit cleanup paths.
+    const force = options.force ?? true;
     await this.runGit(
-      ["worktree", "remove", worktreePath, "--force"],
+      ["worktree", "remove", worktreePath, ...(force ? ["--force"] : [])],
       repo.path
     );
 


### PR DESCRIPTION
## Summary
- add capability-gated signed `unregister_worktree` MCP teardown
- preserve dirty, dotenv, and unpushed work by default
- require live Slack human approval for destructive discard and use non-forced safe removal
- update provider policy tests, worktree docs, and private-agent overlay pointer

## Verification
- `bun run typecheck`
- `bun test` (2324 pass, 4 skipped)
- focused worktree/MCP/policy tests (91 pass)

## Merge notes
- no force push
- base: `main`
