### PR TITLE
fix: isolate Codex reviewer tools

### DIFF
--- a/docs/code_index/mcp-server.md
+++ b/docs/code_index/mcp-server.md
@@ -51,7 +51,8 @@ operations using the bot token and signed run context.
 | `.mcp.json` | Root config contains only the local `slack-bot` server. Per-agent generated configs add Playwright, MongoDB, Mixpanel, and capability-gated hosted Figma/Notion servers as needed. |
 | `.claude/settings.json` | `permissions.allow: ["mcp__slack-bot__*"]` |
 | `src/claude/spawner.ts` | Passes `--mcp-config` for worktree spawns |
-| `src/codex-app-server/spawner.ts` | Routes native approval callbacks through the shared Slack approval bridge |
+| `src/codex-app-server/spawner.ts` | Routes native approval callbacks through the shared Slack approval bridge; enables the local Codex environment only for registered worktree-verification sessions. |
+| `src/codex-app-server/config.ts` | Generates isolated Codex config with inherited connected apps disabled and only Junior's capability-scoped MCP servers enabled. |
 
 ## Key Concepts
 

--- a/docs/features/mcp-server.md
+++ b/docs/features/mcp-server.md
@@ -93,6 +93,11 @@ Status pill updates that agents post mid-run go through `slack_send_message` wit
   `OPENCODE_CONFIG_CONTENT` for all normal runs, including initial lead intake
   from Junior's project root. Explicit `session.cwd` utility runs still skip
   Junior's local MCP wiring.
+- Isolated Codex runtimes disable inherited connected apps. A personal Codex
+  GitHub connection must not bypass Junior's repository-selected identity or
+  capability-scoped MCP tools. Worktree-verification agents receive Codex's
+  local command environment only when their cwd is a registered managed
+  worktree; the compiled sandbox and approval policy still apply.
 - The Mixpanel MCP is intentionally **not** in `.mcp.json` and is injected only
   for `feature-metrics` sessions. Junior exposes one signed, read-only HTTP MCP
   at `/mcp/mixpanel`; it maintains one upstream connection for each configured

--- a/src/codex-app-server/config.test.ts
+++ b/src/codex-app-server/config.test.ts
@@ -195,6 +195,7 @@ describe("buildCodexConfigToml", () => {
     expect(config).toContain('model_reasoning_effort = "medium"');
     expect(config).toContain('sandbox_mode = "danger-full-access"');
     expect(config).toContain("[features]\nmulti_agent = false");
+    expect(config).toContain("multi_agent = false\napps = false");
   });
 });
 

--- a/src/codex-app-server/config.ts
+++ b/src/codex-app-server/config.ts
@@ -136,6 +136,9 @@ export function buildCodexConfigToml(options: {
   lines.push("");
   lines.push("[features]");
   lines.push("multi_agent = false");
+  // Junior supplies capability-scoped MCP tools. Do not inherit personal
+  // Codex connected apps (for example GitHub) from the shared auth session.
+  lines.push("apps = false");
   lines.push("");
 
   for (const [name, server] of Object.entries(options.mcp ?? {})) {

--- a/src/codex-app-server/spawner.test.ts
+++ b/src/codex-app-server/spawner.test.ts
@@ -234,6 +234,43 @@ describe("spawnCodexAppServer", () => {
     }
   });
 
+  it("enables the local Codex environment only for a registered review worktree", async () => {
+    const fakeCodex = installFakeCodex(recordingFakeCodexScript());
+    process.env.CODEX_BIN = fakeCodex.command;
+
+    try {
+      const session = createSession("review-thread", "C01");
+      session.provider = "codex-app-server";
+      session.activeAgentName = "review";
+      session.worktreePath = join(fakeCodex.root, "repo.junior-worktrees", "slack-review-thread");
+      mkdirSync(session.worktreePath, { recursive: true });
+      session.worktreePaths = { repo: session.worktreePath };
+      session.agentPermissions = { intent: "read-only", mcp: [], tools: [] };
+      const config = {
+        ...testConfig,
+        codex: {
+          ...testConfig.codex,
+          isolatedHomePath: join(fakeCodex.root, "codex-home"),
+        },
+      };
+
+      await spawnCodexAppServer(
+        session,
+        "review",
+        config,
+        session.worktreePath,
+      ).result;
+      const requests = readFileSync(join(fakeCodex.root, "requests.jsonl"), "utf8")
+        .trim()
+        .split("\n")
+        .map((line) => JSON.parse(line));
+      const threadStart = requests.find((request) => request.method === "thread/start");
+      expect(threadStart.params).not.toHaveProperty("environments");
+    } finally {
+      fakeCodex.cleanup();
+    }
+  });
+
   it("invokes an assignment skill as a structured turn item without changing developer instructions", async () => {
     const fakeCodex = installFakeCodex(recordingFakeCodexScript());
     process.env.CODEX_BIN = fakeCodex.command;

--- a/src/codex-app-server/spawner.ts
+++ b/src/codex-app-server/spawner.ts
@@ -18,6 +18,7 @@ import { signalProcessTree } from "../lifecycle/process-tree.ts";
 import { resolveTrustedSkill } from "../skills/registry.ts";
 import { skillInvocationPrompt } from "../skills/runtime.ts";
 import { requestSlackApproval } from "../mcp/slack-approval-bridge.ts";
+import { subjectHasCapability } from "../agents/capabilities.ts";
 
 interface JsonRpcResponse {
   id: number;
@@ -244,9 +245,7 @@ export function spawnCodexAppServer(
             approvalPolicy: policy.approvalPolicy,
             sandbox: policy.sandbox,
             sandboxPolicy: policy.sandboxPolicy,
-            // Do not expose Codex's default local environment. Junior's
-            // scoped MCP wiring is the only tool surface for this thread.
-            environments: [],
+            ...codexEnvironmentSelection(session, runtime.cwd),
             developerInstructions: developerInstructions(session),
             excludeTurns: true,
             persistExtendedHistory: false,
@@ -464,9 +463,7 @@ function threadStartParams(options: {
     approvalPolicy: options.policy.approvalPolicy,
     sandbox: options.policy.sandbox,
     sandboxPolicy: options.policy.sandboxPolicy,
-    // Keep the built-in local command environment disabled. Tool access must
-    // come from Junior's scoped MCP contract.
-    environments: [],
+    ...codexEnvironmentSelection(options.session, options.cwd),
     // Omit baseInstructions so Codex retains its native coding-agent operating
     // prompt. Junior is an additive developer layer, not a replacement for
     // Codex's tool, persistence, safety, and editing contract.
@@ -476,6 +473,26 @@ function threadStartParams(options: {
     persistExtendedHistory: false,
     threadSource: "user",
   };
+}
+
+function codexEnvironmentSelection(
+  session: ThreadSession,
+  cwd: string,
+): { environments?: [] } {
+  const worktreeRoots = [
+    session.worktreePath,
+    ...Object.values(session.worktreePaths ?? {}),
+  ].filter((root): root is string => Boolean(root));
+  if (
+    subjectHasCapability(session, "worktree-verify") &&
+    worktreeRoots.includes(cwd)
+  ) {
+    // Omission selects Codex's default local environment. The compiled
+    // read-only/workspace sandbox remains authoritative for this worktree.
+    return {};
+  }
+  // All other Junior sessions stay on the capability-scoped MCP surface.
+  return { environments: [] };
 }
 
 function emitThreadStarted(


### PR DESCRIPTION
## Summary
- Disable inherited Codex connected apps so personal GitHub integrations cannot bypass Junior-selected repository identities
- Allow worktree-verification agents to use the local Codex environment only inside registered managed worktrees
- Document and test the reviewer tool-isolation boundary

## Test plan
- [x] Run targeted Codex app-server tests
- [x] Run TypeScript typecheck
- [x] Run `git diff --check`